### PR TITLE
feat(models): deactivate reve mappings

### DIFF
--- a/packages/models/src/models/reve.ts
+++ b/packages/models/src/models/reve.ts
@@ -24,6 +24,8 @@ export const reveModels = [
 				tools: false,
 				jsonOutput: false,
 				imageGenerations: true,
+				// Reve's public API is winding down, with a full sunset on 2026-08-14
+				deactivatedAt: new Date("2026-08-06"),
 			},
 		],
 	},


### PR DESCRIPTION
Reve announced that their public API is winding down, with a full sunset on Friday, August 14th 2026, as they shift priorities back to their own product-building.

Marks the only `reve` provider mapping — `reve-create` → `reve-create@latest` — with `deactivatedAt: new Date("2026-08-06")` so routing stops selecting it now, ahead of the sunset. Per repo convention the model and provider definitions stay in place (historical usage records and analytics reference them), as does the `reve` provider handling in `get-provider-endpoint.ts`, `prepare-request-body.ts`, and `parse-provider-response.ts`.

The existing changelog entry announcing Reve is left untouched — it is a historical record.

Verified with `pnpm format` and a full `pnpm build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Marked the Reve provider as deactivated effective August 6, 2026.
  * Added a sunset note to clarify the provider’s availability status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->