### PR TITLE
feat: deactivate runware deepseek v4 mappings

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -284,6 +284,9 @@ export const deepseekModels = [
 			{
 				providerId: "runware",
 				externalId: "deepseek-v4-pro",
+				// Temporarily deactivated until we decide to re-enable Runware
+				// for the DeepSeek V4 models.
+				deactivatedAt: new Date("2026-08-05"),
 				inputPrice: "0.961e-6",
 				outputPrice: "1.922e-6",
 				cachedInputPrice: "0.079e-6",
@@ -449,6 +452,9 @@ export const deepseekModels = [
 			{
 				providerId: "runware",
 				externalId: "deepseek-v4-flash",
+				// Temporarily deactivated until we decide to re-enable Runware
+				// for the DeepSeek V4 models.
+				deactivatedAt: new Date("2026-08-05"),
 				inputPrice: "0.076e-6",
 				outputPrice: "0.153e-6",
 				cachedInputPrice: "0.014e-6",


### PR DESCRIPTION
Temporarily deactivate the Runware provider mappings for
DeepSeek V4 Pro and DeepSeek V4 Flash until we decide to
re-enable them.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B8x1DodWXmN1pJ8msQvU5h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * DeepSeek V4 Pro and V4 Flash providers are temporarily unavailable as of August 5, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->