### PR TITLE
feat(admin): provider routing analytics page

### DIFF
--- a/apps/api/src/routes/admin-routing-analytics.spec.ts
+++ b/apps/api/src/routes/admin-routing-analytics.spec.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db, tables } from "@llmgateway/db";
+import { models, type ProviderModelMapping } from "@llmgateway/models";
+
+const originalAdminEmails = process.env.ADMIN_EMAILS;
+
+function isRoutableMapping(mapping: ProviderModelMapping): boolean {
+	return (
+		!mapping.deactivatedAt &&
+		mapping.stability !== "unstable" &&
+		mapping.stability !== "experimental"
+	);
+}
+
+// A catalogue model with at least two routable provider mappings, so the
+// weighted-score path (rather than single-provider selection) is exercised.
+const testModel = models.find(
+	(m) =>
+		!("stability" in m && (m.stability as string) !== "stable") &&
+		m.providers.filter(isRoutableMapping).length >= 2,
+)!;
+const [providerA, providerB] = testModel.providers
+	.filter(isRoutableMapping)
+	.map((p) => p.providerId);
+
+function currentHourStart(): Date {
+	const hour = new Date();
+	hour.setUTCMinutes(0, 0, 0);
+	return hour;
+}
+
+async function get(query: string, token?: string): Promise<Response> {
+	return await app.request(`/admin/routing-analytics${query}`, {
+		headers: token ? { Cookie: token } : {},
+	});
+}
+
+describe("admin routing analytics endpoint", () => {
+	let cookie: string;
+
+	beforeEach(async () => {
+		process.env.ADMIN_EMAILS = "admin@example.com";
+		cookie = await createTestUser();
+	});
+
+	afterEach(async () => {
+		if (originalAdminEmails === undefined) {
+			delete process.env.ADMIN_EMAILS;
+		} else {
+			process.env.ADMIN_EMAILS = originalAdminEmails;
+		}
+		await deleteAll();
+	});
+
+	it("rejects unauthenticated and non-admin requests", async () => {
+		expect((await get(`?modelId=${testModel.id}`)).status).toBe(401);
+
+		process.env.ADMIN_EMAILS = "someone-else@example.com";
+		expect((await get(`?modelId=${testModel.id}`, cookie)).status).toBe(403);
+	});
+
+	it("returns 404 for an unknown model", async () => {
+		const res = await get("?modelId=does-not-exist", cookie);
+		expect(res.status).toBe(404);
+	});
+
+	it("derives hourly metrics and scores from mapping history", async () => {
+		const hour = currentHourStart();
+		await db.insert(tables.modelProviderMappingHistoryHourly).values([
+			{
+				id: "routing-analytics-a",
+				modelId: testModel.id,
+				providerId: providerA,
+				modelProviderMappingId: `${testModel.id}-${providerA}`,
+				hourTimestamp: hour,
+				logsCount: 10,
+				errorsCount: 3,
+				clientErrorsCount: 1,
+				totalOutputTokens: 5000,
+				totalDuration: 10000,
+				totalTimeToFirstToken: 4000,
+				timeToFirstTokenCount: 4,
+			},
+			{
+				id: "routing-analytics-b",
+				modelId: testModel.id,
+				providerId: providerB,
+				modelProviderMappingId: `${testModel.id}-${providerB}`,
+				hourTimestamp: hour,
+				logsCount: 10,
+				errorsCount: 1,
+				clientErrorsCount: 1,
+				totalOutputTokens: 20000,
+				totalDuration: 10000,
+				totalTimeToFirstToken: 2000,
+				timeToFirstTokenCount: 4,
+			},
+		]);
+
+		const res = await get(`?modelId=${testModel.id}&window=24h`, cookie);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+
+		expect(body.model.id).toBe(testModel.id);
+		expect(body.window).toBe("24h");
+		expect(body.hourly).toHaveLength(24);
+		expect(body.config.weights.price).toBeGreaterThan(0);
+
+		const mappingA = body.mappings.find(
+			(m: { providerId: string }) => m.providerId === providerA,
+		);
+		expect(mappingA.routable).toBe(true);
+		expect(mappingA.price).toBeGreaterThanOrEqual(0);
+
+		const lastHour = body.hourly[body.hourly.length - 1];
+		expect(lastHour.hour).toBe(hour.toISOString());
+
+		const entryA = lastHour.providers.find(
+			(p: { providerId: string }) => p.providerId === providerA,
+		);
+		// errors 3 minus client errors 1 = 2 routing errors out of 10 requests
+		expect(entryA.uptime).toBe(80);
+		expect(entryA.latency).toBe(1000);
+		expect(entryA.throughput).toBe(500);
+		expect(entryA.requestCount).toBe(10);
+		expect(entryA.score).not.toBeNull();
+		// uptime 80 is below the 95 penalty threshold, so the exponential
+		// penalty applies: ((95-80)/95*5)^2
+		expect(entryA.breakdown.uptimePenalty).toBeCloseTo(0.6233, 3);
+
+		const entryB = lastHour.providers.find(
+			(p: { providerId: string }) => p.providerId === providerB,
+		);
+		expect(entryB.uptime).toBe(100);
+		expect(entryB.latency).toBe(500);
+		expect(entryB.throughput).toBe(2000);
+		expect(entryB.breakdown.uptimePenalty).toBe(0);
+
+		// An hour without traffic reports null metrics (routing falls back to
+		// configured defaults there) but still carries a computed score.
+		const emptyHour = body.hourly[0];
+		const emptyEntry = emptyHour.providers.find(
+			(p: { providerId: string }) => p.providerId === providerA,
+		);
+		expect(emptyEntry.uptime).toBeNull();
+		expect(emptyEntry.score).not.toBeNull();
+
+		const summaryA = body.summary.find(
+			(s: { providerId: string }) => s.providerId === providerA,
+		);
+		expect(summaryA.requestCount).toBe(10);
+		expect(summaryA.uptime).toBe(80);
+	});
+});

--- a/apps/api/src/routes/admin-routing-analytics.spec.ts
+++ b/apps/api/src/routes/admin-routing-analytics.spec.ts
@@ -3,16 +3,20 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { app } from "@/index.js";
 import { createTestUser, deleteAll } from "@/testing.js";
 
-import { db, tables } from "@llmgateway/db";
+import { cdb, db, tables } from "@llmgateway/db";
 import { models, type ProviderModelMapping } from "@llmgateway/models";
 
 const originalAdminEmails = process.env.ADMIN_EMAILS;
 
+// Routable *and* paid, so the price factor and the discount assertions below
+// operate on a non-zero selection price.
 function isRoutableMapping(mapping: ProviderModelMapping): boolean {
 	return (
 		!mapping.deactivatedAt &&
 		mapping.stability !== "unstable" &&
-		mapping.stability !== "experimental"
+		mapping.stability !== "experimental" &&
+		(Number(mapping.inputPrice ?? 0) > 0 ||
+			Number(mapping.outputPrice ?? 0) > 0)
 	);
 }
 
@@ -22,7 +26,12 @@ const testModel = models.find(
 	(m) =>
 		!("stability" in m && (m.stability as string) !== "stable") &&
 		m.providers.filter(isRoutableMapping).length >= 2,
-)!;
+);
+if (!testModel) {
+	throw new Error(
+		"No stable catalogue model with at least two paid, routable provider mappings; update this fixture.",
+	);
+}
 const [providerA, providerB] = testModel.providers
 	.filter(isRoutableMapping)
 	.map((p) => p.providerId);
@@ -53,6 +62,12 @@ describe("admin routing analytics endpoint", () => {
 		} else {
 			process.env.ADMIN_EMAILS = originalAdminEmails;
 		}
+		// Neither table hangs off a cascade root that deleteAll() clears, so the
+		// fixtures inserted here have to be removed explicitly or the next run
+		// collides on their fixed ids. Discounts go through the cached client so
+		// the cached lookup is dropped with them.
+		await db.delete(tables.modelProviderMappingHistoryHourly);
+		await cdb.delete(tables.discount);
 		await deleteAll();
 	});
 
