### PR TITLE
feat(models): add ranoai deepseek-v4-flash

### DIFF
--- a/apps/gateway/src/api-individual.e2e.ts
+++ b/apps/gateway/src/api-individual.e2e.ts
@@ -729,16 +729,22 @@ describe("e2e individual tests", () => {
 			expect(log.requestedModel).toBe("auto");
 
 			// Verify a reasoning model was selected
-			const usedModel = log.usedModelMapping;
-			expect(usedModel).toBeDefined();
+			expect(log.usedModelMapping).toBeDefined();
 
-			const reasoningAutoRoutingModelIds = new Set([
-				"claude-opus-4-6",
-				"claude-sonnet-4-6",
-			]);
+			// `usedModel` is "<provider>/<model>[:<region>]"; the auto-routing
+			// decision is made on the internal model id, so strip both affixes.
+			// `usedModelMapping` holds the upstream external id (e.g. a dated
+			// Anthropic snapshot or a Bedrock ARN-style id) and never matches an
+			// internal id, so it cannot be used for this check.
+			const usedModelId = log.usedModel?.split("/").pop()?.split(":")[0];
+			const usedModelDefinition = models.find((m) => m.id === usedModelId);
 
-			// Verify reasoningEffort is only auto-set for reasoning-capable Claude models
-			if (usedModel && reasoningAutoRoutingModelIds.has(usedModel)) {
+			// Verify reasoningEffort is only auto-set for reasoning-capable models
+			if (
+				usedModelDefinition?.providers.some(
+					(p) => "reasoning" in p && p.reasoning === true,
+				)
+			) {
 				expect(log.reasoningEffort).toEqual("low");
 			} else {
 				expect(log.reasoningEffort).toBeNull();

--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -575,6 +575,48 @@ export const deepseekModels = [
 				jsonOutput: true,
 				jsonOutputSchema: true,
 			},
+			{
+				// RanoAI serves DeepSeek V4 Flash on Furiosa RNGD NPUs. The NPU
+				// deployment enforces a 128000-token window shared between the prompt
+				// and max_tokens, so a request 400s once the two together exceed it.
+				// Reasoning arrives as `reasoning_content` (streamed as deltas) only
+				// when `reasoning_effort` is passed explicitly — a request without it
+				// returns no reasoning at all, and "none" suppresses it.
+				// `reasoning_tokens` is reported inside completion_tokens, so costs.ts
+				// lists this provider in completionIncludesReasoning.
+				//
+				// All four tool_choice modes are honoured, so none are declared here.
+				// Prompt caching is automatic prefix caching — the first request
+				// misses and later ones report `cached_tokens` — priced at the
+				// `input_cache_read` rate /v1/models advertises.
+				providerId: "ranoai",
+				externalId: "deepseek-v4-flash",
+				inputPrice: "0.15e-6",
+				outputPrice: "0.35e-6",
+				cachedInputPrice: "0.05e-6",
+				requestPrice: "0",
+				contextSize: 128000,
+				maxOutput: 128000,
+				// RanoAI serves NVFP4 weights; the catalogue's quantization union only
+				// carries the generic 4-bit float value.
+				quantization: "fp4",
+				streaming: true,
+				reasoning: true,
+				reasoningEfforts: [
+					"none",
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max",
+				],
+				vision: false,
+				tools: true,
+				jsonOutput: true,
+				jsonOutputSchema: true,
+				supportsN: true,
+			},
 		],
 	},
 ] as const satisfies ModelDefinition[];


### PR DESCRIPTION
RanoAI now serves DeepSeek V4 Flash alongside Gemma 4 31B, so this adds the provider mapping to the existing `deepseek-v4-flash` catalogue entry.

## Pricing and metadata

Pricing, context and quantization come from RanoAI and were cross-checked against their `/v1/models` response:

| Field | Value |
| --- | --- |
| Input | $0.15/M |
| Cached input | $0.05/M |
| Output | $0.35/M |
| Context | 128,000 |
| Quantization | NVFP4 |

The catalogue's `Quantization` union has no `nvfp4` member, so the mapping records the generic `fp4` value with a comment explaining the discrepancy.

## Capabilities (probed against the live deployment)

- The 128k window is **shared** between the prompt and `max_tokens` — the deployment 400s once the two together exceed it, so `contextSize` and `maxOutput` are both 128000, matching how the Gemma mapping models the same NPU behaviour.
- Reasoning is returned as `reasoning_content` only when `reasoning_effort` is passed explicitly; a request without it returns none, and `"none"` suppresses it. All seven effort tiers are accepted.
- All four `tool_choice` modes are honoured, so none are restricted.
- `json_object`, `json_schema`, `n > 1` and streaming all work.
- Prompt caching is automatic prefix caching (`cached_tokens` on repeat requests), billed at the `input_cache_read` rate.
- `reasoning_tokens` is reported inside `completion_tokens`; `costs.ts` already lists `ranoai` in `completionIncludesReasoning`, so no billing change was needed.

## Drive-by e2e fix

`Auto-routing sets reasoning_effort appropriately` was failing on every run, unrelated to this model. It compared `log.usedModelMapping` — which holds the **upstream external id** (a dated Anthropic snapshot, or a Bedrock-style id) — against a set of **internal** model ids, so the reasoning branch was unreachable and the test always asserted a null `reasoningEffort`. Auto-routing picks `claude-haiku-4-5` for short prompts and sets `reasoning_effort` to `"low"` for any reasoning-capable model, so the assertion could never hold.

The check now derives the internal id from `log.usedModel` and takes the expectation from the catalogue.

## Verification

- `TEST_MODELS="ranoai/deepseek-v4-flash" FULL_MODE=true pnpm test:e2e` (gateway): 29 files / 122 tests passing, 24 of them exercising the new mapping — basic, streaming, reasoning at every effort tier, reasoning + streaming, tool calls, tool-call results, JSON and JSON-schema output, and the Responses API.
- `pnpm test:unit`, `pnpm build`, `pnpm format` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)