### PR TITLE
fix(sakana): stop downgrading max effort tier

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -5649,3 +5649,106 @@ describe("prepareRequestBody - developer role normalization", () => {
 		expect(requestBody.messages[0].role).toBe("developer");
 	});
 });
+
+describe("prepareRequestBody - Sakana Fugu reasoning effort", () => {
+	async function prepare(
+		reasoning_effort:
+			| "none"
+			| "minimal"
+			| "low"
+			| "medium"
+			| "high"
+			| "xhigh"
+			| "max"
+			| undefined,
+		stream: boolean,
+	) {
+		return (await prepareRequestBody(
+			"sakana",
+			"fugu-ultra",
+			null,
+			"fugu-ultra",
+			[{ role: "user", content: "Hello" }] as any,
+			stream,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			reasoning_effort,
+			true,
+			false,
+			20,
+			null,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			// useResponsesApi mirrors the endpoint choice: Responses when
+			// non-streaming, Chat Completions when streaming.
+			!stream,
+		)) as any;
+	}
+
+	describe("Responses API (non-streaming)", () => {
+		test("forwards max unchanged as its own tier", async () => {
+			const requestBody = await prepare("max", false);
+			expect(requestBody.reasoning.effort).toBe("max");
+		});
+
+		test("forwards xhigh unchanged", async () => {
+			const requestBody = await prepare("xhigh", false);
+			expect(requestBody.reasoning.effort).toBe("xhigh");
+		});
+
+		test.each(["none", "minimal", "low", "medium", "high"] as const)(
+			"collapses %s onto high",
+			async (effort) => {
+				const requestBody = await prepare(effort, false);
+				expect(requestBody.reasoning.effort).toBe("high");
+			},
+		);
+	});
+
+	describe("Chat Completions (streaming)", () => {
+		test("forwards max unchanged as its own tier", async () => {
+			const requestBody = await prepare("max", true);
+			expect(requestBody.reasoning_effort).toBe("max");
+		});
+
+		test("forwards xhigh unchanged", async () => {
+			const requestBody = await prepare("xhigh", true);
+			expect(requestBody.reasoning_effort).toBe("xhigh");
+		});
+
+		test.each(["minimal", "low", "medium", "high"] as const)(
+			"collapses %s onto high",
+			async (effort) => {
+				const requestBody = await prepare(effort, true);
+				expect(requestBody.reasoning_effort).toBe("high");
+			},
+		);
+
+		// "none" is stripped before the provider switch (the mapping does not
+		// declare it), so nothing is sent and Fugu applies its own Chat
+		// Completions default, which is "high".
+		test("omits reasoning_effort entirely for none", async () => {
+			const requestBody = await prepare("none", true);
+			expect(requestBody.reasoning_effort).toBeUndefined();
+		});
+	});
+
+	test("both API surfaces agree on every declared tier", async () => {
+		for (const effort of ["high", "xhigh", "max"] as const) {
+			const responses = await prepare(effort, false);
+			const chat = await prepare(effort, true);
+			expect(responses.reasoning.effort).toBe(chat.reasoning_effort);
+			expect(responses.reasoning.effort).toBe(effort);
+		}
+	});
+});

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -1914,14 +1914,16 @@ export async function prepareRequestBody(
 					}
 				}
 
-				// Fugu always reasons and only accepts "high"/"xhigh" effort — it has
-				// no off switch and rejects none/minimal/low/medium — so every tier at
-				// or below "high" (including a dropped "none") collapses onto its
-				// minimum ("high"), and "max" maps to its top tier ("xhigh").
+				// Fugu always reasons and only accepts "high"/"xhigh"/"max" effort — it
+				// has no off switch and rejects none/minimal/low/medium — so every tier
+				// at or below "high" (including a dropped "none") collapses onto its
+				// minimum ("high"). "max" is forwarded unchanged: it is a distinct top
+				// tier on fugu-ultra-v1.1 (what the "fugu-ultra" alias resolves to),
+				// and the older deployments still accept it as an alias of "xhigh".
 				const responsesReasoningEffort =
 					usedProvider === "sakana"
 						? reasoning_effort === "xhigh" || reasoning_effort === "max"
-							? "xhigh"
+							? reasoning_effort
 							: "high"
 						: (reasoning_effort ?? defaultEffort);
 
