### PR TITLE
fix(gateway): send Responses-shaped tool_choice

### DIFF
--- a/apps/gateway/src/responses/responses.spec.ts
+++ b/apps/gateway/src/responses/responses.spec.ts
@@ -91,6 +91,25 @@ describe("responsesRequestSchema", () => {
 		expect(result.success).toBe(true);
 	});
 
+	it("accepts both the Responses and Chat Completions tool_choice shapes", () => {
+		// The Responses API nests nothing: `{type:"function",name}`. Clients that
+		// port a chat-completions payload over send the nested form instead, and
+		// both have to get through.
+		const responsesShape = responsesRequestSchema.safeParse({
+			model: "gpt-5.6-sol",
+			input: "hi",
+			tool_choice: { type: "function", name: "get_weather" },
+		});
+		expect(responsesShape.success).toBe(true);
+
+		const chatShape = responsesRequestSchema.safeParse({
+			model: "gpt-5.6-sol",
+			input: "hi",
+			tool_choice: { type: "function", function: { name: "get_weather" } },
+		});
+		expect(chatShape.success).toBe(true);
+	});
+
 	it("accepts reasoning items whose optional fields are explicit nulls", () => {
 		// Codex replays the whole prior output as `input` and serializes its
 		// absent optionals as nulls, so a reasoning item the gateway itself

--- a/apps/gateway/src/responses/responses.ts
+++ b/apps/gateway/src/responses/responses.ts
@@ -313,7 +313,14 @@ responses.post("/", async (c) => {
 		chatRequest.tools = tools;
 	}
 	if (req.tool_choice) {
-		chatRequest.tool_choice = req.tool_choice;
+		// The chat handler speaks Chat Completions, so a Responses-shaped named
+		// function choice (`{type:"function",name}`) has to be nested back under
+		// `function` here; prepare-request-body flattens it again for upstreams
+		// that take the Responses API.
+		chatRequest.tool_choice =
+			typeof req.tool_choice === "object" && "name" in req.tool_choice
+				? { type: "function", function: { name: req.tool_choice.name } }
+				: req.tool_choice;
 	}
 	if (req.reasoning?.effort) {
 		chatRequest.reasoning_effort = req.reasoning.effort;

--- a/apps/gateway/src/responses/schemas.ts
+++ b/apps/gateway/src/responses/schemas.ts
@@ -211,6 +211,13 @@ export const responsesRequestSchema = z.object({
 			z.literal("auto"),
 			z.literal("none"),
 			z.literal("required"),
+			// Canonical Responses API shape: the function name is flat.
+			z.object({
+				type: z.literal("function"),
+				name: z.string(),
+			}),
+			// Chat Completions shape, still accepted because clients that port a
+			// chat-completions payload over to this endpoint keep sending it.
 			z.object({
 				type: z.literal("function"),
 				function: z.object({

--- a/packages/actions/src/prepare-request-body.responses.spec.ts
+++ b/packages/actions/src/prepare-request-body.responses.spec.ts
@@ -2,12 +2,30 @@ import { describe, expect, test } from "vitest";
 
 import { prepareRequestBody } from "./prepare-request-body.js";
 
-import type { BaseMessage } from "@llmgateway/models";
+import type {
+	BaseMessage,
+	ProviderId,
+	ToolChoiceType,
+} from "@llmgateway/models";
 
 interface ResponsesBody {
 	input: Array<Record<string, unknown>>;
 	reasoning?: { context?: string };
+	tool_choice?: unknown;
 }
+
+const WEATHER_TOOL = {
+	type: "function" as const,
+	function: {
+		name: "get_weather",
+		description: "Get the current weather for a given city",
+		parameters: {
+			type: "object",
+			properties: { city: { type: "string" } },
+			required: ["city"],
+		},
+	},
+};
 
 // Tests for the OpenAI Responses API request transform: encrypted reasoning
 // replay provenance and output-item ordering for tool-call turns.
@@ -16,13 +34,20 @@ async function buildOpenAIResponsesBody(
 	messages: BaseMessage[],
 	opts: {
 		reasoning_context?: "auto" | "current_turn" | "all_turns";
+		tool_choice?: ToolChoiceType;
+		provider?: { id: ProviderId; model: string; region: string | null };
 	} = {},
 ): Promise<ResponsesBody> {
+	const provider = opts.provider ?? {
+		id: "openai" as ProviderId,
+		model: "gpt-4o",
+		region: null,
+	};
 	return (await prepareRequestBody(
-		"openai",
-		"gpt-4o",
-		null,
-		"gpt-4o",
+		provider.id,
+		provider.model,
+		provider.region,
+		provider.model,
 		messages,
 		false, // stream
 		undefined, // temperature
@@ -31,8 +56,8 @@ async function buildOpenAIResponsesBody(
 		undefined, // frequency_penalty
 		undefined, // presence_penalty
 		undefined, // response_format
-		undefined, // tools
-		undefined, // tool_choice
+		opts.tool_choice ? [WEATHER_TOOL] : undefined, // tools
+		opts.tool_choice, // tool_choice
 		undefined, // reasoning_effort
 		true, // supportsReasoning
 		false, // isProd
@@ -155,6 +180,47 @@ describe("transform to OpenAI Responses API", () => {
 		);
 		expect(assistantMessage!.phase).toBe("commentary");
 		expect(assistantMessage!.content_before_tool_calls).toBeUndefined();
+	});
+
+	test("flattens a named function tool_choice into the Responses shape", async () => {
+		const body = await buildOpenAIResponsesBody(
+			[{ role: "user", content: "weather in SF?" }],
+			{ tool_choice: { type: "function", function: { name: "get_weather" } } },
+		);
+		expect(body.tool_choice).toEqual({
+			type: "function",
+			name: "get_weather",
+		});
+	});
+
+	test("flattens a named function tool_choice on Bedrock Mantle", async () => {
+		// Mantle is Responses-API-only and rejects the Chat Completions shape
+		// with "Invalid 'tool_choice': value did not match any expected variant".
+		const body = await buildOpenAIResponsesBody(
+			[{ role: "user", content: "weather in SF?" }],
+			{
+				tool_choice: { type: "function", function: { name: "get_weather" } },
+				provider: {
+					id: "aws-mantle" as ProviderId,
+					model: "gpt-5.6-sol",
+					region: "us-east-2",
+				},
+			},
+		);
+		expect(body.tool_choice).toEqual({
+			type: "function",
+			name: "get_weather",
+		});
+	});
+
+	test("passes the tool_choice string modes through unchanged", async () => {
+		for (const mode of ["auto", "none", "required"] as const) {
+			const body = await buildOpenAIResponsesBody(
+				[{ role: "user", content: "weather in SF?" }],
+				{ tool_choice: mode },
+			);
+			expect(body.tool_choice).toBe(mode);
+		}
 	});
 
 	test("forwards reasoning.context (including auto) to OpenAI", async () => {

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -18,6 +18,7 @@ import {
 	type PromptCacheRetention,
 	type ProviderRequestBody,
 	type ReasoningDetail,
+	type ResponsesToolChoice,
 	supportsOpenAIExplicitPromptCache,
 	supportsOpenAIExtendedPromptCache,
 	supportsServiceTier,
@@ -112,6 +113,23 @@ function toolChoiceModeOf(
 		return "function";
 	}
 	return undefined;
+}
+
+/**
+ * Translate a Chat Completions `tool_choice` into the Responses API shape. A
+ * named function choice nests the name under `function` in Chat Completions
+ * but is flat (`{type:"function",name}`) in the Responses API, and upstreams
+ * reject the nested form outright (Bedrock Mantle answers with
+ * `Invalid 'tool_choice': value did not match any expected variant`). The
+ * string modes are identical in both APIs.
+ */
+function toResponsesToolChoice(
+	toolChoice: ToolChoiceType,
+): ResponsesToolChoice {
+	if (typeof toolChoice === "object") {
+		return { type: "function", name: toolChoice.function.name };
+	}
+	return toolChoice;
 }
 
 /**
@@ -2057,7 +2075,7 @@ export async function prepareRequestBody(
 					responsesBody.tools.push(webSearch);
 				}
 				if (resolvedToolChoice) {
-					responsesBody.tool_choice = resolvedToolChoice;
+					responsesBody.tool_choice = toResponsesToolChoice(resolvedToolChoice);
 				}
 
 				// Add optional parameters if they are provided

--- a/packages/models/src/types.ts
+++ b/packages/models/src/types.ts
@@ -236,6 +236,22 @@ export type ToolChoiceType =
 			};
 	  };
 
+/**
+ * `tool_choice` as the OpenAI Responses API expects it. A named function
+ * choice is flat here, while Chat Completions nests the name under
+ * `function` — sending the nested form to a Responses upstream is rejected
+ * (Bedrock Mantle answers `Invalid 'tool_choice': value did not match any
+ * expected variant`).
+ */
+export type ResponsesToolChoice =
+	| "auto"
+	| "none"
+	| "required"
+	| {
+			type: "function";
+			name: string;
+	  };
+
 export type PromptCacheRetention = "in_memory" | "24h";
 
 /**
@@ -353,7 +369,7 @@ export interface OpenAIResponsesRequestBody {
 		description?: string;
 		parameters: FunctionParameter;
 	}>;
-	tool_choice?: ToolChoiceType;
+	tool_choice?: ResponsesToolChoice;
 	stream?: boolean;
 	temperature?: number;
 	max_output_tokens?: number;


### PR DESCRIPTION
## Problem

`gpt-5.6-sol:us-east-2` on AWS Mantle was returning 400s:

```json
{"error":{"code":"validation_error","message":"invalid request body: Invalid 'tool_choice': value did not match any expected variant","param":null,"type":"invalid_request_error"}}
```

A named function `tool_choice` has a different shape in each API:

- Chat Completions: `{"type":"function","function":{"name":"x"}}`
- Responses: `{"type":"function","name":"x"}`

`prepare-request-body.ts` transformed `tools` into the Responses shape but forwarded `tool_choice` verbatim, so any forced-tool request against a Responses-API upstream shipped the nested Chat Completions form. Bedrock Mantle is Responses-API-only and rejects it outright; the string modes (`auto` / `none` / `required`) are identical in both APIs and were never affected.

The gateway's own `/v1/responses` endpoint had the mirror-image bug: its request schema accepted **only** the nested Chat Completions form, so a client sending the canonical Responses shape got a gateway-side 400.

## Fix

- Flatten a named function `tool_choice` to `{type,name}` when building the Responses request body.
- Type `OpenAIResponsesRequestBody.tool_choice` as the new `ResponsesToolChoice` instead of the Chat Completions `ToolChoiceType`, so the two shapes can't be confused again.
- Accept both shapes on `POST /v1/responses` and normalize back to the Chat Completions shape when handing off to the chat handler (which speaks Chat Completions internally).

## Not fixed here

The `tool_choice` resolution block looks the mapping up with a raw `modelDef.providers.find(...)` rather than the region-aware `getProviderMapping()` helper, so it never matches a mapping declared via a `regions` array. That is why the nested value reached Mantle at all — with the lookup working, `supportedParameters` (which omits `tool_choice` on the aws-mantle mappings) would have downgraded it to `"auto"`. Fixing the lookup in isolation would silently downgrade `tool_choice` on 16 regional mappings (aws-mantle, aws-bedrock Claude, Alibaba Qwen), so it needs its own pass over those `supportedParameters` lists.

## Verification

`pnpm format`, `pnpm build`, and `pnpm vitest run packages/actions/src apps/gateway/src/responses` (646 tests) all pass. Not verified against live Mantle — both local AWS keys currently 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)