### PR TITLE
feat(models): add scx-ai-gp Qwen3.8 Max mapping

### DIFF
--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -1681,6 +1681,29 @@ export const alibabaModels = [
 					"reasoning_effort",
 				],
 			},
+			{
+				providerId: "scx-ai-gp",
+				externalId: "qwen3.8-max",
+				// SCX has not brought this deployment online yet: it is absent from
+				// their /v1/models listing and chat completions return "Unsupported
+				// model". Drop this once the deployment is live and verified.
+				test: "skip",
+				inputPrice: "1.815e-6",
+				cachedInputPrice: "0.21e-6",
+				outputPrice: "5.4461e-6",
+				requestPrice: "0",
+				contextSize: 1000000,
+				maxOutput: 131072,
+				quantization: "fp8",
+				streaming: true,
+				reasoning: true,
+				// The upstream model is natively multimodal, but image input on SCX's
+				// deployment is unverified. Leave false so routing does not send image
+				// requests here until it is confirmed to work.
+				vision: false,
+				tools: true,
+				jsonOutput: true,
+			},
 		],
 	},
 	{


### PR DESCRIPTION
Adds an `scx-ai-gp` provider mapping to the existing `qwen3.8-max` model, so SCX.ai's general-purpose endpoint can serve Qwen3.8 Max once the deployment goes live.

Pricing is set natively in USD, consistent with the rest of the SCX mappings (see #3201):

| | USD / M tokens |
|---|---|
| input | 1.815 |
| cached input | 0.21 |
| output | 5.4461 |

### Notes for reviewers

**The deployment is not live yet, so the mapping is `test: "skip"`.** SCX has not brought it online: it is absent from `https://api.scx.ai/v1/models`, and chat completions return `{"error":{"message":"Unsupported model"}}` for every casing tried. Without the skip, e2e would fail on this mapping on every run. Drop the skip once the deployment is up and verified.

**`externalId` is unverified.** `qwen3.8-max` is what SCX indicated they will use, but since the endpoint currently rejects every id, it could not be confirmed against a live response. This is the one field that must be re-checked when the deployment lands — the rest degrade gracefully, a wrong `externalId` does not.

**`vision: false`, unlike the `alibaba` mapping on the same model.** Qwen3.8 Max is natively multimodal and the Alibaba mapping declares `vision: true`, but image input on SCX's deployment is unverified. Declaring a capability the deployment rejects would route image requests here and 400 them, so it is left off until confirmed. Both this and the skip are documented in comments at the mapping.

`contextSize` (1M) and `maxOutput` (131072) mirror the Alibaba mapping; `quantization: "fp8"` matches the other SCX GLM/Qwen deployments.

### Verification

- `pnpm format`, `pnpm build` — pass
- `packages/models` unit tests (125), plus the catalogue-validating `apps/gateway/src/models/models.spec.ts` and `packages/actions/src/prepare-request-body.adaptive.spec.ts` (36) — pass
- e2e not run: the deployment does not exist yet, which is the reason for the skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration support for the `qwen3.8-max` AI model, including streaming, reasoning, tool use, JSON output, and large-context support.
  * Vision capabilities are currently unavailable pending verification.
  * The model remains disabled until its deployment is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->