### PR TITLE
fix(ui): show error cause in log details

### DIFF
--- a/apps/api/src/routes/logs.spec.ts
+++ b/apps/api/src/routes/logs.spec.ts
@@ -744,6 +744,77 @@ describe("logs route", () => {
 			);
 		});
 	});
+
+	// Network failures log a bare "fetch failed" message; the actual reason only
+	// exists in the cause chain, so the public endpoints have to serve it for the
+	// dashboard to show anything useful.
+	describe("error cause is served to the dashboard", () => {
+		const CAUSE =
+			"HeadersTimeoutError: Headers Timeout Error (code: UND_ERR_HEADERS_TIMEOUT)";
+
+		beforeEach(async () => {
+			await db.insert(tables.log).values({
+				id: "fetch-failed-log-id",
+				requestId: "fetch-failed-log-id",
+				organizationId: "test-org-id",
+				projectId: "test-project-id",
+				apiKeyId: "test-api-key-id",
+				duration: 301880,
+				requestedModel: "gpt-4",
+				requestedProvider: "openai",
+				usedModel: "gpt-4",
+				usedProvider: "openai",
+				responseSize: 0,
+				finishReason: "upstream_error",
+				unifiedFinishReason: "upstream_error",
+				hasError: true,
+				errorDetails: {
+					statusCode: 0,
+					statusText: "TypeError",
+					responseText: "fetch failed",
+					cause: CAUSE,
+				},
+				messages: JSON.stringify([{ role: "user", content: "Hello" }]),
+				mode: "credits",
+				usedMode: "credits",
+			});
+		});
+
+		test("list endpoint serves the error cause", async () => {
+			const params = new URLSearchParams({ projectId: "test-project-id" });
+			const res = await app.request("/logs?" + params, {
+				method: "GET",
+				headers: {
+					Cookie: token,
+				},
+			});
+
+			expect(res.status).toBe(200);
+			const json = await res.json();
+			const log = json.logs.find(
+				(entry: { id: string }) => entry.id === "fetch-failed-log-id",
+			);
+			expect(log.errorDetails.cause).toBe(CAUSE);
+		});
+
+		test("detail endpoint serves the error cause", async () => {
+			const res = await app.request("/logs/fetch-failed-log-id", {
+				method: "GET",
+				headers: {
+					Cookie: token,
+				},
+			});
+
+			expect(res.status).toBe(200);
+			const json = await res.json();
+			expect(json.log.errorDetails).toEqual({
+				statusCode: 0,
+				statusText: "TypeError",
+				responseText: "fetch failed",
+				cause: CAUSE,
+			});
+		});
+	});
 	// Project access is not key access: a developer may only read logs produced by
 	// the api keys they created, since the payload holds the full prompt and
 	// completion.

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
@@ -1416,6 +1416,17 @@ export function LogDetailClient({
 									{log.errorDetails.responseText}
 								</pre>
 							</div>
+							{/* Network failures surface as a bare "fetch failed" message; the
+							    underlying reason (timeouts, DNS, TLS, connection resets) only
+							    exists in the cause chain, so it has to be shown separately. */}
+							{!!log.errorDetails.cause && (
+								<div>
+									<p className="text-xs text-red-400 mb-1">Cause</p>
+									<pre className="text-xs overflow-auto whitespace-pre-wrap break-all font-mono bg-background rounded border p-3">
+										{log.errorDetails.cause}
+									</pre>
+								</div>
+							)}
 							{log.retried && log.retriedByLogId && (
 								<div className="flex items-center gap-2 rounded-md border border-amber-500/20 bg-amber-500/10 p-3 text-sm">
 									<RefreshCw className="h-4 w-4 text-amber-600" />


### PR DESCRIPTION
## Problem

A failed request whose upstream fetch never got a response shows only this on the log detail page:

```
Status Code   0
Status Text   TypeError
Error Message fetch failed
```

"fetch failed" is Node's generic message — the actual reason lives in the error's `cause` chain. The gateway already extracts and stores it (`extractErrorCause`), and the API already serves it, so the log row for the reported request looked like:

```json
{"statusCode":0,"statusText":"TypeError","responseText":"fetch failed","cause":"HeadersTimeoutError: Headers Timeout Error (code: UND_ERR_HEADERS_TIMEOUT)"}
```

The dashboard just never rendered the `cause` field, so the one piece of information that identifies the failure (headers timeout vs. DNS vs. TLS vs. connection reset) was invisible.

## Change

- Render `errorDetails.cause` as its own block in the Error Details section of the log detail page, when present.
- Add API tests pinning that the public list and detail log endpoints serve `cause`, since the UI now depends on it.

No gateway change was needed — capture is already in place on every fetch/timeout/body-read path.

Stealth providers are unaffected: `redactErrorDetails` drops `cause` from the public `errorDetails` before insert, so nothing new is exposed.

## Verification

- `pnpm vitest run apps/api/src/routes/logs.spec.ts` — 24 passed, including the two new cases.
- `pnpm build`, `pnpm format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visibility for network error causes in log details when available.
  * Error causes are displayed in a labeled, scrollable format for easier troubleshooting.

* **Bug Fixes**
  * Ensured network error causes are preserved and returned in both log list and detail responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->