### PR TITLE
feat(admin): search devpass by profile username

### DIFF
--- a/apps/api/src/routes/admin-devpass-search.spec.ts
+++ b/apps/api/src/routes/admin-devpass-search.spec.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db, eq, tables } from "@llmgateway/db";
+
+const ORG_ID = "admin-devpass-search-org";
+const originalAdminEmails = process.env.ADMIN_EMAILS;
+
+interface ListResponse {
+	subscribers: {
+		id: string;
+		ownerEmail: string | null;
+		ownerUsername: string | null;
+	}[];
+	total: number;
+}
+
+async function insertOrg() {
+	await db.insert(tables.organization).values({
+		id: ORG_ID,
+		name: "Personal Org",
+		billingEmail: "admin@example.com",
+		kind: "devpass",
+		devPlan: "pro",
+		devPlanCreditsUsed: "20",
+		devPlanCreditsLimit: "237",
+	});
+	await db.insert(tables.userOrganization).values({
+		userId: "test-user-id",
+		organizationId: ORG_ID,
+		role: "owner",
+	});
+}
+
+async function listSubscribers(
+	cookie: string,
+	search: string,
+): Promise<ListResponse> {
+	const res = await app.request(
+		`/admin/devpass?search=${encodeURIComponent(search)}`,
+		{ headers: { Cookie: cookie } },
+	);
+	expect(res.status).toBe(200);
+	return (await res.json()) as ListResponse;
+}
+
+describe("admin devpass search", () => {
+	let cookie: string;
+
+	beforeEach(async () => {
+		process.env.ADMIN_EMAILS = "admin@example.com";
+		cookie = await createTestUser();
+		await db
+			.update(tables.user)
+			.set({ username: "CodeWizard" })
+			.where(eq(tables.user.id, "test-user-id"));
+		await insertOrg();
+	});
+
+	afterEach(async () => {
+		if (originalAdminEmails === undefined) {
+			delete process.env.ADMIN_EMAILS;
+		} else {
+			process.env.ADMIN_EMAILS = originalAdminEmails;
+		}
+		await db.delete(tables.transaction);
+		await deleteAll();
+	});
+
+	it("finds a subscriber by their DevPass profile username", async () => {
+		const body = await listSubscribers(cookie, "codewiz");
+		expect(body.total).toBe(1);
+		expect(body.subscribers[0].id).toBe(ORG_ID);
+		expect(body.subscribers[0].ownerUsername).toBe("CodeWizard");
+	});
+
+	it("returns nothing when no owner username or org field matches", async () => {
+		const body = await listSubscribers(cookie, "someoneelse");
+		expect(body.total).toBe(0);
+		expect(body.subscribers).toHaveLength(0);
+	});
+});

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -11764,6 +11764,7 @@ const devpassSubscriberSchema = z.object({
 	ownerUserId: z.string().nullable(),
 	ownerName: z.string().nullable(),
 	ownerEmail: z.string().nullable(),
+	ownerUsername: z.string().nullable(),
 	tier: devpassTierSchema,
 	pendingTier: devpassTierSchema.nullable(),
 	status: devpassStatusSchema,
@@ -12186,6 +12187,7 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 			userId: tables.user.id,
 			userName: tables.user.name,
 			userEmail: tables.user.email,
+			userUsername: tables.user.username,
 		})
 		.from(tables.userOrganization)
 		.innerJoin(tables.user, eq(tables.userOrganization.userId, tables.user.id))
@@ -12391,6 +12393,7 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 				sql`LOWER(${tables.organization.billingEmail}) LIKE ${`%${searchLower}%`}`,
 				sql`${tables.organization.id} LIKE ${`%${search}%`}`,
 				sql`LOWER(${ownerSub.userEmail}) LIKE ${`%${searchLower}%`}`,
+				sql`LOWER(${ownerSub.userUsername}) LIKE ${`%${searchLower}%`}`,
 			)!,
 		);
 	}
@@ -12446,6 +12449,7 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 			ownerUserId: ownerSub.userId,
 			ownerName: ownerSub.userName,
 			ownerEmail: ownerSub.userEmail,
