### PR TITLE
fix(actions): surface image size limit errors instead of the generic message

### DIFF
--- a/packages/actions/src/process-image-url.spec.ts
+++ b/packages/actions/src/process-image-url.spec.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ImageSizeLimitError, processImageUrl } from "./process-image-url.js";
+
+const MAX_SIZE_MB = 1;
+const REMOTE_URL = "https://example.com/huge.png";
+
+function imageResponseWithContentLength(bytes: number): Response {
+	return new Response(new Uint8Array(0), {
+		headers: {
+			"content-type": "image/png",
+			"content-length": String(bytes),
+		},
+	});
+}
+
+function imageResponseWithBody(bytes: number): Response {
+	// A stream body carries no Content-Length, so the pre-check is skipped and
+	// the post-download size check is the one that rejects.
+	const stream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(new Uint8Array(bytes));
+			controller.close();
+		},
+	});
+	return new Response(stream, { headers: { "content-type": "image/png" } });
+}
+
+// The SSRF guard is a no-op under vitest (the global setup sets
+// ALLOW_INSECURE_PROVIDER_URLS), so these exercise the default validateSsrf
+// path without DNS or network access.
+describe("processImageUrl size limits", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	// The catch block used to sniff for "Image size exceeds", which the generated
+	// message ("Image size (32.0MB) exceeds your current limit of 1MB.") never
+	// contains, so every remote-URL size rejection surfaced as the generic
+	// "Failed to process image from URL" and users were never told why.
+	it("surfaces the size message when Content-Length exceeds the limit", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			imageResponseWithContentLength(32 * 1024 * 1024),
+		);
+
+		try {
+			await processImageUrl(REMOTE_URL, false, MAX_SIZE_MB);
+			throw new Error("expected throw");
+		} catch (err) {
+			// The message is asserted before the type on purpose: this is the line
+			// that fails on the unfixed code, and it fails for the reason the user
+			// experiences ("Failed to process image from URL") rather than because
+			// a new export is missing.
+			expect((err as Error).message).toContain(
+				"Image size (32.0MB) exceeds your current limit of 1MB.",
+			);
+			expect(err).toBeInstanceOf(ImageSizeLimitError);
+		}
+	});
+
+	it("surfaces the size message when the downloaded body exceeds the limit", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			imageResponseWithBody(2 * 1024 * 1024),
+		);
+
+		try {
+			await processImageUrl(REMOTE_URL, false, MAX_SIZE_MB);
+			throw new Error("expected throw");
+		} catch (err) {
+			expect((err as Error).message).toContain(
+				"Image size (2.0MB) exceeds your current limit of 1MB.",
+			);
+			expect(err).toBeInstanceOf(ImageSizeLimitError);
+		}
+	});
+
+	// The data URL branch throws from outside the try block, so it always
+	// surfaced the real message. Remote URLs must report the same way.
+	it("reports data URL and remote URL rejections the same way", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			imageResponseWithContentLength(2 * 1024 * 1024),
+		);
+
+		const remote = await processImageUrl(REMOTE_URL, false, MAX_SIZE_MB).catch(
+			(err: unknown) => err,
+		);
+		const dataUrl = await processImageUrl(
+			`data:image/png;base64,${"A".repeat(2 * 1024 * 1024)}`,
+			false,
+			MAX_SIZE_MB,
+		).catch((err: unknown) => err);
+
+		const sizeMessage =
+			/^Image size \(\d+\.\d+MB\) exceeds your current limit of 1MB\.$/;
+		// Data URLs already reported correctly (they throw outside the try), so
+		// this asymmetry is the whole bug: same rejection, two different answers
+		// depending on how the image arrived.
+		expect((dataUrl as Error).message).toMatch(sizeMessage);
+		expect((remote as Error).message).toMatch(sizeMessage);
+		expect(remote).toBeInstanceOf(ImageSizeLimitError);
+		expect(dataUrl).toBeInstanceOf(ImageSizeLimitError);
+	});
+
+	// The passthrough must stay narrow: anything that is not a size rejection is
+	// still sanitized so upstream/network detail does not leak to the caller.
+	it("still sanitizes non-size failures", async () => {
+		vi.spyOn(globalThis, "fetch").mockRejectedValue(
+			new Error("connect ECONNREFUSED 10.0.0.1:443"),
+		);
+
+		await expect(
+			processImageUrl(REMOTE_URL, false, MAX_SIZE_MB),
+		).rejects.toThrow("Failed to process image from URL");
+	});
+});

--- a/packages/actions/src/process-image-url.ts
+++ b/packages/actions/src/process-image-url.ts
@@ -5,6 +5,21 @@ import { parseDataUrl } from "./parse-data-url.js";
 import { RequestError } from "./request-error.js";
 
 /**
+ * Thrown when an image exceeds the caller's size limit. Typed so the catch
+ * block in `processImageUrl` can re-throw it as-is: the previous check sniffed
+ * the message for "Image size exceeds", which never matched the generated text
+ * ("Image size (32.0MB) exceeds your current limit of 1MB."), so every remote
+ * URL size rejection was flattened into the generic "Failed to process image
+ * from URL" and users were never told their image was too big.
+ */
+export class ImageSizeLimitError extends Error {
+	public constructor(message: string) {
+		super(message);
+		this.name = "ImageSizeLimitError";
+	}
+}
+
+/**
  * Generates a user-friendly error message for image size limits
  */
 function getImageSizeErrorMessage(
@@ -74,7 +89,7 @@ export async function processImageUrl(
 				maxSizeMB,
 				actualSizeMB,
 			});
