### PR TITLE
chore(models): deactivate retired openai models

### DIFF
--- a/packages/models/src/models/openai.ts
+++ b/packages/models/src/models/openai.ts
@@ -1115,6 +1115,10 @@ export const openaiModels = [
 			{
 				providerId: "openai",
 				externalId: "gpt-5-chat-latest",
+				// Shut down by OpenAI on 2026-07-23 (announced 2026-04-22);
+				// requests now 404 with "has been deprecated". Replacement is
+				// gpt-5.6-sol.
+				deactivatedAt: new Date("2026-07-23"),
 				inputPrice: "1.25e-6",
 				outputPrice: "10.0e-6",
 				cachedInputPrice: "0.125e-6",
@@ -1248,6 +1252,11 @@ export const openaiModels = [
 			{
 				providerId: "openai",
 				externalId: "gpt-5.1-codex",
+				// Shut down by OpenAI on 2026-07-23 (announced 2026-04-22);
+				// requests now 404 with "has been deprecated". Replacement is
+				// gpt-5.6-sol. The azure mapping below stays active — Azure runs
+				// its own schedule and does not retire this until 2027-05-15.
+				deactivatedAt: new Date("2026-07-23"),
 				serviceTiers: ["priority"],
 				serviceTierMultipliers: { priority: 2 },
 				inputPrice: "1.25e-6",
@@ -1296,6 +1305,11 @@ export const openaiModels = [
 			{
 				providerId: "openai",
 				externalId: "gpt-5.1-codex-mini",
+				// Shut down by OpenAI on 2026-07-23 (announced 2026-04-22);
+				// requests now 404 with "has been deprecated". Replacement is
+				// gpt-5.6-terra. The azure mapping below stays active — Azure runs
+				// its own schedule and does not retire this until 2027-05-15.
+				deactivatedAt: new Date("2026-07-23"),
 				inputPrice: "0.25e-6",
 				outputPrice: "2e-6",
 				cachedInputPrice: "0.025e-6",
@@ -2334,6 +2348,11 @@ export const openaiModels = [
 			{
 				providerId: "openai",
 				externalId: "gpt-5.2-codex",
+				// Shut down by OpenAI on 2026-07-23 (announced 2026-04-22);
+				// requests now 404 with "has been deprecated". Replacement is
+				// gpt-5.6-sol. The azure mapping below stays active — Azure runs
+				// its own schedule and does not retire this until 2027-07-13.
+				deactivatedAt: new Date("2026-07-23"),
 				inputPrice: "1.75e-6",
 				outputPrice: "14.0e-6",
 				cachedInputPrice: "0.175e-6",


### PR DESCRIPTION
## Problem

30 of the failures in the last e2e run were four OpenAI models failing *every* test type — `basic`, `json`, `reasoning`, `tool calls`, `service_tier` — with 500s. Probed against the live OpenAI API, all four are gone:

```
gpt-5-chat-latest    404  The model `gpt-5-chat-latest` has been deprecated
gpt-5.1-codex        404  The model `gpt-5.1-codex` has been deprecated
gpt-5.1-codex-mini   404  The model `gpt-5.1-codex-mini` has been deprecated
gpt-5.2-codex        404  The model `gpt-5.2-codex` has been deprecated
```

Per OpenAI's deprecations page they were announced on 2026-04-22 and shut down on **2026-07-23**, replaced by `gpt-5.6-sol` (`gpt-5.6-terra` for codex-mini). They still appear in `GET /v1/models`, which is why this wasn't obvious — only an actual inference call reveals it.

Nothing to fix on our side: the models are simply retired upstream.

## Change

`deactivatedAt: new Date("2026-07-23")` on the four **openai** mappings — the real shutdown date, not today's, matching the existing `o1-mini` precedent in this file.

**The azure mappings stay active.** Azure runs its own retirement schedule and still serves all three codex deployments — `gpt-5.1-codex` and `gpt-5.1-codex-mini` until 2027-05-15, `gpt-5.2-codex` until 2027-07-13 (per the Foundry model retirement schedule). Deactivating them would break BYOK users with working Azure deployments. `gpt-5-chat-latest` has no azure mapping, so that model goes away entirely.

## Verification

Swept every active `openai` provider mapping in the catalogue against the live API with an intentionally-invalid parameter (so a live model 400s without generating tokens, a retired one 404s). These four are the only dead ones — the remaining 404s are `gpt-5.2-pro` / `gpt-5.4-pro` / `gpt-5.5-pro` / `gpt-5.3-codex` returning "not a chat model", which is expected for Responses-only models and confirmed working on `/v1/responses`.

`pnpm format` and `pnpm build` pass; `packages/models`, `packages/actions`, and the gateway/api model-route specs pass (809 tests). The full `pnpm test:unit` run is unusable on this machine — it shares Postgres with other worktrees and times out under parallel load; the same specs pass when run scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Model Availability**
  * Updated model listings to reflect the retirement of four OpenAI models.
  * Documented recommended replacement models and applicable retirement timelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->