### PR TITLE
fix(admin): match devpass top-up refunds correctly

### DIFF
--- a/apps/api/src/routes/admin-devpass-payg.spec.ts
+++ b/apps/api/src/routes/admin-devpass-payg.spec.ts
@@ -6,6 +6,7 @@ import { createTestUser, deleteAll } from "@/testing.js";
 import { db, tables } from "@llmgateway/db";
 
 const ORG_ID = "admin-devpass-payg-org";
+const OTHER_ORG_ID = "admin-devpass-payg-other-org";
 const PROJECT_ID = "admin-devpass-payg-project";
 const originalAdminEmails = process.env.ADMIN_EMAILS;
 
@@ -202,6 +203,94 @@ describe("admin devpass PAYG overflow reporting", () => {
 			refunds: 5,
 			net: 21.25,
 		});
+	});
+
+	it("ignores refunds whose original top-up is not counted as gross", async () => {
+		// Legacy rows can link a refund to a `credit_topup` no gross top-up sum
+		// ever counted: one that never completed, one carrying no amount, and
+		// one booked on a different organization. Subtracting those would drag
+		// the reported net below the gross it was never part of.
+		await db.insert(tables.organization).values({
+			id: OTHER_ORG_ID,
+			name: "Other Org",
+			billingEmail: "other@example.com",
+			kind: "default",
+		});
+		const uncountedOriginals = await db
+			.insert(tables.transaction)
+			.values([
+				{
+					organizationId: ORG_ID,
+					type: "credit_topup",
+					amount: "40",
+					creditAmount: "40",
+					status: "pending",
+				},
+				{
+					organizationId: ORG_ID,
+					type: "credit_topup",
+					amount: null,
+					creditAmount: null,
+					status: "completed",
+				},
+				{
+					organizationId: OTHER_ORG_ID,
+					type: "credit_topup",
+					amount: "60",
+					creditAmount: "60",
+					status: "completed",
+				},
+			])
+			.returning();
+		await db.insert(tables.transaction).values(
+			uncountedOriginals.map((original) => ({
+				organizationId: ORG_ID,
+				type: "credit_refund" as const,
+				amount: "40",
+				creditAmount: "0",
+				status: "completed" as const,
+				relatedTransactionId: original.id,
+			})),
+		);
+
+		const paygRes = await app.request("/admin/devpass/payg", {
+			headers: { Cookie: cookie },
+		});
+		expect(paygRes.status).toBe(200);
+		const payg = (await paygRes.json()) as {
+			topups: {
+				thisMonth: { gross: number; refunds: number; net: number };
+				allTime: { gross: number; refunds: number; net: number };
+			};
+		};
+		expect(payg.topups.allTime).toEqual({
+			gross: 26.25,
+			refunds: 0,
+			net: 26.25,
+		});
+		expect(payg.topups.thisMonth).toEqual({
+			gross: 26.25,
+			refunds: 0,
+			net: 26.25,
+		});
+
+		const listRes = await app.request("/admin/devpass", {
+			headers: { Cookie: cookie },
+		});
+		expect(listRes.status).toBe(200);
+		const list = (await listRes.json()) as ListResponse;
+		expect(list.subscribers.find((s) => s.id === ORG_ID)!.allTimeRevenue).toBe(
+			105.25,
+		);
+
+		const detailRes = await app.request(`/admin/devpass/${ORG_ID}`, {
+			headers: { Cookie: cookie },
+		});
+		expect(detailRes.status).toBe(200);
+		const detail = (await detailRes.json()) as {
+			subscriber: PaygSubscriber;
+		};
+		expect(detail.subscriber.allTimeRevenue).toBe(105.25);
 	});
 
 	it("detail endpoint carries the same PAYG fields", async () => {

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -22,6 +22,7 @@ import {
 	notEndUserWalletFilter,
 	notPlanFilter,
 	paidTransactionFilter,
+	refundsCountedTopupFilter,
 } from "@/utils/devpass-filter.js";
 import {
 	HOURLY_BUCKET_THRESHOLD_MINUTES,
@@ -12388,13 +12389,19 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 			and(
 				eq(tables.transaction.type, "credit_refund"),
 				eq(tables.transaction.status, "completed"),
-				inArray(allTimeRefundOriginalTx.type, [
-					...DEV_PLAN_TX_TYPES,
-					...LEGACY_DEV_PLAN_TX_TYPES,
+				or(
+					inArray(allTimeRefundOriginalTx.type, [
+						...DEV_PLAN_TX_TYPES,
+						...LEGACY_DEV_PLAN_TX_TYPES,
+					]),
 					// PAYG overflow top-up refunds net out of all-time revenue,
-					// mirroring the top-up subquery below on the revenue side.
-					"credit_topup",
-				]),
+					// mirroring the top-up subquery below on the revenue side —
+					// so they are restricted to the same rows that subquery sums.
+					refundsCountedTopupFilter(
+						tables.transaction,
+						allTimeRefundOriginalTx,
+					),
+				)!,
 			),
 		)
 		.groupBy(tables.transaction.organizationId)
@@ -13237,7 +13244,7 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 				gte(tables.transaction.createdAt, startDate),
 				lte(tables.transaction.createdAt, endDate),
 				eq(tables.organization.kind, "devpass"),
-				eq(topupRefundOriginalTx.type, "credit_topup"),
+				refundsCountedTopupFilter(tables.transaction, topupRefundOriginalTx),
 			),
 		)
 		.groupBy(sql`DATE(${tables.transaction.createdAt})`)
