### PR TITLE
fix(gateway): log why routing narrowed providers

### DIFF
--- a/apps/api/src/routes/logs.ts
+++ b/apps/api/src/routes/logs.ts
@@ -222,6 +222,16 @@ const logSchema = z.object({
 					}),
 				)
 				.optional(),
+			filteredProviders: z
+				.array(
+					z.object({
+						providerId: z.string(),
+						reasons: z.array(z.string()),
+					}),
+				)
+				.optional(),
+			strippedParameters: z.array(z.string()).optional(),
+			serviceTierSource: z.enum(["request", "coding-plan-default"]).optional(),
 		})
 		.nullable()
 		.optional(),

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -2049,6 +2049,13 @@ describe("api", () => {
 		expect(logs[0].routingMetadata?.selectionReason).toBe(
 			"single-candidate-after-filtering",
 		);
+		// availableProviders stays the candidate set — the providers that dropped
+		// out are listed separately, with the reason, rather than being silently
+		// missing from both lists.
+		expect(logs[0].routingMetadata?.availableProviders).toEqual(["openai"]);
+		expect(logs[0].routingMetadata?.serviceTierSource).toBe(
+			"coding-plan-default",
+		);
 		const filtered = logs[0].routingMetadata?.filteredProviders ?? [];
 		expect(filtered.map((f) => f.providerId).sort()).toEqual([
 			"aws-mantle",

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -1992,15 +1992,73 @@ describe("api", () => {
 		expect(res.status).toBe(200);
 		const json = await res.json();
 		expect(json.service_tier).toBe("flex");
-		// The tier came from the org default, not the request, so only the
-		// used tier is surfaced.
-		expect(json.metadata?.requested_service_tier).toBeUndefined();
+		// The tier came from the org default rather than the request, but the
+		// gateway did request it upstream — and it narrows provider routing — so
+		// it is reported, with the source recorded in the routing metadata.
+		expect(json.metadata?.requested_service_tier).toBe("flex");
 		expect(json.metadata?.used_service_tier).toBe("flex");
 
 		const logs = await waitForLogs(1);
 		expect(logs.length).toBe(1);
-		expect(logs[0].requestedServiceTier).toBeNull();
+		expect(logs[0].requestedServiceTier).toBe("flex");
 		expect(logs[0].usedServiceTier).toBe("flex");
+		expect(logs[0].routingMetadata?.serviceTierSource).toBe(
+			"coding-plan-default",
+		);
+	});
+
+	test("/v1/chat/completions records providers dropped by the dev-plan flex default", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id-devplan-flex-filtered",
+			token: "real-token-devplan-flex-filtered",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-devplan-flex-filtered",
+			token: "sk-test-key",
+			provider: "openai",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		await harness.setDevPlan({ devPlan: "pro", serviceTier: "flex" });
+
+		// gpt-5.6-sol maps to openai, azure and aws-mantle, but only the openai
+		// mapping sells flex. Routing therefore collapses to a single candidate —
+		// the log has to say so rather than implying the model has one provider.
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-devplan-flex-filtered",
+			},
+			body: JSON.stringify({
+				model: "gpt-5.6-sol",
+				messages: [{ role: "user", content: "Hello!" }],
+			}),
+		});
+
+		expect(res.status).toBe(200);
+
+		const logs = await waitForLogs(1);
+		expect(logs.length).toBe(1);
+		expect(logs[0].usedProvider).toBe("openai");
+		expect(logs[0].routingMetadata?.selectionReason).toBe(
+			"single-candidate-after-filtering",
+		);
+		const filtered = logs[0].routingMetadata?.filteredProviders ?? [];
+		expect(filtered.map((f) => f.providerId).sort()).toEqual([
+			"aws-mantle",
+			"azure",
+		]);
+		for (const entry of filtered) {
+			expect(entry.reasons).toContain(
+				"service tier 'flex' (coding plan default) not supported",
+			);
+		}
 	});
 
 	test("/v1/chat/completions lets an explicit service_tier win over the dev-plan default", async () => {

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -290,6 +290,7 @@ import { transformStreamingToOpenai } from "./tools/transform-streaming-to-opena
 import { validateFreeModelUsage } from "./tools/validate-free-model-usage.js";
 import { validateModelCapabilities } from "./tools/validate-model-capabilities.js";
 
+import type { FilteredProvider } from "./tools/provider-filter-reasons.js";
 import type { OriginalRequestParams } from "./tools/resolve-provider-context.js";
 import type { ServerTypes } from "@/vars.js";
 
@@ -945,6 +946,30 @@ function mappingSupportsRequestedServiceTier(
 	);
 }
 
+// Distinct providers the catalog still offers for a model, ignoring every
+// request-scoped filter. Used to tell "this model only has one provider" apart
+// from "this request was narrowed down to one provider".
+function countActiveCatalogueProviders(modelId: string): number {
+	const definition = models.find((m) => m.id === modelId);
+	if (!definition) {
+		return 0;
+	}
+	const now = new Date();
+	return new Set(
+		(definition.providers as ProviderModelMapping[])
+			.filter(
+				(mapping) => !(mapping.deactivatedAt && now > mapping.deactivatedAt),
+			)
+			.map((mapping) => mapping.providerId),
+	).size;
+}
+
+// Coding plans only route to mappings that price cached input, so a provider
+// without prompt caching is dropped before selection. Shared by the direct and
+// auto-routing paths so both log the exclusion identically.
+const CODING_PLAN_CACHED_INPUT_FILTER_REASON =
+	"no cached input pricing (coding plan)";
+
 // Pre-compiled regex pattern to avoid recompilation per request
 const SSE_FIELD_PATTERN = /^[a-zA-Z_-]+:\s*/;
 const IMMEDIATE_STREAM_ERROR_PEEK_LIMIT = 64 * 1024;
@@ -1429,12 +1454,19 @@ chat.openapi(completions, async (c) => {
 	// doesn't specify one.
 	let service_tier = validationResult.data.service_tier;
 
-	// The processing tier the client explicitly requested (flex / priority).
-	// Null when no premium tier was requested. Stored on every log alongside the
-	// tier the provider actually served (usedServiceTier).
-	const requestedServiceTier = isRequestedServiceTier(service_tier)
+	// The processing tier the gateway ends up requesting upstream (flex /
+	// priority). Null when no premium tier is in play. Stored on every log
+	// alongside the tier the provider actually served (usedServiceTier).
+	// Mutable for the same reason `service_tier` is: a dev-plan (DevPass) org's
+	// default tier is resolved further below, and it narrows provider routing
+	// exactly like an explicit tier does — recording only the client-supplied
+	// value would leave those logs with no trace of why routing was narrowed.
+	// `serviceTierSource` keeps the two apart.
+	let requestedServiceTier = isRequestedServiceTier(service_tier)
 		? service_tier
 		: null;
+	let serviceTierSource: "request" | "coding-plan-default" | null =
+		requestedServiceTier ? "request" : null;
 	// The processing tier the provider actually served (Flex / Priority),
 	// resolved from the upstream response — Vertex's usageMetadata.trafficType or
 	// AI Studio's x-gemini-service-tier header. Billing scales token costs by
@@ -1442,6 +1474,42 @@ chat.openapi(completions, async (c) => {
 	// unsupported tiers to standard. Null = standard / no tier. Declared here
 	// (ahead of the insertLogEntry wrapper) so every log path can record it.
 	let servedServiceTier: "flex" | "priority" | null = null;
+
+	// Providers dropped *before* provider selection runs — by the service-tier
+	// filter, the coding-plan prompt-caching requirement, the service-tier key
+	// eligibility check or the compliance policy. Routing metadata otherwise only
+	// records what the routing-time eligibility filter dropped, so a request whose
+	// candidates were narrowed earlier looks like the model simply has one
+	// provider mapping. Merged into routingMetadata.filteredProviders on every
+	// path below.
+	const preRoutingFilteredProviders: FilteredProvider[] = [];
+	const recordPreRoutingDrops = (
+		before: readonly ProviderModelMapping[],
+		after: readonly ProviderModelMapping[],
+		reason: string,
+	) => {
+		// Provider-level, not mapping-level: with regional expansion a provider is
+		// only "filtered out" once none of its mappings survived.
+		const kept = new Set(after.map((mapping) => mapping.providerId));
+		for (const mapping of before) {
+			if (!kept.has(mapping.providerId)) {
+				recordFilteredProvider(
+					preRoutingFilteredProviders,
+					mapping.providerId,
+					[reason],
+				);
+			}
+		}
+	};
+	const filteredProvidersMetadata = (
+		filtered: FilteredProvider[] = [],
+	): { filteredProviders?: FilteredProvider[] } => {
+		const merged: FilteredProvider[] = [];
+		for (const entry of [...preRoutingFilteredProviders, ...filtered]) {
+			recordFilteredProvider(merged, entry.providerId, entry.reasons);
+		}
+		return merged.length > 0 ? { filteredProviders: merged } : {};
+	};
 
 	// Sticky-routing session key, in priority order: the explicit x-session-id
 	// header, then the session-affinity/session-id headers coding agents attach
@@ -2121,6 +2189,11 @@ chat.openapi(completions, async (c) => {
 		);
 		if (supportsDefaultFlex) {
 			service_tier = "flex";
+			// Record the defaulted tier so the log and the response metadata show
+			// the tier the request was actually routed and processed under, not
+			// just what the client typed.
+			requestedServiceTier = "flex";
+			serviceTierSource = "coding-plan-default";
 		}
 	}
 
@@ -2251,6 +2324,13 @@ chat.openapi(completions, async (c) => {
 				configIndex,
 				envVariant,
 			);
+		recordPreRoutingDrops(
+			serviceTierCandidateProviders,
+			serviceTierSupportedProviders,
+			serviceTierSource === "coding-plan-default"
+				? `service tier '${service_tier}' (coding plan default) not supported`
+				: `service tier '${service_tier}' not supported`,
+		);
 		modelInfo = {
 			...modelInfo,
 			providers: modelInfo.providers.filter(supportsRequestedTier),
@@ -2804,9 +2884,13 @@ chat.openapi(completions, async (c) => {
 		if (!compliancePolicy) {
 			return;
 		}
-		iamFilteredModelProviders = applyCompliancePolicy(
+		const compliantProviders = applyCompliancePolicy(iamFilteredModelProviders);
+		recordPreRoutingDrops(
 			iamFilteredModelProviders,
+			compliantProviders,
+			"excluded by compliance policy",
 		);
+		iamFilteredModelProviders = compliantProviders;
 		expandedIamFilteredModelProviders = applyCompliancePolicy(
 			expandedIamFilteredModelProviders,
 		);
@@ -2842,9 +2926,15 @@ chat.openapi(completions, async (c) => {
 	};
 
 	if (isDevPlan) {
-		iamFilteredModelProviders = iamFilteredModelProviders.filter(
+		const cachedInputProviders = iamFilteredModelProviders.filter(
 			providerSupportsCachedInput,
 		);
+		recordPreRoutingDrops(
+			iamFilteredModelProviders,
+			cachedInputProviders,
+			CODING_PLAN_CACHED_INPUT_FILTER_REASON,
+		);
+		iamFilteredModelProviders = cachedInputProviders;
 		expandedIamFilteredModelProviders =
 			expandedIamFilteredModelProviders.filter(providerSupportsCachedInput);
 		if (iamFilteredModelProviders.length === 0) {
@@ -2893,9 +2983,15 @@ chat.openapi(completions, async (c) => {
 		if (serviceTierOrgKeys === undefined) {
 			serviceTierOrgKeys = await findActiveProviderKeys(project.organizationId);
 		}
-		iamFilteredModelProviders = iamFilteredModelProviders.filter((provider) =>
+		const tierEligibleProviders = iamFilteredModelProviders.filter((provider) =>
 			isProviderServiceTierEligible(provider.providerId),
 		);
+		recordPreRoutingDrops(
+			iamFilteredModelProviders,
+			tierEligibleProviders,
+			`no service-tier-eligible key for '${service_tier}'`,
+		);
+		iamFilteredModelProviders = tierEligibleProviders;
 		expandedIamFilteredModelProviders =
 			expandedIamFilteredModelProviders.filter((provider) =>
 				isProviderServiceTierEligible(provider.providerId),
@@ -3347,9 +3443,7 @@ chat.openapi(completions, async (c) => {
 				routingMetadata = {
 					...cheapestResult.metadata,
 					...getNoFallbackRoutingMetadata(noFallback, xNoFallbackHeaderSet),
-					...(selectedFilteredProviders.length > 0
-						? { filteredProviders: selectedFilteredProviders }
-						: {}),
+					...filteredProvidersMetadata(selectedFilteredProviders),
 				};
 			} else {
 				// Fallback to first available provider if price comparison fails
@@ -3441,9 +3535,15 @@ chat.openapi(completions, async (c) => {
 				)
 			: expandAllProviderRegions(modelInfo.providers);
 		if (isDevPlan) {
-			iamFilteredModelProviders = iamFilteredModelProviders.filter(
+			const cachedInputProviders = iamFilteredModelProviders.filter(
 				providerSupportsCachedInput,
 			);
+			recordPreRoutingDrops(
+				iamFilteredModelProviders,
+				cachedInputProviders,
+				CODING_PLAN_CACHED_INPUT_FILTER_REASON,
+			);
+			iamFilteredModelProviders = cachedInputProviders;
 			expandedIamFilteredModelProviders =
 				expandedIamFilteredModelProviders.filter(providerSupportsCachedInput);
 		}
@@ -3847,6 +3947,7 @@ chat.openapi(completions, async (c) => {
 									noFallback,
 									xNoFallbackHeaderSet,
 								),
+								...filteredProvidersMetadata(),
 							};
 							const preferredCandidateSet = new Set(
 								preferredCandidatesForRouting,
@@ -4090,9 +4191,7 @@ chat.openapi(completions, async (c) => {
 										noFallback,
 										xNoFallbackHeaderSet,
 									),
-									...(filteredOutProvidersFallback.length > 0
-										? { filteredProviders: filteredOutProvidersFallback }
-										: {}),
+									...filteredProvidersMetadata(filteredOutProvidersFallback),
 								};
 								const preferredBetterUptimeSet = new Set(
 									preferredBetterUptimeProviders,
@@ -4390,9 +4489,7 @@ chat.openapi(completions, async (c) => {
 							selectedProvider: usedProvider,
 							selectionReason: hysteresisSelectionReason,
 							...getNoFallbackRoutingMetadata(noFallback, xNoFallbackHeaderSet),
-							...(filteredOutProvidersDirect.length > 0
-								? { filteredProviders: filteredOutProvidersDirect }
-								: {}),
+							...filteredProvidersMetadata(filteredOutProvidersDirect),
 						},
 						contentFilterMatched,
 						contentFilterRoutingExcludedProviders,
@@ -4473,8 +4570,16 @@ chat.openapi(completions, async (c) => {
 		let selectionReason: string;
 		if (requestedProvider && requestedProvider !== "llmgateway") {
 			selectionReason = "direct-provider-specified";
-		} else if (modelInfo.providers.length === 1) {
-			selectionReason = "single-provider-available";
+		} else if (iamFilteredModelProviders.length === 1) {
+			// The single-candidate shortcut above skipped provider selection. Only
+			// claim the model has a single provider when the catalog says so:
+			// otherwise the candidates were narrowed to one by request-scoped
+			// filters (service tier, coding-plan prompt caching, IAM, compliance),
+			// and `filteredProviders` explains which ones dropped out.
+			selectionReason =
+				countActiveCatalogueProviders(modelInfo.id) > 1
+					? "single-candidate-after-filtering"
+					: "single-provider-available";
 		} else {
 			selectionReason = "fallback-first-available";
 		}
@@ -4634,6 +4739,7 @@ chat.openapi(completions, async (c) => {
 				selectionReason,
 				providerScores: allProviderScores,
 				...getNoFallbackRoutingMetadata(noFallback, xNoFallbackHeaderSet),
+				...filteredProvidersMetadata(),
 			},
 			contentFilterMatched,
 			contentFilterRoutingExcludedProviders,
@@ -4642,6 +4748,17 @@ chat.openapi(completions, async (c) => {
 			project.organizationId,
 			providerDiscountResolver,
 		);
+	}
+
+	// Record where the processing tier came from. A dev-plan (DevPass) org's
+	// default tier narrows routing exactly like an explicit one, so without this
+	// the log shows a tier the caller never asked for and no reason for the
+	// narrowed candidate list.
+	if (routingMetadata && serviceTierSource) {
+		routingMetadata = {
+			...routingMetadata,
+			serviceTierSource,
+		};
 	}
 
 	// Re-resolve the model definition for the routed provider so we have the

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
@@ -981,7 +981,11 @@ export function LogDetailClient({
 												label="Requested Service Tier"
 												value={
 													log.requestedServiceTier.charAt(0).toUpperCase() +
-													log.requestedServiceTier.slice(1)
+													log.requestedServiceTier.slice(1) +
+													(log.routingMetadata?.serviceTierSource ===
+													"coding-plan-default"
+														? " (coding plan default)"
+														: "")
 												}
 											/>
 										)}

--- a/packages/actions/src/get-cheapest-from-available-providers.ts
+++ b/packages/actions/src/get-cheapest-from-available-providers.ts
@@ -135,6 +135,10 @@ export interface RoutingMetadata {
 		providerId: string;
 		reasons: string[];
 	}>;
+	// Where the requested service tier came from: the request body, or a dev-plan
+	// (DevPass) org's configured default tier. Only set when a premium tier was in
+	// play — a defaulted tier narrows routing without appearing in the request.
+	serviceTierSource?: "request" | "coding-plan-default";
 	// Parameters that were stripped from the request because the selected provider doesn't support them
 	strippedParameters?: string[];
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1932,6 +1932,10 @@ export const log = pgTable(
 				providerId: string;
 				reasons: string[];
 			}>;
+			// Where the requested service tier came from: the request body, or a
+			// dev-plan (DevPass) org's configured default tier. Only set when a
+			// premium tier was in play.
+			serviceTierSource?: "request" | "coding-plan-default";
 			strippedParameters?: string[];
 		}>(),
 		processedAt: timestamp(),

--- a/packages/shared/src/components/log-card.tsx
+++ b/packages/shared/src/components/log-card.tsx
@@ -90,6 +90,11 @@ interface RoutingMetadata {
 		apiKeyHash?: string;
 		logId?: string;
 	}>;
+	filteredProviders?: Array<{
+		providerId: string;
+		reasons: string[];
+	}>;
+	serviceTierSource?: string;
 }
 
 interface ErrorDetails {
@@ -702,6 +707,31 @@ export function LogCard({
 													</span>
 												</div>
 											)}
+										{routingMetadata.filteredProviders &&
+											routingMetadata.filteredProviders.length > 0 && (
+												<div className="pt-1 border-t border-dashed">
+													<div className="text-muted-foreground mb-1">
+														Filtered Out
+													</div>
+													<div className="space-y-1">
+														{routingMetadata.filteredProviders.map(
+															(filtered) => (
+																<div
+																	key={filtered.providerId}
+																	className="flex justify-between items-start gap-2"
+																>
+																	<span className="font-mono text-amber-600">
+																		{filtered.providerId}
+																	</span>
+																	<span className="text-muted-foreground text-right">
+																		{filtered.reasons.join(", ")}
+																	</span>
+																</div>
+															),
+														)}
+													</div>
+												</div>
+											)}
 										{routingMetadata.providerScores &&
 											routingMetadata.providerScores.length > 0 && (
 												<div className="pt-1 border-t border-dashed">
@@ -1082,6 +1112,12 @@ export function LogCard({
 													<span className="capitalize">
 														{log.requestedServiceTier}
 													</span>
+													{routingMetadata?.serviceTierSource ===
+														"coding-plan-default" && (
+														<span className="ml-1 text-muted-foreground">
+															(coding plan default)
+														</span>
+													)}
 												</div>
 											</>
 										)}


### PR DESCRIPTION
## Problem

A request to `gpt-5.6-sol` reported this in its log:

```
Selection   single-provider-available
Available   openai
```

…even though the model has three provider mappings (`openai`, `azure`, `aws-mantle`). Nothing in the log explained the difference, and no service tier was shown either.

The cause is a chain of three separate reporting gaps, all triggered by a dev-plan (DevPass) org whose dashboard setting defaults routing to flex:

1. **The effective service tier was never logged.** `requestedServiceTier` is snapshotted from the request body at parse time, ~700 lines before the dev-plan default assigns `service_tier = "flex"`. So a request the gateway genuinely routed *and processed* as flex was logged with `requestedServiceTier: null` and — when the upstream call fails before returning a tier — no tier at all.
2. **The tier filter's exclusions were invisible.** Only the `openai` mapping of `gpt-5.6-sol` declares `serviceTiers`, so flex drops `azure` and `aws-mantle` from `modelInfo.providers` before provider selection ever runs. `routingMetadata.filteredProviders` is only populated by the routing-time eligibility filter, so these earlier drops left no trace. The same blind spot covers the coding-plan cached-input requirement, service-tier key eligibility, and the compliance policy.
3. **`single-provider-available` was derived from the post-filter list.** With one candidate left, routing is short-circuited and the reason was computed from `modelInfo.providers.length === 1` — i.e. after filtering — so a narrowed-down request was labelled as if the model only ever had one provider.

## Approach

- Record the tier the gateway actually requests upstream, and where it came from: `requestedServiceTier` is updated when the dev-plan default applies, and `routingMetadata.serviceTierSource` distinguishes `"request"` from `"coding-plan-default"`.
- Collect providers dropped *before* selection into `routingMetadata.filteredProviders`, with a reason per filter, merged into every routing-metadata construction site (direct, auto, rate-limit fallback, low-uptime fallback, single-candidate shortcut).
- Report `single-candidate-after-filtering` when request-scoped filters narrowed a multi-provider model down to one; `single-provider-available` now only means what it says. Checked against the catalog, not the filtered list.
- Surface both in the UI: the log card (the panel where this was spotted) gains a **Filtered Out** section it never had — it only existed on the full log-detail page — and both views annotate the tier with *(coding plan default)* when it wasn't client-requested.

## What it looks like

The same request, as rendered in the activity log card. `Filtered Out` is new, and the tier is now labelled with where it came from:

<img width="1120" alt="Routing Info block showing Selection single-candidate-after-filtering, Available openai, and a Filtered Out section listing azure and aws-mantle with the reason: service tier 'flex' (coding plan default) not supported" src="https://raw.githubusercontent.com/theopenco/llmgateway/ef1d7c968f5a794c3d00a9b619a158b1dd9a2ed8/routing-info.png" />

Full card — note `Requested Service Tier: Flex (coding plan default)` under Cost Information, which was previously blank for these requests:

<img width="1440" alt="Expanded activity log card for openai/gpt-5.6-sol showing Request Details, the Routing Info block with Filtered Out providers, and Cost Information with Requested Service Tier Flex (coding plan default)" src="https://raw.githubusercontent.com/theopenco/llmgateway/ef1d7c968f5a794c3d00a9b619a158b1dd9a2ed8/log-card-expanded.png" />

## Behavior change worth flagging

`metadata.requested_service_tier` in the API response, and `log.requestedServiceTier`, now report a plan-defaulted tier instead of staying null. An existing test asserted the old behavior on the grounds that the client didn't ask for it; the update is deliberate — the gateway *did* request that tier upstream, and it changes both routing and billing, so a caller debugging a slow request needs to see it. `serviceTierSource` keeps client-requested and org-defaulted distinguishable for anyone who needs the distinction.

## Verification

- New spec reproduces the original log: a DevPass org on flex calling `gpt-5.6-sol` routes to `openai` alone, with `azure` and `aws-mantle` recorded as filtered for `service tier 'flex' (coding plan default) not supported`, and `selectionReason: single-candidate-after-filtering`.
- `pnpm vitest run apps/gateway/src/api.spec.ts` and `apps/gateway/src/fallback.spec.ts` pass (run separately — these suites share ports/DB state and fail spuriously in parallel).
- `pnpm test:unit`: 4030 passed. The only failures are `apps/worker/src/services/sync-models.spec.ts`, which times out identically on a clean checkout of this branch's base — unrelated and pre-existing.
- `pnpm build` and `pnpm format` clean.

## Not fixed here

`model: "auto"` combined with an explicit `service_tier` returns `Service tier 'flex' is not available for model auto`, because the tier filter runs against the synthetic `llmgateway` mapping before auto-routing resolves a real model. Pre-existing, unrelated to DevPass (the plan default can't trigger on the synthetic model), and left alone to keep this diff scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