+			ownerUsername: ownerSub.userUsername,
 		})
 		.from(tables.organization)
 		.leftJoin(
@@ -12788,6 +12792,7 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 			ownerUserId: row.ownerUserId ?? null,
 			ownerName: row.ownerName ?? null,
 			ownerEmail: row.ownerEmail ?? null,
+			ownerUsername: row.ownerUsername ?? null,
 			tier,
 			pendingTier: row.pendingTier ?? null,
 			status,
@@ -13256,6 +13261,7 @@ admin.openapi(getDevpassSubscriber, async (c) => {
 			userId: tables.user.id,
 			userName: tables.user.name,
 			userEmail: tables.user.email,
+			userUsername: tables.user.username,
 		})
 		.from(tables.userOrganization)
 		.innerJoin(tables.user, eq(tables.userOrganization.userId, tables.user.id))
@@ -13433,6 +13439,7 @@ admin.openapi(getDevpassSubscriber, async (c) => {
 		ownerUserId: owner[0]?.userId ?? null,
 		ownerName: owner[0]?.userName ?? null,
 		ownerEmail: owner[0]?.userEmail ?? null,
+		ownerUsername: owner[0]?.userUsername ?? null,
 		tier: org.devPlan,
 		pendingTier: org.devPlanPendingTier ?? null,
 		status,

--- a/ee/admin/src/app/devpass/[orgId]/page.tsx
+++ b/ee/admin/src/app/devpass/[orgId]/page.tsx
@@ -207,6 +207,12 @@ export default async function DevpassDetailPage({
 					</div>
 					<div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
 						<span>{sub.ownerEmail ?? sub.billingEmail}</span>
+						{sub.ownerUsername && (
+							<>
+								<span>•</span>
+								<span>@{sub.ownerUsername}</span>
+							</>
+						)}
 						<span>•</span>
 						<span>Subscribed {formatDate(sub.subscribedSince)}</span>
 					</div>

--- a/ee/admin/src/app/devpass/page.tsx
+++ b/ee/admin/src/app/devpass/page.tsx
@@ -689,7 +689,7 @@ export default async function DevpassPage({
 						<input
 							type="text"
 							name="search"
-							placeholder="Search by org name, email, owner, or ID..."
+							placeholder="Search by org name, email, owner, username, or ID..."
 							defaultValue={search}
 							className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
 						/>
@@ -945,6 +945,11 @@ export default async function DevpassPage({
 										<p className="text-xs text-muted-foreground">
 											{sub.ownerEmail ?? sub.billingEmail}
 										</p>
+										{sub.ownerUsername && (
+											<p className="text-xs text-muted-foreground">
+												@{sub.ownerUsername}
+											</p>
+										)}
 									</TableCell>
 									<TableCell>
 										<Badge variant={getTierBadgeVariant(sub.tier)}>


### PR DESCRIPTION
The DevPass admin page could only be searched by org name, billing email, owner email, or org ID. Users are far more recognizable by their DevPass profile username (the `/profiles/:username` slug), so looking someone up from a username meant first translating it to an email by hand.

## Changes

- `GET /admin/devpass` now also matches `user.username` of the org owner (case-insensitive substring, same as the other text fields).
- `ownerUsername` added to the DevPass subscriber schema, so it comes back on both the list and the detail endpoint.
- Admin UI shows `@username` under the subscriber in the table and in the detail header, and the search placeholder mentions usernames.

The username column is nullable — it stays null until the user claims a profile — so subscribers without one are unaffected.

## Verification

- New `apps/api/src/routes/admin-devpass-search.spec.ts`: finds a subscriber by a partial, differently-cased username and returns nothing when nothing matches.
- `pnpm format` and full `pnpm build` pass; existing `admin-devpass-gift-reset-passes.spec.ts` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - DevPass subscriber searches now support searching by organization owner username.
  - Subscriber listings and detail pages display the owner’s username when available.
  - Search guidance now indicates that owner usernames can be used.

- **Bug Fixes**
  - Improved DevPass subscriber information by including the organization owner username alongside email details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->