### PR TITLE
feat(models): declare reasoning efforts for groq gpt-oss mappings

### DIFF
--- a/packages/models/src/models/openai.ts
+++ b/packages/models/src/models/openai.ts
@@ -690,6 +690,7 @@ export const openaiModels = [
 				vision: false,
 				tools: true,
 				reasoning: true,
+				reasoningEfforts: ["low", "medium", "high"],
 				jsonOutput: true,
 			},
 			{
@@ -853,6 +854,7 @@ export const openaiModels = [
 				vision: false,
 				tools: true,
 				reasoning: true,
+				reasoningEfforts: ["low", "medium", "high"],
 				jsonOutput: true,
 			},
 			{


### PR DESCRIPTION
## Summary

Declares `reasoningEfforts` for both live groq mappings (`openai/gpt-oss-120b`, `openai/gpt-oss-20b`) in `packages/models/src/models/openai.ts`, per #3028.

## Changes

- `openai/gpt-oss-120b` → `["low", "medium", "high"]`
- `openai/gpt-oss-20b` → `["low", "medium", "high"]`

Source: [Groq's Reasoning docs](https://console.groq.com/docs/reasoning) — lists both models under `reasoning_effort` support, table confirms `low`/`medium`/`high` are supported specifically by GPT-OSS 20B/120B, while `none`/`default` are Qwen-3.6-27B-only (not in the catalog, different enum entirely). `none` correctly excluded — rejected for GPT-OSS models.

## Not changed — 4 other groq mappings

`moonshotai/kimi-k2-instruct`, `deepseek-r1-distill-llama-70b`, `gemma2-9b-it`, `meta-llama/llama-guard-4-12b` are all deactivated — out of scope.

## Testing

- `pnpm format` — only `openai.ts` changed, 2 lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting low, medium, or high reasoning effort when using Groq’s GPT-OSS 120B and 20B models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->