@@ -13473,7 +13480,7 @@ admin.openapi(getDevpassPaygStats, async (c) => {
 				eq(tables.transaction.type, "credit_refund"),
 				eq(tables.transaction.status, "completed"),
 				eq(tables.organization.kind, "devpass"),
-				eq(paygRefundOriginalTx.type, "credit_topup"),
+				refundsCountedTopupFilter(tables.transaction, paygRefundOriginalTx),
 			),
 		);
 
@@ -13834,11 +13841,12 @@ admin.openapi(getDevpassSubscriber, async (c) => {
 				eq(tables.transaction.organizationId, orgId),
 				eq(tables.transaction.type, "credit_refund"),
 				eq(tables.transaction.status, "completed"),
-				inArray(detailRefundOriginalTx.type, [
-					...allTimeRevenueTypes,
-					// Top-up refunds net out of revenue like the top-ups counted in.
-					"credit_topup",
-				]),
+				or(
+					inArray(detailRefundOriginalTx.type, allTimeRevenueTypes),
+					// Top-up refunds net out of revenue like the top-ups counted
+					// in, so they match the same rows allTimeTopUps sums.
+					refundsCountedTopupFilter(tables.transaction, detailRefundOriginalTx),
+				)!,
 			),
 		);
 

--- a/apps/api/src/utils/devpass-filter.ts
+++ b/apps/api/src/utils/devpass-filter.ts
@@ -1,4 +1,4 @@
-import { sql, tables } from "@llmgateway/db";
+import { and, eq, sql, tables } from "@llmgateway/db";
 
 // All plan/subscription transaction types (DevPass dev plans, legacy
 // subscriptions, Chat Plans). These are excluded from the credits-economy
@@ -76,6 +76,25 @@ export const CHAT_PLAN_TX_TYPES = [
 	"chat_plan_downgrade",
 	"chat_plan_renewal",
 ] as const;
+
+// Matches `credit_refund` rows that reverse a top-up the gross top-up sums
+// actually counted: a completed, positive-`amount` `credit_topup` booked on the
+// same organization as the refund. Every gross top-up figure filters on exactly
+// those three things, so matching refunds on the original's type alone lets a
+// refund be subtracted from a base it was never part of — which can push a
+// reported net below zero. Always pair this with the refund-side filters
+// (`type = 'credit_refund'`, `status = 'completed'`, the org scope).
+export function refundsCountedTopupFilter(
+	refund: typeof tables.transaction,
+	original: typeof tables.transaction,
+) {
+	return and(
+		eq(original.type, "credit_topup"),
+		eq(original.status, "completed"),
+		sql`CAST(${original.amount} AS NUMERIC) > 0`,
+		eq(original.organizationId, refund.organizationId),
+	)!;
+}
 
 // Keeps exactly one transaction per (stripe_invoice_id, organization_id): the
 // FIRST invoice of a subscription triggers BOTH `checkout.session.completed`


### PR DESCRIPTION
## Problem

The DevPass top-up figures net refunds out of gross top-ups, but the two halves select different rows.

Gross top-up revenue only counts `credit_topup` rows that are `status = 'completed'`, carry `amount > 0`, and belong to the DevPass org being reported on. The refund side matched on one thing: the type of the row the refund links back to. Any `credit_refund` whose original is a `credit_topup` that never completed, carries no amount, or was booked on another organization was therefore subtracted from a base that never included it — and the reported net could drop below zero.

The same mismatch existed in four places, since each one pairs its own gross sum with its own refund query.

## Approach

Add `refundsCountedTopupFilter(refund, original)` to `utils/devpass-filter.ts`. It matches a refund only when its original purchase is one of the rows the gross sums actually count: a completed, positive-`amount` `credit_topup` on the same organization as the refund.

Applied to every place a `credit_refund` is netted against top-up revenue:

- `allTimeRefundSub` — subscriber list all-time revenue
- `topupRefundsPerDay` — DevPass revenue timeseries
- `refundRow` — `/admin/devpass/payg` this-month / all-time / range windows
- `allTimeRefundRow` — `/admin/devpass/:orgId` detail

Plan and Reset Pass refunds keep their existing type-based matching; only the top-up branch is narrowed, so this changes nothing for a refund that reverses a top-up the gross figures counted.

## Verification

New regression test in `admin-devpass-payg.spec.ts` links refunds to three uncounted originals (pending, amount-less, other-org) and asserts the payg windows, the subscriber list and the detail endpoint all ignore them. It fails on `main` (net goes negative) and passes with the fix.

`pnpm format`, `pnpm build`, and the admin/devpass specs (`admin-devpass-payg`, `admin-devpass-gift-reset-passes`, `admin-devpass-search`, `admin-org-details`, `admin-metrics-gross-revenue`, `admin-paid-customers`, `dev-plans-payg` — 47 tests) all pass.

## Not included

The card is labelled DevPass top-up revenue but counts every `credit_topup` on a `kind = 'devpass'` org, including credit purchases made on personal orgs before PAYG overflow existed. Scoping it to the feature's launch would need a hardcoded cutoff date, so it is left as a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected PAYG revenue calculations to exclude refunds associated with pending, amountless, or unrelated top-ups.
  - Ensured only valid, completed top-ups reduce gross and net revenue.
  - Improved consistency of all-time revenue figures across list, detail, statistics, and time-series views.
  - Added regression coverage to prevent incorrect revenue reductions in future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->