### PR TITLE
test(gateway): induce reasoning in responses e2e

### DIFF
--- a/apps/gateway/src/responses.e2e.ts
+++ b/apps/gateway/src/responses.e2e.ts
@@ -206,11 +206,15 @@ describe("e2e", getConcurrentTestOptions(), () => {
 		"responses stateless encrypted reasoning $model",
 		getTestOptions(),
 		async ({ model }) => {
+			// The prompt has to make the model actually think: cheap reasoning
+			// models (e.g. gpt-5.6-luna) spend zero reasoning tokens on a trivial
+			// "remember my name" turn and then emit no reasoning item at all, so
+			// there would be no encrypted payload to round-trip.
 			const firstInput = [
 				{
 					role: "user",
 					content:
-						"My name is Ada. Please remember it. Reply with a brief acknowledgement.",
+						"My name is Ada. Please remember it. Also work out 17 * 23 step by step and state the result.",
 				},
 			];
 			const firstRequestId = generateTestRequestId();


### PR DESCRIPTION
## Problem

`responses stateless encrypted reasoning` in `apps/gateway/src/responses.e2e.ts` fails deterministically when the pinned OpenAI model is a cheap reasoning model:

```
FAIL  apps/gateway/src/responses.e2e.ts > e2e > responses stateless encrypted reasoning 'openai/gpt-5.6-luna'
AssertionError: expected undefined to be defined
```

The first turn asks only "My name is Ada. Please remember it. Reply with a brief acknowledgement." `gpt-5.6-luna` spends **0 reasoning tokens** on that, so the Responses API returns no `reasoning` output item at all — and the test's whole point is to round-trip that item's `encrypted_content` through a stateless second turn.

This is not a gateway defect. Calling `https://api.openai.com/v1/responses` directly with the same body, bypassing the gateway entirely, returns the same thing:

```
output types: ['message']   has encrypted: False   reasoning_tokens: 0
```

Raising `reasoning.effort` to `high` does not help either — the turn is simply too trivial to reason about. The test was implicitly relying on the model it happened to pick per provider always emitting a reasoning item.

## Approach

Extend the first-turn prompt with a small arithmetic task so the model actually reasons, while still establishing the name the second turn has to recall. Nothing else about the test changes — the assertions, the stateless replay, and the `upstreamRequest` check that proves the encrypted item reached the upstream unchanged all stay as they were.

Verified 3/3 consecutive calls emit a reasoning item with non-empty `encrypted_content`, on both the real OpenAI endpoint and the proxied one.

## Verification

Scoped e2e with `TEST_MODELS="openai/gpt-5.6-luna"`, run against an OpenAI-compatible upstream:

- Before: `Test Files 1 failed | 28 passed | 2 skipped (31)` / `Tests 1 failed | 110 passed | 90 skipped (201)`
- After: `Test Files 29 passed | 2 skipped (31)` / `Tests 111 passed | 90 skipped (201)`

`pnpm format` and `pnpm build` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated encrypted reasoning coverage to use a prompt that reliably produces reasoning output.
  * Strengthened round-trip validation for encrypted reasoning payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->