### PR TITLE
fix(devpass): keep billing usable after plan ends

### DIFF
--- a/apps/api/src/routes/dev-plans.spec.ts
+++ b/apps/api/src/routes/dev-plans.spec.ts
@@ -1186,4 +1186,36 @@ describe("dev plan status billing history", () => {
 
 		expect(await getStatus()).toMatchObject({ hasBillingHistory: false });
 	});
+
+	it("counts legacy pre-rename subscription rows", async () => {
+		// Dev plans were billed as `subscription_*` before the DevPass rename; on
+		// a devpass-kind org those rows are a past DevPass subscriber.
+		await db.insert(tables.transaction).values({
+			organizationId: ORG_ID,
+			type: "subscription_start",
+			amount: "50",
+			currency: "USD",
+			status: "completed",
+		});
+		await db
+			.update(tables.organization)
+			.set({ devPlan: "none", devPlanStripeSubscriptionId: null })
+			.where(eq(tables.organization.id, ORG_ID));
+
+		expect(await getStatus()).toMatchObject({ hasBillingHistory: true });
+	});
+
+	it("counts an unsettled charge, matching the invoice list", async () => {
+		// The invoices endpoint renders pending and failed charges too (with a
+		// status badge), so the page has content to show and must stay reachable.
+		await db.insert(tables.transaction).values({
+			organizationId: ORG_ID,
+			type: "dev_plan_start",
+			amount: "29",
+			currency: "USD",
+			status: "failed",
+		});
+
+		expect(await getStatus()).toMatchObject({ hasBillingHistory: true });
+	});
 });

--- a/apps/api/src/routes/dev-plans.spec.ts
+++ b/apps/api/src/routes/dev-plans.spec.ts
@@ -1100,3 +1100,90 @@ describe("dev plan tier changes", () => {
 		expect(stripeMock.subscriptions.update).not.toHaveBeenCalled();
 	});
 });
+
+describe("dev plan status billing history", () => {
+	let token: string;
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		token = await createTestUser();
+
+		await db.insert(tables.organization).values({
+			id: ORG_ID,
+			name: "Personal Org",
+			billingEmail: "admin@example.com",
+			kind: "devpass",
+			devPlan: "lite",
+			devPlanStripeSubscriptionId: SUBSCRIPTION_ID,
+		});
+		await db.insert(tables.userOrganization).values({
+			userId: "test-user-id",
+			organizationId: ORG_ID,
+			role: "owner",
+		});
+	});
+
+	afterEach(async () => {
+		await db.delete(tables.transaction);
+		await deleteAll();
+	});
+
+	async function getStatus() {
+		const res = await app.request("/dev-plans/status", {
+			headers: { Cookie: token },
+		});
+		expect(res.status).toBe(200);
+		return await res.json();
+	}
+
+	it("reports no billing history before the first charge", async () => {
+		expect(await getStatus()).toMatchObject({
+			hasPersonalOrg: true,
+			hasBillingHistory: false,
+		});
+	});
+
+	it("reports billing history once a plan payment exists", async () => {
+		await db.insert(tables.transaction).values({
+			organizationId: ORG_ID,
+			type: "dev_plan_start",
+			amount: "29",
+			currency: "USD",
+			status: "completed",
+		});
+
+		expect(await getStatus()).toMatchObject({ hasBillingHistory: true });
+	});
+
+	it("keeps reporting billing history after the plan ends", async () => {
+		// Ending a plan clears every devPlan* column, so the invoices are the only
+		// remaining signal that this user still needs the billing page.
+		await db.insert(tables.transaction).values({
+			organizationId: ORG_ID,
+			type: "dev_plan_start",
+			amount: "29",
+			currency: "USD",
+			status: "completed",
+		});
+		await db
+			.update(tables.organization)
+			.set({ devPlan: "none", devPlanStripeSubscriptionId: null })
+			.where(eq(tables.organization.id, ORG_ID));
+
+		expect(await getStatus()).toMatchObject({
+			devPlan: "none",
+			hasBillingHistory: true,
+		});
+	});
+
+	it("ignores non-invoice bookkeeping rows", async () => {
+		await db.insert(tables.transaction).values({
+			organizationId: ORG_ID,
+			type: "dev_plan_cancel",
+			currency: "USD",
+			status: "completed",
+		});
+
+		expect(await getStatus()).toMatchObject({ hasBillingHistory: false });
+	});
+});

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -74,6 +74,14 @@ export const devPlans = new OpenAPIHono<ServerTypes>();
 // lease this old cannot still have an upgrade charge in flight.
 const STALE_TIER_CHANGE_CLAIM_MS = 15 * 60 * 1000;
 
