### PR TITLE
docs: link live pricing for image gen models

### DIFF
--- a/apps/docs/content/features/image-generation.mdx
+++ b/apps/docs/content/features/image-generation.mdx
@@ -666,15 +666,15 @@ curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
 | `n`          | integer | Number of images to generate (1-4)                                                               |
 | `seed`       | integer | Random seed for reproducible generation                                                          |
 
-Available Alibaba models:
+Available Alibaba models (see the [models page](https://llmgateway.io/models?filters=1&imageGeneration=true) for current pricing):
 
-| Model                        | Price                               | Description                                             |
-| ---------------------------- | ----------------------------------- | ------------------------------------------------------- |
-| `alibaba/qwen-image`         | $0.035/image                        | Standard quality image generation                       |
-| `alibaba/qwen-image-plus`    | $0.03/image                         | Good balance of quality and cost                        |
-| `alibaba/qwen-image-max`     | $0.075/image                        | Highest quality image generation                        |
-| `alibaba/qwen-image-3.0`     | $0.03/image                         | Third-generation image generation and editing           |
-| `alibaba/qwen-image-3.0-pro` | $0.04/image (1K), $0.075/image (2K) | Highest quality third-generation generation and editing |
+| Model                        | Description                                                                          |
+| ---------------------------- | ------------------------------------------------------------------------------------ |
+| `alibaba/qwen-image`         | Standard quality image generation                                                    |
+| `alibaba/qwen-image-plus`    | Good balance of quality and cost                                                     |
+| `alibaba/qwen-image-max`     | Highest quality image generation                                                     |
+| `alibaba/qwen-image-3.0`     | Third-generation image generation and editing                                        |
+| `alibaba/qwen-image-3.0-pro` | Highest quality third-generation generation and editing. Priced per output size tier |
 
 <Callout type="info">
 	Alibaba models use explicit pixel dimensions (e.g., `"1024x1536"`) instead of
@@ -707,12 +707,12 @@ curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
 | `image_size` | string  | Image dimensions in `WIDTHxHEIGHT` format. Examples: `"1024x1024"`, `"2048x1024"`, `"1024x2048"` |
 | `n`          | integer | Number of images to generate                                                                     |
 
-Available Z.AI models:
+Available Z.AI models (see the [models page](https://llmgateway.io/models?filters=1&imageGeneration=true) for current pricing):
 
-| Model           | Price        | Description                                                                                                         |
-| --------------- | ------------ | ------------------------------------------------------------------------------------------------------------------- |
-| `zai/cogview-4` | $0.01/image  | CogView-4 with bilingual support and excellent text rendering                                                       |
-| `zai/glm-image` | $0.015/image | GLM-Image with hybrid auto-regressive architecture, excellent for text-rendering and knowledge-intensive generation |
+| Model           | Description                                                                                                         |
+| --------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `zai/cogview-4` | CogView-4 with bilingual support and excellent text rendering                                                       |
+| `zai/glm-image` | GLM-Image with hybrid auto-regressive architecture, excellent for text-rendering and knowledge-intensive generation |
 
 <Callout type="info">
 	CogView-4 supports both Chinese and English prompts and excels at generating
@@ -783,12 +783,12 @@ curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
 | ------------ | ------ | ------------------------------------------------------------------------------------------------ |
 | `image_size` | string | Image dimensions in `WIDTHxHEIGHT` format. Examples: `"1024x1024"`, `"2048x2048"`, `"4096x4096"` |
 
-Available ByteDance models:
+Available ByteDance models (see the [models page](https://llmgateway.io/models?filters=1&imageGeneration=true) for current pricing):
 
-| Model                    | Price        | Description                                                     |
-| ------------------------ | ------------ | --------------------------------------------------------------- |
-| `bytedance/seedream-4-0` | $0.035/image | High-quality text-to-image generation with 2K default output    |
-| `bytedance/seedream-4-5` | $0.045/image | Enhanced quality and consistency with improved prompt adherence |
+| Model                    | Description                                                     |
+| ------------------------ | --------------------------------------------------------------- |
+| `bytedance/seedream-4-0` | High-quality text-to-image generation with 2K default output    |
+| `bytedance/seedream-4-5` | Enhanced quality and consistency with improved prompt adherence |
 
 <Callout type="info">
 	Seedream models support up to 2-10 reference images for multi-image fusion and


### PR DESCRIPTION
## Summary

Follow-up to #3440, addressing the one CodeRabbit review thread left unresolved at merge: the image-generation docs page hardcoded catalogue-derived per-image prices, which drift the moment the catalogue changes.

- Removed the **Price** column from the Alibaba, Z.AI, and ByteDance model tables in `apps/docs/content/features/image-generation.mdx` and pointed each table at the live [models page](https://llmgateway.io/models?filters=1&imageGeneration=true) for current pricing — matching the style the Google and OpenAI tables in the same file already use (model + description only).
- Kept the model IDs, descriptions, and per-model call constraints (sizes, `image_config` parameters), which the repo guidelines explicitly allow and prefer for image-generation models since they're how users figure out how to call them. The `qwen-image-3.0-pro` row now notes it is priced per output size tier without pinning the dollar amounts.
- All other feedback from #3440 (per-image billing without prompt usage in `costs.ts`, discount-aware per-image displays, selected-model dialog pricing, OG-image default tier) was verified as already fixed in the merged code — no changes needed there.

## Test plan

- [x] `pnpm format` clean
- [x] `turbo run build --filter=docs` passes (validates the MDX compiles)
- [x] No `$`-prices remain anywhere in `image-generation.mdx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLQwrenT7zLYQFjAZWR1qi

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLQwrenT7zLYQFjAZWR1qi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated image-generation model listings for Alibaba, Z.AI, and ByteDance.
  * Removed per-image pricing columns and directed readers to the models page for current pricing.
  * Retained model descriptions and supported model information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->