@@ -2209,7 +2211,7 @@ export async function prepareRequestBody(
 					if (usedProvider === "sakana") {
 						// Streaming Fugu uses Chat Completions, which (like its Responses
 						// API) only accepts "high"/"xhigh"/"max". Collapse the lower
-						// OpenAI tiers onto "high".
+						// OpenAI tiers onto "high" and forward the top tiers unchanged.
 						requestBody.reasoning_effort =
 							reasoning_effort === "xhigh" || reasoning_effort === "max"
 								? reasoning_effort

--- a/packages/models/src/models/sakana.ts
+++ b/packages/models/src/models/sakana.ts
@@ -11,6 +11,7 @@ export const sakanaModels = [
 		providers: [
 			{
 				providerId: "sakana" as const,
+				// Unpinned alias; Sakana currently resolves it to fugu-ultra-v1.1.
 				externalId: "fugu-ultra",
 				// Multi-agent orchestration is far too slow for e2e (reasoning
 				// prompts exceed the test timeout); excluded from the suite
@@ -39,7 +40,10 @@ export const sakanaModels = [
 				contextSize: 1000000,
 				streaming: true,
 				reasoning: true,
-				reasoningEfforts: ["high", "xhigh"],
+				// Fugu has no off switch and rejects none/minimal/low/medium. "max" is
+				// a distinct top tier on fugu-ultra-v1.1; the older fugu-ultra-v1.0
+				// deployment still accepts it as an alias of "xhigh".
+				reasoningEfforts: ["high", "xhigh", "max"],
 				// Fugu reasoning summaries are only exposed via the OpenAI Responses
 				// API, so route through it. Summaries are adaptive (omitted for
 				// simpler prompts), hence reasoningOutput is "omit".


### PR DESCRIPTION
## Problem

Sakana's `fugu-ultra` model id is an unpinned alias, and it now resolves to `fugu-ultra-v1.1`. On v1.1, `max` is a **distinct** top reasoning tier — it is no longer just an alias of `xhigh`, which is what it was on `fugu-ultra-v1.0` when the mapping was originally added in #2802.

Two things followed from that:

1. `prepare-request-body.ts` collapsed `max` onto `xhigh` on the Responses path, but forwarded it unchanged on the Chat Completions path. Since the gateway picks the endpoint by whether the request streams (Responses for non-streaming, Chat Completions for streaming), the *same* `reasoning_effort: "max"` request was served at two different effort depths depending only on `stream`.
2. The catalogue declared `reasoningEfforts: ["high", "xhigh"]`, so `max` was undocumented on `/v1/models` and excluded from effort-tier e2e generation.

The downgrade also contradicted the gateway's own OpenAPI contract, which states it "never downgrades effort tiers: providers that accept an effort parameter receive the value unchanged".

## Approach

Forward `max` unchanged on both paths, and declare it on the mapping.

Lower tiers keep collapsing onto `high` — that part of #2802 is still correct and deliberate: Fugu has no off switch and rejects `none`/`minimal`/`low`/`medium` outright. Only the `max` special case is removed.

This is safe in both directions. Per Sakana's docs, `fugu`, `fugu-ultra-v1.0` and `fugu-cyber` still accept `max` "for compatibility" and map it to `xhigh`, so forwarding `max` cannot 400 even if the alias were repointed back to v1.0.

## Sources

Two independent Sakana-owned sources, since their two doc pages disagree:

- [console.sakana.ai/get-started](https://console.sakana.ai/get-started): *"model=\"fugu-ultra-v1.1\" (also accepted as model=\"fugu-ultra\") supports three reasoning effort levels: high, xhigh, and max (a distinct maximum level for the hardest problems). model=\"fugu\", model=\"fugu-ultra-v1.0\", and model=\"fugu-cyber\" support high and xhigh (max is also accepted for compatibility and maps to xhigh)."*
- The canonical Codex model config in [SakanaAI/fugu](https://github.com/SakanaAI/fugu) (`configs/files/fugu.json`), which lists `supported_reasoning_levels` per slug:

  | slug | efforts |
  | --- | --- |
  | `fugu` | high, xhigh |
  | `fugu-ultra-v1.1` | high, xhigh, **max** ("Maximum reasoning for the hardest problems") |
  | `fugu-ultra-v1.0` | high, xhigh |
  | `fugu-cyber` | high, xhigh |

The `/models` API-reference table is the stale one — it still carries the pre-v1.1 line *"xhigh and max are aliases of the same reasoning effort"*.

## Verification

- New specs in `prepare-request-body.spec.ts` cover every tier on both API surfaces, plus a test asserting the two surfaces now agree on `high`/`xhigh`/`max`.
- `pnpm test:unit` — 3728 passed, `pnpm build`, `pnpm format` all clean.

**Not live-tested against the provider.** `api.sakana.ai` returns `403` at its edge for every path from this network, including unauthenticated `GET /` — so this could not be confirmed with a real request. The change rests on the two catalogue sources above. Worth a `/e2e` run (or a manual curl from an unblocked network) before merge if you want the live confirmation; note the mapping is `test: "skip"`, so it needs `TEST_MODELS="sakana/fugu-ultra" FULL_MODE=true`.

## Left alone deliberately

Pricing was re-checked and is unchanged — Sakana's pricing page quotes one fixed rate for *"fugu-ultra-v1.1 and fugu-ultra-v1.0"* ($5/$30/$0.50, and $10/$45/$1.00 over 272K), which matches the existing `pricingTiers` exactly. So the v1.0→v1.1 alias drift has no billing impact and no catalogue price change is needed.

The `externalId` is left as the unpinned `fugu-ultra` alias rather than pinned to `fugu-ultra-v1.1`, matching how it has always been served; a comment now records what it resolves to. Pinning it is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `max` reasoning effort level for Sakana models, enabling enhanced reasoning capabilities alongside existing effort tiers.

* **Tests**
  * Comprehensive test coverage for reasoning-effort handling across both Responses API and streaming Chat Completions endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->