### PR TITLE
feat(seo): month-aware timeline + blog FAQ schema

### DIFF
--- a/apps/ui/content-collections.ts
+++ b/apps/ui/content-collections.ts
@@ -29,10 +29,19 @@ const blog = defineCollection({
 		id: z.string(),
 		slug: z.string(),
 		date: z.string(),
+		updatedAt: z.string().optional(),
 		title: z.string(),
 		summary: z.string(),
 		draft: z.boolean().optional(),
 		categories: z.array(z.string()).default([]),
+		faqs: z
+			.array(
+				z.object({
+					question: z.string(),
+					answer: z.string(),
+				}),
+			)
+			.default([]),
 		image: z
 			.object({
 				src: z.string(),

--- a/apps/ui/src/app/blog/[slug]/page.tsx
+++ b/apps/ui/src/app/blog/[slug]/page.tsx
@@ -34,7 +34,7 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
 		headline: entry.title,
 		description: entry.summary ?? "LLM Gateway blog post",
 		datePublished: entry.date,
-		dateModified: entry.date,
+		dateModified: entry.updatedAt ?? entry.date,
 		author: {
 			"@type": "Organization",
 			name: "LLM Gateway",
@@ -64,6 +64,18 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
 			},
 		}),
 	};
+
+	const faqSchema = entry.faqs.length
+		? {
+				"@context": "https://schema.org",
+				"@type": "FAQPage",
+				mainEntity: entry.faqs.map((faq) => ({
+					"@type": "Question",
+					name: faq.question,
+					acceptedAnswer: { "@type": "Answer", text: faq.answer },
+				})),
+			}
+		: null;
 
 	const breadcrumbSchema = {
 		"@context": "https://schema.org",
@@ -106,6 +118,15 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
 					__html: JSON.stringify(breadcrumbSchema),
 				}}
 			/>
+			{faqSchema ? (
+				<script
+					type="application/ld+json"
+					// eslint-disable-next-line @eslint-react/dom/no-dangerously-set-innerhtml
+					dangerouslySetInnerHTML={{
+						__html: JSON.stringify(faqSchema),
+					}}
+				/>
+			) : null}
 			<HeroRSC navbarOnly />
 			<div className="min-h-screen bg-white text-black dark:bg-black dark:text-white pt-30">
 				<main className="container mx-auto px-4 py-8">
@@ -135,6 +156,18 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
 											day: "numeric",
 										})}
 									</time>
+									{entry.updatedAt && (
+										<span className="text-sm italic">
+											{" · Updated "}
+											<time dateTime={entry.updatedAt}>
+												{new Date(entry.updatedAt).toLocaleDateString("en-US", {
+													year: "numeric",
+													month: "long",
+													day: "numeric",
+												})}
+											</time>
+										</span>
+									)}
 								</div>
 							</header>
 
@@ -157,6 +190,29 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
 									{entry.content}
 								</Markdown>
 							</div>
+
+							{entry.faqs.length ? (
+								<section
+									aria-labelledby="blog-faq-heading"
+									className="mt-12 border-t border-border pt-8"
+								>
+									<h2 id="blog-faq-heading" className="text-2xl font-bold mb-6">
+										Frequently asked questions
+									</h2>
+									<dl className="divide-y divide-border">
+										{entry.faqs.map((faq) => (
+											<div key={faq.question} className="py-5">
+												<dt className="text-lg font-semibold">
+													{faq.question}
+												</dt>
+												<dd className="mt-2 leading-relaxed text-muted-foreground">
+													{faq.answer}
+												</dd>
+											</div>
+										))}
+									</dl>
+								</section>
+							) : null}
 						</article>
 					</div>
 				</main>

--- a/apps/ui/src/app/timeline/page.tsx
+++ b/apps/ui/src/app/timeline/page.tsx
@@ -13,36 +13,65 @@ import {
 	buildTimelineModels,
 	buildTimelineStats,
 	formatDate,
+	getMonthSummary,
 	getYearSummaries,
 	isoDate,
 	recentModels,
 } from "@/lib/timeline-data";
 
