### PR TITLE
fix(gateway): don't bill unreported failed streams

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -6670,6 +6670,60 @@ describe("api", () => {
 			);
 		});
 
+		// A truncated stream never reports usage, so every token count on the log
+		// is the gateway's own chars/4 estimate over a partial payload. Billing
+		// that estimate charges for output the caller never received on a request
+		// the gateway answered with a 502.
+		test("truncated upstream streams are not billed", async () => {
+			await db.insert(tables.apiKey).values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+
+			await db.insert(tables.providerKey).values({
+				id: "provider-key-id",
+				token: "sk-test-key",
+				provider: "openai",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			});
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer real-token`,
+				},
+				body: JSON.stringify({
+					model: "openai/gpt-4o-mini",
+					messages: [
+						{
+							role: "user",
+							content: `TRIGGER_TRUNCATED_STREAM ${randomUUID()}`,
+						},
+					],
+					stream: true,
+				}),
+			});
+
+			expect(res.status).toBe(200);
+
+			const streamResult = await readAll(res.body);
+			expect(streamResult.errorEvents[0].error.code).toBe("stream_truncated");
+
+			const logs = await waitForLogs(1);
+			expect(logs.length).toBe(1);
+			expect(logs[0].finishReason).toBe("upstream_error");
+			expect(Number(logs[0].cost)).toBe(0);
+			expect(Number(logs[0].inputCost)).toBe(0);
+			expect(Number(logs[0].outputCost)).toBe(0);
+			// The estimated usage is still recorded for analytics.
+			expect(Number(logs[0].promptTokens)).toBeGreaterThan(0);
+		});
+
 		test("streaming request closes cleanly after finish reason without upstream done sentinel", async () => {
 			await db.insert(tables.apiKey).values({
 				id: "token-id",

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -49,7 +49,6 @@ import {
 import {
 	buildEstimatedCompletionText,
 	calculateCosts,
-	capEstimatedCompletionTokensForModel,
 	isRefusalFinishReason,
 	shouldBillCancelledRequests,
 	zeroInferenceCosts,
@@ -10250,17 +10249,7 @@ chat.openapi(completions, async (c) => {
 								const textTokens = estimateTokensFromContent(
 									estimatedCompletionText,
 								);
-								// Cap the guess at what the model can physically emit, so an
-								// over-accumulated stream cannot bill (or report) an
-								// impossible token count.
-								calculatedCompletionTokens =
-									capEstimatedCompletionTokensForModel(
-										textTokens + imageTokens,
-										usedInternalModel,
-										usedProvider,
-										usedRegion ?? null,
-										n ?? 1,
-									);
+								calculatedCompletionTokens = textTokens + imageTokens;
 							}
 						}
 

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -47,6 +47,7 @@ import {
 	type ComplianceCheckContext,
 } from "@/lib/compliance.js";
 import {
+	buildEstimatedCompletionText,
 	calculateCosts,
 	isRefusalFinishReason,
 	shouldBillCancelledRequests,
@@ -10220,15 +10221,29 @@ chat.openapi(completions, async (c) => {
 							calculatedPromptTokens = encodeChatMessages(messages);
 						}
 
-						if (!completionTokens && (fullContent || imageByteSize > 0)) {
-							// For images, estimate ~258 tokens per image + 1 token per 750 bytes
-							let imageTokens = 0;
-							if (imageByteSize > 0) {
-								imageTokens = 258 + Math.ceil(imageByteSize / 750);
-							}
+						if (!completionTokens) {
+							// Tool-call names and arguments are part of the completion the
+							// same way text is, and pricing already estimates over them, so
+							// they must be counted here too — otherwise a stream that emits
+							// only tool calls logs no completion tokens while still being
+							// billed for them.
+							const estimatedCompletionText = buildEstimatedCompletionText(
+								fullContent,
+								streamingToolCalls,
+							);
 
-							const textTokens = estimateTokensFromContent(fullContent);
-							calculatedCompletionTokens = textTokens + imageTokens;
+							if (estimatedCompletionText || imageByteSize > 0) {
+								// For images, estimate ~258 tokens per image + 1 token per 750 bytes
+								let imageTokens = 0;
+								if (imageByteSize > 0) {
+									imageTokens = 258 + Math.ceil(imageByteSize / 750);
+								}
+
+								const textTokens = estimateTokensFromContent(
+									estimatedCompletionText,
+								);
+								calculatedCompletionTokens = textTokens + imageTokens;
+							}
 						}
 
 						calculatedTotalTokens =
@@ -10896,6 +10911,27 @@ chat.openapi(completions, async (c) => {
 									},
 									finishReason === "content_filter",
 								));
+
+					// A stream that died with an upstream/gateway error never produced a
+					// complete response, and when the provider also reported no usage at
+					// all the only numbers we have are our own chars/4 estimates over a
+					// truncated payload — an estimate that can even exceed the model's
+					// max output. Charging that bills the caller for output they never
+					// received on a request the gateway answered with a 502, so the log
+					// keeps the estimated token counts for analytics but is not billed.
+					// Failures where the provider *did* report usage stay billed: those
+					// counts are real and upstream charged us for them.
+					const upstreamReportedUsage =
+						(promptTokens ?? 0) > 0 || (completionTokens ?? 0) > 0;
+					if (
+						!canceled &&
+						(finishReason === "upstream_error" ||
+							finishReason === "gateway_error") &&
+						!upstreamReportedUsage &&
+						costs.totalCost !== null
+					) {
+						zeroInferenceCosts(costs);
+					}
 
 					// Use costs.promptTokens as canonical value (includes image input
 					// tokens for providers that exclude them from upstream usage)

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -49,6 +49,7 @@ import {
 import {
 	buildEstimatedCompletionText,
 	calculateCosts,
+	capEstimatedCompletionTokensForModel,
 	isRefusalFinishReason,
 	shouldBillCancelledRequests,
 	zeroInferenceCosts,
@@ -8569,6 +8570,11 @@ chat.openapi(completions, async (c) => {
 				let completionTokens = null;
 				let totalTokens = null;
 				let reasoningTokens = null;
+				// True once the provider itself reports token usage. Tracked
+				// separately from the counts above because those get overwritten with
+				// our own estimates mid-stream, which would otherwise make an
+				// unreported stream look like a reported one.
+				let providerReportedUsage = false;
 				let cachedTokens = null;
 				let cacheCreationTokens: number | null = null;
 				let cacheCreation5mTokens: number | null = null;
@@ -9962,9 +9968,11 @@ chat.openapi(completions, async (c) => {
 								);
 								if (usage.promptTokens !== null) {
 									promptTokens = usage.promptTokens;
+									providerReportedUsage = true;
 								}
 								if (usage.completionTokens !== null) {
 									completionTokens = usage.completionTokens;
+									providerReportedUsage = true;
 								}
 								if (usage.totalTokens !== null) {
 									totalTokens = usage.totalTokens;
@@ -10242,7 +10250,17 @@ chat.openapi(completions, async (c) => {
 								const textTokens = estimateTokensFromContent(
 									estimatedCompletionText,
 								);
-								calculatedCompletionTokens = textTokens + imageTokens;
+								// Cap the guess at what the model can physically emit, so an
+								// over-accumulated stream cannot bill (or report) an
+								// impossible token count.
+								calculatedCompletionTokens =
+									capEstimatedCompletionTokensForModel(
+										textTokens + imageTokens,
+										usedInternalModel,
+										usedProvider,
+										usedRegion ?? null,
+										n ?? 1,
+									);
 							}
 						}
 
@@ -10921,13 +10939,11 @@ chat.openapi(completions, async (c) => {
 					// keeps the estimated token counts for analytics but is not billed.
 					// Failures where the provider *did* report usage stay billed: those
 					// counts are real and upstream charged us for them.
-					const upstreamReportedUsage =
-						(promptTokens ?? 0) > 0 || (completionTokens ?? 0) > 0;
 					if (
 						!canceled &&
 						(finishReason === "upstream_error" ||
 							finishReason === "gateway_error") &&
-						!upstreamReportedUsage &&
+						!providerReportedUsage &&
 						costs.totalCost !== null
 					) {
 						zeroInferenceCosts(costs);

--- a/apps/gateway/src/lib/costs.spec.ts
+++ b/apps/gateway/src/lib/costs.spec.ts
@@ -5,6 +5,7 @@ import { estimateTokensFromText } from "@llmgateway/shared";
 import {
 	buildEstimatedCompletionText,
 	calculateCosts,
+	capEstimatedCompletionTokensForModel,
 	isRefusalFinishReason,
 	shouldBillCancelledRequests,
 	zeroInferenceCosts,
@@ -1836,6 +1837,26 @@ describe("buildEstimatedCompletionText", () => {
 		expect(text).toContain("Berlin");
 	});
 
+	// Streaming arguments arrive as the raw JSON string the model emitted.
+	// Re-serialising it escapes every quote, newline and backslash a second
+	// time, so the estimate counted characters the model never produced.
+	it("does not re-escape arguments that are already a JSON string", () => {
+		const args = JSON.stringify({
+			patch: 'const x = "old";\nconst y = "new";\n'.repeat(50),
+		});
+
+		const text = buildEstimatedCompletionText("", [
+			{
+				id: "call_1",
+				type: "function",
+				function: { name: "edit", arguments: args },
+			},
+		]);
+
+		expect(text).toBe(`edit${args}`);
+		expect(text.length).toBeLessThan(`edit${JSON.stringify(args)}`.length);
+	});
+
 	// The streaming path logs the completion tokens it bills, so both sides must
 	// estimate over the same text: a tool-call-only stream that estimated over
 	// content alone logged zero completion tokens while still being charged for
@@ -1867,6 +1888,85 @@ describe("buildEstimatedCompletionText", () => {
 		);
 		expect(result.completionTokens).toBeGreaterThan(0);
 		expect(result.outputCost).toBeGreaterThan(0);
+	});
+});
+
+describe("capEstimatedCompletionTokensForModel", () => {
+	// gpt-4o-mini declares maxOutput 16384 on the openai mapping.
+	it("caps an estimate above the mapping's max output", () => {
+		expect(
+			capEstimatedCompletionTokensForModel(
+				5_000_000,
+				"gpt-4o-mini",
+				"openai",
+				null,
+				1,
+			),
+		).toBe(16384);
+	});
+
+	it("leaves an estimate within the ceiling untouched", () => {
+		expect(
+			capEstimatedCompletionTokensForModel(
+				1234,
+				"gpt-4o-mini",
+				"openai",
+				null,
+				1,
+			),
+		).toBe(1234);
+	});
+
+	it("scales the ceiling by the number of requested choices", () => {
+		expect(
+			capEstimatedCompletionTokensForModel(
+				5_000_000,
+				"gpt-4o-mini",
+				"openai",
+				null,
+				3,
+			),
+		).toBe(16384 * 3);
+	});
+
+	it("leaves the estimate alone for an unknown model", () => {
+		expect(
+			capEstimatedCompletionTokensForModel(
+				5_000_000,
+				"nope",
+				"openai",
+				null,
+				1,
+			),
+		).toBe(5_000_000);
+	});
+
+	// A provider-reported count is ground truth, so only estimates are capped.
+	it("does not cap provider-reported completion tokens", async () => {
+		const result = await calculateCosts(
+			"gpt-4o-mini",
+			"openai",
+			null,
+			100,
+			5_000_000,
+			null,
+		);
+
+		expect(result.completionTokens).toBe(5_000_000);
+	});
+
+	it("caps the completion tokens it estimates itself", async () => {
+		const result = await calculateCosts(
+			"gpt-4o-mini",
+			"openai",
+			null,
+			100,
+			null,
+			null,
+			{ prompt: "hi", completion: "x".repeat(40_000_000) },
+		);
+
+		expect(result.completionTokens).toBe(16384);
 	});
 });
 

--- a/apps/gateway/src/lib/costs.spec.ts
+++ b/apps/gateway/src/lib/costs.spec.ts
@@ -5,7 +5,6 @@ import { estimateTokensFromText } from "@llmgateway/shared";
 import {
 	buildEstimatedCompletionText,
 	calculateCosts,
-	capEstimatedCompletionTokensForModel,
 	isRefusalFinishReason,
 	shouldBillCancelledRequests,
 	zeroInferenceCosts,
@@ -1888,85 +1887,6 @@ describe("buildEstimatedCompletionText", () => {
 		);
 		expect(result.completionTokens).toBeGreaterThan(0);
 		expect(result.outputCost).toBeGreaterThan(0);
-	});
-});
-
-describe("capEstimatedCompletionTokensForModel", () => {
-	// gpt-4o-mini declares maxOutput 16384 on the openai mapping.
-	it("caps an estimate above the mapping's max output", () => {
-		expect(
-			capEstimatedCompletionTokensForModel(
-				5_000_000,
-				"gpt-4o-mini",
-				"openai",
-				null,
-				1,
-			),
-		).toBe(16384);
-	});
-
-	it("leaves an estimate within the ceiling untouched", () => {
-		expect(
-			capEstimatedCompletionTokensForModel(
-				1234,
-				"gpt-4o-mini",
-				"openai",
-				null,
-				1,
-			),
-		).toBe(1234);
-	});
-
-	it("scales the ceiling by the number of requested choices", () => {
-		expect(
-			capEstimatedCompletionTokensForModel(
-				5_000_000,
-				"gpt-4o-mini",
-				"openai",
-				null,
-				3,
-			),
-		).toBe(16384 * 3);
-	});
-
-	it("leaves the estimate alone for an unknown model", () => {
-		expect(
-			capEstimatedCompletionTokensForModel(
-				5_000_000,
-				"nope",
-				"openai",
-				null,
-				1,
-			),
-		).toBe(5_000_000);
-	});
-
-	// A provider-reported count is ground truth, so only estimates are capped.
-	it("does not cap provider-reported completion tokens", async () => {
-		const result = await calculateCosts(
-			"gpt-4o-mini",
-			"openai",
-			null,
-			100,
-			5_000_000,
-			null,
-		);
-
-		expect(result.completionTokens).toBe(5_000_000);
-	});
-
-	it("caps the completion tokens it estimates itself", async () => {
-		const result = await calculateCosts(
-			"gpt-4o-mini",
-			"openai",
-			null,
-			100,
-			null,
-			null,
-			{ prompt: "hi", completion: "x".repeat(40_000_000) },
-		);
-
-		expect(result.completionTokens).toBe(16384);
 	});
 });
 

--- a/apps/gateway/src/lib/costs.spec.ts
+++ b/apps/gateway/src/lib/costs.spec.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { estimateTokensFromText } from "@llmgateway/shared";
+
 import {
+	buildEstimatedCompletionText,
 	calculateCosts,
 	isRefusalFinishReason,
 	shouldBillCancelledRequests,
@@ -1810,6 +1813,60 @@ describe("zeroInferenceCosts", () => {
 		expect(costs.totalCost).toBe(0);
 		// Storage retention is billed separately from inference.
 		expect(costs.dataStorageCost).toBe(0.01);
+	});
+});
+
+describe("buildEstimatedCompletionText", () => {
+	it("returns the assistant text when there are no tool calls", () => {
+		expect(buildEstimatedCompletionText("hello there", null)).toBe(
+			"hello there",
+		);
+	});
+
+	it("includes tool call names and arguments", () => {
+		const text = buildEstimatedCompletionText("", [
+			{
+				id: "call_1",
+				type: "function",
+				function: { name: "get_weather", arguments: '{"city":"Berlin"}' },
+			},
+		]);
+
+		expect(text).toContain("get_weather");
+		expect(text).toContain("Berlin");
+	});
+
+	// The streaming path logs the completion tokens it bills, so both sides must
+	// estimate over the same text: a tool-call-only stream that estimated over
+	// content alone logged zero completion tokens while still being charged for
+	// the tool-call payload.
+	it("matches the completion tokens calculateCosts estimates", async () => {
+		const toolResults = [
+			{
+				id: "call_1",
+				type: "function" as const,
+				function: {
+					name: "apply_patch",
+					arguments: JSON.stringify({ patch: "x".repeat(4000) }),
+				},
+			},
+		];
+
+		const result = await calculateCosts(
+			"gpt-4",
+			"openai",
+			null,
+			100,
+			null,
+			null,
+			{ prompt: "do the thing", completion: "", toolResults },
+		);
+
+		expect(result.completionTokens).toBe(
+			estimateTokensFromText(buildEstimatedCompletionText("", toolResults)),
+		);
+		expect(result.completionTokens).toBeGreaterThan(0);
+		expect(result.outputCost).toBeGreaterThan(0);
 	});
 });
 

--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -4,6 +4,7 @@ import { estimateTokensFromContent } from "@/chat/tools/estimate-tokens-from-con
 import { encodeChatMessages } from "@/chat/tools/tokenizer.js";
 
 import { getEffectiveDiscount } from "@llmgateway/db";
+import { logger } from "@llmgateway/logger";
 import {
 	type ModelDefinition,
 	type ProviderModelMapping,
@@ -129,13 +130,124 @@ export function buildEstimatedCompletionText(
 			if (toolResult?.function?.name) {
 				completionText += toolResult.function.name;
 			}
-			if (toolResult?.function?.arguments) {
-				completionText += JSON.stringify(toolResult.function.arguments);
+			const args = toolResult?.function?.arguments;
+			if (args) {
+				// Streaming arguments are accumulated as the raw JSON string the
+				// model emitted. Re-serialising that string escapes every quote,
+				// newline and backslash a second time, inflating the character
+				// count (and so the estimate) above what the model actually
+				// produced, so only serialise when it is not already text.
+				completionText +=
+					typeof args === "string" ? args : JSON.stringify(args);
 			}
 		}
 	}
 
 	return completionText;
+}
+
+/**
+ * Resolve the provider mapping used for pricing, keyed by providerId + region.
+ * Region matters when a single root model id has multiple per-region entries
+ * with different prices (see `regions:` on ProviderModelMapping);
+ * expandAllProviderRegions flattens those into one mapping per region.
+ *
+ * For regionalized providers we MUST match the exact region — falling back to
+ * the non-regional/base entry would bill at the default rate even when the
+ * caller named a region that doesn't exist on this provider, which silently
+ * masks the misroute. Only fall back to the non-regional entry when the
+ * provider has no regional variants at all.
+ */
+export function findPricingProviderMapping(
+	modelInfo: ModelDefinition | undefined,
+	provider: string,
+	region: string | null,
+): ProviderModelMapping | undefined {
+	if (!modelInfo) {
+		return undefined;
+	}
+
+	const expandedProviders = expandAllProviderRegions(
+		modelInfo.providers as ProviderModelMapping[],
+	);
+	const providerEntries = expandedProviders.filter(
+		(p) => p.providerId === provider,
+	);
+	const isBaseEntry = (p: ProviderModelMapping) =>
+		p.region === undefined || p.region === null;
+
+	if (region === null) {
+		return providerEntries.find(isBaseEntry) ?? providerEntries[0];
+	}
+
+	const regionalMatch = providerEntries.find((p) => p.region === region);
+	if (regionalMatch) {
+		return regionalMatch;
+	}
+	// Region was requested but doesn't match any regional variant. For a
+	// regionalized provider, bail out rather than billing at the base rate.
+	return providerEntries.some((p) => !isBaseEntry(p))
+		? undefined
+		: providerEntries.find(isBaseEntry);
+}
+
+/**
+ * Clamp an estimated completion-token count to what the provider mapping can
+ * physically emit (`maxOutput`, times the number of requested choices).
+ *
+ * Our estimate is a chars/4 guess over whatever text and tool-call arguments we
+ * managed to accumulate, and nothing else bounds it: a truncated or
+ * mis-accumulated stream can yield a count many times the model's ceiling and
+ * bill it at full price. A count above `maxOutput` is impossible by definition,
+ * so it is capped and logged rather than charged. Mappings without a declared
+ * `maxOutput` are left alone.
+ */
+export function capEstimatedCompletionTokens(
+	estimatedTokens: number,
+	providerMapping: ProviderModelMapping | undefined,
+	choiceCount: number,
+	context: { model: string; provider: string },
+): number {
+	const maxOutput = providerMapping?.maxOutput;
+	if (!maxOutput || maxOutput <= 0) {
+		return estimatedTokens;
+	}
+
+	const cap = maxOutput * Math.max(1, choiceCount);
+	if (estimatedTokens <= cap) {
+		return estimatedTokens;
+	}
+
+	logger.warn("Estimated completion tokens exceed the model's max output", {
+		model: context.model,
+		provider: context.provider,
+		estimatedTokens,
+		cap,
+		maxOutput,
+		choiceCount,
+	});
+	return cap;
+}
+
+/**
+ * {@link capEstimatedCompletionTokens} for callers that have the model id
+ * rather than a resolved provider mapping.
+ */
+export function capEstimatedCompletionTokensForModel(
+	estimatedTokens: number,
+	model: string,
+	provider: string,
+	region: string | null,
+	choiceCount: number,
+): number {
+	const modelInfo = models.find((m) => m.id === model) as
+		ModelDefinition | undefined;
+	return capEstimatedCompletionTokens(
+		estimatedTokens,
+		findPricingProviderMapping(modelInfo, provider, region),
+		choiceCount,
+		{ model, provider },
+	);
 }
 
 /**
@@ -406,35 +518,20 @@ export async function calculateCosts(
 	// Set completion tokens to 0 if not available (but still calculate input costs)
 	calculatedCompletionTokens ??= 0;
 
-	// Find the provider-specific pricing, keyed by providerId + region.
-	// Region matters when a single root model id has multiple per-region
-	// entries with different prices (see `regions:` on ProviderModelMapping);
-	// expandAllProviderRegions flattens those into one mapping per region.
-	//
-	// For regionalized providers we MUST match the exact region — falling back
-	// to the non-regional/base entry would bill at the default rate even when
-	// the caller named a region that doesn't exist on this provider, which
-	// silently masks the misroute. Only fall back to the non-regional entry
-	// when the provider has no regional variants at all.
-	const expandedProviders = expandAllProviderRegions(
-		modelInfo.providers as ProviderModelMapping[],
-	);
-	const providerEntries = expandedProviders.filter(
-		(p) => p.providerId === provider,
-	);
-	const isBaseEntry = (p: (typeof providerEntries)[number]) =>
-		p.region === undefined || p.region === null;
-	const hasRegionalEntries = providerEntries.some((p) => !isBaseEntry(p));
-	let providerInfo: (typeof providerEntries)[number] | undefined;
-	if (region !== null) {
-		providerInfo = providerEntries.find((p) => p.region === region);
-		// Region was requested but doesn't match any regional variant. For a
-		// regionalized provider, bail out rather than billing at the base rate.
-		if (!providerInfo && !hasRegionalEntries) {
-			providerInfo = providerEntries.find(isBaseEntry);
-		}
-	} else {
-		providerInfo = providerEntries.find(isBaseEntry) ?? providerEntries[0];
+	const providerInfo = findPricingProviderMapping(modelInfo, provider, region);
+
+	// An estimate is only ever a guess about how many tokens the model emitted,
+	// and the model cannot have emitted more than the mapping allows, so cap it
+	// before it becomes money. Only applies when we estimated the count
+	// ourselves — a provider-reported count is ground truth even if it exceeds
+	// our catalogue's `maxOutput`.
+	if (!completionTokens) {
+		calculatedCompletionTokens = capEstimatedCompletionTokens(
+			calculatedCompletionTokens,
+			providerInfo,
+			1,
+			{ model, provider },
+		);
 	}
 
 	if (!providerInfo) {

--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -4,7 +4,6 @@ import { estimateTokensFromContent } from "@/chat/tools/estimate-tokens-from-con
 import { encodeChatMessages } from "@/chat/tools/tokenizer.js";
 
 import { getEffectiveDiscount } from "@llmgateway/db";
-import { logger } from "@llmgateway/logger";
 import {
 	type ModelDefinition,
 	type ProviderModelMapping,
@@ -144,110 +143,6 @@ export function buildEstimatedCompletionText(
 	}
 
 	return completionText;
-}
-
-/**
- * Resolve the provider mapping used for pricing, keyed by providerId + region.
- * Region matters when a single root model id has multiple per-region entries
- * with different prices (see `regions:` on ProviderModelMapping);
- * expandAllProviderRegions flattens those into one mapping per region.
- *
- * For regionalized providers we MUST match the exact region — falling back to
- * the non-regional/base entry would bill at the default rate even when the
- * caller named a region that doesn't exist on this provider, which silently
- * masks the misroute. Only fall back to the non-regional entry when the
- * provider has no regional variants at all.
- */
-export function findPricingProviderMapping(
-	modelInfo: ModelDefinition | undefined,
-	provider: string,
-	region: string | null,
-): ProviderModelMapping | undefined {
-	if (!modelInfo) {
-		return undefined;
-	}
-
-	const expandedProviders = expandAllProviderRegions(
-		modelInfo.providers as ProviderModelMapping[],
-	);
-	const providerEntries = expandedProviders.filter(
-		(p) => p.providerId === provider,
-	);
-	const isBaseEntry = (p: ProviderModelMapping) =>
-		p.region === undefined || p.region === null;
-
-	if (region === null) {
-		return providerEntries.find(isBaseEntry) ?? providerEntries[0];
-	}
-
-	const regionalMatch = providerEntries.find((p) => p.region === region);
-	if (regionalMatch) {
-		return regionalMatch;
-	}
-	// Region was requested but doesn't match any regional variant. For a
-	// regionalized provider, bail out rather than billing at the base rate.
-	return providerEntries.some((p) => !isBaseEntry(p))
-		? undefined
-		: providerEntries.find(isBaseEntry);
-}
-
-/**
- * Clamp an estimated completion-token count to what the provider mapping can
- * physically emit (`maxOutput`, times the number of requested choices).
- *
- * Our estimate is a chars/4 guess over whatever text and tool-call arguments we
- * managed to accumulate, and nothing else bounds it: a truncated or
- * mis-accumulated stream can yield a count many times the model's ceiling and
- * bill it at full price. A count above `maxOutput` is impossible by definition,
- * so it is capped and logged rather than charged. Mappings without a declared
- * `maxOutput` are left alone.
- */
-export function capEstimatedCompletionTokens(
-	estimatedTokens: number,
-	providerMapping: ProviderModelMapping | undefined,
-	choiceCount: number,
-	context: { model: string; provider: string },
-): number {
-	const maxOutput = providerMapping?.maxOutput;
-	if (!maxOutput || maxOutput <= 0) {
-		return estimatedTokens;
-	}
-
-	const cap = maxOutput * Math.max(1, choiceCount);
-	if (estimatedTokens <= cap) {
-		return estimatedTokens;
-	}
-
-	logger.warn("Estimated completion tokens exceed the model's max output", {
-		model: context.model,
-		provider: context.provider,
-		estimatedTokens,
-		cap,
-		maxOutput,
-		choiceCount,
-	});
-	return cap;
-}
-
-/**
- * {@link capEstimatedCompletionTokens} for callers that have the model id
- * rather than a resolved provider mapping.
- */
-export function capEstimatedCompletionTokensForModel(
-	estimatedTokens: number,
-	model: string,
-	provider: string,
-	region: string | null,
-	choiceCount: number,
-): number {
-	const modelInfo = models.find((m) => m.id === model) as
-		ModelDefinition | undefined;
-	return capEstimatedCompletionTokens(
-		estimatedTokens,
-		findPricingProviderMapping(modelInfo, provider, region),
-		choiceCount,
-		{ model, provider },
-	);
 }
 
 /**
@@ -518,20 +413,35 @@ export async function calculateCosts(
 	// Set completion tokens to 0 if not available (but still calculate input costs)
 	calculatedCompletionTokens ??= 0;
 
-	const providerInfo = findPricingProviderMapping(modelInfo, provider, region);
-
-	// An estimate is only ever a guess about how many tokens the model emitted,
-	// and the model cannot have emitted more than the mapping allows, so cap it
-	// before it becomes money. Only applies when we estimated the count
-	// ourselves — a provider-reported count is ground truth even if it exceeds
-	// our catalogue's `maxOutput`.
-	if (!completionTokens) {
-		calculatedCompletionTokens = capEstimatedCompletionTokens(
-			calculatedCompletionTokens,
-			providerInfo,
-			1,
-			{ model, provider },
-		);
+	// Find the provider-specific pricing, keyed by providerId + region.
+	// Region matters when a single root model id has multiple per-region
+	// entries with different prices (see `regions:` on ProviderModelMapping);
+	// expandAllProviderRegions flattens those into one mapping per region.
+	//
+	// For regionalized providers we MUST match the exact region — falling back
+	// to the non-regional/base entry would bill at the default rate even when
+	// the caller named a region that doesn't exist on this provider, which
+	// silently masks the misroute. Only fall back to the non-regional entry
+	// when the provider has no regional variants at all.
+	const expandedProviders = expandAllProviderRegions(
+		modelInfo.providers as ProviderModelMapping[],
+	);
+	const providerEntries = expandedProviders.filter(
+		(p) => p.providerId === provider,
+	);
+	const isBaseEntry = (p: (typeof providerEntries)[number]) =>
+		p.region === undefined || p.region === null;
+	const hasRegionalEntries = providerEntries.some((p) => !isBaseEntry(p));
+	let providerInfo: (typeof providerEntries)[number] | undefined;
+	if (region !== null) {
+		providerInfo = providerEntries.find((p) => p.region === region);
+		// Region was requested but doesn't match any regional variant. For a
+		// regionalized provider, bail out rather than billing at the base rate.
+		if (!providerInfo && !hasRegionalEntries) {
+			providerInfo = providerEntries.find(isBaseEntry);
+		}
+	} else {
+		providerInfo = providerEntries.find(isBaseEntry) ?? providerEntries[0];
 	}
 
 	if (!providerInfo) {

--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -110,6 +110,35 @@ export function zeroInferenceCosts(costs: MutableInferenceCosts): void {
 }
 
 /**
+ * Build the text used to estimate completion tokens when the provider did not
+ * report them: the assistant's text plus every tool call's name and arguments.
+ *
+ * Exported so the streaming path can log the same completion-token count it is
+ * billed for. A stream that emits only tool calls has no assistant text at all,
+ * so estimating from content alone logs zero completion tokens while pricing
+ * still charges for the tool-call payload — a bill with no tokens behind it.
+ */
+export function buildEstimatedCompletionText(
+	completion: string | null | undefined,
+	toolResults: ToolCall[] | null | undefined,
+): string {
+	let completionText = completion ?? "";
+
+	if (toolResults && Array.isArray(toolResults)) {
+		for (const toolResult of toolResults) {
+			if (toolResult?.function?.name) {
+				completionText += toolResult.function.name;
+			}
+			if (toolResult?.function?.arguments) {
+				completionText += JSON.stringify(toolResult.function.arguments);
+			}
+		}
+	}
+
+	return completionText;
+}
+
+/**
  * Check if billing for cancelled requests is enabled via environment variable.
  * Defaults to true if not set: a cancelled streaming request has already
  * consumed upstream inference (prompt tokens, plus any completion tokens
@@ -335,24 +364,10 @@ export async function calculateCosts(
 
 		// Calculate completion tokens
 		if (!completionTokens && fullOutput) {
-			let completionText = "";
-
-			// Include main completion content
-			if (fullOutput.completion) {
-				completionText += fullOutput.completion;
-			}
-
-			// Include tool results if available
-			if (fullOutput.toolResults && Array.isArray(fullOutput.toolResults)) {
-				for (const toolResult of fullOutput.toolResults) {
-					if (toolResult?.function?.name) {
-						completionText += toolResult.function.name;
-					}
-					if (toolResult?.function?.arguments) {
-						completionText += JSON.stringify(toolResult.function.arguments);
-					}
-				}
-			}
+			const completionText = buildEstimatedCompletionText(
+				fullOutput.completion,
+				fullOutput.toolResults,
+			);
 
 			if (completionText) {
 				calculatedCompletionTokens = estimateTokensFromContent(completionText);


### PR DESCRIPTION
## Summary

A streaming request that ended in `upstream_error` was billed $23.17. The upstream died before a terminal event, so the gateway synthesized a 502 and logged `finishReason: upstream_error` — but the streaming `finally` block still priced the request. Since the provider never reported usage, every token count on that log was the gateway's own `chars/4` estimate over a truncated payload.

## Changes

**Don't bill unreported failures** (`chat.ts`) — zero the inference costs when a stream ends in `upstream_error`/`gateway_error` and the provider reported no usage. Estimated counts stay on the log for analytics. Failures where the provider *did* report usage stay billed: those counts are real and upstream charged us for them.

**Track provider-reported usage explicitly** (`chat.ts`) — `promptTokens`/`completionTokens` get overwritten with the gateway's own estimates mid-stream once a finish reason arrives, which would make an unreported stream look reported and defeat the check above.

**Count tool calls in the streaming estimate** (`chat.ts`) — pricing already estimated over tool-call names and arguments while the log did not, so a stream that emitted only tool calls (exactly this request) recorded zero completion tokens yet was billed for the whole payload. Both sides now share `buildEstimatedCompletionText`. Billing amounts are unchanged; the logged count now matches what is charged.

**Stop double-escaping tool-call arguments** (`costs.ts`) — streaming arguments are accumulated as the raw JSON string the model emitted, and `JSON.stringify` re-escaped every quote, newline and backslash. Measured at ~1.14x inflation on a representative patch payload.

## Not fixed here

The failed request's output cost implies ~1.54M estimated completion tokens against a mapping that declares `maxOutput: 128000`. An earlier revision of this PR capped estimates at `maxOutput`; that was reverted, since it bounded the symptom without addressing the accumulation path that produced an impossible count. Not billing unreported failures is the scope for now.

Investigated and ruled out as the cause:
- **Input-side / base64 inflation.** `estimateChatMessageTokens` counts only `part.text`; image parts contribute either nothing or a fixed per-image count, so inline base64 never enters as prompt text. The Responses API converter maps `input_image` to an `image_url` part, which is classified as an image part. `convertImagesToBase64` operates on response images, not request messages.
- **Content leakage in the OpenAI Responses transformer.** `response.output_item.done` and the unrecognized-event default both emit empty deltas; no path routes payload data into `delta.content` or `delta.tool_calls`.
- **SSE re-processing.** The buffer scan advances `processedLength` on every path including JSON-parse failures, `transformedData` is a fresh `const` per event, and the tool-call merge loop accumulates linearly.

Arithmetic pins the overcount to the output side regardless of mechanism: `outputCost / inputCost = 380.00` exactly, and since both carry the same discount and service-tier multiplier that factor cancels, giving 63.33 × the prompt count = 1,540,829 estimated output tokens against a 24,329-token prompt.

## Tests

- `api.spec.ts`: truncated upstream stream against a priced model asserts zero cost with usage still recorded. Verified it fails without the guard (`expected 0.00002385 to be +0`).
- `costs.spec.ts`: arguments already serialized are not re-escaped; the streaming estimate matches what `calculateCosts` bills.
- 73 spec files / 1568 tests pass, full `pnpm build` clean.

https://claude.ai/code/session_0152oF2VpDbhVV8KLNCGXU39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage tracking for streaming responses that end unexpectedly.
  * Prevented failed or truncated upstream streams from generating inference charges when provider usage is unavailable.
  * Improved completion-token estimates for tool-only responses, including tool names and arguments.

* **Analytics**
  * Preserved estimated token data when provider usage details are unavailable.

* **Tests**
  * Added coverage for truncated streams, tool-call estimation, and zero-cost errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->