### PR TITLE
feat(models): muse-spark-1.2 + qwen image 3.0

### DIFF
--- a/apps/api/src/routes/internal-models.ts
+++ b/apps/api/src/routes/internal-models.ts
@@ -107,6 +107,7 @@ const modelProviderMappingSchema = z.object({
 	supportsVideoAudio: z.boolean().nullable(),
 	supportsVideoWithoutAudio: z.boolean().nullable(),
 	perSecondPrice: z.record(z.string()).nullable(),
+	perImagePrice: z.record(z.string()).nullable(),
 	pricingTiers: z.array(pricingTierSchema).nullable(),
 	serviceTiers: z.array(z.string()).nullable(),
 	deprecatedAt: z.coerce.date().nullable(),
@@ -296,6 +297,13 @@ internalModels.openapi(getModelsRoute, async (c) => {
 				perSecondPrice: sharedMapping?.perSecondPrice
 					? Object.fromEntries(
 							Object.entries(sharedMapping.perSecondPrice).map(
+								([key, price]) => [key, price.toString()],
+							),
+						)
+					: null,
+				perImagePrice: sharedMapping?.perImagePrice
+					? Object.fromEntries(
+							Object.entries(sharedMapping.perImagePrice).map(
 								([key, price]) => [key, price.toString()],
 							),
 						)

--- a/apps/docs/content/features/image-generation.mdx
+++ b/apps/docs/content/features/image-generation.mdx
@@ -668,13 +668,13 @@ curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
 
 Available Alibaba models:
 
-| Model                        | Price        | Description                                             |
-| ---------------------------- | ------------ | ------------------------------------------------------- |
-| `alibaba/qwen-image`         | $0.035/image | Standard quality image generation                       |
-| `alibaba/qwen-image-plus`    | $0.03/image  | Good balance of quality and cost                        |
-| `alibaba/qwen-image-max`     | $0.075/image | Highest quality image generation                        |
-| `alibaba/qwen-image-3.0`     | $0.03/image  | Third-generation image generation and editing           |
-| `alibaba/qwen-image-3.0-pro` | $0.075/image | Highest quality third-generation generation and editing |
+| Model                        | Price                               | Description                                             |
+| ---------------------------- | ----------------------------------- | ------------------------------------------------------- |
+| `alibaba/qwen-image`         | $0.035/image                        | Standard quality image generation                       |
+| `alibaba/qwen-image-plus`    | $0.03/image                         | Good balance of quality and cost                        |
+| `alibaba/qwen-image-max`     | $0.075/image                        | Highest quality image generation                        |
+| `alibaba/qwen-image-3.0`     | $0.03/image                         | Third-generation image generation and editing           |
+| `alibaba/qwen-image-3.0-pro` | $0.04/image (1K), $0.075/image (2K) | Highest quality third-generation generation and editing |
 
 <Callout type="info">
 	Alibaba models use explicit pixel dimensions (e.g., `"1024x1536"`) instead of

--- a/apps/docs/content/features/image-generation.mdx
+++ b/apps/docs/content/features/image-generation.mdx
@@ -668,13 +668,13 @@ curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
 
 Available Alibaba models:
 
-| Model                      | Price        | Description                                             |
-| -------------------------- | ------------ | ------------------------------------------------------- |
-| `alibaba/qwen-image`       | $0.035/image | Standard quality image generation                       |
-| `alibaba/qwen-image-plus`  | $0.03/image  | Good balance of quality and cost                        |
-| `alibaba/qwen-image-max`   | $0.075/image | Highest quality image generation                        |
-| `alibaba/qwen-image-3`     | $0.03/image  | Third-generation image generation and editing           |
-| `alibaba/qwen-image-3-pro` | $0.04/image  | Highest quality third-generation generation and editing |
+| Model                        | Price        | Description                                             |
+| ---------------------------- | ------------ | ------------------------------------------------------- |
+| `alibaba/qwen-image`         | $0.035/image | Standard quality image generation                       |
+| `alibaba/qwen-image-plus`    | $0.03/image  | Good balance of quality and cost                        |
+| `alibaba/qwen-image-max`     | $0.075/image | Highest quality image generation                        |
+| `alibaba/qwen-image-3.0`     | $0.03/image  | Third-generation image generation and editing           |
+| `alibaba/qwen-image-3.0-pro` | $0.075/image | Highest quality third-generation generation and editing |
 
 <Callout type="info">
 	Alibaba models use explicit pixel dimensions (e.g., `"1024x1536"`) instead of

--- a/apps/docs/content/features/image-generation.mdx
+++ b/apps/docs/content/features/image-generation.mdx
@@ -668,11 +668,13 @@ curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
 
 Available Alibaba models:
 
-| Model                     | Price        | Description                       |
-| ------------------------- | ------------ | --------------------------------- |
-| `alibaba/qwen-image`      | $0.035/image | Standard quality image generation |
-| `alibaba/qwen-image-plus` | $0.03/image  | Good balance of quality and cost  |
-| `alibaba/qwen-image-max`  | $0.075/image | Highest quality image generation  |
+| Model                      | Price        | Description                                             |
+| -------------------------- | ------------ | ------------------------------------------------------- |
+| `alibaba/qwen-image`       | $0.035/image | Standard quality image generation                       |
+| `alibaba/qwen-image-plus`  | $0.03/image  | Good balance of quality and cost                        |
+| `alibaba/qwen-image-max`   | $0.075/image | Highest quality image generation                        |
+| `alibaba/qwen-image-3`     | $0.03/image  | Third-generation image generation and editing           |
+| `alibaba/qwen-image-3-pro` | $0.04/image  | Highest quality third-generation generation and editing |
 
 <Callout type="info">
 	Alibaba models use explicit pixel dimensions (e.g., `"1024x1536"`) instead of

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -13081,6 +13081,16 @@ chat.openapi(completions, async (c) => {
 		reasoningTokens,
 		reasoningContent,
 	);
+	// Alibaba's per-image models bill by the served resolution tier, which
+	// DashScope reports in usage.output_image_type (e.g. "qima_output_2k").
+	// Bill on that tier rather than the requested size: the model auto-picks
+	// the final resolution when no size is given, and perImagePrice keys on
+	// tier names ("1K"/"2K"), not on pixel-dimension size strings.
+	const alibabaServedImageTier =
+		usedProvider === "alibaba" &&
+		typeof json?.usage?.output_image_type === "string"
+			? json.usage.output_image_type.match(/_(\d+k)$/)?.[1]?.toUpperCase()
+			: undefined;
 	const costs = await calculateCosts(
 		usedInternalModel,
 		usedProvider,
@@ -13095,7 +13105,7 @@ chat.openapi(completions, async (c) => {
 		},
 		reasoningTokens,
 		convertedImages?.length || 0,
-		image_config?.image_size,
+		alibabaServedImageTier ?? image_config?.image_size,
 		inputImageCount,
 		webSearchCount,
 		project.organizationId,

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -13089,7 +13089,7 @@ chat.openapi(completions, async (c) => {
 	const alibabaServedImageTier =
 		usedProvider === "alibaba" &&
 		typeof json?.usage?.output_image_type === "string"
-			? json.usage.output_image_type.match(/_(\d+k)$/)?.[1]?.toUpperCase()
+			? json.usage.output_image_type.match(/_(\d+k)$/i)?.[1]?.toUpperCase()
 			: undefined;
 	const costs = await calculateCosts(
 		usedInternalModel,

--- a/apps/gateway/src/chat/tools/is-model-truly-free.ts
+++ b/apps/gateway/src/chat/tools/is-model-truly-free.ts
@@ -1,7 +1,7 @@
 import type { ModelDefinition } from "@llmgateway/models";
 
 /**
- * Checks if a model is truly free (has free flag AND no per-request or per-second pricing)
+ * Checks if a model is truly free (has free flag AND no per-request, per-image, or per-second pricing)
  */
 export function isModelTrulyFree(modelInfo: ModelDefinition): boolean {
 	if (!modelInfo.free) {
@@ -13,6 +13,9 @@ export function isModelTrulyFree(modelInfo: ModelDefinition): boolean {
 		const hasPerSecondPrice = Object.values(provider.perSecondPrice ?? {}).some(
 			(price) => Number(price) > 0,
 		);
-		return hasRequestPrice || hasPerSecondPrice;
+		const hasPerImagePrice = Object.values(provider.perImagePrice ?? {}).some(
+			(price) => Number(price) > 0,
+		);
+		return hasRequestPrice || hasPerSecondPrice || hasPerImagePrice;
 	});
 }

--- a/apps/gateway/src/lib/costs.spec.ts
+++ b/apps/gateway/src/lib/costs.spec.ts
@@ -1499,6 +1499,43 @@ describe("calculateCosts", () => {
 		);
 	});
 
+	it("bills perImagePrice even when prompt usage is absent or zero", async () => {
+		// An upstream response that omits prompt usage must still charge for the
+		// generated images instead of bailing out of cost calculation entirely.
+		const noPromptTokens = await calculateCosts(
+			"qwen-image-3.0",
+			"alibaba",
+			null,
+			null,
+			null,
+			null,
+			undefined,
+			null,
+			1,
+			"1K",
+			0,
+		);
+		expect(noPromptTokens.imageOutputCost).toBeCloseTo(0.03);
+		expect(noPromptTokens.outputCost).toBeCloseTo(0.03);
+		expect(noPromptTokens.totalCost).toBeCloseTo(0.03);
+
+		const zeroPromptTokens = await calculateCosts(
+			"qwen-image-3.0",
+			"alibaba",
+			null,
+			0,
+			0,
+			null,
+			undefined,
+			null,
+			1,
+			"1K",
+			0,
+		);
+		expect(zeroPromptTokens.imageOutputCost).toBeCloseTo(0.03);
+		expect(zeroPromptTokens.totalCost).toBeCloseTo(0.03);
+	});
+
 	it("should include image costs in totalCost sum", async () => {
 		// totalCost = inputCost + outputCost + cachedInputCost + requestCost + webSearchCost
 		// (inputCost already includes imageInputCost, outputCost already includes imageOutputCost)

--- a/apps/gateway/src/lib/costs.spec.ts
+++ b/apps/gateway/src/lib/costs.spec.ts
@@ -1408,6 +1408,97 @@ describe("calculateCosts", () => {
 		expect(result.imageOutputCost).toBeCloseTo(1120 * (60 / 1e6));
 	});
 
+	it("bills perImagePrice by the served resolution tier for qwen-image-3.0-pro", async () => {
+		// qwen-image-3.0-pro: $0.04/image at 1K, $0.075/image at 2K
+		const at1k = await calculateCosts(
+			"qwen-image-3.0-pro",
+			"alibaba",
+			null,
+			100,
+			0,
+			null,
+			undefined,
+			null,
+			1, // outputImageCount
+			"1K",
+			0,
+		);
+		expect(at1k.imageOutputCost).toBeCloseTo(0.04);
+		expect(at1k.outputCost).toBeCloseTo(0.04);
+
+		const at2k = await calculateCosts(
+			"qwen-image-3.0-pro",
+			"alibaba",
+			null,
+			100,
+			0,
+			null,
+			undefined,
+			null,
+			1,
+			"2K",
+			0,
+		);
+		expect(at2k.imageOutputCost).toBeCloseTo(0.075);
+		expect(at2k.outputCost).toBeCloseTo(0.075);
+	});
+
+	it("falls back to the default perImagePrice tier for unknown or missing sizes", async () => {
+		// A raw pixel size that is not a tier key must not undercharge: it falls
+		// back to "default" ($0.075 for the pro model, the no-size 2K case).
+		const unknownSize = await calculateCosts(
+			"qwen-image-3.0-pro",
+			"alibaba",
+			null,
+			100,
+			0,
+			null,
+			undefined,
+			null,
+			1,
+			"1024x1024",
+			0,
+		);
+		expect(unknownSize.imageOutputCost).toBeCloseTo(0.075);
+
+		const noSize = await calculateCosts(
+			"qwen-image-3.0-pro",
+			"alibaba",
+			null,
+			100,
+			0,
+			null,
+			undefined,
+			null,
+			1,
+			undefined,
+			0,
+		);
+		expect(noSize.imageOutputCost).toBeCloseTo(0.075);
+	});
+
+	it("multiplies perImagePrice by the output image count", async () => {
+		// qwen-image-3.0 is $0.03/image at every tier; n=3 bills 3 images.
+		const result = await calculateCosts(
+			"qwen-image-3.0",
+			"alibaba",
+			null,
+			100,
+			0,
+			null,
+			undefined,
+			null,
+			3,
+			"1K",
+			0,
+		);
+		expect(result.imageOutputCost).toBeCloseTo(0.09);
+		expect(result.outputCost).toBeCloseTo(0.09);
+		expect(result.totalCost).toBeCloseTo(
+			(result.inputCost ?? 0) + 0.09 + (result.requestCost ?? 0),
+		);
+	});
+
 	it("should include image costs in totalCost sum", async () => {
 		// totalCost = inputCost + outputCost + cachedInputCost + requestCost + webSearchCost
 		// (inputCost already includes imageInputCost, outputCost already includes imageOutputCost)

--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -663,6 +663,8 @@ export async function calculateCosts(
 	// Calculate output cost, handling separate image output pricing if applicable.
 	// Models with token-based image pricing use imageOutputTokensByResolution
 	// for per-resolution token counts and imageOutputPrice for the per-token price.
+	// Models with flat per-image pricing use perImagePrice, keyed by resolution
+	// tier (imageSize) with a "default" fallback.
 	let outputCost: Decimal;
 	let imageOutputTokens: number | null = null;
 	let imageOutputCost: Decimal | null = null;
@@ -671,7 +673,20 @@ export async function calculateCosts(
 		imageSize,
 	);
 	const imageOutputPricePerToken = providerInfo.imageOutputPrice;
-	if (imageOutputPricePerToken && outputImageCount > 0) {
+	const perImagePriceMap = providerInfo.perImagePrice;
+	if (perImagePriceMap && outputImageCount > 0) {
+		const perImagePrice =
+			perImagePriceMap[imageSize ?? "default"] ??
+			perImagePriceMap["default"] ??
+			"0";
+		imageOutputCost = new Decimal(perImagePrice)
+			.times(outputImageCount)
+			.times(discountMultiplier);
+		outputCost = new Decimal(totalOutputTokens)
+			.times(outputPrice)
+			.times(tokenDiscountMultiplier)
+			.plus(imageOutputCost);
+	} else if (imageOutputPricePerToken && outputImageCount > 0) {
 		const LEGACY_DEFAULT_TOKENS_PER_IMAGE = 1120;
 		imageOutputTokens =
 			isImageOutputModel &&

--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -360,37 +360,6 @@ export async function calculateCosts(
 		}
 	}
 
-	// If we don't have prompt tokens, we can't calculate any costs
-	if (!calculatedPromptTokens) {
-		return {
-			inputCost: null,
-			outputCost: null,
-			cachedInputCost: null,
-			cacheWriteInputCost: null,
-			requestCost: null,
-			webSearchCost: null,
-			contentFilterCost: null,
-			imageInputTokens: null,
-			imageOutputTokens: null,
-			imageInputCost: null,
-			imageOutputCost: null,
-			audioInputTokens: null,
-			audioInputCost: null,
-			totalCost: null,
-			dataStorageCost: null as number | null,
-			promptTokens: calculatedPromptTokens,
-			completionTokens: calculatedCompletionTokens,
-			cachedTokens,
-			cacheWriteTokens,
-			estimatedCost: isEstimated,
-			discount: undefined,
-			pricingTier: undefined,
-		};
-	}
-
-	// Set completion tokens to 0 if not available (but still calculate input costs)
-	calculatedCompletionTokens ??= 0;
-
 	// Find the provider-specific pricing, keyed by providerId + region.
 	// Region matters when a single root model id has multiple per-region
 	// entries with different prices (see `regions:` on ProviderModelMapping);
@@ -440,6 +409,41 @@ export async function calculateCosts(
 			totalCost: null,
 			dataStorageCost: null as number | null,
 			promptTokens: calculatedPromptTokens,
+			completionTokens: calculatedCompletionTokens ?? 0,
+			cachedTokens,
+			cacheWriteTokens,
+			estimatedCost: isEstimated,
+			discount: undefined,
+			pricingTier: undefined,
+		};
+	}
+
+	// Without prompt tokens we can't calculate token costs — except for
+	// mappings that bill independently of token usage (per generated image via
+	// perImagePrice, or a flat positive requestPrice), which must still charge
+	// when the upstream response omits prompt usage. Those fall through with
+	// prompt tokens normalized to zero.
+	const billsWithoutTokenUsage =
+		(providerInfo.perImagePrice && outputImageCount > 0) ||
+		parseFloat(providerInfo.requestPrice ?? "0") > 0;
+	if (!calculatedPromptTokens && !billsWithoutTokenUsage) {
+		return {
+			inputCost: null,
+			outputCost: null,
+			cachedInputCost: null,
+			cacheWriteInputCost: null,
+			requestCost: null,
+			webSearchCost: null,
+			contentFilterCost: null,
+			imageInputTokens: null,
+			imageOutputTokens: null,
+			imageInputCost: null,
+			imageOutputCost: null,
+			audioInputTokens: null,
+			audioInputCost: null,
+			totalCost: null,
+			dataStorageCost: null as number | null,
+			promptTokens: calculatedPromptTokens,
 			completionTokens: calculatedCompletionTokens,
 			cachedTokens,
 			cacheWriteTokens,
@@ -448,6 +452,9 @@ export async function calculateCosts(
 			pricingTier: undefined,
 		};
 	}
+	calculatedPromptTokens = calculatedPromptTokens || 0;
+	// Set completion tokens to 0 if not available (but still calculate input costs)
+	calculatedCompletionTokens ??= 0;
 
 	// Get pricing based on token count (supports tiered pricing)
 	const pricing = getPricingForTokenCount(
@@ -511,15 +518,20 @@ export async function calculateCosts(
 		serviceTierMultiplier,
 	);
 
-	// Resolve the tokens-per-image for the given imageSize from a resolution map.
-	function resolveTokensPerImage(
-		byResolution: Record<string, number> | undefined,
+	// Resolve the value for the given imageSize from a resolution-keyed map,
+	// falling back to the "default" key. Own-property lookups only: imageSize
+	// is caller-controlled, so keys like "constructor" must not resolve to
+	// inherited Object.prototype members.
+	function resolveByResolution<T>(
+		byResolution: Record<string, T> | undefined,
 		size: string | undefined,
-	): number | undefined {
+	): T | undefined {
 		if (!byResolution) {
 			return undefined;
 		}
-		return byResolution[size ?? "default"] ?? byResolution["default"];
+		const own = (key: string) =>
+			Object.hasOwn(byResolution, key) ? byResolution[key] : undefined;
+		return own(size ?? "default") ?? own("default");
 	}
 
 	// Track image input tokens separately. For image-output models (e.g.
@@ -527,7 +539,7 @@ export async function calculateCosts(
 	// the provider tokenises the input image and bills against it directly.
 	// For Google image-generation models we fall back to inputImageCount *
 	// imageInputTokensByResolution[size] (or 560/image legacy default).
-	const imageInputTokensPerImage = resolveTokensPerImage(
+	const imageInputTokensPerImage = resolveByResolution(
 		providerInfo.imageInputTokensByResolution,
 		imageSize,
 	);
@@ -668,17 +680,22 @@ export async function calculateCosts(
 	let outputCost: Decimal;
 	let imageOutputTokens: number | null = null;
 	let imageOutputCost: Decimal | null = null;
-	const imageOutputTokensPerImage = resolveTokensPerImage(
+	const imageOutputTokensPerImage = resolveByResolution(
 		providerInfo.imageOutputTokensByResolution,
 		imageSize,
 	);
 	const imageOutputPricePerToken = providerInfo.imageOutputPrice;
 	const perImagePriceMap = providerInfo.perImagePrice;
 	if (perImagePriceMap && outputImageCount > 0) {
+		// A map without a "default" key falls back to its most expensive tier so
+		// a lookup miss can only overcharge, never bill a generated image at $0
+		// (same stance as the unknown-size → "default" fallback).
 		const perImagePrice =
-			perImagePriceMap[imageSize ?? "default"] ??
-			perImagePriceMap["default"] ??
-			"0";
+			resolveByResolution(perImagePriceMap, imageSize) ??
+			Object.values(perImagePriceMap).reduce(
+				(max, v) => (new Decimal(v).gt(max) ? v : max),
+				"0",
+			);
 		imageOutputCost = new Decimal(perImagePrice)
 			.times(outputImageCount)
 			.times(discountMultiplier);

--- a/apps/gateway/src/models/models.ts
+++ b/apps/gateway/src/models/models.ts
@@ -61,6 +61,7 @@ const modelSchema = z.object({
 					input_audio_cache_read: z.string().optional(),
 					output_audio: z.string().optional(),
 					per_second: z.record(z.string()).optional(),
+					per_image: z.record(z.string()).optional(),
 					request: z.string().optional(),
 					input_cache_read: z.string().optional(),
 					input_cache_write: z.string().optional(),
@@ -109,6 +110,7 @@ const modelSchema = z.object({
 		input_audio_cache_read: z.string().optional(),
 		output_audio: z.string().optional(),
 		per_second: z.record(z.string()).optional(),
+		per_image: z.record(z.string()).optional(),
 		request: z.string().optional(),
 		input_cache_read: z.string().optional(),
 		input_cache_write: z.string().optional(),
@@ -517,6 +519,7 @@ function hasPricing(p: ProviderModelMapping): boolean {
 		p.outputPrice !== undefined ||
 		p.imageInputPrice !== undefined ||
 		p.perSecondPrice !== undefined ||
+		p.perImagePrice !== undefined ||
 		p.ocrPagePrice !== undefined ||
 		p.inputAudioHourPrice !== undefined
 	);
@@ -537,6 +540,14 @@ function buildPricingFields(p: ProviderModelMapping | undefined) {
 		per_second: p?.perSecondPrice
 			? Object.fromEntries(
 					Object.entries(p.perSecondPrice).map(([resolution, price]) => [
+						resolution,
+						price.toString(),
+					]),
+				)
+			: undefined,
+		per_image: p?.perImagePrice
+			? Object.fromEntries(
+					Object.entries(p.perImagePrice).map(([resolution, price]) => [
 						resolution,
 						price.toString(),
 					]),
@@ -570,6 +581,10 @@ function pricingScore(p: ProviderModelMapping): number {
 	}
 	if (p.perSecondPrice) {
 		const values = Object.values(p.perSecondPrice).map(Number);
+		return values.length > 0 ? Math.min(...values) : Infinity;
+	}
+	if (p.perImagePrice) {
+		const values = Object.values(p.perImagePrice).map(Number);
 		return values.length > 0 ? Math.min(...values) : Infinity;
 	}
 	if (p.requestPrice !== undefined) {

--- a/apps/gateway/src/models/models.ts
+++ b/apps/gateway/src/models/models.ts
@@ -570,8 +570,15 @@ function pricingScore(p: ProviderModelMapping): number {
 	const input = p.inputPrice !== undefined ? Number(p.inputPrice) : undefined;
 	const output =
 		p.outputPrice !== undefined ? Number(p.outputPrice) : undefined;
-	if (input !== undefined || output !== undefined) {
-		return (input ?? 0) + (output ?? 0);
+	const tokenScore =
+		input !== undefined || output !== undefined
+			? (input ?? 0) + (output ?? 0)
+			: undefined;
+	// Only a positive token price is authoritative: per-unit-priced mappings
+	// (image, video, OCR, request) declare token prices as "0", so a zero
+	// token score must fall through to the per-unit branches below.
+	if (tokenScore !== undefined && tokenScore > 0) {
+		return tokenScore;
 	}
 	if (p.ocrPagePrice !== undefined) {
 		return Number(p.ocrPagePrice);
@@ -593,7 +600,7 @@ function pricingScore(p: ProviderModelMapping): number {
 	if (p.imageInputPrice !== undefined) {
 		return Number(p.imageInputPrice);
 	}
-	return Infinity;
+	return tokenScore ?? Infinity;
 }
 
 // Pick the provider mapping that represents the model-level pricing: the

--- a/apps/playground/src/components/model-selector.tsx
+++ b/apps/playground/src/components/model-selector.tsx
@@ -50,6 +50,7 @@ import {
 import { cn } from "@/lib/utils";
 
 import {
+	formatPerImagePriceRange,
 	getProviderIcon,
 	providerLogoUrls,
 } from "@llmgateway/shared/components";
@@ -280,6 +281,7 @@ interface RootAggregateInfo {
 	minRequestPrice?: number;
 	minImageInputPrice?: number;
 	minImageOutputPrice?: number;
+	minPerImagePrice?: number;
 	maxContextSize?: number;
 	maxOutput?: number;
 	capabilities: string[];
@@ -294,6 +296,7 @@ function getRootAggregateInfo(model: ApiModel): RootAggregateInfo {
 	let minRequestPrice: number | undefined;
 	let minImageInputPrice: number | undefined;
 	let minImageOutputPrice: number | undefined;
+	let minPerImagePrice: number | undefined;
 	let maxContextSize: number | undefined;
 	let maxOutput: number | undefined;
 	const capabilitySet = new Set<string>();
@@ -379,6 +382,19 @@ function getRootAggregateInfo(model: ApiModel): RootAggregateInfo {
 			minImageInputPrice = effectiveImageInput;
 		}
 
+		if (mapping.perImagePrice) {
+			for (const tier of Object.values(mapping.perImagePrice)) {
+				const effectiveTier = applyDiscount(tier, mapping.discount);
+				if (
+					effectiveTier !== undefined &&
+					effectiveTier > 0 &&
+					(minPerImagePrice === undefined || effectiveTier < minPerImagePrice)
+				) {
+					minPerImagePrice = effectiveTier;
+				}
+			}
+		}
+
 		if (
 			mapping.contextSize !== null &&
 			mapping.contextSize !== undefined &&
@@ -412,6 +428,7 @@ function getRootAggregateInfo(model: ApiModel): RootAggregateInfo {
 		minRequestPrice,
 		minImageInputPrice,
 		minImageOutputPrice,
+		minPerImagePrice,
 		maxContextSize,
 		maxOutput,
 		capabilities: Array.from(capabilitySet),
@@ -444,6 +461,20 @@ function estimateImageCost(
 	}
 	const request = mapping.requestPrice ? parseFloat(mapping.requestPrice) : 0;
 	const discount = mapping.discount ? parseFloat(mapping.discount) : 0;
+	// Flat per-image pricing: estimate on the typical 1K tier.
+	if (mapping.perImagePrice) {
+		const tier =
+			mapping.perImagePrice["1K"] ??
+			mapping.perImagePrice["default"] ??
+			Object.values(mapping.perImagePrice)[0];
+		const base = tier !== undefined ? parseFloat(tier) : NaN;
+		if (Number.isFinite(base) && base > 0) {
+			return {
+				base,
+				discounted: discount > 0 ? base * (1 - discount) : base,
+			};
+		}
+	}
 	const imageOut = mapping.imageOutputPrice
 		? parseFloat(mapping.imageOutputPrice)
 		: 0;
@@ -1802,7 +1833,8 @@ export function ModelSelector({
 														((aggregate.minRequestPrice !== undefined &&
 															aggregate.minRequestPrice > 0) ||
 															aggregate.minImageInputPrice !== undefined ||
-															aggregate.minImageOutputPrice !== undefined);
+															aggregate.minImageOutputPrice !== undefined ||
+															aggregate.minPerImagePrice !== undefined);
 
 													const imageEstimate =
 														mode === "image"
@@ -1945,6 +1977,23 @@ export function ModelSelector({
 															{hasImagePricing && (
 																<div className="pt-2">
 																	<div className="grid grid-cols-2 gap-3">
+																		{aggregate.minPerImagePrice !==
+																			undefined && (
+																			<div className="space-y-1">
+																				<span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
+																					Per Image
+																				</span>
+																				<p className="text-xs font-mono">
+																					$
+																					{parseFloat(
+																						aggregate.minPerImagePrice.toFixed(
+																							4,
+																						),
+																					)}
+																					/image
+																				</p>
+																			</div>
+																		)}
 																		{aggregate.minRequestPrice !== undefined &&
 																			aggregate.minRequestPrice > 0 && (
 																				<div className="space-y-1">
@@ -2254,19 +2303,15 @@ export function ModelSelector({
 																			</span>
 																			<p className="text-xs font-mono">
 																				{(() => {
-																					const values = Object.values(
-																						previewEntry.mapping.perImagePrice,
-																					)
-																						.map(Number)
-																						.filter(Number.isFinite);
-																					if (values.length === 0) {
-																						return "Unknown";
-																					}
-																					const min = Math.min(...values);
-																					const max = Math.max(...values);
-																					return min === max
-																						? `$${min.toFixed(3)}/image`
-																						: `$${min.toFixed(3)} – $${max.toFixed(3)}/image`;
+																					const range =
+																						formatPerImagePriceRange(
+																							previewEntry.mapping
+																								.perImagePrice,
+																							previewEntry.mapping.discount,
+																						);
+																					return range
+																						? `${range}/image`
+																						: "Unknown";
 																				})()}
 																			</p>
 																		</div>
@@ -2506,7 +2551,8 @@ export function ModelSelector({
 												(aggregate.minRequestPrice !== undefined &&
 													aggregate.minRequestPrice > 0) ||
 												aggregate.minImageInputPrice !== undefined ||
-												aggregate.minImageOutputPrice !== undefined;
+												aggregate.minImageOutputPrice !== undefined ||
+												aggregate.minPerImagePrice !== undefined;
 
 											const hasCapabilities = aggregate.capabilities.length > 0;
 
@@ -2598,6 +2644,20 @@ export function ModelSelector({
 													{hasImagePricing && (
 														<div className="pt-2">
 															<div className="grid grid-cols-2 gap-3">
+																{aggregate.minPerImagePrice !== undefined && (
+																	<div className="space-y-1">
+																		<span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+																			Per Image
+																		</span>
+																		<p className="text-sm font-mono">
+																			$
+																			{parseFloat(
+																				aggregate.minPerImagePrice.toFixed(4),
+																			)}
+																			/image
+																		</p>
+																	</div>
+																)}
 																{aggregate.minRequestPrice !== undefined &&
 																	aggregate.minRequestPrice > 0 && (
 																		<div className="space-y-1">
@@ -2817,12 +2877,33 @@ export function ModelSelector({
 												)}
 											{/* Image Generation Pricing */}
 											{(selectedDetails.mapping?.requestPrice ??
+												selectedDetails.mapping?.perImagePrice ??
 												selectedDetails.mapping?.imageInputPrice) && (
 												<div className="pt-2 border-t border-dashed">
 													<span className="text-xs font-medium text-muted-foreground uppercase tracking-wide block mb-2">
 														Image Pricing
 													</span>
 													<div className="grid grid-cols-2 gap-3">
+														{selectedDetails.mapping?.perImagePrice &&
+															Object.keys(selectedDetails.mapping.perImagePrice)
+																.length > 0 && (
+																<div className="space-y-1">
+																	<span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+																		Per Image
+																	</span>
+																	<p className="text-sm font-mono">
+																		{(() => {
+																			const range = formatPerImagePriceRange(
+																				selectedDetails.mapping.perImagePrice,
+																				selectedDetails.mapping.discount,
+																			);
+																			return range
+																				? `${range}/image`
+																				: "Unknown";
+																		})()}
+																	</p>
+																</div>
+															)}
 														{selectedDetails.mapping?.requestPrice &&
 															parseFloat(selectedDetails.mapping.requestPrice) >
 																0 && (

--- a/apps/playground/src/components/model-selector.tsx
+++ b/apps/playground/src/components/model-selector.tsx
@@ -2240,9 +2240,37 @@ export function ModelSelector({
 														})()}
 													{/* Image Generation Pricing */}
 													{(previewEntry.mapping?.requestPrice ??
+														previewEntry.mapping?.perImagePrice ??
 														previewEntry.mapping?.imageInputPrice) && (
 														<div className="pt-2">
 															<div className="grid grid-cols-2 gap-3">
+																{previewEntry.mapping?.perImagePrice &&
+																	Object.keys(
+																		previewEntry.mapping.perImagePrice,
+																	).length > 0 && (
+																		<div className="space-y-1">
+																			<span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
+																				Per Image
+																			</span>
+																			<p className="text-xs font-mono">
+																				{(() => {
+																					const values = Object.values(
+																						previewEntry.mapping.perImagePrice,
+																					)
+																						.map(Number)
+																						.filter(Number.isFinite);
+																					if (values.length === 0) {
+																						return "Unknown";
+																					}
+																					const min = Math.min(...values);
+																					const max = Math.max(...values);
+																					return min === max
+																						? `$${min.toFixed(3)}/image`
+																						: `$${min.toFixed(3)} – $${max.toFixed(3)}/image`;
+																				})()}
+																			</p>
+																		</div>
+																	)}
 																{previewEntry.mapping?.requestPrice &&
 																	parseFloat(
 																		previewEntry.mapping.requestPrice,

--- a/apps/playground/src/lib/fetch-models.ts
+++ b/apps/playground/src/lib/fetch-models.ts
@@ -62,6 +62,7 @@ export interface ApiModelProviderMapping {
 	supportsVideoAudio: boolean | null;
 	supportsVideoWithoutAudio: boolean | null;
 	perSecondPrice: Record<string, string> | null;
+	perImagePrice: Record<string, string> | null;
 	deprecatedAt: string | null;
 	deactivatedAt: string | null;
 	status: "active" | "inactive";

--- a/apps/playground/src/lib/video-gen.spec.ts
+++ b/apps/playground/src/lib/video-gen.spec.ts
@@ -67,6 +67,7 @@ function makeMapping(
 		supportsVideoAudio: true,
 		supportsVideoWithoutAudio: true,
 		perSecondPrice: null,
+		perImagePrice: null,
 		deprecatedAt: null,
 		deactivatedAt: null,
 		status: "active",

--- a/apps/ui/src/app/models/[name]/[provider]/opengraph-image.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/opengraph-image.tsx
@@ -139,6 +139,14 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 					]),
 				)
 			: undefined;
+		const perImagePrice = selectedMapping?.perImagePrice
+			? Object.fromEntries(
+					Object.entries(selectedMapping.perImagePrice).map(([k, v]) => [
+						k,
+						Number(v),
+					]),
+				)
+			: undefined;
 		const isVideoGen = selectedMapping?.videoGenerations === true;
 		const isImageGen = selectedMapping?.imageGenerations === true;
 		const isOcr = selectedMapping?.ocr === true;
@@ -421,6 +429,7 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 					{(hasTokenPricing ||
 						(requestPrice !== undefined && requestPrice !== 0) ||
 						(perSecondPrice && Object.keys(perSecondPrice).length > 0) ||
+						(perImagePrice && Object.keys(perImagePrice).length > 0) ||
 						hasOcrPricing ||
 						hasCharPricing ||
 						hasAudioHourPricing) && (
@@ -441,14 +450,16 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 										? "Pricing per second"
 										: hasOcrPricing
 											? "Pricing per 1K pages"
-											: isImageGen &&
-												  requestPrice !== undefined &&
-												  requestPrice !== 0 &&
-												  !hasTokenPricing
-												? "Pricing per request"
-												: requestPrice !== undefined && requestPrice !== 0
-													? "Pricing"
-													: "Pricing per 1M tokens"}
+											: isImageGen && perImagePrice && !hasTokenPricing
+												? "Pricing per image"
+												: isImageGen &&
+													  requestPrice !== undefined &&
+													  requestPrice !== 0 &&
+													  !hasTokenPricing
+													? "Pricing per request"
+													: requestPrice !== undefined && requestPrice !== 0
+														? "Pricing"
+														: "Pricing per 1M tokens"}
 						</span>
 					)}
 					<div
@@ -575,6 +586,42 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 											{key === "default"
 												? "Per Second"
 												: key.replace(/_/g, " ")}
+										</span>
+										<span style={{ fontWeight: 700, fontSize: 56 }}>
+											${price.toFixed(4)}
+										</span>
+									</div>
+								))}
+
+						{/* Per-Image Price for image gen, tiered by output resolution */}
+						{isImageGen &&
+							perImagePrice &&
+							Object.entries(perImagePrice)
+								.filter(([key]) => key !== "default")
+								.slice(0, 2)
+								.map(([key, price]) => (
+									<div
+										key={key}
+										style={{
+											display: "flex",
+											flexDirection: "column",
+											gap: 10,
+											padding: "28px 36px",
+											backgroundColor: "#0A0A0A",
+											borderRadius: 20,
+											border: "1px solid #1F2937",
+										}}
+									>
+										<span
+											style={{
+												color: "#9CA3AF",
+												fontSize: 20,
+												fontWeight: 500,
+												textTransform: "uppercase",
+												letterSpacing: "0.05em",
+											}}
+										>
+											{key === "default" ? "Per Image" : `Per Image (${key})`}
 										</span>
 										<span style={{ fontWeight: 700, fontSize: 56 }}>
 											${price.toFixed(4)}

--- a/apps/ui/src/app/models/[name]/[provider]/opengraph-image.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/opengraph-image.tsx
@@ -171,11 +171,24 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 			inputAudioHourPrice > 0 &&
 			!(Number(selectedMapping?.inputPrice ?? 0) > 0) &&
 			!(Number(selectedMapping?.outputPrice ?? 0) > 0);
+		const hasPerImagePricing =
+			isImageGen &&
+			perImagePrice !== undefined &&
+			Object.keys(perImagePrice).length > 0;
+		const hasPositiveTokenPrice = [
+			pricing?.input,
+			pricing?.output,
+			pricing?.cachedInput,
+		].some((p) => (p?.original ?? 0) > 0);
+		// Per-image mappings declare token prices as the string "0" — placeholder
+		// values, not real token pricing — so zero token prices only count when
+		// the mapping has no per-image pricing to show instead.
 		const hasTokenPricing =
 			!isOcr &&
 			!hasCharPricing &&
 			!hasAudioHourPricing &&
-			(pricing?.input ?? pricing?.output ?? pricing?.cachedInput);
+			Boolean(pricing?.input ?? pricing?.output ?? pricing?.cachedInput) &&
+			(hasPositiveTokenPrice || !hasPerImagePricing);
 
 		const contextSize = selectedMapping?.contextSize ?? 0;
 
@@ -593,13 +606,19 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 									</div>
 								))}
 
-						{/* Per-Image Price for image gen, tiered by output resolution */}
+						{/* Per-Image Price for image gen, tiered by output resolution.
+						    Fall back to the "default" tier when it is the only entry. */}
 						{isImageGen &&
 							perImagePrice &&
-							Object.entries(perImagePrice)
-								.filter(([key]) => key !== "default")
-								.slice(0, 2)
-								.map(([key, price]) => (
+							(() => {
+								const tierEntries = Object.entries(perImagePrice).filter(
+									([key]) => key !== "default",
+								);
+								const entries =
+									tierEntries.length > 0
+										? tierEntries
+										: Object.entries(perImagePrice);
+								return entries.slice(0, 2).map(([key, price]) => (
 									<div
 										key={key}
 										style={{
@@ -623,11 +642,10 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 										>
 											{key === "default" ? "Per Image" : `Per Image (${key})`}
 										</span>
-										<span style={{ fontWeight: 700, fontSize: 56 }}>
-											${price.toFixed(4)}
-										</span>
+										{formatUnitPrice(price, "/image")}
 									</div>
-								))}
+								));
+							})()}
 
 						{/* Request Price */}
 						{requestPrice !== undefined && requestPrice !== 0 && (

--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -439,6 +439,36 @@ export default async function ModelPage({ params }: PageProps) {
 									video generation
 								</div>
 							)}
+							{visibleProviders.some(
+								(p) =>
+									p.perImagePrice && Object.keys(p.perImagePrice).length > 0,
+							) && (
+								<div>
+									Starting at{" "}
+									{(() => {
+										let minPrice: number | undefined;
+										for (const p of visibleProviders) {
+											if (!p.perImagePrice) {
+												continue;
+											}
+											for (const v of Object.values(p.perImagePrice)) {
+												const n =
+													typeof v === "number" ? v : parseFloat(String(v));
+												if (
+													Number.isFinite(n) &&
+													(minPrice === undefined || n < minPrice)
+												) {
+													minPrice = n;
+												}
+											}
+										}
+										return minPrice !== undefined
+											? `$${minPrice}/image`
+											: "Unknown";
+									})()}{" "}
+									image generation
+								</div>
+							)}
 							{visibleProviders.some((p) => p.ocrPagePrice !== undefined) && (
 								<div>
 									Starting at{" "}

--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -452,18 +452,19 @@ export default async function ModelPage({ params }: PageProps) {
 												continue;
 											}
 											for (const v of Object.values(p.perImagePrice)) {
-												const n =
+												const raw =
 													typeof v === "number" ? v : parseFloat(String(v));
-												if (
-													Number.isFinite(n) &&
-													(minPrice === undefined || n < minPrice)
-												) {
+												if (!Number.isFinite(raw)) {
+													continue;
+												}
+												const n = applyDiscount(raw, p.discount);
+												if (minPrice === undefined || n < minPrice) {
 													minPrice = n;
 												}
 											}
 										}
 										return minPrice !== undefined
-											? `$${minPrice}/image`
+											? `$${parseFloat(minPrice.toFixed(4))}/image`
 											: "Unknown";
 									})()}{" "}
 									image generation

--- a/apps/ui/src/components/custom-models/org-models-client.tsx
+++ b/apps/ui/src/components/custom-models/org-models-client.tsx
@@ -253,6 +253,7 @@ export function OrgModelsClient({
 				supportsVideoAudio: null,
 				supportsVideoWithoutAudio: null,
 				perSecondPrice: null,
+				perImagePrice: null,
 				pricingTiers: null,
 				discount: null,
 				stability: null,

--- a/apps/ui/src/components/models-supported.tsx
+++ b/apps/ui/src/components/models-supported.tsx
@@ -152,6 +152,14 @@ const convertToApiModel = (
 								]),
 							)
 						: null,
+					perImagePrice: map.perImagePrice
+						? Object.fromEntries(
+								Object.entries(map.perImagePrice).map(([k, v]) => [
+									k,
+									v.toString(),
+								]),
+							)
+						: null,
 					pricingTiers: map.pricingTiers
 						? map.pricingTiers.map((t) => ({
 								name: t.name,

--- a/apps/ui/src/components/models/adapt-model.ts
+++ b/apps/ui/src/components/models/adapt-model.ts
@@ -85,6 +85,7 @@ export function adaptProviderMapping(
 			supportsVideoAudio: p.supportsVideoAudio ?? null,
 			supportsVideoWithoutAudio: p.supportsVideoWithoutAudio ?? null,
 			perSecondPrice: toStrRecord(p.perSecondPrice),
+			perImagePrice: toStrRecord(p.perImagePrice),
 			pricingTiers: p.pricingTiers
 				? p.pricingTiers.map((t) => ({
 						name: t.name,

--- a/apps/ui/src/components/models/model-provider-card.tsx
+++ b/apps/ui/src/components/models/model-provider-card.tsx
@@ -614,6 +614,32 @@ export function ModelProviderCard({
 								</div>
 							</div>
 						)}
+					{provider.perImagePrice &&
+						Object.keys(provider.perImagePrice).length > 0 && (
+							<div className="mt-3 pt-3 border-t">
+								<div className="text-muted-foreground text-xs mb-2">
+									Image Pricing (per image, by output resolution)
+								</div>
+								<div className="space-y-1">
+									{Object.entries(provider.perImagePrice).map(
+										([key, price]) => (
+											<div
+												key={key}
+												className="flex justify-between items-center text-xs py-0.5"
+											>
+												<span className="text-muted-foreground">
+													{key.replace(/_/g, " ")}
+												</span>
+												<span className="font-mono">
+													${Number(price).toFixed(4)}
+													/image
+												</span>
+											</div>
+										),
+									)}
+								</div>
+							</div>
+						)}
 					{(() => {
 						const tiers = provider.providerInfo?.serviceTiers;
 						if (

--- a/apps/ui/src/components/models/model-provider-card.tsx
+++ b/apps/ui/src/components/models/model-provider-card.tsx
@@ -621,22 +621,37 @@ export function ModelProviderCard({
 									Image Pricing (per image, by output resolution)
 								</div>
 								<div className="space-y-1">
-									{Object.entries(provider.perImagePrice).map(
-										([key, price]) => (
-											<div
-												key={key}
-												className="flex justify-between items-center text-xs py-0.5"
-											>
-												<span className="text-muted-foreground">
-													{key.replace(/_/g, " ")}
-												</span>
-												<span className="font-mono">
-													${Number(price).toFixed(4)}
-													/image
-												</span>
-											</div>
-										),
-									)}
+									{(() => {
+										const allEntries = Object.entries(provider.perImagePrice);
+										const tierEntries = allEntries.filter(
+											([key]) => key !== "default",
+										);
+										const entries =
+											tierEntries.length > 0 ? tierEntries : allEntries;
+										const discount = Number(provider.discount ?? "0");
+										return entries.map(([key, price]) => {
+											const effective =
+												discount > 0
+													? Number(price) * (1 - discount)
+													: Number(price);
+											return (
+												<div
+													key={key}
+													className="flex justify-between items-center text-xs py-0.5"
+												>
+													<span className="text-muted-foreground">
+														{key === "default"
+															? "per image"
+															: key.replace(/_/g, " ")}
+													</span>
+													<span className="font-mono">
+														${effective.toFixed(4)}
+														/image
+													</span>
+												</div>
+											);
+										});
+									})()}
 								</div>
 							</div>
 						)}

--- a/packages/actions/src/get-cheapest-from-available-providers.ts
+++ b/packages/actions/src/get-cheapest-from-available-providers.ts
@@ -299,7 +299,11 @@ export function getProviderSelectionPrice(
 	providerInfo:
 		| Pick<
 				ProviderModelMapping,
-				"inputPrice" | "outputPrice" | "perSecondPrice" | "requestPrice"
+				| "inputPrice"
+				| "outputPrice"
+				| "perSecondPrice"
+				| "perImagePrice"
+				| "requestPrice"
 		  >
 		| undefined,
 	videoPricing?: VideoPricingContext,
@@ -326,6 +330,15 @@ export function getProviderSelectionPrice(
 		return new Decimal(inputPrice ?? "0").plus(outputPrice ?? "0").div(2);
 	}
 
+	if (providerInfo?.perImagePrice) {
+		const perImagePrice =
+			providerInfo.perImagePrice["default"] ??
+			Object.values(providerInfo.perImagePrice)[0];
+		if (perImagePrice !== undefined) {
+			return new Decimal(perImagePrice);
+		}
+	}
+
 	if (requestPrice !== undefined && !hasPositiveTokenPrice) {
 		return new Decimal(requestPrice);
 	}
@@ -340,7 +353,11 @@ export function getProviderSelectionPrice(
 type ProviderSelectionPriceInfo = AvailableModelProvider &
 	Pick<
 		ProviderModelMapping,
-		"inputPrice" | "outputPrice" | "perSecondPrice" | "requestPrice"
+		| "inputPrice"
+		| "outputPrice"
+		| "perSecondPrice"
+		| "perImagePrice"
+		| "requestPrice"
 	>;
 
 export async function getDiscountedProviderSelectionPrice(

--- a/packages/actions/src/get-cheapest-from-available-providers.ts
+++ b/packages/actions/src/get-cheapest-from-available-providers.ts
@@ -331,11 +331,16 @@ export function getProviderSelectionPrice(
 	}
 
 	if (providerInfo?.perImagePrice) {
-		const perImagePrice =
-			providerInfo.perImagePrice["default"] ??
-			Object.values(providerInfo.perImagePrice)[0];
-		if (perImagePrice !== undefined) {
-			return new Decimal(perImagePrice);
+		// Represent the mapping by its cheapest obtainable tier, matching how
+		// every other branch (and the gateway's pricingScore) ranks mappings.
+		const values = Object.values(providerInfo.perImagePrice).filter(
+			(v) => v !== undefined,
+		);
+		if (values.length > 0) {
+			return values.reduce(
+				(min, v) => (new Decimal(v).lt(min) ? new Decimal(v) : min),
+				new Decimal(values[0]),
+			);
 		}
 	}
 

--- a/packages/actions/src/models.spec.ts
+++ b/packages/actions/src/models.spec.ts
@@ -76,7 +76,7 @@ describe("Models", () => {
 		const isZero = (p: string | undefined) =>
 			p !== undefined && Number(p) === 0;
 
-		// Filter models that have zero input/output pricing AND no request or per-second price
+		// Filter models that have zero input/output pricing AND no request, per-second, or per-image price
 		const modelsWithZeroPricing = models.filter((model) =>
 			model.providers.some(
 				(provider) =>
@@ -84,6 +84,9 @@ describe("Models", () => {
 					!(provider as ProviderModelMapping).requestPrice &&
 					!Object.values(
 						(provider as ProviderModelMapping).perSecondPrice ?? {},
+					).some((price) => Number(price) > 0) &&
+					!Object.values(
+						(provider as ProviderModelMapping).perImagePrice ?? {},
 					).some((price) => Number(price) > 0) &&
 					!hasImagePricing(provider as ProviderModelMapping) &&
 					!isEmbeddingProvider(provider as ProviderModelMapping),
@@ -102,6 +105,9 @@ describe("Models", () => {
 						!(p as ProviderModelMapping).requestPrice &&
 						!Object.values(
 							(p as ProviderModelMapping).perSecondPrice ?? {},
+						).some((price) => Number(price) > 0) &&
+						!Object.values(
+							(p as ProviderModelMapping).perImagePrice ?? {},
 						).some((price) => Number(price) > 0) &&
 						!hasImagePricing(p as ProviderModelMapping) &&
 						!isEmbeddingProvider(p as ProviderModelMapping),

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -301,6 +301,15 @@ export interface ProviderModelMapping {
 	 */
 	perSecondPrice?: Record<string, Price>;
 	/**
+	 * Price per generated output image in USD, keyed by resolution tier
+	 * (e.g. "1K", "2K") with a "default" fallback. For image models whose
+	 * provider bills a flat per-image rate that varies with the served
+	 * resolution rather than per token (e.g. Alibaba's qwen-image family,
+	 * whose usage reports the billed tier in `output_image_type`). Billed
+	 * per output image, unlike `requestPrice` which is flat per request.
+	 */
+	perImagePrice?: Record<string, Price>;
+	/**
 	 * Pricing tiers for models with context-length based pricing.
 	 * When set, inputPrice and outputPrice represent the base tier.
 	 * Tiers should be sorted by upToTokens in ascending order.

--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -2043,6 +2043,58 @@ export const alibabaModels = [
 		],
 	},
 	{
+		id: "qwen-image-3",
+		name: "Qwen Image 3",
+		description:
+			"Alibaba's third-generation Qwen image model for text-to-image generation and image editing with strong text rendering.",
+		family: "alibaba",
+		output: ["text", "image"],
+		releasedAt: new Date("2026-08-05"),
+		providers: [
+			{
+				test: "skip",
+				providerId: "alibaba",
+				externalId: "qwen-image-3",
+				inputPrice: "0",
+				outputPrice: "0",
+				requestPrice: "0.03",
+				contextSize: 65536,
+				maxOutput: 4096,
+				streaming: false,
+				vision: true,
+				tools: false,
+				jsonOutput: false,
+				imageGenerations: true,
+			},
+		],
+	},
+	{
+		id: "qwen-image-3-pro",
+		name: "Qwen Image 3 Pro",
+		description:
+			"Alibaba's flagship third-generation Qwen image model for highest quality text-to-image generation and image editing.",
+		family: "alibaba",
+		output: ["text", "image"],
+		releasedAt: new Date("2026-08-05"),
+		providers: [
+			{
+				test: "skip",
+				providerId: "alibaba",
+				externalId: "qwen-image-3-pro",
+				inputPrice: "0",
+				outputPrice: "0",
+				requestPrice: "0.04",
+				contextSize: 65536,
+				maxOutput: 4096,
+				streaming: false,
+				vision: true,
+				tools: false,
+				jsonOutput: false,
+				imageGenerations: true,
+			},
+		],
+	},
+	{
 		id: "qwen-image-plus",
 		name: "Qwen Image Plus",
 		description:

--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -2057,7 +2057,11 @@ export const alibabaModels = [
 				externalId: "qwen-image-3.0",
 				inputPrice: "0",
 				outputPrice: "0",
-				requestPrice: "0.03",
+				perImagePrice: {
+					"1K": "0.03",
+					"2K": "0.03",
+					default: "0.03",
+				},
 				contextSize: 4500,
 				maxOutput: 4096,
 				streaming: false,
@@ -2083,10 +2087,14 @@ export const alibabaModels = [
 				externalId: "qwen-image-3.0-pro",
 				inputPrice: "0",
 				outputPrice: "0",
-				// Alibaba prices this model per output resolution ($0.04/image at
-				// 1K, $0.075/image at 2K); the gateway sends no default size and
-				// the endpoint returns 2K, so the flat rate has to be the 2K one.
-				requestPrice: "0.075",
+				// The tier is billed on the served resolution DashScope reports in
+				// usage.output_image_type; "default" covers requests without a size,
+				// where the model auto-picks a resolution and serves 2K.
+				perImagePrice: {
+					"1K": "0.04",
+					"2K": "0.075",
+					default: "0.075",
+				},
 				contextSize: 4500,
 				maxOutput: 4096,
 				streaming: false,

--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -2057,9 +2057,9 @@ export const alibabaModels = [
 				externalId: "qwen-image-3.0",
 				inputPrice: "0",
 				outputPrice: "0",
+				// Every resolution bills the same rate, so a single "default" tier
+				// covers all sizes; add explicit tier keys only if pricing splits.
 				perImagePrice: {
-					"1K": "0.03",
-					"2K": "0.03",
 					default: "0.03",
 				},
 				contextSize: 4500,

--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -2043,8 +2043,8 @@ export const alibabaModels = [
 		],
 	},
 	{
-		id: "qwen-image-3",
-		name: "Qwen Image 3",
+		id: "qwen-image-3.0",
+		name: "Qwen Image 3.0",
 		description:
 			"Alibaba's third-generation Qwen image model for text-to-image generation and image editing with strong text rendering.",
 		family: "alibaba",
@@ -2054,11 +2054,11 @@ export const alibabaModels = [
 			{
 				test: "skip",
 				providerId: "alibaba",
-				externalId: "qwen-image-3",
+				externalId: "qwen-image-3.0",
 				inputPrice: "0",
 				outputPrice: "0",
 				requestPrice: "0.03",
-				contextSize: 65536,
+				contextSize: 4500,
 				maxOutput: 4096,
 				streaming: false,
 				vision: true,
@@ -2069,8 +2069,8 @@ export const alibabaModels = [
 		],
 	},
 	{
-		id: "qwen-image-3-pro",
-		name: "Qwen Image 3 Pro",
+		id: "qwen-image-3.0-pro",
+		name: "Qwen Image 3.0 Pro",
 		description:
 			"Alibaba's flagship third-generation Qwen image model for highest quality text-to-image generation and image editing.",
 		family: "alibaba",
@@ -2080,11 +2080,14 @@ export const alibabaModels = [
 			{
 				test: "skip",
 				providerId: "alibaba",
-				externalId: "qwen-image-3-pro",
+				externalId: "qwen-image-3.0-pro",
 				inputPrice: "0",
 				outputPrice: "0",
-				requestPrice: "0.04",
-				contextSize: 65536,
+				// Alibaba prices this model per output resolution ($0.04/image at
+				// 1K, $0.075/image at 2K); the gateway sends no default size and
+				// the endpoint returns 2K, so the flat rate has to be the 2K one.
+				requestPrice: "0.075",
+				contextSize: 4500,
 				maxOutput: 4096,
 				streaming: false,
 				vision: true,

--- a/packages/models/src/models/meta.ts
+++ b/packages/models/src/models/meta.ts
@@ -2,6 +2,41 @@ import type { ModelDefinition } from "@/models.js";
 
 export const metaModels = [
 	{
+		id: "muse-spark-1.2",
+		name: "Muse Spark 1.2",
+		description:
+			"Meta's latest multimodal reasoning model, improving on Muse Spark 1.1's agentic tool calling, coding, structured output, and long-context workflows with image and video understanding.",
+		family: "meta",
+		releasedAt: new Date("2026-08-06"),
+		providers: [
+			{
+				providerId: "meta",
+				externalId: "muse-spark-1.2",
+				stability: "beta",
+				inputPrice: "1.25e-6",
+				cachedInputPrice: "0.15e-6",
+				outputPrice: "4.25e-6",
+				requestPrice: "0",
+				contextSize: 1048576,
+				maxOutput: 131072,
+				streaming: true,
+				reasoning: true,
+				reasoningEfforts: ["minimal", "low", "medium", "high", "xhigh"],
+				reasoningMode: "adaptive",
+				reasoningOutput: "omit",
+				supportsResponsesApi: true,
+				vision: true,
+				tools: true,
+				// Muse Spark's endpoint only accepts tool_choice="auto"; it rejects
+				// "none", "required", and named function choices with
+				// invalid_request_error (same endpoint behavior as 1.1)
+				supportedToolChoices: ["auto"],
+				jsonOutput: true,
+				jsonOutputSchema: true,
+			},
+		],
+	},
+	{
 		id: "muse-spark-1.1",
 		name: "Muse Spark 1.1",
 		description:

--- a/packages/models/src/types.ts
+++ b/packages/models/src/types.ts
@@ -453,6 +453,7 @@ export interface ModelWithPricing {
 		inputPrice?: string;
 		outputPrice?: string;
 		perSecondPrice?: Record<string, string>;
+		perImagePrice?: Record<string, string>;
 		supportedParameters?: string[];
 		externalId: string;
 		region?: string;

--- a/packages/shared/src/components/index.tsx
+++ b/packages/shared/src/components/index.tsx
@@ -5,6 +5,7 @@ export * from "./model-selector";
 export * from "./models-directory/all-models";
 export * from "./models-directory/api-types";
 export * from "./models-directory/deactivation";
+export * from "./models-directory/format";
 export * from "./models-directory/model-card";
 export * from "./models-directory/model-category-filters";
 export * from "./models-directory/model-code-example-dialog";

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -539,6 +539,34 @@ const ModelTableRow = React.memo(
 									<p className="text-xs">Per-request pricing (not per token)</p>
 								</TooltipContent>
 							</Tooltip>
+						) : (!row.provider.inputPrice ||
+								parseFloat(row.provider.inputPrice) === 0) &&
+						  row.provider.perImagePrice &&
+						  Object.keys(row.provider.perImagePrice).length > 0 ? (
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<span className="text-amber-500 cursor-help">
+										{(() => {
+											const values = Object.values(row.provider.perImagePrice)
+												.map(Number)
+												.filter(Number.isFinite);
+											if (values.length === 0) {
+												return "—";
+											}
+											const min = Math.min(...values);
+											const max = Math.max(...values);
+											return min === max
+												? `$${min}/image`
+												: `$${min} – $${max}/image`;
+										})()}
+									</span>
+								</TooltipTrigger>
+								<TooltipContent>
+									<p className="text-xs">
+										Per-image pricing by output resolution (not per token)
+									</p>
+								</TooltipContent>
+							</Tooltip>
 						) : (
 							formatPrice(row.provider.inputPrice, row.provider.discount)
 						)}
@@ -571,6 +599,8 @@ const ModelTableRow = React.memo(
 								parseFloat(row.provider.outputPrice) === 0) &&
 						  ((row.provider.requestPrice &&
 								parseFloat(row.provider.requestPrice) > 0) ||
+								(row.provider.perImagePrice &&
+									Object.keys(row.provider.perImagePrice).length > 0) ||
 								(row.provider.inputCharacterPrice &&
 									parseFloat(row.provider.inputCharacterPrice) > 0)) ? (
 							<span className="text-muted-foreground">—</span>
@@ -650,6 +680,30 @@ const ModelTableRow = React.memo(
 													}
 													const firstValue = Object.values(prices)[0];
 													return firstValue ? `$${firstValue}/sec` : "";
+												})()}
+											</Badge>
+										)}
+									{row.provider.perImagePrice &&
+										Object.keys(row.provider.perImagePrice).length > 0 && (
+											<Badge
+												variant="outline"
+												className="text-sm px-3 py-1.5 bg-background"
+											>
+												Per Image{" "}
+												{(() => {
+													const values = Object.values(
+														row.provider.perImagePrice!,
+													)
+														.map(Number)
+														.filter(Number.isFinite);
+													if (values.length === 0) {
+														return "";
+													}
+													const min = Math.min(...values);
+													const max = Math.max(...values);
+													return min === max
+														? `$${min}`
+														: `$${min} – $${max} by resolution`;
 												})()}
 											</Badge>
 										)}
@@ -1300,6 +1354,11 @@ export function AllModels({
 					(provider.perSecondPrice !== null &&
 						provider.perSecondPrice !== undefined &&
 						Object.values(provider.perSecondPrice).some(
+							(price) => parseFloat(price) > 0,
+						)) ||
+					(provider.perImagePrice !== null &&
+						provider.perImagePrice !== undefined &&
+						Object.values(provider.perImagePrice).some(
 							(price) => parseFloat(price) > 0,
 						));
 

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -77,7 +77,7 @@ import {
 import { cn } from "@/lib/utils";
 
 import { isMappingDeactivated } from "./deactivation";
-import { formatDeprecationDate } from "./format";
+import { formatDeprecationDate, formatPerImagePriceRange } from "./format";
 import { ModelCard } from "./model-card";
 import { applyCategoryFilter } from "./model-category-filters";
 import { useIsMobile } from "./use-mobile";
@@ -547,17 +547,11 @@ const ModelTableRow = React.memo(
 								<TooltipTrigger asChild>
 									<span className="text-amber-500 cursor-help">
 										{(() => {
-											const values = Object.values(row.provider.perImagePrice)
-												.map(Number)
-												.filter(Number.isFinite);
-											if (values.length === 0) {
-												return "—";
-											}
-											const min = Math.min(...values);
-											const max = Math.max(...values);
-											return min === max
-												? `$${min}/image`
-												: `$${min} – $${max}/image`;
+											const range = formatPerImagePriceRange(
+												row.provider.perImagePrice,
+												row.provider.discount,
+											);
+											return range ? `${range}/image` : "—";
 										})()}
 									</span>
 								</TooltipTrigger>
@@ -690,21 +684,10 @@ const ModelTableRow = React.memo(
 												className="text-sm px-3 py-1.5 bg-background"
 											>
 												Per Image{" "}
-												{(() => {
-													const values = Object.values(
-														row.provider.perImagePrice!,
-													)
-														.map(Number)
-														.filter(Number.isFinite);
-													if (values.length === 0) {
-														return "";
-													}
-													const min = Math.min(...values);
-													const max = Math.max(...values);
-													return min === max
-														? `$${min}`
-														: `$${min} – $${max} by resolution`;
-												})()}
+												{formatPerImagePriceRange(
+													row.provider.perImagePrice!,
+													row.provider.discount,
+												) ?? ""}
 											</Badge>
 										)}
 								</div>
@@ -1113,12 +1096,19 @@ export function AllModels({
 				return false;
 			}
 			if (filters.capabilities.free) {
-				// A model is only considered free if it has the free flag AND no provider has a per-request cost
-				const hasRequestPrice = model.providerDetails.some(
+				// A model is only considered free if it has the free flag AND no
+				// provider bills per request, per generated image, or per second
+				// (mirrors the gateway's isModelTrulyFree definition).
+				const hasNonTokenPrice = model.providerDetails.some(
 					(p) =>
-						p.provider.requestPrice && parseFloat(p.provider.requestPrice) > 0,
+						(p.provider.requestPrice &&
+							parseFloat(p.provider.requestPrice) > 0) ||
+						(p.provider.perImagePrice &&
+							Object.keys(p.provider.perImagePrice).length > 0) ||
+						(p.provider.perSecondPrice &&
+							Object.keys(p.provider.perSecondPrice).length > 0),
 				);
-				if (!model.free || hasRequestPrice) {
+				if (!model.free || hasNonTokenPrice) {
 					return false;
 				}
 			}

--- a/packages/shared/src/components/models-directory/api-types.ts
+++ b/packages/shared/src/components/models-directory/api-types.ts
@@ -61,6 +61,7 @@ export interface ApiModelProviderMapping {
 	supportsVideoAudio: boolean | null;
 	supportsVideoWithoutAudio: boolean | null;
 	perSecondPrice: Record<string, string> | null;
+	perImagePrice: Record<string, string> | null;
 	pricingTiers: Array<{
 		name: string;
 		upToTokens: number | null;

--- a/packages/shared/src/components/models-directory/format.ts
+++ b/packages/shared/src/components/models-directory/format.ts
@@ -44,3 +44,29 @@ export function formatDeprecationDate(
 		? `Deactivated since ${formatted}`
 		: `Deactivating on ${formatted}`;
 }
+
+/**
+ * Formats a perImagePrice resolution-tier map as a discounted price range,
+ * e.g. "$0.04 – $0.075" (or "$0.03" when every tier costs the same).
+ * Callers append their own unit suffix (e.g. "/image").
+ * @param perImagePrice - Resolution tier → USD-per-image price map
+ * @param discount - Provider discount fraction as a string (e.g. "0.3")
+ * @returns The formatted range, or null when the map has no finite prices
+ */
+export function formatPerImagePriceRange(
+	perImagePrice: Record<string, string | number>,
+	discount?: string | null,
+): string | null {
+	const discountNum = discount ? parseFloat(discount) : 0;
+	const values = Object.values(perImagePrice)
+		.map(Number)
+		.filter(Number.isFinite)
+		.map((v) => (discountNum > 0 ? v * (1 - discountNum) : v));
+	if (values.length === 0) {
+		return null;
+	}
+	const fmt = (n: number) => `$${parseFloat(n.toFixed(4))}`;
+	const min = Math.min(...values);
+	const max = Math.max(...values);
+	return min === max ? fmt(min) : `${fmt(min)} – ${fmt(max)}`;
+}

--- a/packages/shared/src/components/models-directory/model-card.tsx
+++ b/packages/shared/src/components/models-directory/model-card.tsx
@@ -868,6 +868,31 @@ export function ProviderSection({
 								}
 							}
 						}
+						if (perImage === null && activeMapping.perImagePrice) {
+							const tierEntries = Object.entries(
+								activeMapping.perImagePrice,
+							).filter(([k]) => k !== "default");
+							const entries =
+								tierEntries.length > 0
+									? tierEntries
+									: Object.entries(activeMapping.perImagePrice);
+							const values = entries
+								.map(([, v]) => parseFloat(v))
+								.filter(Number.isFinite);
+							if (values.length > 0) {
+								const min = Math.min(...values);
+								const max = Math.max(...values);
+								perImage = max * serviceTierMultiplier;
+								if (min !== max) {
+									const maxKey = entries.find(
+										([, v]) => parseFloat(v) === max,
+									)?.[0];
+									label = maxKey
+										? `Per image (${maxKey}, cheaper at lower resolutions)`
+										: "Per image";
+								}
+							}
+						}
 						if (perImage === null) {
 							return null;
 						}

--- a/packages/shared/src/components/models-directory/model-category-filters.ts
+++ b/packages/shared/src/components/models-directory/model-category-filters.ts
@@ -197,6 +197,7 @@ export const OPEN_SOURCE_MODEL_IDS: ReadonlySet<string> = new Set([
 // API-only Muse Spark models alongside the open Llama family)
 export const CLOSED_SOURCE_MODEL_IDS: ReadonlySet<string> = new Set([
 	"muse-spark-1.1",
+	"muse-spark-1.2",
 	// API-only at launch; no open weights published (unlike the K2 family)
 	"kimi-k3",
 ]);


### PR DESCRIPTION
## Summary

### New models

- **Meta `muse-spark-1.2`** — mirrors the live-verified 1.1 mapping: $1.25/M input, $4.25/M output, $0.15/M cached input, 1M context, 131K max output, beta stability, Responses-API adaptive reasoning, vision, tools (`tool_choice: "auto"` only), JSON output + schema. Registered in `CLOSED_SOURCE_MODEL_IDS`. Audio/document/video input flags left off pending live verification through the gateway transform path.
- **Alibaba `qwen-image-3.0` ($0.03/image) and `qwen-image-3.0-pro` ($0.04 at 1K / $0.075 at 2K)** — third-generation Qwen image models, released 2026-08-05, with image-input editing (`vision: true`), documented on the image-generation docs page.

### Resolution-tiered per-image pricing (`perImagePrice`)

New mapping field (mirroring `perSecondPrice`): USD per generated image keyed by resolution tier with a `default` fallback, multiplied by output image count. The gateway bills on the tier DashScope reports in `usage.output_image_type` (case-insensitive), never the requested pixel size; unmatched or missing tiers fall back to `default` so a miss can only overcharge, never undercharge. Surfaced through `/v1/models` (`per_image`), internal-models, the models directory, model pages, playground, and OG images. Verified live: basic e2e bills $0.03 (3.0) and $0.075 (pro at its 2K default) with `request_cost` 0.

### Review fixes (CodeRabbit + multi-agent code review)

Billing:
- `calculateCosts` now bills mappings priced per image or per flat request even when upstream omits prompt usage (previously returned null costs → free generations); regression tests added
- Per-image tier lookups use own-property access (a crafted `image_size` like `"constructor"` can no longer throw mid-billing) via a shared `resolveByResolution` helper
- A `perImagePrice` map without a `default` key falls back to its most expensive tier instead of billing $0
- `pricingScore` and `getProviderSelectionPrice` no longer treat the placeholder `"0"` token prices as authoritative, and rank per-image mappings by their cheapest tier

Display:
- Provider discounts are applied to every per-image price display through a shared `formatPerImagePriceRange` helper (models directory ×2, playground ×2, provider card, model page minimum)
- Playground: per-image pricing added to the selected-model dialog, the per-image estimate card, and root-aggregate pricing (per-image models no longer look free)
- OG image: models with only per-image pricing get the "Pricing per image" header and per-image cards (no more "$0.00" token cells), with a default-tier fallback
- Provider card no longer renders the internal `default` key as a user-facing tier row
- Models-directory "Free" filter now mirrors `isModelTrulyFree` (per-image/per-second priced models are not free)
- `qwen-image-3.0`'s three identical tier entries collapsed to a single `default`

Deliberately not changed: the `default`-tier fallback for unmatched sizes (documented never-undercharge design), the display-only `serviceTierMultiplier` divergence on per-image prices (latent; no per-image mapping defines service tiers), and the un-commented `test: "skip"` flags (follows the file-wide precedent).

## Test plan

- [x] `pnpm build` passes (17/17 tasks)
- [x] `pnpm format` clean
- [x] Catalogue + billing + selection specs pass: 680 tests across `packages/models`, `packages/shared`, `packages/actions`, `costs.spec.ts` (incl. new missing-usage regression tests) + 24 in gateway `models.spec.ts`
- [x] perImagePrice billing verified live by @steebchen (see above)
- Full `pnpm test:unit` has pre-existing DB/Redis-dependent failures locally (Docker down) — unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGwHtiSDhiUyPc2i9K2QKf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Alibaba’s Qwen Image 3 and Qwen Image 3 Pro for text-to-image generation and image editing.
  * Added Meta’s beta Muse Spark 1.2 model with multimodal reasoning, structured output, and tool support.
  * Added resolution-based per-image pricing across model pages, directories, provider cards, and the playground.
  * Improved image-generation cost estimates, billing, and provider selection for image pricing.
  * Updated model categorization to identify Muse Spark 1.2 as closed source.

* **Documentation**
  * Added pricing, descriptions, and availability details for the new Alibaba image-generation models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->