@@ -115,11 +130,19 @@ describe("admin routing analytics endpoint", () => {
 		);
 		expect(mappingA.routable).toBe(true);
 		expect(mappingA.price).toBeGreaterThanOrEqual(0);
+		expect(mappingA.discount).toBe(0);
+		expect(mappingA.price).toBe(mappingA.listPrice);
 
-		const lastHour = body.hourly[body.hourly.length - 1];
-		expect(lastHour.hour).toBe(hour.toISOString());
+		// Look the bucket up by timestamp rather than taking the last one: the
+		// handler derives its own window end, so crossing an hour boundary between
+		// the insert and the request would otherwise shift the inserted row into
+		// the second-to-last bucket.
+		const trafficHour = body.hourly.find(
+			(h: { hour: string }) => h.hour === hour.toISOString(),
+		);
+		expect(trafficHour).toBeDefined();
 
-		const entryA = lastHour.providers.find(
+		const entryA = trafficHour.providers.find(
 			(p: { providerId: string }) => p.providerId === providerA,
 		);
 		// errors 3 minus client errors 1 = 2 routing errors out of 10 requests
@@ -132,7 +155,7 @@ describe("admin routing analytics endpoint", () => {
 		// penalty applies: ((95-80)/95*5)^2
 		expect(entryA.breakdown.uptimePenalty).toBeCloseTo(0.6233, 3);
 
-		const entryB = lastHour.providers.find(
+		const entryB = trafficHour.providers.find(
 			(p: { providerId: string }) => p.providerId === providerB,
 		);
 		expect(entryB.uptime).toBe(100);
@@ -154,5 +177,46 @@ describe("admin routing analytics endpoint", () => {
 		);
 		expect(summaryA.requestCount).toBe(10);
 		expect(summaryA.uptime).toBe(80);
+	});
+
+	it("scores the discounted selection price", async () => {
+		const before = await get(`?modelId=${testModel.id}&window=24h`, cookie);
+		const baseline = await before.json();
+		const baselineA = baseline.mappings.find(
+			(m: { providerId: string }) => m.providerId === providerA,
+		);
+
+		// Insert through the cached client so its onMutate hook drops the cached
+		// discount lookup the baseline request above just populated.
+		await cdb.insert(tables.discount).values({
+			id: "routing-analytics-discount",
+			organizationId: null,
+			provider: providerA,
+			model: testModel.id,
+			discountPercent: "0.25",
+		});
+
+		const res = await get(`?modelId=${testModel.id}&window=24h`, cookie);
+		const body = await res.json();
+		const mappingA = body.mappings.find(
+			(m: { providerId: string }) => m.providerId === providerA,
+		);
+
+		expect(mappingA.discount).toBe(0.25);
+		expect(mappingA.listPrice).toBe(baselineA.listPrice);
+		expect(mappingA.price).toBeCloseTo(baselineA.listPrice * 0.75, 12);
+
+		// The cheaper price has to move the score the page reports, otherwise it
+		// would not be the score that actually elected the provider.
+		const summaryA = body.summary.find(
+			(s: { providerId: string }) => s.providerId === providerA,
+		);
+		const baselineSummaryA = baseline.summary.find(
+			(s: { providerId: string }) => s.providerId === providerA,
+		);
+		expect(summaryA.score).toBeLessThanOrEqual(baselineSummaryA.score);
+		expect(summaryA.breakdown.priceContribution).toBeLessThanOrEqual(
+			baselineSummaryA.breakdown.priceContribution,
+		);
 	});
 });

--- a/apps/api/src/routes/admin-routing-analytics.ts
+++ b/apps/api/src/routes/admin-routing-analytics.ts
@@ -1,0 +1,525 @@
+import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
+import { Decimal } from "decimal.js";
+import { HTTPException } from "hono/http-exception";
+import { z } from "zod";
+
+import { adminMiddleware } from "@/middleware/admin.js";
+
+import {
+	getProviderSelectionPrice,
+	providerSupportsCaching,
+	computeWeightedProviderScores,
+	getEffectiveScoringWeights,
+	type CandidateScoreInput,
+} from "@llmgateway/actions";
+import {
+	and,
+	db,
+	effectiveTtftTotals,
+	eq,
+	gte,
+	modelProviderMappingHistoryHourly,
+} from "@llmgateway/db";
+import {
+	getProviderDefinition,
+	models,
+	type ProviderModelMapping,
+} from "@llmgateway/models";
+import { getDefaultRoutingConfig } from "@llmgateway/shared/routing-config";
+
+import type { ServerTypes } from "@/vars.js";
+
+export const adminRoutingAnalytics = new OpenAPIHono<ServerTypes>();
+
+adminRoutingAnalytics.use("/*", adminMiddleware);
+
+const routingWindowSchema = z.enum(["24h", "3d", "7d"]);
+
+const WINDOW_HOURS: Record<z.infer<typeof routingWindowSchema>, number> = {
+	"24h": 24,
+	"3d": 72,
+	"7d": 168,
+};
+
+const scoreBreakdownSchema = z
+	.object({
+		priceScore: z.number(),
+		uptimeScore: z.number(),
+		throughputScore: z.number(),
+		latencyScore: z.number(),
+		cacheScore: z.number(),
+		priceContribution: z.number(),
+		uptimeContribution: z.number(),
+		throughputContribution: z.number(),
+		latencyContribution: z.number(),
+		cacheContribution: z.number(),
+		priorityPenalty: z.number(),
+		uptimePenalty: z.number(),
+		baseScore: z.number(),
+	})
+	.openapi({});
+
+const providerHourEntrySchema = z
+	.object({
+		providerId: z.string(),
+		requestCount: z.number(),
+		errorCount: z.number(),
+		clientErrorCount: z.number(),
+		// Derived metric inputs; null when the mapping saw no traffic in the hour
+		// (routing then falls back to thresholds.default*).
+		uptime: z.number().nullable(),
+		latency: z.number().nullable(),
+		throughput: z.number().nullable(),
+		score: z.number().nullable(),
+		breakdown: scoreBreakdownSchema.nullable(),
+	})
+	.openapi({});
+
+const routingHourSchema = z
+	.object({
+		hour: z.string(),
+		providers: z.array(providerHourEntrySchema),
+	})
+	.openapi({});
+
+const routingMappingSchema = z
+	.object({
+		providerId: z.string(),
+		providerName: z.string(),
+		stability: z.string(),
+		deactivatedAt: z.string().nullable(),
+		priority: z.number(),
+		price: z.number(),
+		cacheSupported: z.boolean(),
+		routable: z.boolean(),
+		excludedReasons: z.array(z.string()),
+	})
+	.openapi({});
+
+const routingSummaryEntrySchema = z
+	.object({
+		providerId: z.string(),
+		requestCount: z.number(),
+		errorCount: z.number(),
+		uptime: z.number().nullable(),
+		latency: z.number().nullable(),
+		throughput: z.number().nullable(),
+		score: z.number().nullable(),
+		breakdown: scoreBreakdownSchema.nullable(),
+	})
+	.openapi({});
+
+const routingAnalyticsResponseSchema = z
+	.object({
+		model: z
+			.object({
+				id: z.string(),
+				name: z.string().nullable(),
+				family: z.string(),
+				isImageModel: z.boolean(),
+			})
+			.openapi({}),
+		config: z
+			.object({
+				weights: z
+					.object({
+						price: z.number(),
+						imagePrice: z.number(),
+						uptime: z.number(),
+						throughput: z.number(),
+						latency: z.number(),
+						cache: z.number(),
+					})
+					.openapi({}),
+				effectiveWeights: z
+					.object({
+						price: z.number(),
+						uptime: z.number(),
+						throughput: z.number(),
+						latency: z.number(),
+						cache: z.number(),
+						total: z.number(),
+					})
+					.openapi({}),
+				thresholds: z
+					.object({
+						cachePromptTokens: z.number(),
+						uptimePenalty: z.number(),
+						defaultUptime: z.number(),
+						defaultLatency: z.number(),
+						defaultThroughput: z.number(),
+						explorationRate: z.number(),
+					})
+					.openapi({}),
+			})
+			.openapi({}),
+		window: routingWindowSchema,
+		mappings: z.array(routingMappingSchema),
+		summary: z.array(routingSummaryEntrySchema),
+		hourly: z.array(routingHourSchema),
+	})
+	.openapi({});
+
+interface HourlyTotals {
+	requestCount: number;
+	errorCount: number;
+	clientErrorCount: number;
+	totalDuration: number;
+	totalOutputTokens: number;
+	totalTimeToFirstToken: number;
+	timeToFirstTokenCount: number;
+	totalTimeToFirstReasoningToken: number;
+	timeToFirstReasoningTokenCount: number;
+}
+
+function emptyTotals(): HourlyTotals {
+	return {
+		requestCount: 0,
+		errorCount: 0,
+		clientErrorCount: 0,
+		totalDuration: 0,
+		totalOutputTokens: 0,
+		totalTimeToFirstToken: 0,
+		timeToFirstTokenCount: 0,
+		totalTimeToFirstReasoningToken: 0,
+		timeToFirstReasoningTokenCount: 0,
+	};
+}
+
+function addRow(
+	totals: HourlyTotals,
+	row: typeof modelProviderMappingHistoryHourly.$inferSelect,
+): void {
+	totals.requestCount += row.logsCount;
+	totals.errorCount += row.errorsCount;
+	totals.clientErrorCount += row.clientErrorsCount;
+	totals.totalDuration += row.totalDuration;
+	totals.totalOutputTokens += row.totalOutputTokens;
+	totals.totalTimeToFirstToken += row.totalTimeToFirstToken;
+	totals.timeToFirstTokenCount += row.timeToFirstTokenCount;
+	totals.totalTimeToFirstReasoningToken += row.totalTimeToFirstReasoningToken;
+	totals.timeToFirstReasoningTokenCount += row.timeToFirstReasoningTokenCount;
+}
+
+interface DerivedMetrics {
+	uptime: number | null;
+	latency: number | null;
+	throughput: number | null;
+}
+
+// Mirrors rowToMetrics in packages/db/src/provider-metrics-history.ts, minus
+// the tier weighting: routing weights recent minutes higher, while this view
+// deliberately smooths each bucket into a plain hourly average.
+function deriveMetrics(totals: HourlyTotals): DerivedMetrics {
+	if (totals.requestCount <= 0) {
+		return { uptime: null, latency: null, throughput: null };
+	}
+	const routingErrors = Math.max(
+		totals.errorCount - totals.clientErrorCount,
+		0,
+	);
+	const uptime = Math.max(
+		0,
+		((totals.requestCount - routingErrors) / totals.requestCount) * 100,
+	);
+	const { total: effectiveTtft, count: effectiveTtftCount } =
+		effectiveTtftTotals(totals);
+	const latency =
+		effectiveTtft > 0 && effectiveTtftCount > 0
+			? effectiveTtft / effectiveTtftCount
+			: null;
+	const throughput =
+		totals.totalDuration > 0
+			? (totals.totalOutputTokens / totals.totalDuration) * 1000
+			: null;
+	return { uptime, latency, throughput };
+}
+
+function round(value: number, decimals: number): number {
+	const factor = Math.pow(10, decimals);
+	return Math.round(value * factor) / factor;
+}
+
+interface MappingInfo {
+	providerId: string;
+	providerName: string;
+	stability: string;
+	deactivatedAt: string | null;
+	priority: number;
+	price: number;
+	cacheSupported: boolean;
+	routable: boolean;
+	excludedReasons: string[];
+}
+
+function buildMappingInfos(model: (typeof models)[number]): MappingInfo[] {
+	return model.providers.map((mapping: ProviderModelMapping) => {
+		const providerDef = getProviderDefinition(mapping.providerId);
+		const modelStability =
+			"stability" in model
+				? (model.stability as string | undefined)
+				: undefined;
+		const stability = mapping.stability ?? modelStability ?? "stable";
+		const priority = providerDef?.priority ?? 1;
+		const excludedReasons: string[] = [];
+		if (mapping.deactivatedAt) {
+			excludedReasons.push("deactivated");
+		}
+		if (stability === "unstable" || stability === "experimental") {
+			excludedReasons.push(`stability: ${stability}`);
+		}
+		if (priority <= 0) {
+			excludedReasons.push("priority disabled");
+		}
+		return {
+			providerId: mapping.providerId,
+			providerName: providerDef?.name ?? mapping.providerId,
+			stability,
+			deactivatedAt: mapping.deactivatedAt
+				? mapping.deactivatedAt.toISOString()
+				: null,
+			priority,
+			price: getProviderSelectionPrice(mapping).toNumber(),
+			cacheSupported: providerSupportsCaching(mapping),
+			routable: excludedReasons.length === 0,
+			excludedReasons,
+		};
+	});
+}
+
+function scoreEntries(
+	routableMappings: MappingInfo[],
+	metricsByProvider: Map<string, DerivedMetrics>,
+	cfg: ReturnType<typeof getDefaultRoutingConfig>,
+	isImageModel: boolean,
+): Map<
+	string,
+	{ score: number; breakdown: z.infer<typeof scoreBreakdownSchema> }
+> {
+	const candidates: CandidateScoreInput[] = routableMappings.map((mapping) => {
+		const metrics = metricsByProvider.get(mapping.providerId);
+		return {
+			price: new Decimal(mapping.price),
+			uptime: metrics?.uptime ?? undefined,
+			latency: metrics?.latency ?? undefined,
+			throughput: metrics?.throughput ?? undefined,
+			cacheSupported: mapping.cacheSupported,
+			priority: mapping.priority,
+		};
+	});
+	const breakdowns = computeWeightedProviderScores(candidates, cfg, {
+		// Score as the common case: a streaming text request with a prompt below
+		// the cache threshold, matching how most chat traffic is elected.
+		isStreaming: true,
+		isImageModel,
+		cacheRelevant: false,
+	});
+	const result = new Map<
+		string,
+		{ score: number; breakdown: z.infer<typeof scoreBreakdownSchema> }
+	>();
+	for (const [index, mapping] of routableMappings.entries()) {
+		const b = breakdowns[index];
+		result.set(mapping.providerId, {
+			score: b.score.toDecimalPlaces(3).toNumber(),
+			breakdown: {
+				priceScore: round(b.priceScore.toNumber(), 4),
+				uptimeScore: round(b.uptimeScore.toNumber(), 4),
+				throughputScore: round(b.throughputScore.toNumber(), 4),
+				latencyScore: round(b.latencyScore.toNumber(), 4),
+				cacheScore: round(b.cacheScore.toNumber(), 4),
+				priceContribution: round(b.priceContribution.toNumber(), 4),
+				uptimeContribution: round(b.uptimeContribution.toNumber(), 4),
+				throughputContribution: round(b.throughputContribution.toNumber(), 4),
+				latencyContribution: round(b.latencyContribution.toNumber(), 4),
+				cacheContribution: round(b.cacheContribution.toNumber(), 4),
+				priorityPenalty: round(b.priorityPenalty.toNumber(), 4),
+				uptimePenalty: round(b.uptimePenalty.toNumber(), 4),
+				baseScore: round(b.baseScore.toNumber(), 4),
+			},
+		});
+	}
+	return result;
+}
+
+const getRoutingAnalytics = createRoute({
+	method: "get",
+	path: "/routing-analytics",
+	request: {
+		query: z.object({
+			modelId: z.string(),
+			window: routingWindowSchema.default("3d").optional(),
+		}),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: routingAnalyticsResponseSchema,
+				},
+			},
+			description:
+				"Hourly per-provider routing inputs (uptime, latency, throughput, price, priority) and the resulting weighted routing score for every mapping of a model.",
+		},
+		404: {
+			description: "Model not found.",
+		},
+	},
+});
+
+adminRoutingAnalytics.openapi(getRoutingAnalytics, async (c) => {
+	const query = c.req.valid("query");
+	const window = query.window ?? "3d";
+	const hours = WINDOW_HOURS[window];
+
+	const model = models.find((m) => m.id === query.modelId);
+	if (!model) {
+		throw new HTTPException(404, {
+			message: `Model ${query.modelId} not found`,
+		});
+	}
+
+	const cfg = getDefaultRoutingConfig();
+	const isImageModel =
+		"output" in model
+			? ((model.output as string[] | undefined)?.includes("image") ?? false)
+			: false;
+	const mappings = buildMappingInfos(model);
+	const routableMappings = mappings.filter((m) => m.routable);
+
+	const hourEnd = new Date();
+	hourEnd.setUTCMinutes(0, 0, 0);
+	const windowMs = (hours - 1) * 3_600_000;
+	const windowStart = new Date(hourEnd.getTime() - windowMs);
+
+	const rows = await db
+		.select()
+		.from(modelProviderMappingHistoryHourly)
+		.where(
+			and(
+				eq(modelProviderMappingHistoryHourly.modelId, model.id),
+				gte(modelProviderMappingHistoryHourly.hourTimestamp, windowStart),
+			),
+		);
+
+	// Sum rows into per-(hour, provider) and per-provider window totals. The
+	// unique key is (mappingId, hour), so a provider whose mapping id changed
+	// mid-window can contribute multiple rows to the same bucket.
+	const hourlyTotals = new Map<number, Map<string, HourlyTotals>>();
+	const windowTotals = new Map<string, HourlyTotals>();
+	for (const row of rows) {
+		const hourMs = row.hourTimestamp.getTime();
+		let providerMap = hourlyTotals.get(hourMs);
+		if (!providerMap) {
+			providerMap = new Map();
+			hourlyTotals.set(hourMs, providerMap);
+		}
+		let bucket = providerMap.get(row.providerId);
+		if (!bucket) {
+			bucket = emptyTotals();
+			providerMap.set(row.providerId, bucket);
+		}
+		addRow(bucket, row);
+		let windowBucket = windowTotals.get(row.providerId);
+		if (!windowBucket) {
+			windowBucket = emptyTotals();
+			windowTotals.set(row.providerId, windowBucket);
+		}
+		addRow(windowBucket, row);
+	}
+
+	const hourly: z.infer<typeof routingHourSchema>[] = [];
+	for (let i = 0; i < hours; i++) {
+		const hourOffsetMs = i * 3_600_000;
+		const hour = new Date(windowStart.getTime() + hourOffsetMs);
+		const providerMap = hourlyTotals.get(hour.getTime());
+		const metricsByProvider = new Map<string, DerivedMetrics>();
+		for (const mapping of mappings) {
+			metricsByProvider.set(
+				mapping.providerId,
+				deriveMetrics(providerMap?.get(mapping.providerId) ?? emptyTotals()),
+			);
+		}
+		const scores = scoreEntries(
+			routableMappings,
+			metricsByProvider,
+			cfg,
+			isImageModel,
+		);
+		hourly.push({
+			hour: hour.toISOString(),
+			providers: mappings.map((mapping) => {
+				const totals = providerMap?.get(mapping.providerId) ?? emptyTotals();
+				const metrics = metricsByProvider.get(mapping.providerId)!;
+				const scored = scores.get(mapping.providerId);
+				return {
+					providerId: mapping.providerId,
+					requestCount: totals.requestCount,
+					errorCount: totals.errorCount,
+					clientErrorCount: totals.clientErrorCount,
+					uptime: metrics.uptime !== null ? round(metrics.uptime, 2) : null,
+					latency: metrics.latency !== null ? round(metrics.latency, 0) : null,
+					throughput:
+						metrics.throughput !== null ? round(metrics.throughput, 2) : null,
+					score: scored?.score ?? null,
+					breakdown: scored?.breakdown ?? null,
+				};
+			}),
+		});
+	}
+
+	const windowMetricsByProvider = new Map<string, DerivedMetrics>();
+	for (const mapping of mappings) {
+		windowMetricsByProvider.set(
+			mapping.providerId,
+			deriveMetrics(windowTotals.get(mapping.providerId) ?? emptyTotals()),
+		);
+	}
+	const windowScores = scoreEntries(
+		routableMappings,
+		windowMetricsByProvider,
+		cfg,
+		isImageModel,
+	);
+	const summary = mappings.map((mapping) => {
+		const totals = windowTotals.get(mapping.providerId) ?? emptyTotals();
+		const metrics = windowMetricsByProvider.get(mapping.providerId)!;
+		const scored = windowScores.get(mapping.providerId);
+		return {
+			providerId: mapping.providerId,
+			requestCount: totals.requestCount,
+			errorCount: totals.errorCount,
+			uptime: metrics.uptime !== null ? round(metrics.uptime, 2) : null,
+			latency: metrics.latency !== null ? round(metrics.latency, 0) : null,
+			throughput:
+				metrics.throughput !== null ? round(metrics.throughput, 2) : null,
+			score: scored?.score ?? null,
+			breakdown: scored?.breakdown ?? null,
+		};
+	});
+
+	const effectiveWeights = getEffectiveScoringWeights(cfg, {
+		isStreaming: true,
+		isImageModel,
+		cacheRelevant: false,
+	});
+
+	return c.json({
+		model: {
+			id: model.id,
+			name:
+				"name" in model ? ((model.name as string | undefined) ?? null) : null,
+			family: model.family,
+			isImageModel,
+		},
+		config: {
+			weights: cfg.weights,
+			effectiveWeights,
+			thresholds: cfg.thresholds,
+		},
+		window,
+		mappings,
+		summary,
+		hourly,
+	});
+});

