### PR TITLE
chore(models): update scx-ai-gp GLM-5.2 pricing

### DIFF
--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -185,9 +185,9 @@ export const zaiModels = [
 			{
 				providerId: "scx-ai-gp",
 				externalId: "GLM-5.2",
-				inputPrice: "0.822e-6",
-				cachedInputPrice: "0.206e-6",
-				outputPrice: "2.888e-6",
+				inputPrice: "0.55e-6",
+				cachedInputPrice: "0.1375e-6",
+				outputPrice: "1.9255e-6",
 				requestPrice: "0",
 				contextSize: 1000000,
 				// SCX rejects max_tokens above 131072 ("expected a value <= 131072"),


### PR DESCRIPTION
## Problem

The `scx-ai-gp` provider mapping for `glm-5.2` carried the pricing it was originally onboarded with. SCX's general-purpose deployment now bills GLM-5.2 at lower rates, so the catalogue over-charges every request routed through that mapping.

## Change

Updates the three per-token prices on the `scx-ai-gp` mapping of `glm-5.2` in `packages/models/src/models/zai.ts`:

| Field | Before | After |
| --- | --- | --- |
| `inputPrice` | `0.822e-6` ($0.822/M) | `0.55e-6` ($0.55/M) |
| `cachedInputPrice` | `0.206e-6` ($0.206/M) | `0.1375e-6` ($0.1375/M) |
| `outputPrice` | `2.888e-6` ($2.888/M) | `1.9255e-6` ($1.9255/M) |

Nothing else on the mapping changes — `requestPrice`, `contextSize`, the `maxOutput: 131072` cap (and the comment explaining why it is below the advertised ceiling), quantization, and capability flags are all untouched. No other provider mapping for `glm-5.2` is affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Reduced pricing for GLM-5.2 input, cached-input, and output usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->