### PR TITLE
fix(gateway): don't double-count Anthropic reasoning tokens in cost

### DIFF
--- a/apps/gateway/src/lib/costs.spec.ts
+++ b/apps/gateway/src/lib/costs.spec.ts
@@ -692,6 +692,29 @@ describe("calculateCosts", () => {
 		expect(result.estimatedCost).toBe(false);
 	});
 
+	it("should not double-count reasoning tokens for Anthropic", async () => {
+		// Anthropic's output_tokens already includes thinking tokens, so the
+		// cost layer must not add reasoning again. Here 136 completion tokens
+		// already contain 31 reasoning tokens; output cost is 136 * price,
+		// not 167 * price.
+		const result = await calculateCosts(
+			"claude-3-5-sonnet-20241022",
+			"anthropic",
+			null,
+			51,
+			136, // completionTokens already includes the 31 reasoning tokens
+			0,
+			undefined,
+			31,
+		);
+
+		expect(result.inputCost).toBeCloseTo(0.000153, 6); // 51 * 0.000003
+		expect(result.outputCost).toBeCloseTo(0.00204, 6); // 136 * 0.000015, not 167 * 0.000015 = 0.002505
+		expect(result.totalCost).toBeCloseTo(0.002193, 6); // 0.000153 + 0.00204
+		expect(result.completionTokens).toBe(136);
+		expect(result.estimatedCost).toBe(false);
+	});
+
 	it("should handle null reasoning tokens gracefully", async () => {
 		const result = await calculateCosts(
 			"gemini-2.5-pro",

--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -643,8 +643,10 @@ export async function calculateCosts(
 	// For Google models, completionTokens already includes reasoning tokens
 	// (merged during extraction). The same holds for OpenAI-style Responses API
 	// providers (OpenAI, Azure, Sakana, Meta), whose `output_tokens` counts
-	// reasoning — their `reasoning_tokens` detail is informational only. For
-	// remaining providers, add reasoning separately.
+	// reasoning — their `reasoning_tokens` detail is informational only. Anthropic
+	// behaves the same: `output_tokens` already includes thinking tokens (see
+	// extract-token-usage, which builds totalTokens as prompt + output without
+	// re-adding reasoning). For remaining providers, add reasoning separately.
 	const completionIncludesReasoning =
 		provider === "google-ai-studio" ||
 		provider === "glacier" ||
@@ -655,7 +657,9 @@ export async function calculateCosts(
 		provider === "azure" ||
 		provider === "sakana" ||
 		provider === "meta" ||
-		provider === "aws-mantle";
+		provider === "aws-mantle" ||
+		provider === "anthropic" ||
+		provider === "vertex-anthropic";
 	const totalOutputTokens = completionIncludesReasoning
 		? calculatedCompletionTokens
 		: calculatedCompletionTokens + (reasoningTokens ?? 0);


### PR DESCRIPTION
Output costs come out ~23% high on Anthropic reasoning requests. In `costs.ts`, the `completionIncludesReasoning` allow-list has Google and the OpenAI-style Responses providers but not `anthropic`/`vertex-anthropic`, so those fall through to `completionTokens + reasoningTokens` — adding reasoning that's already in `completionTokens`.

That completion count already includes thinking tokens: `extractTokenUsage` reads `output_tokens` straight into `completionTokens` and builds `totalTokens` as `prompt + output` without re-adding reasoning (its own spec pins this — 51 in, 136 out incl. 31 reasoning, total 187, not 218). The extract layer and the cost layer disagreed; this lines them up by adding both Anthropic providers to the allow-list.

Added a cost test with 136 completion tokens carrying 31 reasoning: output cost is 136 × price, not 167 × price. aws-bedrock bundles reasoning into outputTokens the same way and has no separate reasoning source, so it's already correct — no change needed there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cost calculations for Anthropic-based providers by preventing reasoning tokens from being counted twice.
  * Corrected output and total cost totals for supported Anthropic, Vertex, and AWS Bedrock models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->