-			throw new Error(
+			throw new ImageSizeLimitError(
 				getImageSizeErrorMessage(maxSizeMB, actualSizeMB, userPlan),
 			);
 		}
@@ -126,7 +141,7 @@ export async function processImageUrl(
 				maxSizeMB,
 				actualSizeMB,
 			});
-			throw new Error(
+			throw new ImageSizeLimitError(
 				getImageSizeErrorMessage(maxSizeMB, actualSizeMB, userPlan),
 			);
 		}
@@ -150,7 +165,7 @@ export async function processImageUrl(
 				maxSizeMB,
 				actualSizeMB,
 			});
-			throw new Error(
+			throw new ImageSizeLimitError(
 				getImageSizeErrorMessage(maxSizeMB, actualSizeMB, userPlan),
 			);
 		}
@@ -173,10 +188,7 @@ export async function processImageUrl(
 			url: url.substring(0, 50) + "...",
 		});
 
-		if (
-			error instanceof Error &&
-			error.message.includes("Image size exceeds")
-		) {
+		if (error instanceof ImageSizeLimitError) {
 			throw error; // Re-throw size limit errors as-is
 		}
 		if (


### PR DESCRIPTION
## Summary

`processImageUrl()` never tells a caller that their image was too big. The size-limit passthrough in the `catch` block sniffs the error message for `"Image size exceeds"`:

```ts
if (error instanceof Error && error.message.includes("Image size exceeds")) {
	throw error; // Re-throw size limit errors as-is
}
```

but the message `getImageSizeErrorMessage()` actually produces is

```
Image size (32.0MB) exceeds your current limit of 1MB.
```

The size parenthetical sits between `Image size` and `exceeds`, so the substring never matches. **That branch is dead.** Both remote-URL size checks — the `Content-Length` pre-check and the post-download body check — are swallowed and rethrown as the generic `"Failed to process image from URL"`.

The asymmetry is what gives it away: the data URL branch throws from *outside* the `try`, so it always reported the real message. Same rejection, two different answers depending on how the image arrived.

## Fix

Replace the message sniffing with a typed `ImageSizeLimitError`. The passthrough then keys off the type, so it cannot rot again the next time the wording changes — which is exactly how it broke.

The other two passthroughs in the same `catch` (`"Failed to fetch image: HTTP"` and `"URL does not point to a valid image"`) also use `.includes()`, but those substrings do match the messages that are actually thrown, so they work today. I left them alone rather than widen this PR.

## Tests

New `packages/actions/src/process-image-url.spec.ts`, 4 tests:

- **`Content-Length` exceeds the limit** — the pre-check path.
- **downloaded body exceeds the limit** — a streamed response carries no `Content-Length`, so the post-download check is the one that rejects.
- **data URL and remote URL report the same way** — pins the asymmetry that is the whole bug.
- **non-size failures are still sanitized** — the passthrough must stay narrow, so upstream/network detail does not leak to the caller.

In each size test the **message** is asserted before the type, on purpose: that is the line that fails on `main`, and it fails for the reason a user experiences rather than because a new export is missing.

Without the fix (source reverted to `main`, tests kept):

```
 FAIL  process-image-url.spec.ts > surfaces the size message when Content-Length exceeds the limit
AssertionError: expected 'Failed to process image from URL' to contain 'Image size (32.0MB) exceeds your curr…'

 FAIL  process-image-url.spec.ts > surfaces the size message when the downloaded body exceeds the limit
AssertionError: expected 'Failed to process image from URL' to contain 'Image size (2.0MB) exceeds your curre…'

 FAIL  process-image-url.spec.ts > reports data URL and remote URL rejections the same way
AssertionError: expected 'Failed to process image from URL' to match /^Image size \(\d+\.\d+MB\) exceeds yo…/

 Tests  3 failed | 1 passed (4)
```

With the fix: `Tests  4 passed (4)`.

## What I did not verify

`pnpm exec vitest run packages/actions` is **534 passed, 4 failed**; the 4 failures are `provider-key/env-inventory.spec.ts` hitting `ECONNREFUSED 127.0.0.1:6379`. I re-ran that file on a clean `main` and it fails identically, so it is a missing local Redis and not this change — but I have not run the suite anywhere with the service up. `tsc --noEmit`, `eslint` and `prettier --check` are clean on both changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image size-limit handling for remote and data URL images.
  * Added consistent, clearly typed errors when images exceed the allowed size.
  * Prevented unrelated image download failures from being misidentified as size-limit errors.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->