### PR TITLE
fix(models): scx-ai-gp qwen3.8-max web search

### DIFF
--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -1698,11 +1698,6 @@ export const alibabaModels = [
 				streaming: true,
 				vision: true,
 				tools: true,
-				// No webSearch: Alibaba's `enable_search` is a DashScope platform
-				// feature, not something the model carries to other deployments. SCX's
-				// plain OpenAI-compatible endpoint accepts the request but performs no
-				// search and reports no search usage, so declaring it would silently
-				// route web-search requests to a provider that cannot serve them.
 				jsonOutput: true,
 				supportedParameters: [
 					"temperature",

--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -1684,7 +1684,6 @@ export const alibabaModels = [
 			{
 				providerId: "scx-ai-gp",
 				externalId: "qwen3.8-max",
-				test: "skip",
 				inputPrice: "1.815e-6",
 				cachedInputPrice: "0.21e-6",
 				cacheReadInputPrice: "0.17e-6",
@@ -1699,8 +1698,11 @@ export const alibabaModels = [
 				streaming: true,
 				vision: true,
 				tools: true,
-				webSearch: true,
-				webSearchPrice: "0.01",
+				// No webSearch: Alibaba's `enable_search` is a DashScope platform
+				// feature, not something the model carries to other deployments. SCX's
+				// plain OpenAI-compatible endpoint accepts the request but performs no
+				// search and reports no search usage, so declaring it would silently
+				// route web-search requests to a provider that cannot serve them.
 				jsonOutput: true,
 				supportedParameters: [
 					"temperature",


### PR DESCRIPTION
## Problem

Ran the scoped e2e suite for the `scx-ai-gp` / `qwen3.8-max` mapping merged in #3439. Two findings:

1. **Web search does not work on this deployment.** All three `chat-websearch` cases (non-streaming, streaming, Responses API) fail with `webSearchCost` of `0`. The request succeeds, but SCX's plain OpenAI-compatible endpoint performs no search and reports no search usage — `enable_search` is a DashScope platform feature, not something the model carries to other deployments. #3439's own description said web search should deliberately *not* be mirrored from the `alibaba` mapping; the merged code mirrors it anyway.

2. **The deployment is live.** The mapping still carries `test: "skip"` from #3437, when SCX had not brought it online. It now serves every case the suite exercises.

## Approach

- Drop `webSearch` / `webSearchPrice`, with a comment explaining why so it does not get "restored" from the `alibaba` mapping later.
- Drop `test: "skip"` so the mapping is covered by default e2e.

## Verification

`TEST_MODELS="scx-ai-gp/qwen3.8-max" FULL_MODE=true TEST_WEB_SEARCH=1 pnpm test:e2e` — 15 cases named the mapping, all passing:

`chat-basic`, `chat-streaming`, `chat-reasoning`, `chat-rs` (reasoning + streaming), `chat-full` (reasoning + tool calls), `chat-toolcalls` (both), `chat-toolcalls-result`, `chat-json` (both), `chat-empty-response`, and all four `responses` cases (single-turn, multi-turn, tool calls, tool calls stateless).

Before this change the same run also produced 3 failing web-search cases; after it, the mapping no longer generates them. `pnpm format` and `pnpm build` are clean.

## Left alone

`cacheReadInputPrice` / `cacheWriteInputPrice` were also mirrored from `alibaba` against #3439's stated intent — those are Alibaba's published off-ratio explicit-cache rates. `chat-prompt-caching.e2e.ts` has no case for this mapping, so unlike web search there is no evidence either way, and I did not want to change billing on a guess. Worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled the SCX-AI deployment of `qwen3.8-max`.
  * Removed unsupported web-search availability and pricing details for this deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->