+// Transaction types that surface as invoices on the DevPass billing page.
+const DEV_PLAN_INVOICE_TYPES = [
+	"dev_plan_start",
+	"dev_plan_renewal",
+	"dev_plan_upgrade",
+	"dev_plan_reset_pass",
+] as const;
+
 // A failed release is swallowed: the lease then simply expires via the
 // staleness window instead of blocking upgrades until renewal.
 async function releaseTierChangeLease(organizationId: string) {
@@ -1708,6 +1716,10 @@ const getStatus = createRoute({
 				"application/json": {
 					schema: z.object({
 						hasPersonalOrg: z.boolean(),
+						// Whether the org ever produced a DevPass invoice. Stays true
+						// after a plan ends, so the dashboard keeps showing billing to
+						// past subscribers (invoices, receipts, Reset Pass refunds).
+						hasBillingHistory: z.boolean(),
 						devPlan: z.enum(["none", "lite", "pro", "max"]),
 						devPlanPendingTier: z.enum(["lite", "pro", "max"]).nullable(),
 						devPlanCycle: z.enum(["monthly", "annual"]),
@@ -1773,6 +1785,7 @@ devPlans.openapi(getStatus, async (c) => {
 	if (!personalOrg) {
 		return c.json({
 			hasPersonalOrg: false,
+			hasBillingHistory: false,
 			devPlan: "none" as const,
 			devPlanPendingTier: null,
 			devPlanCycle: "monthly" as const,
@@ -1801,6 +1814,17 @@ devPlans.openapi(getStatus, async (c) => {
 	const creditsUsed = parseFloat(personalOrg.devPlanCreditsUsed);
 	const creditsLimit = parseFloat(personalOrg.devPlanCreditsLimit);
 	const creditsRemaining = Math.max(0, creditsLimit - creditsUsed);
+
+	// Ending a dev plan clears every devPlan* column on the org, so the billing
+	// transactions are the only lasting record that the user was ever a
+	// subscriber — and the dashboard needs it to keep the billing page reachable.
+	const billingTransaction = await db.query.transaction.findFirst({
+		where: {
+			organizationId: { eq: personalOrg.id },
+			type: { in: [...DEV_PLAN_INVOICE_TYPES] },
+		},
+		columns: { id: true },
+	});
 
 	// Weekly premium fair-use allowance, computed with the same helpers the
 	// gateway uses for enforcement. An expired window reports zero usage and no
@@ -1856,6 +1880,7 @@ devPlans.openapi(getStatus, async (c) => {
 
 	return c.json({
 		hasPersonalOrg: true,
+		hasBillingHistory: Boolean(billingTransaction),
 		devPlan: personalOrg.devPlan,
 		devPlanPendingTier: personalOrg.devPlanPendingTier,
 		devPlanCycle: personalOrg.devPlanCycle,
@@ -2329,12 +2354,7 @@ devPlans.openapi(getInvoices, async (c) => {
 
 	const invoices = transactions
 		.filter((t) =>
-			[
-				"dev_plan_start",
-				"dev_plan_renewal",
-				"dev_plan_upgrade",
-				"dev_plan_reset_pass",
-			].includes(t.type),
+			(DEV_PLAN_INVOICE_TYPES as readonly string[]).includes(t.type),
 		)
 		.map((t) => ({
 			id: t.id,

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -19,6 +19,7 @@ import {
 	isDevPlanCardDedupeEnforced,
 } from "@/stripe.js";
 import { findDefaultOrganization } from "@/utils/default-org.js";
+import { LEGACY_DEV_PLAN_TX_TYPES } from "@/utils/devpass-filter.js";
 import {
 	buildInvoiceDataForTransaction,
 	generateAndEmailInvoice,
@@ -1818,10 +1819,14 @@ devPlans.openapi(getStatus, async (c) => {
 	// Ending a dev plan clears every devPlan* column on the org, so the billing
 	// transactions are the only lasting record that the user was ever a
 	// subscriber — and the dashboard needs it to keep the billing page reachable.
+	// The legacy `subscription_*` rows predate the DevPass rename and mean a dev
+	// plan only on a devpass-kind org, which `personalOrg` always is. Status is
+	// deliberately not filtered: this mirrors the invoice list, which also
+	// renders pending and failed charges.
 	const billingTransaction = await db.query.transaction.findFirst({
 		where: {
 			organizationId: { eq: personalOrg.id },
-			type: { in: [...DEV_PLAN_INVOICE_TYPES] },
+			type: { in: [...DEV_PLAN_INVOICE_TYPES, ...LEGACY_DEV_PLAN_TX_TYPES] },
 		},
 		columns: { id: true },
 	});

--- a/apps/code/src/app/dashboard/(main)/billing/BillingClient.tsx
+++ b/apps/code/src/app/dashboard/(main)/billing/BillingClient.tsx
@@ -4,6 +4,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { format, formatDistanceToNowStrict } from "date-fns";
 import { Info, Loader2 } from "lucide-react";
 import dynamic from "next/dynamic";
+import Link from "next/link";
 import { usePostHog } from "posthog-js/react";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -262,7 +263,43 @@ export default function BillingClient({
 	}
 
 	const currentPlan = devPlanStatus.devPlan ?? null;
+	const hasActivePlan = currentPlan !== null && currentPlan !== "none";
 	const currentPlanData = plans.find((p) => p.tier === currentPlan);
+	// A plan that ended — or was refunded, which cancels immediately — clears the
+	// tier, but this page stays useful: invoices and receipts remain
+	// downloadable and an unused Reset Pass is still refundable. Everything that
+	// acts on a live subscription (payment method, tier changes, cancel/resume)
+	// is dropped, since those endpoints require one.
+	if (!hasActivePlan) {
+		return (
+			<div className="space-y-10">
+				<BillingHeader />
+
+				<div className="rounded-xl border bg-card p-6">
+					<div className="flex flex-wrap items-start justify-between gap-4">
+						<div>
+							<h2 className="font-semibold">No active plan</h2>
+							<p className="mt-1 text-sm text-muted-foreground">
+								{devPlanStatus.hasBillingHistory
+									? "Your DevPass subscription has ended. Your invoices and receipts stay available here."
+									: "You don't have a DevPass plan yet."}
+							</p>
+						</div>
+						<Button asChild size="sm">
+							<Link href="/dashboard">Choose a plan</Link>
+						</Button>
+					</div>
+				</div>
+
+				{/* Past invoices */}
+				<DevPassInvoices />
+
+				{/* Billing details (invoice details) */}
+				<DevPassBillingDetails />
+			</div>
+		);
+	}
+
 	const pendingTier = devPlanStatus.devPlanPendingTier ?? null;
 	const pendingPlanData = plans.find((p) => p.tier === pendingTier);
 	const cycle = devPlanStatus.devPlanCycle ?? "monthly";
@@ -314,12 +351,7 @@ export default function BillingClient({
 
 	return (
 		<div className="space-y-10">
-			<div>
-				<h1 className="text-lg font-semibold tracking-tight">Billing</h1>
-				<p className="mt-0.5 text-sm text-muted-foreground">
-					Manage your DevPass subscription and plan.
-				</p>
-			</div>
+			<BillingHeader />
 
 			{/* Current subscription summary */}
 			<div className="rounded-xl border bg-card p-6">
@@ -451,6 +483,17 @@ export default function BillingClient({
 
 			{/* Billing details (invoice details) */}
 			<DevPassBillingDetails />
+		</div>
+	);
+}
+
+function BillingHeader() {
+	return (
+		<div>
+			<h1 className="text-lg font-semibold tracking-tight">Billing</h1>
+			<p className="mt-0.5 text-sm text-muted-foreground">
+				Manage your DevPass subscription and plan.
+			</p>
 		</div>
 	);
 }

--- a/apps/code/src/app/dashboard/(main)/settings/page.tsx
+++ b/apps/code/src/app/dashboard/(main)/settings/page.tsx
@@ -43,10 +43,16 @@ export default function SettingsPage() {
 				</div>
 			</div>
 
-			<DevPlanSettings
-				devPlanServiceTier={devPlanStatus.devPlanServiceTier ?? "default"}
-				defaultRoutingStrategy={devPlanStatus.defaultRoutingStrategy ?? "auto"}
-			/>
+			{/* Routing and service-tier settings apply to the live plan only — the
+			    endpoint rejects updates once the subscription has ended. */}
+			{devPlanStatus.devPlan !== "none" && (
+				<DevPlanSettings
+					devPlanServiceTier={devPlanStatus.devPlanServiceTier ?? "default"}
+					defaultRoutingStrategy={
+						devPlanStatus.defaultRoutingStrategy ?? "auto"
+					}
+				/>
+			)}
 
 			<DeleteAccount />
 		</div>

--- a/apps/code/src/app/dashboard/DashboardShell.tsx
+++ b/apps/code/src/app/dashboard/DashboardShell.tsx
@@ -9,6 +9,7 @@ import {
 	Loader2,
 	LogOut,
 	Settings,
+	Sparkles,
 	Stamp,
 	UserRound,
 } from "lucide-react";
@@ -64,6 +65,15 @@ const navItems: Array<{ label: string; href: Route; icon: typeof BarChart3 }> =
 		{ label: "Profile", href: "/dashboard/profile" as Route, icon: UserRound },
 		{ label: "Settings", href: "/dashboard/settings" as Route, icon: Settings },
 	];
+
+// Pages that stay usable without an active plan: past invoices, receipts and
+// self-refunds, the public profile, and account settings all outlive the
+// subscription. Only the usage overview is replaced by the plan chooser.
+const planIndependentRoutes: string[] = [
+	"/dashboard/billing",
+	"/dashboard/profile",
+	"/dashboard/settings",
+];
 
 // Pages that live on the DevPass site but outside the dashboard shell, so
 // they're rendered in their own subtle nav section with a link-out marker.
@@ -442,7 +452,49 @@ export default function DashboardShell({
 
 	const hasActivePlan =
 		devPlanStatus?.devPlan && devPlanStatus.devPlan !== "none";
+	const isPlanIndependentRoute = planIndependentRoutes.includes(pathname);
+	// A plan that ended (or was refunded) clears the tier, but the user still
+	// needs billing: past invoices, receipts, unused Reset Pass refunds. Keep the
+	// full dashboard chrome for anyone who has ever been billed, and for the
+	// account pages themselves — brand-new visitors still land on the focused,
+	// full-width plan chooser.
+	const showDashboardChrome =
+		hasActivePlan ||
+		Boolean(devPlanStatus?.hasBillingHistory) ||
+		isPlanIndependentRoute;
 	const currentPlanName = devPlanStatus?.devPlan?.toUpperCase() ?? "";
+	// Without a plan the usage tab is the plan chooser, so label it as such.
+	const mainNavItems = hasActivePlan
+		? navItems
+		: navItems.map((item) =>
+				item.href === "/dashboard"
+					? { ...item, label: "Plans", icon: Sparkles }
+					: item,
+			);
+	const planChooser = (
+		<div className="space-y-10">
+			<div className="mx-auto max-w-md text-center pt-4">
+				<div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+					<Code className="h-6 w-6 text-muted-foreground" />
+				</div>
+				<h1 className="text-xl font-semibold mb-2">
+					{devPlanStatus?.hasBillingHistory
+						? "Choose a new Dev Plan"
+						: "Choose your Dev Plan"}
+				</h1>
+				<p className="text-sm text-muted-foreground leading-relaxed">
+					Pick a plan to get your API key and start coding with 200+ models.
+					Every dollar gives you 3x in usage.
+				</p>
+			</div>
+
+			<InactivePlanChooser
+				plans={plans}
+				subscribingTier={subscribingTier}
+				onSubscribe={handleSubscribe}
+			/>
+		</div>
+	);
 	const activeSetupActivationStatus =
 		setupActivationStatus ?? (setupSessionId ? "finalizing" : null);
 	const activeSetupActivationCopy = activeSetupActivationStatus
@@ -579,12 +631,12 @@ export default function DashboardShell({
 						<Skeleton className="h-32 w-full rounded-xl" />
 					</main>
 				</div>
-			) : hasActivePlan ? (
+			) : showDashboardChrome ? (
 				<div className="container mx-auto flex flex-col gap-8 px-4 py-8 lg:flex-row">
 					{/* Sidebar */}
 					<aside className="lg:w-56 lg:shrink-0">
 						<nav className="flex gap-1 overflow-x-auto lg:sticky lg:top-8 lg:flex-col lg:overflow-visible">
-							{navItems.map((item) => {
+							{mainNavItems.map((item) => {
 								const isActive = pathname === item.href;
 								const Icon = item.icon;
 								return (
@@ -623,31 +675,15 @@ export default function DashboardShell({
 						</nav>
 					</aside>
 
-					{/* Page content */}
-					<main className="min-w-0 flex-1">{children}</main>
+					{/* Page content — the usage overview needs a plan, the account and
+					    billing pages do not. */}
+					<main className="min-w-0 flex-1">
+						{hasActivePlan || isPlanIndependentRoute ? children : planChooser}
+					</main>
 				</div>
 			) : (
 				<main className="container mx-auto max-w-6xl px-4 py-8">
-					<div className="space-y-10">
-						<div className="mx-auto max-w-md text-center pt-4">
-							<div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
-								<Code className="h-6 w-6 text-muted-foreground" />
-							</div>
-							<h1 className="text-xl font-semibold mb-2">
-								Choose your Dev Plan
-							</h1>
-							<p className="text-sm text-muted-foreground leading-relaxed">
-								Pick a plan to get your API key and start coding with 200+
-								models. Every dollar gives you 3x in usage.
-							</p>
-						</div>
-
-						<InactivePlanChooser
-							plans={plans}
-							subscribingTier={subscribingTier}
-							onSubscribe={handleSubscribe}
-						/>
-					</div>
+					{planChooser}
 				</main>
 			)}
 		</div>


### PR DESCRIPTION
## Problem

When a DevPass subscription ends, the Stripe `subscription.deleted` handler resets every `devPlan*` column on the org, including `devPlan: "none"`. The dashboard shell gated on exactly that (`hasActivePlan`) and replaced **all** page content with the plan chooser — so a past subscriber could no longer reach:

- past invoices and their PDF receipts
- self-refunds (an unused Reset Pass stays refundable for 7 days after the plan is gone)
- billing details used on those invoices
- account settings / delete account

A self-refund made it sharper: refunding a plan payment cancels the subscription immediately, so the user was bounced off the very page they had just used.

## Approach

- **Shell** (`DashboardShell`): keep the sidebar chrome for anyone who has ever been billed, and for the billing/profile/settings routes themselves. Only the usage overview is swapped for the plan chooser, which now renders inside the content area with the nav item relabelled "Plans". Brand-new visitors (no plan, no billing history) still land on the focused, full-width chooser, so the signup funnel is unchanged.
- **Billing page**: renders a "No active plan" state that drops everything requiring a live subscription (payment method, tier changes, cancel/resume — those endpoints reject an inactive plan) and keeps invoices and billing details.
- **Settings page**: hides the routing / service-tier section, whose `PATCH /dev-plans/settings` returns 400 without an active plan. Account details and delete-account stay.
- **API**: `/dev-plans/status` gains `hasBillingHistory`. Ending a plan clears every `devPlan*` column, so the billing transactions are the only lasting record that the user was ever a subscriber — one indexed `findFirst` on `transaction`.

Two deliberate calls on how `hasBillingHistory` is defined, both raised in review:

- It matches `DEV_PLAN_INVOICE_TYPES` **plus** `LEGACY_DEV_PLAN_TX_TYPES`. Dev plans were billed as `subscription_*` before the DevPass rename, and admin revenue still counts those rows on devpass-kind orgs as DevPass revenue; the query is already scoped to the devpass personal org, which is the pairing that constant requires.
- Transaction status is **not** filtered. Every dev-plan invoice row is written `completed` today, and `GET /dev-plans/invoices` renders pending/failed charges with a status badge — so filtering here would hide a page that has content. `hasBillingHistory` answers "does the billing page have something to show", so it mirrors the invoice list.

Refund eligibility itself is unchanged: plan payments correctly report `plan_inactive` once the subscription is gone (there is nothing left to cancel), while unused Reset Passes remain refundable, which is exactly why the page has to stay reachable.

## Verification

- New specs in `apps/api/src/routes/dev-plans.spec.ts` cover `hasBillingHistory`: false before the first charge, true after a plan payment, still true after the plan ends, true for a legacy `subscription_start` row and for an unsettled charge, and unaffected by non-invoice bookkeeping rows (`dev_plan_cancel`). Full file: 26 passed.
- `pnpm format`, `pnpm lint`, `pnpm build` all clean.
- Driven locally against a seeded DevPass org with `devPlan` forced to `none`:

**Billing after the plan ended — invoices, receipts and refunds still reachable**

<img width="1440" alt="Billing page with no active plan: sidebar intact, No active plan card, invoices with Invoice/Refund actions, billing details" src="https://raw.githubusercontent.com/theopenco/llmgateway/99a564a2f20e8f3975d24eb127b995b18c80a259/billing-ended.png" />

**Usage tab becomes the plan chooser, nav still exposes Billing**

<img width="1440" alt="Dashboard with no active plan: sidebar shows Plans/Billing/Profile/Settings with the plan chooser in the content area" src="https://raw.githubusercontent.com/theopenco/llmgateway/99a564a2f20e8f3975d24eb127b995b18c80a259/dashboard-ended.png" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)