### PR TITLE
chore(models): deprecate together-ai kimi-k2.6

### DIFF
--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -484,6 +484,12 @@ export const moonshotModels = [
 				vision: true,
 				tools: false,
 				jsonOutput: false,
+				// Together AI removes this model from its serverless API on
+				// 2026-08-19 and warns that capacity may already be reduced before
+				// then, so stop selecting it now and fail requests after the cutoff.
+				// Their recommended replacement, Kimi K3, is already mapped.
+				deprecatedAt: new Date("2026-08-07"),
+				deactivatedAt: new Date("2026-08-19"),
 			},
 			{
 				providerId: "gonka24",


### PR DESCRIPTION
## Summary

Together AI announced that `moonshotai/Kimi-K2.6` is removed from their serverless API on **2026-08-19**, with `moonshotai/Kimi-K3` as the recommended replacement, and warned that capacity on the deprecated model may already be reduced before the cutoff.

This marks the `together-ai` mapping of `kimi-k2.6`:

- `deprecatedAt: 2026-08-07` — takes it out of automatic provider selection immediately, while it still resolves when explicitly pinned (`together-ai/kimi-k2.6`).
- `deactivatedAt: 2026-08-19` — the gateway rejects requests for it after the announced removal date.

No replacement mapping is needed: `together-ai` already serves `kimi-k3` (`moonshotai/Kimi-K3`), so requests that fall through provider selection land on Together's recommended successor or on another `kimi-k2.6` provider.

All other `kimi-k2.6` providers (moonshot, runware, canopywave, novita, gonka24, tundra, nebius) are unaffected.

## Test plan

- [x] `pnpm format`
- [x] `pnpm build`
- [x] `pnpm test:unit packages/models` (125 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added deprecation and deactivation dates for the Together AI `kimi-k2.6` model.
  * The model is scheduled for deprecation on August 7, 2026, and deactivation on August 19, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->