--- a/apps/api/src/routes/admin-routing-analytics.ts
+++ b/apps/api/src/routes/admin-routing-analytics.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { adminMiddleware } from "@/middleware/admin.js";
 
 import {
+	getDiscountedProviderSelectionPrice,
 	getProviderSelectionPrice,
 	providerSupportsCaching,
 	computeWeightedProviderScores,
@@ -17,6 +18,7 @@ import {
 	db,
 	effectiveTtftTotals,
 	eq,
+	getEffectiveDiscount,
 	gte,
 	modelProviderMappingHistoryHourly,
 } from "@llmgateway/db";
@@ -89,6 +91,8 @@ const routingMappingSchema = z
 		stability: z.string(),
 		deactivatedAt: z.string().nullable(),
 		priority: z.number(),
+		listPrice: z.number(),
+		discount: z.number(),
 		price: z.number(),
 		cacheSupported: z.boolean(),
 		routable: z.boolean(),
@@ -246,45 +250,70 @@ interface MappingInfo {
 	stability: string;
 	deactivatedAt: string | null;
 	priority: number;
+	/** Catalogue selection price, before any discount. */
+	listPrice: number;
+	/** Platform-wide discount fraction applied to listPrice (0 when none). */
+	discount: number;
+	/** Selection price the score is computed from: listPrice * (1 - discount). */
 	price: number;
 	cacheSupported: boolean;
 	routable: boolean;
 	excludedReasons: string[];
 }
 
-function buildMappingInfos(model: (typeof models)[number]): MappingInfo[] {
-	return model.providers.map((mapping: ProviderModelMapping) => {
-		const providerDef = getProviderDefinition(mapping.providerId);
-		const modelStability =
-			"stability" in model
-				? (model.stability as string | undefined)
-				: undefined;
-		const stability = mapping.stability ?? modelStability ?? "stable";
-		const priority = providerDef?.priority ?? 1;
-		const excludedReasons: string[] = [];
-		if (mapping.deactivatedAt) {
-			excludedReasons.push("deactivated");
-		}
-		if (stability === "unstable" || stability === "experimental") {
-			excludedReasons.push(`stability: ${stability}`);
-		}
-		if (priority <= 0) {
-			excludedReasons.push("priority disabled");
-		}
-		return {
-			providerId: mapping.providerId,
-			providerName: providerDef?.name ?? mapping.providerId,
-			stability,
-			deactivatedAt: mapping.deactivatedAt
-				? mapping.deactivatedAt.toISOString()
-				: null,
-			priority,
-			price: getProviderSelectionPrice(mapping).toNumber(),
-			cacheSupported: providerSupportsCaching(mapping),
-			routable: excludedReasons.length === 0,
-			excludedReasons,
-		};
-	});
+async function buildMappingInfos(
+	model: (typeof models)[number],
+): Promise<MappingInfo[]> {
+	return await Promise.all(
+		model.providers.map(async (mapping: ProviderModelMapping) => {
+			const providerDef = getProviderDefinition(mapping.providerId);
+			const modelStability =
+				"stability" in model
+					? (model.stability as string | undefined)
+					: undefined;
+			const stability = mapping.stability ?? modelStability ?? "stable";
+			const priority = providerDef?.priority ?? 1;
+			const excludedReasons: string[] = [];
+			if (mapping.deactivatedAt) {
+				excludedReasons.push("deactivated");
+			}
+			if (stability === "unstable" || stability === "experimental") {
+				excludedReasons.push(`stability: ${stability}`);
+			}
+			if (priority <= 0) {
+				excludedReasons.push("priority disabled");
+			}
+			// Routing scores the discounted price, so this page has to as well or
+			// the score it shows would not be the score that elected the provider.
+			// This view is not scoped to an organization, so only platform-wide
+			// (global) discounts are resolved — an org-specific discount can still
+			// shift that org's price below what is shown here.
+			const { price, discount } = await getDiscountedProviderSelectionPrice(
+				mapping,
+				model.id,
+				{
+					providerDiscountResolver: async (provider, modelId) =>
+						(await getEffectiveDiscount(null, provider.providerId, modelId))
+							.discount,
+				},
+			);
+			return {
+				providerId: mapping.providerId,
+				providerName: providerDef?.name ?? mapping.providerId,
+				stability,
+				deactivatedAt: mapping.deactivatedAt
+					? mapping.deactivatedAt.toISOString()
+					: null,
+				priority,
+				listPrice: getProviderSelectionPrice(mapping).toNumber(),
+				discount: discount.toNumber(),
+				price: price.toNumber(),
+				cacheSupported: providerSupportsCaching(mapping),
+				routable: excludedReasons.length === 0,
+				excludedReasons,
+			};
+		}),
+	);
 }
 
 function scoreEntries(
@@ -384,7 +413,7 @@ adminRoutingAnalytics.openapi(getRoutingAnalytics, async (c) => {
 		"output" in model
 			? ((model.output as string[] | undefined)?.includes("image") ?? false)
 			: false;
-	const mappings = buildMappingInfos(model);
+	const mappings = await buildMappingInfos(model);
 	const routableMappings = mappings.filter((m) => m.routable);
 
 	const hourEnd = new Date();

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -5,6 +5,7 @@ import { apiAuth as auth } from "@/auth/config.js";
 import { activity } from "./activity.js";
 import { adminOrgDetails } from "./admin-org-details.js";
 import adminProviderCredentials from "./admin-provider-credentials.js";
+import { adminRoutingAnalytics } from "./admin-routing-analytics.js";
 import admin from "./admin.js";
 import { analytics } from "./analytics.js";
 import { auditLogs } from "./audit-logs.js";
@@ -62,6 +63,7 @@ routes.route("/activity", activity);
 routes.route("/admin", admin);
 routes.route("/admin", adminProviderCredentials);
 routes.route("/admin", adminOrgDetails);
+routes.route("/admin", adminRoutingAnalytics);
 
 routes.route("/analytics", analytics);
 

--- a/ee/admin/src/app/routing-analytics/client.tsx
+++ b/ee/admin/src/app/routing-analytics/client.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { format, parseISO } from "date-fns";
 import { Check, ChevronsUpDown, Route } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useMemo, useState } from "react";
@@ -111,6 +110,36 @@ const SERIES_COLORS = [
 	"hsl(15 86% 55%)",
 	"hsl(200 60% 40%)",
 ];
+
+// Buckets are UTC hour boundaries, so they are rendered in UTC too — a
+// browser-local render would put the labels off the hour and disagree with the
+// "UTC" suffix on the tooltips.
+const AXIS_HOUR_FORMATTER = new Intl.DateTimeFormat("en-US", {
+	timeZone: "UTC",
+	month: "short",
+	day: "numeric",
+	hour: "2-digit",
+	minute: "2-digit",
+	hour12: false,
+});
+
+const TOOLTIP_HOUR_FORMATTER = new Intl.DateTimeFormat("en-US", {
+	timeZone: "UTC",
+	year: "numeric",
+	month: "short",
+	day: "numeric",
+	hour: "2-digit",
+	minute: "2-digit",
+	hour12: false,
+});
+
+function formatAxisHour(value: string): string {
+	return AXIS_HOUR_FORMATTER.format(new Date(value));
+}
+
+function formatTooltipHour(value: string): string {
+	return `${TOOLTIP_HOUR_FORMATTER.format(new Date(value))} UTC`;
+}
 
 function parseWindow(value: string | null): RoutingWindow {
 	return WINDOW_OPTIONS.some((o) => o.value === value)
@@ -437,7 +466,9 @@ export function RoutingAnalyticsClient() {
 							</CardTitle>
 							<CardDescription>
 								Window averages with every factor the router considers. Sorted
-								by score (lowest routes first).
+								by score (lowest routes first). Prices include platform-wide
+								discounts; an organization-specific discount can lower its own
+								price further and shift that organization&apos;s election.
 							</CardDescription>
 						</CardHeader>
 						<CardContent className="overflow-x-auto">
@@ -505,6 +536,17 @@ export function RoutingAnalyticsClient() {
 														mapping.price,
 														data.model.isImageModel,
 													)}
+													{mapping.discount > 0 ? (
+														<div className="text-[11px] text-muted-foreground">
+															<span className="line-through">
+																{formatSelectionPrice(
+																	mapping.listPrice,
+																	data.model.isImageModel,
+																)}
+															</span>{" "}
+															−{(mapping.discount * 100).toFixed(0)}%
+														</div>
+													) : null}
 												</TableCell>
 												<TableCell className="text-right font-mono text-xs">
 													{mapping.priority}
@@ -586,9 +628,7 @@ export function RoutingAnalyticsClient() {
 										axisLine={false}
 										tickMargin={8}
 										minTickGap={48}
-										tickFormatter={(value: string) =>
-											format(parseISO(value), "MMM d HH:mm")
-										}
+										tickFormatter={formatAxisHour}
 									/>
 									<YAxis
 										tickLine={false}
@@ -602,9 +642,7 @@ export function RoutingAnalyticsClient() {
 									<ChartTooltip
 										content={
 											<ChartTooltipContent
-												labelFormatter={(value: string) =>
-													format(parseISO(value), "MMM d, yyyy HH:mm 'UTC'")
-												}
+												labelFormatter={formatTooltipHour}
 												formatter={(value, name, item) => (
 													<>
 														<span
@@ -671,18 +709,12 @@ export function RoutingAnalyticsClient() {
 										axisLine={false}
 										tickMargin={8}
 										minTickGap={48}
-										tickFormatter={(value: string) =>
-											format(parseISO(value), "MMM d HH:mm")
-										}
+										tickFormatter={formatAxisHour}
 									/>
 									<YAxis tickLine={false} axisLine={false} width={50} />
 									<ChartTooltip
 										content={
-											<ChartTooltipContent
-												labelFormatter={(value: string) =>
-													format(parseISO(value), "MMM d, yyyy HH:mm 'UTC'")
-												}
-											/>
+											<ChartTooltipContent labelFormatter={formatTooltipHour} />
 										}
 									/>
 									<ChartLegend content={<ChartLegendContent />} />

--- a/ee/admin/src/app/routing-analytics/client.tsx
+++ b/ee/admin/src/app/routing-analytics/client.tsx
@@ -1,0 +1,789 @@
+"use client";
+
+import { format, parseISO } from "date-fns";
+import { Check, ChevronsUpDown, Route } from "lucide-react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useMemo, useState } from "react";
+import {
+	Bar,
+	BarChart,
+	CartesianGrid,
+	Line,
+	LineChart,
+	XAxis,
+	YAxis,
+} from "recharts";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import {
+	ChartContainer,
+	ChartLegend,
+	ChartLegendContent,
+	ChartTooltip,
+	ChartTooltipContent,
+} from "@/components/ui/chart";
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@/components/ui/command";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { useApi } from "@/lib/fetch-client";
+import { cn } from "@/lib/utils";
+
+import type { ChartConfig } from "@/components/ui/chart";
+
+type RoutingWindow = "24h" | "3d" | "7d";
+
+const WINDOW_OPTIONS: { value: RoutingWindow; label: string }[] = [
+	{ value: "24h", label: "24 hours" },
+	{ value: "3d", label: "3 days" },
+	{ value: "7d", label: "7 days" },
+];
+
+type MetricKey = "score" | "uptime" | "latency" | "throughput";
+
+const METRIC_OPTIONS: {
+	value: MetricKey;
+	label: string;
+	description: string;
+}[] = [
+	{
+		value: "score",
+		label: "Routing score",
+		description:
+			"Weighted score the router assigns each mapping per hourly bucket — the lowest score wins the election.",
+	},
+	{
+		value: "uptime",
+		label: "Uptime",
+		description:
+			"Successful requests / total requests per hour (client 4xx errors don't count against a provider).",
+	},
+	{
+		value: "latency",
+		label: "Latency (TTFT)",
+		description:
+			"Average time to first token in ms, from streamed requests only.",
+	},
+	{
+		value: "throughput",
+		label: "Throughput",
+		description: "Output tokens per second across the hourly bucket.",
+	},
+];
+
+// Distinct, color-blind-friendly hues. Repeat for >12 series.
+const SERIES_COLORS = [
+	"hsl(221 83% 53%)",
+	"hsl(142 71% 45%)",
+	"hsl(32 95% 44%)",
+	"hsl(280 65% 60%)",
+	"hsl(0 72% 51%)",
+	"hsl(189 94% 43%)",
+	"hsl(340 75% 55%)",
+	"hsl(48 96% 53%)",
+	"hsl(160 60% 45%)",
+	"hsl(258 76% 58%)",
+	"hsl(15 86% 55%)",
+	"hsl(200 60% 40%)",
+];
+
+function parseWindow(value: string | null): RoutingWindow {
+	return WINDOW_OPTIONS.some((o) => o.value === value)
+		? (value as RoutingWindow)
+		: "3d";
+}
+
+function parseMetric(value: string | null): MetricKey {
+	return METRIC_OPTIONS.some((o) => o.value === value)
+		? (value as MetricKey)
+		: "score";
+}
+
+function formatMetricValue(metric: MetricKey, value: number): string {
+	switch (metric) {
+		case "score":
+			return value.toFixed(3);
+		case "uptime":
+			return `${value.toFixed(1)}%`;
+		case "latency":
+			return `${Math.round(value)} ms`;
+		case "throughput":
+			return `${value.toFixed(1)} tok/s`;
+	}
+}
+
+function formatSelectionPrice(price: number, isImageModel: boolean): string {
+	if (price === 0) {
+		return "free";
+	}
+	if (isImageModel) {
+		return `$${price.toFixed(4)}/image`;
+	}
+	return `$${(price * 1e6).toFixed(2)}/M`;
+}
+
+function formatContribution(value: number): string {
+	if (value === 0) {
+		return "—";
+	}
+	return value > 0 ? `+${value.toFixed(3)}` : value.toFixed(3);
+}
+
+function ModelCombobox({
+	modelId,
+	onSelect,
+}: {
+	modelId: string | null;
+	onSelect: (id: string) => void;
+}) {
+	const $api = useApi();
+	const [open, setOpen] = useState(false);
+	const [search, setSearch] = useState("");
+
+	const { data, isLoading } = $api.useQuery("get", "/admin/models", {
+		params: {
+			query: {
+				search: search || undefined,
+				limit: 50,
+				sortBy: "logsCount",
+				sortOrder: "desc",
+			},
+		},
+	});
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<Button
+					variant="outline"
+					role="combobox"
+					aria-expanded={open}
+					className="w-[320px] justify-between font-mono text-xs"
+				>
+					{modelId ?? "Select a model…"}
+					<ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent className="w-[320px] p-0" align="start">
+				<Command shouldFilter={false}>
+					<CommandInput
+						placeholder="Search models…"
+						value={search}
+						onValueChange={setSearch}
+					/>
+					<CommandList>
+						<CommandEmpty>
+							{isLoading ? "Loading…" : "No models found."}
+						</CommandEmpty>
+						<CommandGroup>
+							{(data?.models ?? []).map((model) => (
+								<CommandItem
+									key={model.id}
+									value={model.id}
+									onSelect={(value) => {
+										onSelect(value);
+										setOpen(false);
+									}}
+								>
+									<Check
+										className={cn(
+											"mr-2 h-4 w-4",
+											modelId === model.id ? "opacity-100" : "opacity-0",
+										)}
+									/>
+									<span className="truncate font-mono text-xs">{model.id}</span>
+									<span className="ml-auto pl-2 text-xs text-muted-foreground">
+										{model.providerCount}p
+									</span>
+								</CommandItem>
+							))}
+						</CommandGroup>
+					</CommandList>
+				</Command>
+			</PopoverContent>
+		</Popover>
+	);
+}
+
+export function RoutingAnalyticsClient() {
+	const $api = useApi();
+	const router = useRouter();
+	const pathname = usePathname();
+	const searchParams = useSearchParams();
+
+	const modelId = searchParams.get("modelId");
+	const window = parseWindow(searchParams.get("window"));
+	const metric = parseMetric(searchParams.get("metric"));
+
+	const updateParam = useCallback(
+		(key: string, value: string) => {
+			const params = new URLSearchParams(searchParams.toString());
+			params.set(key, value);
+			router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+		},
+		[searchParams, router, pathname],
+	);
+
+	const { data, isLoading, isError } = $api.useQuery(
+		"get",
+		"/admin/routing-analytics",
+		{
+			params: { query: { modelId: modelId ?? "", window } },
+		},
+		{ enabled: Boolean(modelId) },
+	);
+
+	// Chart every mapping that is either electable or actually saw traffic in
+	// the window (a deactivated mapping with residual history stays visible).
+	const chartedProviders = useMemo(() => {
+		if (!data) {
+			return [];
+		}
+		return data.mappings.filter(
+			(mapping) =>
+				mapping.routable ||
+				(data.summary.find((s) => s.providerId === mapping.providerId)
+					?.requestCount ?? 0) > 0,
+		);
+	}, [data]);
+
+	const chartConfig = useMemo(() => {
+		const config: ChartConfig = {};
+		chartedProviders.forEach((mapping, index) => {
+			config[mapping.providerId] = {
+				label: mapping.providerName,
+				color: SERIES_COLORS[index % SERIES_COLORS.length],
+			};
+		});
+		return config;
+	}, [chartedProviders]);
+
+	const metricChartData = useMemo(() => {
+		if (!data) {
+			return [];
+		}
+		return data.hourly.map((hour) => {
+			const row: Record<string, string | number | null> = { hour: hour.hour };
+			for (const entry of hour.providers) {
+				row[entry.providerId] = entry[metric];
+			}
+			return row;
+		});
+	}, [data, metric]);
+
+	const trafficChartData = useMemo(() => {
+		if (!data) {
+			return [];
+		}
+		return data.hourly.map((hour) => {
+			const row: Record<string, string | number> = { hour: hour.hour };
+			for (const entry of hour.providers) {
+				row[entry.providerId] = entry.requestCount;
+			}
+			return row;
+		});
+	}, [data]);
+
+	const totalRequests = useMemo(
+		() => data?.summary.reduce((sum, s) => sum + s.requestCount, 0) ?? 0,
+		[data],
+	);
+
+	const sortedSummary = useMemo(() => {
+		if (!data) {
+			return [];
+		}
+		return [...data.summary].sort((a, b) => {
+			if (a.score === null && b.score === null) {
+				return b.requestCount - a.requestCount;
+			}
+			if (a.score === null) {
+				return 1;
+			}
+			if (b.score === null) {
+				return -1;
+			}
+			return a.score - b.score;
+		});
+	}, [data]);
+
+	const metricOption = METRIC_OPTIONS.find((o) => o.value === metric)!;
+
+	return (
+		<div className="space-y-6">
+			<div className="flex flex-wrap items-start justify-between gap-4">
+				<div>
+					<h1 className="flex items-center gap-2 text-2xl font-semibold">
+						<Route className="h-6 w-6" />
+						Routing Analytics
+					</h1>
+					<p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+						Why the gateway elects a specific provider mapping for a routed
+						model id: hourly-averaged routing inputs (uptime, latency,
+						throughput), static factors (price, priority, cache support), and
+						the resulting weighted score per mapping. Live routing uses the same
+						formula over a tier-weighted 60-minute window; hourly buckets are
+						shown here to smooth out fluctuations.
+					</p>
+				</div>
+				<div className="flex flex-wrap items-center gap-2">
+					<ModelCombobox
+						modelId={modelId}
+						onSelect={(id) => updateParam("modelId", id)}
+					/>
+					<div className="flex items-center rounded-md border p-0.5">
+						{WINDOW_OPTIONS.map((option) => (
+							<Button
+								key={option.value}
+								variant={window === option.value ? "secondary" : "ghost"}
+								size="sm"
+								className="h-8 text-xs"
+								onClick={() => updateParam("window", option.value)}
+							>
+								{option.label}
+							</Button>
+						))}
+					</div>
+				</div>
+			</div>
+
+			{!modelId ? (
+				<Card>
+					<CardContent className="flex h-[200px] items-center justify-center text-sm text-muted-foreground">
+						Select a model to inspect its provider routing.
+					</CardContent>
+				</Card>
+			) : isError ? (
+				<Card>
+					<CardContent className="flex h-[200px] items-center justify-center text-sm text-muted-foreground">
+						Failed to load routing analytics for {modelId}.
+					</CardContent>
+				</Card>
+			) : isLoading || !data ? (
+				<Card>
+					<CardContent className="flex h-[200px] items-center justify-center text-sm text-muted-foreground">
+						Loading…
+					</CardContent>
+				</Card>
+			) : (
+				<>
+					<Card>
+						<CardHeader>
+							<CardTitle>Scoring weights</CardTitle>
+							<CardDescription>
+								Default weights applied to a streaming text request (short
+								prompt). Score = weighted factor scores + priority penalty +
+								exponential uptime penalty (below{" "}
+								{data.config.thresholds.uptimePenalty}% uptime). Lowest score
+								wins. Missing metrics fall back to{" "}
+								{data.config.thresholds.defaultUptime}% uptime,{" "}
+								{data.config.thresholds.defaultLatency} ms latency and{" "}
+								{data.config.thresholds.defaultThroughput} tok/s.{" "}
+								{Math.round(data.config.thresholds.explorationRate * 100)}% of
+								requests are routed randomly for exploration.
+							</CardDescription>
+						</CardHeader>
+						<CardContent className="flex flex-wrap gap-2">
+							{(
+								[
+									["Price", data.config.effectiveWeights.price],
+									["Uptime", data.config.effectiveWeights.uptime],
+									["Throughput", data.config.effectiveWeights.throughput],
+									["Latency", data.config.effectiveWeights.latency],
+									["Cache", data.config.effectiveWeights.cache],
+								] as const
+							).map(([label, weight]) => (
+								<Badge key={label} variant="secondary" className="text-xs">
+									{label}:{" "}
+									{(
+										(weight / data.config.effectiveWeights.total) *
+										100
+									).toFixed(1)}
+									%
+								</Badge>
+							))}
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardHeader>
+							<CardTitle>
+								Mappings for <span className="font-mono">{data.model.id}</span>
+							</CardTitle>
+							<CardDescription>
+								Window averages with every factor the router considers. Sorted
+								by score (lowest routes first).
+							</CardDescription>
+						</CardHeader>
+						<CardContent className="overflow-x-auto">
+							<Table>
+								<TableHeader>
+									<TableRow>
+										<TableHead>Provider</TableHead>
+										<TableHead>Status</TableHead>
+										<TableHead className="text-right">Price</TableHead>
+										<TableHead className="text-right">Priority</TableHead>
+										<TableHead className="text-center">Cache</TableHead>
+										<TableHead className="text-right">Uptime</TableHead>
+										<TableHead className="text-right">TTFT</TableHead>
+										<TableHead className="text-right">Throughput</TableHead>
+										<TableHead className="text-right">Requests</TableHead>
+										<TableHead className="text-right">Share</TableHead>
+										<TableHead className="text-right">Score</TableHead>
+									</TableRow>
+								</TableHeader>
+								<TableBody>
+									{sortedSummary.map((summary) => {
+										const mapping = data.mappings.find(
+											(m) => m.providerId === summary.providerId,
+										)!;
+										return (
+											<TableRow key={summary.providerId}>
+												<TableCell>
+													<div className="flex items-center gap-2">
+														<span
+															className="h-2.5 w-2.5 shrink-0 rounded-full"
+															style={{
+																backgroundColor:
+																	chartConfig[summary.providerId]?.color,
+															}}
+														/>
+														<span className="font-medium">
+															{mapping.providerName}
+														</span>
+														<span className="font-mono text-xs text-muted-foreground">
+															{mapping.providerId}
+														</span>
+													</div>
+												</TableCell>
+												<TableCell>
+													{mapping.routable ? (
+														<Badge variant="outline" className="text-xs">
+															{mapping.stability}
+														</Badge>
+													) : (
+														<div className="flex flex-wrap gap-1">
+															{mapping.excludedReasons.map((reason) => (
+																<Badge
+																	key={reason}
+																	variant="destructive"
+																	className="text-xs"
+																>
+																	{reason}
+																</Badge>
+															))}
+														</div>
+													)}
+												</TableCell>
+												<TableCell className="text-right font-mono text-xs">
+													{formatSelectionPrice(
+														mapping.price,
+														data.model.isImageModel,
+													)}
+												</TableCell>
+												<TableCell className="text-right font-mono text-xs">
+													{mapping.priority}
+												</TableCell>
+												<TableCell className="text-center">
+													{mapping.cacheSupported ? "✓" : "—"}
+												</TableCell>
+												<TableCell className="text-right font-mono text-xs">
+													{summary.uptime !== null
+														? `${summary.uptime.toFixed(1)}%`
+														: "—"}
+												</TableCell>
+												<TableCell className="text-right font-mono text-xs">
+													{summary.latency !== null
+														? `${Math.round(summary.latency)} ms`
+														: "—"}
+												</TableCell>
+												<TableCell className="text-right font-mono text-xs">
+													{summary.throughput !== null
+														? `${summary.throughput.toFixed(1)} tok/s`
+														: "—"}
+												</TableCell>
+												<TableCell className="text-right font-mono text-xs">
+													{summary.requestCount.toLocaleString()}
+												</TableCell>
+												<TableCell className="text-right font-mono text-xs">
+													{totalRequests > 0
+														? `${((summary.requestCount / totalRequests) * 100).toFixed(1)}%`
+														: "—"}
+												</TableCell>
+												<TableCell className="text-right font-mono text-xs font-semibold">
+													{summary.score !== null
+														? summary.score.toFixed(3)
+														: "—"}
+												</TableCell>
+											</TableRow>
+										);
+									})}
+								</TableBody>
+							</Table>
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardHeader>
+							<div className="flex flex-wrap items-start justify-between gap-3">
+								<div>
+									<CardTitle>{metricOption.label} over time</CardTitle>
+									<CardDescription>{metricOption.description}</CardDescription>
+								</div>
+								<div className="flex items-center rounded-md border p-0.5">
+									{METRIC_OPTIONS.map((option) => (
+										<Button
+											key={option.value}
+											variant={metric === option.value ? "secondary" : "ghost"}
+											size="sm"
+											className="h-8 text-xs"
+											onClick={() => updateParam("metric", option.value)}
+										>
+											{option.label}
+										</Button>
+									))}
+								</div>
+							</div>
+						</CardHeader>
+						<CardContent>
+							<ChartContainer
+								config={chartConfig}
+								className="aspect-auto h-[320px] w-full"
+							>
+								<LineChart
+									data={metricChartData}
+									margin={{ left: 12, right: 12 }}
+								>
+									<CartesianGrid vertical={false} />
+									<XAxis
+										dataKey="hour"
+										tickLine={false}
+										axisLine={false}
+										tickMargin={8}
+										minTickGap={48}
+										tickFormatter={(value: string) =>
+											format(parseISO(value), "MMM d HH:mm")
+										}
+									/>
+									<YAxis
+										tickLine={false}
+										axisLine={false}
+										width={70}
+										domain={metric === "uptime" ? [0, 100] : ["auto", "auto"]}
+										tickFormatter={(value: number) =>
+											formatMetricValue(metric, value)
+										}
+									/>
+									<ChartTooltip
+										content={
+											<ChartTooltipContent
+												labelFormatter={(value: string) =>
+													format(parseISO(value), "MMM d, yyyy HH:mm 'UTC'")
+												}
+												formatter={(value, name, item) => (
+													<>
+														<span
+															className="size-2 shrink-0 rounded-[2px]"
+															style={{ backgroundColor: item.color }}
+														/>
+														<span className="text-muted-foreground">
+															{chartConfig[name as string]?.label ?? name}
+														</span>
+														<span className="ml-auto font-mono font-medium tabular-nums text-foreground">
+															{formatMetricValue(metric, Number(value))}
+														</span>
+													</>
+												)}
+											/>
+										}
+									/>
+									<ChartLegend content={<ChartLegendContent />} />
+									{chartedProviders.map((mapping) => (
+										<Line
+											key={mapping.providerId}
+											dataKey={mapping.providerId}
+											type="monotone"
+											stroke={`var(--color-${mapping.providerId})`}
+											strokeWidth={2}
+											dot={false}
+											connectNulls={false}
+										/>
+									))}
+								</LineChart>
+							</ChartContainer>
+							{metric === "score" ? (
+								<p className="mt-2 text-xs text-muted-foreground">
+									Lower is better — the mapping with the lowest score wins the
+									election. Hours without traffic are scored with the default
+									metric fallbacks.
+								</p>
+							) : null}
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardHeader>
+							<CardTitle>Requests per hour</CardTitle>
+							<CardDescription>
+								Where traffic actually went — the outcome of the elections above
+								(including pinned providers, sticky sessions, fallbacks and
+								exploration).
+							</CardDescription>
+						</CardHeader>
+						<CardContent>
+							<ChartContainer
+								config={chartConfig}
+								className="aspect-auto h-[260px] w-full"
+							>
+								<BarChart
+									data={trafficChartData}
+									margin={{ left: 12, right: 12 }}
+								>
+									<CartesianGrid vertical={false} />
+									<XAxis
+										dataKey="hour"
+										tickLine={false}
+										axisLine={false}
+										tickMargin={8}
+										minTickGap={48}
+										tickFormatter={(value: string) =>
+											format(parseISO(value), "MMM d HH:mm")
+										}
+									/>
+									<YAxis tickLine={false} axisLine={false} width={50} />
+									<ChartTooltip
+										content={
+											<ChartTooltipContent
+												labelFormatter={(value: string) =>
+													format(parseISO(value), "MMM d, yyyy HH:mm 'UTC'")
+												}
+											/>
+										}
+									/>
+									<ChartLegend content={<ChartLegendContent />} />
+									{chartedProviders.map((mapping) => (
+										<Bar
+											key={mapping.providerId}
+											dataKey={mapping.providerId}
+											stackId="requests"
+											fill={`var(--color-${mapping.providerId})`}
+										/>
+									))}
+								</BarChart>
+							</ChartContainer>
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardHeader>
+							<CardTitle>Score composition (window average)</CardTitle>
+							<CardDescription>
+								How each factor contributes to the final score. Factor
+								contributions are the weighted ratio against the best mapping (0
+								= best); penalties are added on top.
+							</CardDescription>
+						</CardHeader>
+						<CardContent className="overflow-x-auto">
+							<Table>
+								<TableHeader>
+									<TableRow>
+										<TableHead>Provider</TableHead>
+										<TableHead className="text-right">Price</TableHead>
+										<TableHead className="text-right">Uptime</TableHead>
+										<TableHead className="text-right">Throughput</TableHead>
+										<TableHead className="text-right">Latency</TableHead>
+										<TableHead className="text-right">Cache</TableHead>
+										<TableHead className="text-right">
+											Priority penalty
+										</TableHead>
+										<TableHead className="text-right">Uptime penalty</TableHead>
+										<TableHead className="text-right">= Score</TableHead>
+									</TableRow>
+								</TableHeader>
+								<TableBody>
+									{sortedSummary
+										.filter((summary) => summary.breakdown !== null)
+										.map((summary) => {
+											const breakdown = summary.breakdown!;
+											const mapping = data.mappings.find(
+												(m) => m.providerId === summary.providerId,
+											)!;
+											return (
+												<TableRow key={summary.providerId}>
+													<TableCell>
+														<div className="flex items-center gap-2">
+															<span
+																className="h-2.5 w-2.5 shrink-0 rounded-full"
+																style={{
+																	backgroundColor:
+																		chartConfig[summary.providerId]?.color,
+																}}
+															/>
+															{mapping.providerName}
+														</div>
+													</TableCell>
+													<TableCell className="text-right font-mono text-xs">
+														{formatContribution(breakdown.priceContribution)}
+													</TableCell>
+													<TableCell className="text-right font-mono text-xs">
+														{formatContribution(breakdown.uptimeContribution)}
+													</TableCell>
+													<TableCell className="text-right font-mono text-xs">
+														{formatContribution(
+															breakdown.throughputContribution,
+														)}
+													</TableCell>
+													<TableCell className="text-right font-mono text-xs">
+														{formatContribution(breakdown.latencyContribution)}
+													</TableCell>
+													<TableCell className="text-right font-mono text-xs">
+														{formatContribution(breakdown.cacheContribution)}
+													</TableCell>
+													<TableCell className="text-right font-mono text-xs">
+														{formatContribution(breakdown.priorityPenalty)}
+													</TableCell>
+													<TableCell className="text-right font-mono text-xs">
+														{formatContribution(breakdown.uptimePenalty)}
+													</TableCell>
+													<TableCell className="text-right font-mono text-xs font-semibold">
+														{summary.score !== null
+															? summary.score.toFixed(3)
+															: "—"}
+													</TableCell>
+												</TableRow>
+											);
+										})}
+								</TableBody>
+							</Table>
+						</CardContent>
+					</Card>
+				</>
+			)}
+		</div>
+	);
+}

--- a/ee/admin/src/app/routing-analytics/page.tsx
+++ b/ee/admin/src/app/routing-analytics/page.tsx
@@ -1,0 +1,14 @@
+import { Suspense } from "react";
+
+import { requireSession } from "@/lib/require-session";
+
+import { RoutingAnalyticsClient } from "./client";
+
+export default async function Page() {
+	await requireSession();
+	return (
+		<Suspense>
+			<RoutingAnalyticsClient />
+		</Suspense>
+	);
+}

--- a/ee/admin/src/components/admin-shell.tsx
+++ b/ee/admin/src/components/admin-shell.tsx
@@ -17,6 +17,7 @@ import {
 	MessageCircle,
 	MessageSquare,
 	Percent,
+	Route,
 	Server,
 	Sparkles,
 } from "lucide-react";
@@ -99,6 +100,7 @@ export function AdminShell({ children }: AdminShellProps) {
 	const isProviderCredentials = pathname.startsWith("/provider-credentials");
 	const isModels = pathname === "/models";
 	const isModelProviderMappings = pathname === "/model-provider-mappings";
+	const isRoutingAnalytics = pathname.startsWith("/routing-analytics");
 	const isUnstableMappings = pathname.startsWith("/unstable-mappings");
 	const isContactSubmissions = pathname.startsWith("/contact-submissions");
 	const isProviderListingRequests = pathname.startsWith(
@@ -231,6 +233,14 @@ export function AdminShell({ children }: AdminShellProps) {
 									>
 										<GitMerge className="h-4 w-4" />
 										<span>Model Mappings</span>
+									</SidebarMenuButton>
+								</Link>
+							</SidebarMenuItem>
+							<SidebarMenuItem>
+								<Link href="/routing-analytics" className="block">
+									<SidebarMenuButton isActive={isRoutingAnalytics} size="lg">
+										<Route className="h-4 w-4" />
+										<span>Routing Analytics</span>
 									</SidebarMenuButton>
 								</Link>
 							</SidebarMenuItem>

--- a/packages/actions/src/compute-provider-scores.ts
+++ b/packages/actions/src/compute-provider-scores.ts
@@ -102,6 +102,14 @@ export function computeWeightedProviderScores(
 	}
 	const { thresholds } = cfg;
 	const weights = getEffectiveScoringWeights(cfg, flags);
+	if (weights.total <= 0) {
+		// Every contribution would divide by zero and decimal.js yields NaN
+		// silently, so surface the caller's mistake instead of returning scores
+		// that quietly compare as equal.
+		throw new Error(
+			"computeWeightedProviderScores requires weights.total > 0; fall back to price-only selection when every weight is zeroed",
+		);
+	}
 	const weightSum = new Decimal(weights.total);
 
 	const minPrice = candidates.reduce(

--- a/packages/actions/src/compute-provider-scores.ts
+++ b/packages/actions/src/compute-provider-scores.ts
@@ -1,0 +1,222 @@
+import { Decimal } from "decimal.js";
+
+import type { ResolvedRoutingConfig } from "@llmgateway/shared/routing-config";
+
+export interface ScoringFlags {
+	isStreaming: boolean;
+	isImageModel: boolean;
+	/**
+	 * Whether cache support participates in the score. Only true when the
+	 * request's estimated prompt tokens reach thresholds.cachePromptTokens.
+	 */
+	cacheRelevant: boolean;
+}
+
+export interface EffectiveScoringWeights {
+	price: number;
+	uptime: number;
+	throughput: number;
+	latency: number;
+	cache: number;
+	total: number;
+}
+
+/**
+ * Resolve the weights that actually apply to a request: image models swap in
+ * the image price weight, latency only counts for streaming requests, and
+ * cache support only counts for prompts large enough to benefit from caching.
+ */
+export function getEffectiveScoringWeights(
+	cfg: ResolvedRoutingConfig,
+	flags: ScoringFlags,
+): EffectiveScoringWeights {
+	const { weights } = cfg;
+	const price = flags.isImageModel ? weights.imagePrice : weights.price;
+	const latency = flags.isStreaming ? weights.latency : 0;
+	const cache = flags.cacheRelevant ? weights.cache : 0;
+	return {
+		price,
+		uptime: weights.uptime,
+		throughput: weights.throughput,
+		latency,
+		cache,
+		total: price + weights.uptime + weights.throughput + latency + cache,
+	};
+}
+
+export function calculateUptimePenalty(
+	uptime: number,
+	threshold: number,
+): number {
+	if (uptime >= threshold) {
+		return 0;
+	}
+	const deficit = (threshold - uptime) / threshold;
+	return Math.pow(deficit * 5, 2);
+}
+
+export interface CandidateScoreInput {
+	price: Decimal;
+	uptime?: number;
+	latency?: number;
+	throughput?: number;
+	cacheSupported: boolean;
+	priority: number;
+}
+
+export interface CandidateScoreBreakdown {
+	/** Final score: baseScore + priorityPenalty + uptimePenalty. Lower wins. */
+	score: Decimal;
+	baseScore: Decimal;
+	/** Per-factor ratio scores before weighting (0 = best candidate). */
+	priceScore: Decimal;
+	uptimeScore: Decimal;
+	throughputScore: Decimal;
+	latencyScore: Decimal;
+	cacheScore: Decimal;
+	/** Per-factor weighted contributions; they sum to baseScore. */
+	priceContribution: Decimal;
+	uptimeContribution: Decimal;
+	throughputContribution: Decimal;
+	latencyContribution: Decimal;
+	cacheContribution: Decimal;
+	priorityPenalty: Decimal;
+	uptimePenalty: Decimal;
+}
+
+/**
+ * The weighted-score core of provider election, extracted so routing and the
+ * admin routing-analytics endpoint share one formula. Sub-scores are ratios
+ * against the best candidate (so proportional differences are preserved),
+ * missing metrics fall back to thresholds.default*, and the caller must
+ * guarantee weights.total > 0 (routing falls back to price-only otherwise).
+ * Returns one breakdown per input, aligned by index.
+ */
+export function computeWeightedProviderScores(
+	candidates: CandidateScoreInput[],
+	cfg: ResolvedRoutingConfig,
+	flags: ScoringFlags,
+): CandidateScoreBreakdown[] {
+	if (candidates.length === 0) {
+		return [];
+	}
+	const { thresholds } = cfg;
+	const weights = getEffectiveScoringWeights(cfg, flags);
+	const weightSum = new Decimal(weights.total);
+
+	const minPrice = candidates.reduce(
+		(min, c) => (c.price.lt(min) ? c.price : min),
+		candidates[0].price,
+	);
+
+	// When the cheapest provider is free (minPrice == 0), the price/minPrice ratio
+	// is undefined, so without this a free and a paid provider would both score 0
+	// on price and the decision would fall to uptime/throughput — letting a paid
+	// provider beat a free one even under `routing: "price"`. Rank paid providers
+	// against the cheapest *positive* price instead, so a free provider always
+	// scores best (0) while paid providers stay ordered among themselves.
+	const minPositivePrice = candidates.reduce<Decimal | null>((min, c) => {
+		if (c.price.gt(0) && (min === null || c.price.lt(min))) {
+			return c.price;
+		}
+		return min;
+	}, null);
+
+	const uptimes = candidates.map((c) => c.uptime ?? thresholds.defaultUptime);
+	const maxUptime = Math.max(...uptimes);
+
+	const throughputs = candidates.map(
+		(c) => c.throughput ?? thresholds.defaultThroughput,
+	);
+	const maxThroughput = Math.max(...throughputs);
+
+	const latencies = candidates.map(
+		(c) => c.latency ?? thresholds.defaultLatency,
+	);
+	const minLatency = Math.min(...latencies);
+
+	return candidates.map((candidate) => {
+		// Price ratio: 0 = cheapest, 0.5 = 50% more expensive, 1.0 = 2x more expensive
+		// This preserves the actual magnitude of price differences
+		const priceScore = minPrice.gt(0)
+			? candidate.price.div(minPrice).minus(1)
+			: candidate.price.gt(0) && minPositivePrice
+				? candidate.price.div(minPositivePrice)
+				: new Decimal(0);
+
+		// Uptime ratio: 0 = best uptime, proportional penalty for worse uptime
+		const uptime = candidate.uptime ?? thresholds.defaultUptime;
+		const uptimeScore =
+			uptime > 0 ? new Decimal(maxUptime).div(uptime).minus(1) : new Decimal(1);
+
+		const uptimePenalty = new Decimal(
+			calculateUptimePenalty(uptime, thresholds.uptimePenalty),
+		);
+
+		// Throughput ratio: 0 = fastest, 0.5 = 50% slower, 1.0 = 2x slower
+		const throughput = candidate.throughput ?? thresholds.defaultThroughput;
+		const throughputScore =
+			throughput > 0
+				? new Decimal(maxThroughput).div(throughput).minus(1)
+				: new Decimal(1);
+
+		// Latency ratio: 0 = fastest, proportional penalty for slower
+		// Only consider latency for streaming requests since it's only measured there
+		let latencyScore = new Decimal(0);
+		if (flags.isStreaming) {
+			const latency = candidate.latency ?? thresholds.defaultLatency;
+			latencyScore =
+				minLatency > 0
+					? new Decimal(latency).div(minLatency).minus(1)
+					: new Decimal(0);
+		}
+
+		// Cache score: 0 when this provider supports prompt caching, 1 otherwise.
+		const cacheScore = candidate.cacheSupported
+			? new Decimal(0)
+			: new Decimal(1);
+
+		const priceContribution = new Decimal(weights.price)
+			.div(weightSum)
+			.times(priceScore);
+		const uptimeContribution = new Decimal(weights.uptime)
+			.div(weightSum)
+			.times(uptimeScore);
+		const throughputContribution = new Decimal(weights.throughput)
+			.div(weightSum)
+			.times(throughputScore);
+		const latencyContribution = new Decimal(weights.latency)
+			.div(weightSum)
+			.times(latencyScore);
+		const cacheContribution = new Decimal(weights.cache)
+			.div(weightSum)
+			.times(cacheScore);
+
+		const baseScore = priceContribution
+			.plus(uptimeContribution)
+			.plus(throughputContribution)
+			.plus(latencyContribution)
+			.plus(cacheContribution);
+
+		// Apply provider priority: lower priority = higher score (less preferred)
+		// Priority defaults to 1. We add (1 - priority) as a penalty.
+		const priorityPenalty = new Decimal(1).minus(candidate.priority);
+
+		return {
+			score: baseScore.plus(priorityPenalty).plus(uptimePenalty),
+			baseScore,
+			priceScore,
+			uptimeScore,
+			throughputScore,
+			latencyScore,
+			cacheScore,
+			priceContribution,
+			uptimeContribution,
+			throughputContribution,
+			latencyContribution,
+			cacheContribution,
+			priorityPenalty,
+			uptimePenalty,
+		};
+	});
+}

--- a/packages/actions/src/get-cheapest-from-available-providers.ts
+++ b/packages/actions/src/get-cheapest-from-available-providers.ts
@@ -17,6 +17,11 @@ import {
 	type ResolvedRoutingConfig,
 } from "@llmgateway/shared/routing-config";
 
+import {
+	computeWeightedProviderScores,
+	getEffectiveScoringWeights,
+} from "./compute-provider-scores.js";
+
 interface ProviderScore<T extends AvailableModelProvider> {
 	provider: T;
 	score: Decimal;
@@ -26,14 +31,6 @@ interface ProviderScore<T extends AvailableModelProvider> {
 	throughput?: number;
 	cacheSupported?: boolean;
 	discount?: Decimal;
-}
-
-function calculateUptimePenalty(uptime: number, threshold: number): number {
-	if (uptime >= threshold) {
-		return 0;
-	}
-	const deficit = (threshold - uptime) / threshold;
-	return Math.pow(deficit * 5, 2);
 }
 
 function getExplorationRate(cfg: ResolvedRoutingConfig): number {
@@ -525,14 +522,16 @@ export async function getCheapestFromAvailableProviders<
 	const videoPricing = options?.videoPricing;
 	const promptTokens = options?.promptTokens;
 	const cfg = options?.routingConfig ?? getDefaultRoutingConfig();
-	const { weights, thresholds } = cfg;
+	const { thresholds } = cfg;
 	// Use higher price weight for image generation models
 	const isImageModel = modelWithPricing.output?.includes("image") ?? false;
-	const effectivePriceWeight = isImageModel
-		? weights.imagePrice
-		: weights.price;
 	const cacheSupportRelevant =
 		promptTokens !== undefined && promptTokens >= thresholds.cachePromptTokens;
+	const scoringFlags = {
+		isStreaming,
+		isImageModel,
+		cacheRelevant: cacheSupportRelevant,
+	};
 	if (availableModelProviders.length === 0) {
 		return null;
 	}
@@ -656,14 +655,7 @@ export async function getCheapestFromAvailableProviders<
 	// If the project zeroed out every scoring weight, the weighted-score path
 	// would divide by zero. Fall back to price-only selection (still honoring
 	// per-provider priority overrides and the priority-0 disable).
-	const effectiveLatencyWeight = isStreaming ? weights.latency : 0;
-	const effectiveCacheWeight = cacheSupportRelevant ? weights.cache : 0;
-	const totalWeight =
-		effectivePriceWeight +
-		weights.uptime +
-		weights.throughput +
-		effectiveLatencyWeight +
-		effectiveCacheWeight;
+	const totalWeight = getEffectiveScoringWeights(cfg, scoringFlags).total;
 	if (totalWeight <= 0) {
 		const priceOnlyResult = selectByPriceOnly(
 			stableProviders,
@@ -720,118 +712,24 @@ export async function getCheapestFromAvailableProviders<
 		});
 	}
 
-	// Find best values for ratio-based scoring
-	// Instead of min-max normalization (which loses magnitude of differences),
-	// we use ratios against the best value so actual proportional differences
-	// are preserved. e.g., a provider 50% cheaper scores much better than one 5% cheaper.
-	const minPrice = providerScores.reduce(
-		(min, p) => (p.price.lt(min) ? p.price : min),
-		providerScores[0].price,
+	// Score all candidates with the shared weighted-score core (ratio-based
+	// sub-scores, priority penalty, exponential uptime penalty — lower wins).
+	// totalWeight is guaranteed > 0 above (zero-total falls back to price-only
+	// selection earlier in this function).
+	const breakdowns = computeWeightedProviderScores(
+		providerScores.map((p) => ({
+			price: p.price,
+			uptime: p.uptime,
+			latency: p.latency,
+			throughput: p.throughput,
+			cacheSupported: p.cacheSupported ?? false,
+			priority: getEffectivePriority(p.provider.providerId, cfg),
+		})),
+		cfg,
+		scoringFlags,
 	);
-
-	// When the cheapest provider is free (minPrice == 0), the price/minPrice ratio
-	// is undefined, so without this a free and a paid provider would both score 0
-	// on price and the decision would fall to uptime/throughput — letting a paid
-	// provider beat a free one even under `routing: "price"`. Rank paid providers
-	// against the cheapest *positive* price instead, so a free provider always
-	// scores best (0) while paid providers stay ordered among themselves.
-	const minPositivePrice = providerScores.reduce<Decimal | null>((min, p) => {
-		if (p.price.gt(0) && (min === null || p.price.lt(min))) {
-			return p.price;
-		}
-		return min;
-	}, null);
-
-	const uptimes = providerScores.map(
-		(p) => p.uptime ?? thresholds.defaultUptime,
-	);
-	const maxUptime = Math.max(...uptimes);
-
-	const throughputs = providerScores.map(
-		(p) => p.throughput ?? thresholds.defaultThroughput,
-	);
-	const maxThroughput = Math.max(...throughputs);
-
-	const latencies = providerScores.map(
-		(p) => p.latency ?? thresholds.defaultLatency,
-	);
-	const minLatency = Math.min(...latencies);
-
-	// Calculate ratio-based scores
-	for (const providerScore of providerScores) {
-		// Price ratio: 0 = cheapest, 0.5 = 50% more expensive, 1.0 = 2x more expensive
-		// This preserves the actual magnitude of price differences
-		const priceScore = minPrice.gt(0)
-			? providerScore.price.div(minPrice).minus(1)
-			: providerScore.price.gt(0) && minPositivePrice
-				? providerScore.price.div(minPositivePrice)
-				: new Decimal(0);
-
-		// Uptime ratio: 0 = best uptime, proportional penalty for worse uptime
-		const uptime = providerScore.uptime ?? thresholds.defaultUptime;
-		const uptimeScore =
-			uptime > 0 ? new Decimal(maxUptime).div(uptime).minus(1) : new Decimal(1);
-
-		// Calculate exponential penalty for truly unstable providers
-		const uptimePenalty = new Decimal(
-			calculateUptimePenalty(uptime, thresholds.uptimePenalty),
-		);
-
-		// Throughput ratio: 0 = fastest, 0.5 = 50% slower, 1.0 = 2x slower
-		// This preserves the actual magnitude of throughput differences
-		const throughput = providerScore.throughput ?? thresholds.defaultThroughput;
-		const throughputScore =
-			throughput > 0
-				? new Decimal(maxThroughput).div(throughput).minus(1)
-				: new Decimal(1);
-
-		// Latency ratio: 0 = fastest, proportional penalty for slower
-		// Only consider latency for streaming requests since it's only measured there
-		let latencyScore = new Decimal(0);
-		if (isStreaming) {
-			const latency = providerScore.latency ?? thresholds.defaultLatency;
-			latencyScore =
-				minLatency > 0
-					? new Decimal(latency).div(minLatency).minus(1)
-					: new Decimal(0);
-		}
-
-		// Cache score: 0 when this provider supports prompt caching, 1 otherwise.
-		// Only weighted in when the prompt is large enough for caching to matter.
-		const cacheScore = providerScore.cacheSupported
-			? new Decimal(0)
-			: new Decimal(1);
-
-		// Calculate base weighted score (lower is better)
-		// When not streaming, latency weight is redistributed to other factors
-		// Image generation models use a higher price weight, and cache weight is
-		// dropped for short prompts where caching has no measurable effect.
-		// totalWeight is guaranteed > 0 above (zero-total falls back to
-		// price-only selection earlier in this function).
-		const weightSum = new Decimal(totalWeight);
-		const baseScore = new Decimal(effectivePriceWeight)
-			.div(weightSum)
-			.times(priceScore)
-			.plus(new Decimal(weights.uptime).div(weightSum).times(uptimeScore))
-			.plus(
-				new Decimal(weights.throughput).div(weightSum).times(throughputScore),
-			)
-			.plus(
-				new Decimal(effectiveLatencyWeight).div(weightSum).times(latencyScore),
-			)
-			.plus(new Decimal(effectiveCacheWeight).div(weightSum).times(cacheScore));
-
-		// Apply provider priority: lower priority = higher score (less preferred)
-		// Priority defaults to 1. We add (1 - priority) as a penalty.
-		const priority = getEffectivePriority(
-			providerScore.provider.providerId,
-			cfg,
-		);
-		const priorityPenalty = new Decimal(1).minus(priority);
-
-		// Final score = base weighted score + priority penalty + exponential uptime penalty
-		// The uptime penalty heavily penalizes providers with <95% uptime
-		providerScore.score = baseScore.plus(priorityPenalty).plus(uptimePenalty);
+	for (const [index, providerScore] of providerScores.entries()) {
+		providerScore.score = breakdowns[index].score;
 	}
 
 	// Select provider with lowest score

--- a/packages/actions/src/index.ts
+++ b/packages/actions/src/index.ts
@@ -8,6 +8,7 @@ export * from "./get-provider-headers.js";
 export * from "./apply-google-service-tier.js";
 export * from "./prepare-request-body.js";
 export * from "./get-provider-endpoint.js";
+export * from "./compute-provider-scores.js";
 export * from "./get-cheapest-from-available-providers.js";
 export * from "./validate-provider-key.js";
 export * from "./get-cheapest-model-for-provider.js";


### PR DESCRIPTION
## Problem

Every request logs its routing decision (`log.routingMetadata` with scores, weights inputs and attempts), but there is no aggregated view of **why** a specific provider mapping keeps winning the election for a routed model id. Per-request blobs fluctuate too much to reason about.

## Approach

A new admin dashboard page, **Routing Analytics** (`/routing-analytics`), that shows every mapping of a model with its performance and every factor the router considers, in **hourly buckets** to smooth out fluctuation:

- **`packages/actions`** — extracts the weighted-score core of `getCheapestFromAvailableProviders` into a pure, exported `computeWeightedProviderScores` (plus `getEffectiveScoringWeights` / `calculateUptimePenalty`), so routing and analytics share one formula. The elector now calls the shared function; behavior is unchanged (all 51 existing scoring tests pass unmodified). The pure function additionally returns per-factor sub-scores and weighted contributions.
- **`GET /admin/routing-analytics`** (new `apps/api` route, admin-gated) — reads `model_provider_mapping_history_hourly` (no `log` scans), derives uptime / TTFT latency / throughput per mapping per hour with the same math as `provider-metrics-history.ts`, and recomputes the routing score per hour across the routable mappings using the shared scorer with default config. Returns the mappings with their static factors (selection price, priority, cache support, stability, exclusion reasons), the config weights/thresholds, a window summary, and the hourly series with full score breakdowns.
- **`ee/admin`** — the page itself: searchable model picker, 24h/3d/7d window, mappings table sorted by score, score/uptime/latency/throughput time-series, requests-per-hour stacked bars (actual election outcomes), and a score-composition table showing how each factor + penalty adds up to the final score. New "Routing Analytics" sidebar entry.

## Notes for review

- Scores are computed as the common case: a streaming text request with a prompt below the cache threshold (latency weight active, cache weight zero). The weights card on the page states this.
- Hourly buckets are deliberately plain averages — live routing uses the same formula over a tier-weighted 60-minute window; the page says so to avoid confusion.
- Hours without traffic report `null` metrics but still get a score (the router would fall back to `thresholds.default*` there, and so does the page).
- Non-routable mappings (deactivated / unstable / experimental / priority 0) are listed with their exclusion reason and no score, but keep their traffic history visible.
- Prices are **discount-adjusted**: routing scores the discounted selection price, so the page resolves the platform-wide (global) discount per mapping and scores that. The response carries `listPrice` / `discount` / `price` and the table renders the markdown. This view is not scoped to an organization, so an org-specific discount can still push that org's price below what is shown — the table says so.

## Verification

- New spec `admin-routing-analytics.spec.ts` (auth gating, 404, metric derivation, score/penalty assertions against inserted hourly rows, and discount-adjusted pricing).
- Full `pnpm build` and `pnpm test:unit` green (4,024 tests).
- Verified in the browser against seeded + synthetic hourly data, with an injected ByteDance outage and a 20% global Runware discount on `glm-5.2`.

### Mappings table — light

Runware's 20% platform discount takes its selection price from $1.68/M to $1.34/M, which is what the score is computed from; that moves it past SCX.ai to the top of the election.

<img width="1200" alt="Routing Analytics mappings table showing scoring weights, per-mapping price/priority/cache/uptime/TTFT/throughput/requests/share/score, with Runware showing a discounted price" src="https://raw.githubusercontent.com/theopenco/llmgateway/bf7c11a0aa0aceb59008382aea4e5e2646e83785/routing-analytics-mappings-light.png" />

### Charts — light

The injected ByteDance outage shows up as the score spike; the bars below are where traffic actually went.

<img width="1200" alt="Routing score over time line chart with an outage spike, and a requests-per-hour stacked bar chart" src="https://raw.githubusercontent.com/theopenco/llmgateway/bf7c11a0aa0aceb59008382aea4e5e2646e83785/routing-analytics-charts-light.png" />

### Score composition — light

<img width="1200" alt="Score composition table breaking the final score into price, uptime, throughput, latency, cache contributions plus priority and uptime penalties" src="https://raw.githubusercontent.com/theopenco/llmgateway/bf7c11a0aa0aceb59008382aea4e5e2646e83785/routing-analytics-composition-light.png" />

### Dark mode

<img width="1200" alt="Routing Analytics mappings table in dark mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/bf7c11a0aa0aceb59008382aea4e5e2646e83785/routing-analytics-mappings-dark.png" />

Tooltip labels render in UTC to match the UTC hour buckets they label (they used to be formatted browser-local while still carrying a "UTC" suffix):

<img width="1200" alt="Routing score chart in dark mode with the tooltip open, showing per-provider scores for the Aug 5, 2026, 22:00 UTC bucket" src="https://raw.githubusercontent.com/theopenco/llmgateway/bf7c11a0aa0aceb59008382aea4e5e2646e83785/routing-analytics-tooltip-dark.png" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
