### PR TITLE
feat(models): mark scx-ai-gp GLM-5.2 as fp8

### DIFF
--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -193,6 +193,7 @@ export const zaiModels = [
 				// SCX rejects max_tokens above 131072 ("expected a value <= 131072"),
 				// despite its catalogue advertising a 128k ceiling
 				maxOutput: 131072,
+				quantization: "fp8",
 				streaming: true,
 				reasoning: true,
 				vision: false,


### PR DESCRIPTION
Follow-up to #3333, which added the `scx-ai-gp` provider and its GLM-5.2
mapping but left the quantization unset.

SCX serves GLM-5.2 on the general-purpose tier at fp8. Declaring it keeps
the model card accurate and puts the mapping in line with its siblings,
which all state their precision — canopywave is fp8, runware and nebius
are fp4.

One-line change; no behavioural effect beyond what the catalogue reports.

## Verification

- `pnpm format` clean, `@llmgateway/models` builds.
- `packages/models/src/providers.spec.ts` and
  `packages/actions/src/models.spec.ts` pass (83 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled FP8 quantization for the GLM-5.2 model through the SCX AI GP provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->