### PR TITLE
fix(actions): redact the provider key from the validation debug log

### DIFF
--- a/packages/actions/src/validate-provider-key.spec.ts
+++ b/packages/actions/src/validate-provider-key.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { logger } from "@llmgateway/logger";
 import { models } from "@llmgateway/models";
 
 import {
@@ -209,5 +210,37 @@ describe("validateProviderKey region resolution", () => {
 		expect(result.model).not.toBe("gpt-5.6-sol");
 		const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
 		expect(body.model).not.toBe("openai.gpt-5.6-sol");
+	});
+});
+
+describe("validateProviderKey credential hygiene", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	// Google AI Studio and Vertex in api-key mode carry the credential in the
+	// query string (`?key=<token>`), so the endpoint string is not safe to log
+	// verbatim. The warn/error sites in the same function already run it through
+	// redactToken; the debug line did not.
+	//
+	// Production defaults to `info`, so this did not leak there by default — but
+	// development defaults to `debug`, and turning debug on to troubleshoot a
+	// failing provider key is exactly when it would have fired.
+	it("keeps the api key out of the debug log for google-ai-studio", async () => {
+		const token = "AIzaSyTESTKEYdoNotUse0123456789abcdefg";
+		const debugSpy = vi.spyOn(logger, "debug").mockImplementation(() => {});
+		const fetchMock = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response("{}", { status: 200 }));
+
+		await validateProviderKey("google-ai-studio", token);
+
+		// The key really is in the URL — without this the test would pass
+		// vacuously if the endpoint ever stopped carrying it.
+		expect(String(fetchMock.mock.calls[0][0])).toContain(`key=${token}`);
+
+		const logged = JSON.stringify(debugSpy.mock.calls);
+		expect(logged).not.toContain(token);
+		expect(logged).toContain("[REDACTED_TOKEN]");
 	});
 });

--- a/packages/actions/src/validate-provider-key.ts
+++ b/packages/actions/src/validate-provider-key.ts
@@ -296,7 +296,11 @@ export async function validateProviderKey(
 		logger.debug("Sending provider key validation request", {
 			provider,
 			model: validationModel?.modelId,
-			endpoint,
+			// Google AI Studio and Vertex in api-key mode carry the credential in
+			// the query string (`?key=<token>`, get-provider-endpoint.ts), so the
+			// endpoint is not safe to log verbatim. The warn/error sites below
+			// already redact; this one was the gap.
+			endpoint: redactToken(endpoint, token),
 		});
 
 		const response = await fetch(endpoint, {


### PR DESCRIPTION
## Summary

`validateProviderKey` logs the upstream endpoint verbatim:

```ts
// packages/actions/src/validate-provider-key.ts
logger.debug("Sending provider key validation request", {
	provider,
	model: validationModel?.modelId,
	endpoint,
});
```

For Google AI Studio and Vertex in api-key mode the credential lives **in the query string**, not in a header — `get-provider-endpoint.ts` builds `queryParams.push(\`key=${token}\`)`. So `endpoint` is `…/v1beta/models/gemini-2.0-flash:generateContent?key=<the user's API key>`, and the plaintext key ends up in the log line.

The same function already knows this: the `warn` on an error response and the `error` on an exception both run their payload through `redactToken(…, token)`. The `debug` line was the gap.

## Scope — deliberately not overstated

**Production is not exposed by default.** `packages/logger/src/index.ts` returns `info` when `NODE_ENV === "production"`, so this line does not emit there unless the level is lowered.

Where it does fire:

- **development**, where the default level is `debug`;
- **any deployment that turns debug on** — and turning debug on to troubleshoot a provider key that will not validate is precisely the situation that reaches this code path.

Affected providers are the ones that receive the token as the URL query param: `google-ai-studio`, `google-vertex`, `vertex-anthropic`, `glacier`, `iceberg`, `quartz`. Providers that authenticate by header are unaffected.

I looked for other unredacted sinks for the same value and did not find any: `endpoint` reaches only this log and the `fetch` call.

## Fix

One line — run it through the helper the neighbouring sites already use:

```diff
-			endpoint,
+			endpoint: redactToken(endpoint, token),
```

`token` is the right value to redact against: the endpoint builder is handed the original `token`, not the exchanged `requestToken`, for exactly the providers listed above.

## Tests

New case in `validate-provider-key.spec.ts`, following the `vi.spyOn(logger, "debug")` pattern already used in `apps/gateway/src/api.spec.ts`.

It asserts the key is present in the fetched URL **first**, so it cannot pass vacuously if the endpoint ever stops carrying the credential — then asserts the debug payload does not contain it and does contain `[REDACTED_TOKEN]`.

Against unpatched `main`:

```
 × keeps the api key out of the debug log for google-ai-studio
AssertionError: expected '[["Using validation model",{"provider…' not to contain 'AIzaSyTESTKEYdoNotUse0123456789abcdefg'
 Tests  1 failed | 13 passed (14)
```

With the fix: `Tests  14 passed (14)`.

`prettier --check`, `eslint` and `tsc --noEmit` clean.

## What I did not verify

`pnpm exec vitest run packages/actions` is **531 passed, 4 failed**; the 4 are `provider-key/env-inventory.spec.ts` hitting `ECONNREFUSED 127.0.0.1:6379`. I re-ran that file on a clean `main` and it fails identically, so it is a missing local Redis rather than this change — but I have not run the suite anywhere with the service up.

I also did not check log sinks outside this repository. If logs are shipped somewhere with their own retention, keys emitted by earlier builds may still be sitting there; that is worth a look on your side and is not something I can see from here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive provider API keys are now automatically redacted from validation-request debug logs.
  * Validation requests continue to use the required credentials while preventing tokens from appearing in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->