### PR TITLE
fix(models): deactivate Runware dsv4 mappings

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -284,6 +284,7 @@ export const deepseekModels = [
 			{
 				providerId: "runware",
 				externalId: "deepseek-v4-pro",
+				deactivatedAt: new Date("2026-08-05"),
 				inputPrice: "0.961e-6",
 				outputPrice: "1.922e-6",
 				cachedInputPrice: "0.079e-6",
@@ -449,6 +450,7 @@ export const deepseekModels = [
 			{
 				providerId: "runware",
 				externalId: "deepseek-v4-flash",
+				deactivatedAt: new Date("2026-08-05"),
 				inputPrice: "0.076e-6",
 				outputPrice: "0.153e-6",
 				cachedInputPrice: "0.014e-6",


### PR DESCRIPTION
Runware's self-hosted vLLM deployment for deepseek-v4-flash has a new regression: the model ignores tool results in multi-turn conversations and loops indefinitely (verified live 2026-08-05). All reasoning-effort levels are affected, and `thinking: disabled` does not help.

Runware is the cheapest Flash provider ($0.076/$0.153 vs $0.14/$0.28 native DeepSeek), so auto-routing picks it on every cold start. Coding-plan users cannot bypass via provider pins (403 blocked). This deactivates both Runware V4 mappings (repeating the PR #3426 pattern) to stop the bleeding while Runware stabilizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Marked the DeepSeek V4 Pro and DeepSeek V4 Flash providers as deactivated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->