+import type { TimelineMonthSummary } from "@/lib/timeline-data";
 import type { Metadata } from "next";
 
 const BASE_URL = "https://llmgateway.io";
 
-export const metadata: Metadata = {
-	title: "LLM Release Timeline — Model Release Dates",
-	description:
-		"Release dates for every major LLM — see when GPT, Claude, Gemini, Llama, Mistral, and DeepSeek models shipped and when each was added to LLM Gateway.",
-	alternates: {
-		canonical: "/timeline",
-	},
-	openGraph: {
-		title: "LLM Release Timeline — Model Release Dates",
-		description:
-			"Release dates for every major LLM — GPT, Claude, Gemini, Llama, Mistral and DeepSeek — with the date each model was added to LLM Gateway.",
-		type: "website",
-		url: `${BASE_URL}/timeline`,
-	},
-	twitter: {
-		card: "summary_large_image",
-		title: "LLM Release Timeline — Model Release Dates",
-		description:
-			"Release dates for every major LLM — GPT, Claude, Gemini, Llama, Mistral and DeepSeek — and when each was added to LLM Gateway.",
-	},
-};
+const FALLBACK_TITLE = "LLM Release Timeline — Model Release Dates";
+const FALLBACK_DESCRIPTION =
+	"Release dates for every major LLM — see when GPT, Claude, Gemini, Llama, Mistral, and DeepSeek models shipped and when each was added to LLM Gateway.";
+
+function buildMonthMeta(month: TimelineMonthSummary | null): {
+	title: string;
+	description: string;
+} {
+	if (!month) {
+		return { title: FALLBACK_TITLE, description: FALLBACK_DESCRIPTION };
+	}
+	const count = month.models.length;
+	const names = month.models
+		.slice(0, 3)
+		.map((model) => model.name)
+		.join(", ");
+	return {
+		title: `New AI Model Releases — ${month.label} Timeline`,
+		description: `${count} AI model${count === 1 ? "" : "s"} released in ${
+			month.label
+		}${month.isCurrentMonth ? " so far" : ""} — ${names} — plus release dates for every major LLM: GPT, Claude, Gemini, DeepSeek and more. Updated daily.`,
+	};
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+	const models = await fetchModels();
+	const month = getMonthSummary(buildTimelineModels(models), new Date());
+	const { title, description } = buildMonthMeta(month);
+
+	return {
+		title,
+		description,
+		alternates: {
+			canonical: "/timeline",
+		},
+		openGraph: {
+			title,
+			description,
+			type: "website",
+			url: `${BASE_URL}/timeline`,
+		},
+		twitter: {
+			card: "summary_large_image",
+			title,
+			description,
+		},
+	};
+}
 
 export default async function TimelinePage() {
 	const models = await fetchModels();
@@ -52,6 +81,8 @@ export default async function TimelinePage() {
 	const faqs = buildTimelineFaqs(timelineModels, stats);
 	const yearSummaries = getYearSummaries(timelineModels);
 	const latest = recentModels(timelineModels, 12);
+	const month = getMonthSummary(timelineModels, new Date());
+	const monthPreview = month?.models.slice(0, 8) ?? [];
 
 	const datasetSchema = {
 		"@context": "https://schema.org",
@@ -217,6 +248,70 @@ export default async function TimelinePage() {
 						</div>
 					</div>
 				</section>
+
+				{month ? (
+					<section
+						className="border-b border-border/60"
+						aria-labelledby="month-releases-heading"
+					>
+						<div className="container mx-auto px-4 py-10 md:py-14">
+							<div className="mx-auto max-w-3xl">
+								<h2
+									id="month-releases-heading"
+									className="font-display text-2xl font-bold tracking-tight md:text-3xl"
+								>
+									{month.isCurrentMonth
+										? `New AI models released in ${month.label}`
+										: `The latest AI model releases — ${month.label}`}
+								</h2>
+								<p className="mt-3 text-sm leading-relaxed text-muted-foreground md:text-base">
+									{month.models.length} new AI{" "}
+									{month.models.length === 1 ? "model was" : "models were"}{" "}
+									released in {month.label}
+									{month.isCurrentMonth ? " so far" : ""}, from{" "}
+									{month.providerCount}{" "}
+									{month.providerCount === 1 ? "provider" : "providers"}. The
+									most recent is {month.models[0].name} from{" "}
+									{month.models[0].providerName}, released{" "}
+									{formatDate(month.models[0].releasedAt)}. Every one is
+									available on LLM Gateway through a single API.
+								</p>
+								<ul className="mt-5 divide-y divide-border/60 rounded-xl border border-border/70 bg-card/50">
+									{monthPreview.map((model) => (
+										<li
+											key={model.id}
+											className="flex items-baseline justify-between gap-4 px-4 py-3"
+										>
+											<Link
+												href={`/models/${encodeURIComponent(model.id)}`}
+												className="text-sm font-medium hover:text-primary"
+											>
+												{model.name}
+											</Link>
+											<span className="shrink-0 text-xs text-muted-foreground">
+												{model.providerName} ·{" "}
+												<time dateTime={isoDate(model.releasedAt)}>
+													{formatDate(model.releasedAt)}
+												</time>
+											</span>
+										</li>
+									))}
+								</ul>
+								<p className="mt-4 text-sm">
+									<Link
+										href={`/timeline/${month.year}`}
+										className="inline-flex items-center gap-1 font-medium text-primary"
+									>
+										{month.models.length > monthPreview.length
+											? `See all ${month.models.length} releases from ${month.label}`
+											: `See every ${month.year} release`}
+										<ArrowRight className="h-3.5 w-3.5" />
+									</Link>
+								</p>
+							</div>
+						</div>
+					</section>
+				) : null}
 
 				<section className="container mx-auto px-4 py-12 md:py-16">
 					<div className="mx-auto max-w-5xl">

--- a/apps/ui/src/content/blog/2025-01-25-what-is-an-llm-gateway.md
+++ b/apps/ui/src/content/blog/2025-01-25-what-is-an-llm-gateway.md
@@ -2,6 +2,7 @@
 id: blog-what-is-an-llm-gateway
 slug: what-is-an-llm-gateway
 date: 2026-01-25
+updatedAt: "2026-08-05"
 title: "What is an LLM Gateway?"
 summary: Learn what an LLM Gateway is, why you need one, and how it simplifies integrating, managing, and deploying large language models in production.
 categories: ["Guides"]
@@ -12,11 +13,11 @@ image:
   height: 592
 ---
 
+An **LLM gateway** is a middleware layer that sits between your application and LLM providers, exposing one unified, OpenAI-compatible API for many models. It handles request routing, failover, caching, cost tracking, and access control — so you can switch between OpenAI, Anthropic, Google, and open-weight models without changing your code.
+
 Large language models power modern AI applications—from chatbots and code assistants to document analysis and automated customer support. But deploying LLMs at scale introduces challenges that most teams aren't prepared for.
 
-Different providers have different APIs. Models have different capabilities and pricing. Requests need routing, caching, and monitoring. Security and compliance requirements add another layer of complexity.
-
-An **LLM Gateway** solves these problems by acting as a centralized orchestration layer between your applications and the AI models they use.
+Different providers have different APIs. Models have different capabilities and pricing. Requests need routing, caching, and monitoring. Security and compliance requirements add another layer of complexity. An LLM gateway solves these problems by acting as a centralized orchestration layer between your applications and the AI models they use.
 
 ## Why LLMs Need a Gateway
 
@@ -99,5 +100,7 @@ Most teams find that adopting an existing gateway pays for itself within weeks t
 ---
 
 _An LLM Gateway isn't just infrastructure—it's the foundation for scaling AI across your organization safely and efficiently._
+
+Comparing your options? See how LLM Gateway stacks up against [OpenRouter](/blog/llm-gateway-vs-openrouter), [LiteLLM](/blog/llm-gateway-vs-litellm), and [Portkey](/blog/llm-gateway-vs-portkey), or browse the [best AI gateways in 2026](/blog/best-ai-gateways).
 
 **Ready to simplify your LLM infrastructure?** [Get started with LLM Gateway](https://llmgateway.io)

--- a/apps/ui/src/content/blog/2026-06-22-best-ai-coding-plans.md
+++ b/apps/ui/src/content/blog/2026-06-22-best-ai-coding-plans.md
@@ -2,6 +2,7 @@
 id: "blog-best-ai-coding-plans"
 slug: "best-ai-coding-plans"
 date: "2026-06-22"
+updatedAt: "2026-08-05"
 title: "10 Best AI Coding Plans in 2026 (Compared)"
 summary: "An honest comparison of the best AI coding plans in 2026 — Claude Code, Cursor, Copilot, Codex and more — ranked on price, model access, and lock-in. DevPass tops the list with one flat rate for every model."
 categories: ["Guides"]
@@ -10,6 +11,15 @@ image:
   alt: "Comparison of the best AI coding plans in 2026 routing to many models through one subscription"
   width: 1536
   height: 1024
+faqs:
+  - question: "What is the best AI coding plan in 2026?"
+    answer: "For most developers, DevPass is the best value because it's the only plan that combines a flat monthly price with access to every frontier model — Claude Opus 5, GPT-5.6, Gemini 3.1 Pro and 200+ others — and works with the coding tools you already use. Single-vendor plans like Claude Code or Cursor are excellent if you're certain you'll only ever want that one company's models."
+  - question: "Can I use DevPass with Claude Code and Cursor?"
+    answer: "Yes. DevPass is OpenAI- and Anthropic-compatible, so it works with Claude Code, OpenCode, Cursor, Cline, Zed, Aider and any tool that accepts a custom base URL and key. You keep your workflow and swap in one key for every model."
+  - question: "Is a flat-rate plan cheaper than paying per token?"
+    answer: "For daily, agent-heavy work, almost always. DevPass turns every $1 into roughly $3 of model usage at provider rates, and the flat ceiling means a runaway agent loop can't produce a surprise invoice. For light or spiky use, raw pay-as-you-go (Cline or Aider on your own key) can still win."
+  - question: "How many models do I get with DevPass?"
+    answer: "Every plan includes all 200+ models on LLM Gateway, from frontier flagships to open-weight coders like GLM-5.1, Qwen3 and Kimi K3. There's no per-model gating between tiers — the tiers differ only in monthly usage allowance."
 ---
 
 AI coding agents have gone from novelty to daily driver. The problem is paying for them. Every tool wants its own subscription, every subscription locks you to one vendor's models, and the ones that meter by token leave you watching a runaway agent loop burn through your budget at 2am.
@@ -22,11 +32,11 @@ The short version: most plans give you one company's models inside one company's
 
 **Best overall. Flat rate. Every model. No token math.**
 
-[DevPass](https://devpass.llmgateway.io) by LLM Gateway isn't an editor and it isn't a single-vendor plan — it's the **model layer** underneath whatever coding tool you already use. One API key unlocks **200+ models** — Claude Opus 4.7, GPT-5.5, Gemini 3.1 Pro, plus the open-weight coders like GLM-4.7, Qwen3 and Kimi K2 — for a flat monthly price.
+[DevPass](https://devpass.llmgateway.io) by LLM Gateway isn't an editor and it isn't a single-vendor plan — it's the **model layer** underneath whatever coding tool you already use. One API key unlocks **200+ models** — Claude Opus 5, GPT-5.6, Gemini 3.1 Pro, plus the open-weight coders like GLM-5.1, Qwen3 and [Kimi K3](/blog/kimi-k3) — for a flat monthly price.
 
 **What sets it apart:**
 
-- **One key, every model** — switch from Claude to GPT-5.5 to a cheap open-weight coder mid-session, no new subscription, no new key
+- **One key, every model** — switch from Claude to GPT-5.6 to a cheap open-weight coder mid-session, no new subscription, no new key
 - **Flat, predictable pricing** — $29, $79, or $179 a month. You know the number on day one; a runaway agent can't run up a surprise invoice
 - **~3× value at provider rates** — every $1 you pay turns into roughly $3 of model usage metered at each provider's published per-token rate, shown in your dashboard in real time
 - **Works with the tools you already have** — Claude Code, OpenCode, Cursor, Cline, Zed, and anything OpenAI- or Anthropic-compatible
@@ -68,7 +78,7 @@ Anthropic's Claude Code is a terminal-native agent that many developers consider
 
 **Weaknesses:**
 
-- **Anthropic models only** — no GPT-5.5, no Gemini, no open-weight coders when a task needs them
+- **Anthropic models only** — no GPT-5.6, no Gemini, no open-weight coders when a task needs them
 - Usage limits are famously opaque; heavy users hit caps without warning
 - The top tier is expensive at roughly $100–$200/mo for one vendor's models
 
@@ -134,7 +144,7 @@ Codex is OpenAI's coding agent, available through ChatGPT plans and the Codex CL
 
 **Strengths:**
 
-- Capable agentic coding on GPT-5.5 and o-series reasoning models
+- Capable agentic coding on GPT-5.6 and o-series reasoning models
 - Cloud and CLI execution modes
 - Comes bundled if you already pay for ChatGPT
 
@@ -236,7 +246,7 @@ Zhipu's GLM Coding Plan offers GLM models at a low flat price. It's a strong dea
 
 **Weaknesses:**
 
-- **Single vendor** — every model comes from Zhipu, so you're blocked from Claude, GPT-5.5 and Gemini
+- **Single vendor** — every model comes from Zhipu, so you're blocked from Claude, GPT-5.6 and Gemini
 - No frontier Western flagships for the tasks that need them
 - One-model focus is a ceiling as much as a feature
 
@@ -287,7 +297,7 @@ Aider is a beloved terminal-based coding assistant that works with any model API
 
 ## How to Choose
 
-**You use more than one model:** DevPass is the only plan that gives you Claude, GPT-5.5, Gemini _and_ the open-weight coders under one key. Every other paid plan locks you to one vendor or a curated handful.
+**You use more than one model:** DevPass is the only plan that gives you Claude, GPT-5.6, Gemini _and_ the open-weight coders under one key. Every other paid plan locks you to one vendor or a curated handful.
 
 **You want a bill you can predict:** Flat-rate plans (DevPass, Claude Max, the Z.ai plan) beat credit metering when you code every day. DevPass adds a spend ceiling without giving up model choice.
 
@@ -295,25 +305,7 @@ Aider is a beloved terminal-based coding assistant that works with any model API
 
 **You only ever use one model:** A single-vendor plan like Claude Max or the Z.ai GLM Coding Plan can be the cheapest fit. The moment you need a second model, you're buying a second subscription.
 
----
-
-## Frequently Asked Questions
-
-### What is the best AI coding plan in 2026?
-
-For most developers, DevPass is the best value because it's the only plan that combines a flat monthly price with access to every frontier model — Claude Opus 4.7, GPT-5.5, Gemini 3.1 Pro and 200+ others — and works with the coding tools you already use. Single-vendor plans like Claude Code or Cursor are excellent if you're certain you'll only ever want that one company's models.
-
-### Can I use DevPass with Claude Code and Cursor?
-
-Yes. DevPass is OpenAI- and Anthropic-compatible, so it works with Claude Code, OpenCode, Cursor, Cline, Zed, Aider and any tool that accepts a custom base URL and key. You keep your workflow and swap in one key for every model.
-
-### Is a flat-rate plan cheaper than paying per token?
-
-For daily, agent-heavy work, almost always. DevPass turns every $1 into roughly $3 of model usage at provider rates, and the flat ceiling means a runaway agent loop can't produce a surprise invoice. For light or spiky use, raw pay-as-you-go (Cline or Aider on your own key) can still win.
-
-### How many models do I get with DevPass?
-
-Every plan includes all 200+ models on LLM Gateway, from frontier flagships to open-weight coders like GLM-4.7, Qwen3 and Kimi K2. There's no per-model gating between tiers — the tiers differ only in monthly usage allowance.
+**You're comparing the gateways underneath these plans:** see how LLM Gateway stacks up against [OpenRouter](/blog/llm-gateway-vs-openrouter) and [LiteLLM](/blog/llm-gateway-vs-litellm), or the full breakdown of [what every AI gateway actually charges](/blog/ai-gateway-fees-compared).
 
 ---
 
@@ -329,4 +321,4 @@ No per-token math. No vendor lock-in. Just every model under one key.
 
 <BlogCta variant="devpass" location="bottom" />
 
-**[Compare DevPass vs Cursor](https://devpass.llmgateway.io/compare/cursor)** | **[Read the 7 best AI gateways](/blog/best-ai-gateways)**
+**[Compare DevPass vs Cursor](https://devpass.llmgateway.io/compare/cursor)** | **[Read the 7 best AI gateways](/blog/best-ai-gateways)** | **[GitHub Copilot alternatives](/blog/github-copilot-alternatives)**

--- a/apps/ui/src/content/blog/2026-06-23-ai-gateway-fees-compared.md
+++ b/apps/ui/src/content/blog/2026-06-23-ai-gateway-fees-compared.md
@@ -2,7 +2,8 @@
 id: "blog-ai-gateway-fees-compared"
 slug: "ai-gateway-fees-compared"
 date: "2026-06-23"
-title: "AI Gateway Fees Compared: Who Marks Up Your Tokens?"
+updatedAt: "2026-08-05"
+title: "AI Gateway Pricing: Fees & Markups Compared (2026)"
 summary: "AI gateway pricing hides in two places — the platform fee on credits and the markup on tokens. Here's what OpenRouter, Vercel, Cloudflare, Portkey, LiteLLM, and LLM Gateway actually charge, and how to pay the least."
 categories: ["Guides"]
 image:
@@ -10,6 +11,13 @@ image:
   alt: "Token streams flowing through a gateway, each tagged with a percentage fee"
   width: 1536
   height: 1024
+faqs:
+  - question: "Do AI gateways mark up your tokens?"
+    answer: "In 2026, the major ones don't. LLM Gateway, OpenRouter, Vercel AI Gateway, Cloudflare, Eden AI, Portkey, and LiteLLM all pass provider token rates through without a per-token markup. They make money on a platform/credit fee or a subscription instead — so compare those, not the token rates."
+  - question: "What is the cheapest AI gateway?"
+    answer: "For most teams, the cheapest path is bringing your own provider keys (0% fee on LLM Gateway) or self-hosting an open-source gateway (LLM Gateway or LiteLLM), which removes the platform fee entirely. On the managed tier, LLM Gateway's flat 5% credit fee is among the lowest, and lower than OpenRouter's 5.5%."
+  - question: "Is a platform fee or a token markup worse?"
+    answer: "A token markup is worse. It scales with every token you ever send, so it compounds as you grow. A flat platform fee on credits is a one-time percentage when you load funds — predictable and far smaller over time."
 ---
 
 Comparing AI gateways on price sounds simple until you read the fine print. The number on the pricing page is rarely the number on your invoice, because gateway fees hide in two separate places: a **platform fee** on the credits you buy, and a **markup** on the tokens you spend. Miss either one and your "cheap" gateway quietly costs more than the provider you were trying to save money on.
@@ -55,22 +63,10 @@ Three levers, in order of impact:
 2. **Self-host.** If data residency or absolute cost control matters, run the gateway yourself. LLM Gateway is AGPLv3 and self-hostable end to end; LiteLLM is a self-hosted proxy. Both drop your platform fee to zero.
 3. **Cache and route.** The cheapest token is the one you never send. Built-in response caching makes repeat requests free, and routing simple requests to budget models keeps your blended cost down. Run your real traffic through the [Token Cost Calculator](/token-cost-calculator) before you commit.
 
-## Frequently Asked Questions
-
-### Do AI gateways mark up your tokens?
-
-In 2026, the major ones don't. LLM Gateway, OpenRouter, Vercel AI Gateway, Cloudflare, Eden AI, Portkey, and LiteLLM all pass provider token rates through without a per-token markup. They make money on a platform/credit fee or a subscription instead — so compare those, not the token rates.
-
-### What is the cheapest AI gateway?
-
-For most teams, the cheapest path is bringing your own provider keys (0% fee on LLM Gateway) or self-hosting an open-source gateway (LLM Gateway or LiteLLM), which removes the platform fee entirely. On the managed tier, LLM Gateway's flat 5% credit fee is among the lowest, and lower than OpenRouter's 5.5%.
-
-### Is a platform fee or a token markup worse?
-
-A token markup is worse. It scales with every token you ever send, so it compounds as you grow. A flat platform fee on credits is a one-time percentage when you load funds — predictable and far smaller over time.
-
 ## Pay provider rates, not gateway rates
 
 The whole point of a gateway is to save you money and effort, not add a tax. LLM Gateway passes provider token rates through with no markup, charges a flat 5% on credits (or 0% with your own keys), and is free to self-host if you'd rather pay nothing at all.
+
+Want the head-to-head detail behind these numbers? Read [LLM Gateway vs OpenRouter](/blog/llm-gateway-vs-openrouter), [LLM Gateway vs LiteLLM](/blog/llm-gateway-vs-litellm), and [LLM Gateway vs Portkey](/blog/llm-gateway-vs-portkey).
 
 **[Try LLM Gateway free](https://llmgateway.io/signup)** | **[Run the Token Cost Calculator](/token-cost-calculator)** | **[See the 8 best AI gateways in 2026](/blog/best-ai-gateways)**

--- a/apps/ui/src/content/blog/2026-07-19-kimi-k3-claude-code.md
+++ b/apps/ui/src/content/blog/2026-07-19-kimi-k3-claude-code.md
@@ -100,3 +100,4 @@ The ones that route their full agent loop through your endpoint: Claude Code, Cl
 - **[Get DevPass](https://devpass.llmgateway.io)** — flat-rate Kimi K3 in your coding agent from $29/mo
 - **[Try LLM Gateway free](https://llmgateway.io/signup)** — one key for K3 and 200+ models
 - New to K3? Start with [Kimi K3 and China's Open-Weight Model Wave](/blog/kimi-k3), or see how it stacks up in [Kimi K3 vs Claude Opus 4.8](/blog/kimi-k3-vs-claude-opus)
+- Requests failing? Check the live [Kimi K3 status page](/models/kimi-k3/uptime) for per-provider uptime before you debug your setup

--- a/apps/ui/src/lib/timeline-data.ts
+++ b/apps/ui/src/lib/timeline-data.ts
@@ -253,6 +253,63 @@ export function buildTimelineFaqs(
 	return faqs;
 }
 
+const monthYearFormatter = new Intl.DateTimeFormat("en-US", {
+	month: "long",
+	year: "numeric",
+	timeZone: "UTC",
+});
+
+export interface TimelineMonthSummary {
+	/** e.g. "August 2026" */
+	label: string;
+	year: string;
+	/** False when no model has shipped yet this month and we fell back. */
+	isCurrentMonth: boolean;
+	models: TimelineModel[];
+	providerCount: number;
+}
+
+/**
+ * Models released in the month containing `now`, newest first, for the hub's
+ * month answer block. Falls back to the month of the most recent release so
+ * the section never renders empty in the first days of a new month.
+ */
+export function getMonthSummary(
+	models: TimelineModel[],
+	now: Date,
+): TimelineMonthSummary | null {
+	const released = recentModels(models, models.length);
+	if (!released.length) {
+		return null;
+	}
+
+	const monthKey = (d: Date) =>
+		`${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+	const currentKey = monthKey(now);
+	let monthModels = released.filter(
+		(model) => monthKey(new Date(model.releasedAt!)) === currentKey,
+	);
+
+	const isCurrentMonth = monthModels.length > 0;
+	const anchor = isCurrentMonth ? now : new Date(released[0].releasedAt!);
+	if (!isCurrentMonth) {
+		const fallbackKey = monthKey(anchor);
+		monthModels = released.filter(
+			(model) => monthKey(new Date(model.releasedAt!)) === fallbackKey,
+		);
+	}
+
+	const providers = new Set(monthModels.map((model) => model.providerName));
+
+	return {
+		label: monthYearFormatter.format(anchor),
+		year: String(anchor.getUTCFullYear()),
+		isCurrentMonth,
+		models: monthModels,
+		providerCount: providers.size,
+	};
+}
+
 export interface TimelineYearSummary {
 	year: string;
 	count: number;


### PR DESCRIPTION
## Problem

July GSC audit findings (12.8K clicks / 724K impressions):

- `/timeline` earned **155K impressions at position ~7.6 with 0.28% CTR**. The "ai model releases july 2026 / latest ai model releases" query family (41K+ impressions) clicked through at ~0% — the page ranks 4–9 behind AI Overviews with a static, evergreen title that can't compete for month-stamped, freshness-hungry queries.
- The vs pages sit just off page 1 (vs-litellm pos 13.5, vs-openrouter pos 13.4; 15K combined impressions) with few internal links from high-authority pages.
- `/blog/best-ai-coding-plans` (52.8K impressions, pos 7, top non-brand page) had a markdown-only FAQ with no FAQPage schema, no visible freshness signal, and stale flagship model names.
- "ai gateway pricing" (219 impr, pos 12.2) didn't appear in the fees post's title; "what is llm gateway" (483 impr, pos 11.2) had no extractable definition lead; "kimi status" (1.9K impr, pos 6) uptime pages had no interlinks from the kimi posts.

## Approach

**Timeline month-awareness** (`timeline-data.ts`, `timeline/page.tsx`)
- New `getMonthSummary()` returns the current month's releases (falls back to the latest month with releases in the first days of a new month).
- Static `metadata` → `generateMetadata()`: title becomes "New AI Model Releases — {Month Year} Timeline" with a description naming the month's top releases. The route is server-rendered (models fetch revalidates every 60s), so it stays current without redeploys.
- New answer-block section after the hero: an H2 naming the month, a ~50-word extractable summary (count, providers, most recent release), and the month's models linked to their detail pages. This is the passage format AI Overviews and ChatGPT/Perplexity extract, so the page can be cited even in zero-click SERPs.
- Deliberately **not** generating per-month routes — thin programmatic month pages risk the scaled-content policy; one strong page with month-fresh metadata is the safe version.

**Blog infrastructure** (`content-collections.ts`, `blog/[slug]/page.tsx`)
- Optional `updatedAt` frontmatter → visible "Updated {date}" and Article `dateModified`.
- Optional `faqs` frontmatter → crawlable `<dl>` FAQ section (no accordion, per house convention) + FAQPage JSON-LD.

**Content refreshes**
- `best-ai-coding-plans`: FAQ moved to frontmatter (schema + single render), flagship names refreshed (Opus 5, GPT-5.6, GLM-5.1, Kimi K3), `updatedAt`, contextual links to vs-openrouter/vs-litellm/fees-compared and the Copilot alternatives listicle.
- `ai-gateway-fees-compared`: title now leads with "AI Gateway Pricing", FAQ → frontmatter, links to all three vs pages.
- `what-is-an-llm-gateway`: 40–60-word definition now leads the post; links to the vs pages.
- `kimi-k3-claude-code`: added a "Kimi K3 status page" link to the uptime page.

## Verification

- `turbo run build --filter=ui` passes (13/13 tasks); `/timeline` builds as dynamic (ƒ) so month metadata is computed at request time.
- `pnpm format` clean.
- Content-collections schema validates the new frontmatter at build time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUapVpJ1Q4Vic6d3e6C7HT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Blog posts can now display updated dates and structured FAQ sections when available.
  * Timeline pages now highlight monthly release activity, including model counts, providers, latest releases, and year navigation.
  * Added a live status page link for Kimi K3 troubleshooting.

* **Content Updates**
  * Refreshed AI gateway, coding plan, and model comparison articles with updated information, recommendations, and related links.
  * Added FAQ content to selected articles for improved discoverability and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->