### PR TITLE
fix(models): map developer role for deepseek

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -5648,6 +5648,26 @@ describe("prepareRequestBody - developer role normalization", () => {
 		const requestBody = await prepare("openai", "gpt-4o-mini");
 		expect(requestBody.messages[0].role).toBe("developer");
 	});
+
+	test("rewrites developer to system for deepseek/deepseek-v4-pro", async () => {
+		const requestBody = await prepare("deepseek", "deepseek-v4-pro");
+		expect(requestBody.messages[0].role).toBe("system");
+		expect(requestBody.messages[0].content).toBe(
+			"You are a helpful assistant.",
+		);
+		expect(requestBody.messages[1].role).toBe("user");
+	});
+
+	test("rewrites developer to system for deepseek/deepseek-v4-flash", async () => {
+		const requestBody = await prepare("deepseek", "deepseek-v4-flash");
+		expect(requestBody.messages[0].role).toBe("system");
+		expect(requestBody.messages[1].role).toBe("user");
+	});
+
+	test("preserves developer role for another deepseek-v4-pro provider (deepinfra)", async () => {
+		const requestBody = await prepare("deepinfra", "deepseek-v4-pro");
+		expect(requestBody.messages[0].role).toBe("developer");
+	});
 });
 
 describe("prepareRequestBody - Sakana Fugu reasoning effort", () => {

--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -120,6 +120,11 @@ export const deepseekModels = [
 				streaming: true,
 				vision: false,
 				tools: true,
+				// DeepSeek's API 400s on the OpenAI-only `developer` role
+				// ("unknown variant `developer`, expected one of `system`, `user`,
+				// `assistant`, `tool`, `latest_reminder`"), so it gets rewritten to
+				// `system` before the request goes out.
+				supportsDeveloperRole: false,
 				deactivatedAt: new Date("2026-05-01"),
 			},
 			{
@@ -268,6 +273,11 @@ export const deepseekModels = [
 				reasoningEfforts: ["none", "high", "max"],
 				vision: false,
 				tools: true,
+				// DeepSeek's API 400s on the OpenAI-only `developer` role
+				// ("unknown variant `developer`, expected one of `system`, `user`,
+				// `assistant`, `tool`, `latest_reminder`"), so it gets rewritten to
+				// `system` before the request goes out.
+				supportsDeveloperRole: false,
 				supportedParameters: [
 					"temperature",
 					"max_tokens",
@@ -433,6 +443,11 @@ export const deepseekModels = [
 				reasoningEfforts: ["none", "high", "max"],
 				vision: false,
 				tools: true,
+				// DeepSeek's API 400s on the OpenAI-only `developer` role
+				// ("unknown variant `developer`, expected one of `system`, `user`,
+				// `assistant`, `tool`, `latest_reminder`"), so it gets rewritten to
+				// `system` before the request goes out.
+				supportsDeveloperRole: false,
 				supportedParameters: [
 					"temperature",
 					"max_tokens",


### PR DESCRIPTION
## Problem

Streaming requests to `deepseek/deepseek-v4-pro` were failing with a 400 from DeepSeek's API whenever the client sent a `developer` message:

```json
{"error":{"message":"Failed to deserialize the JSON body into the target type: messages[0].role: unknown variant `developer`, expected one of `system`, `user`, `assistant`, `tool`, `latest_reminder` at line 1 column 58","type":"invalid_request_error","code":"invalid_request_error"}}
```

`developer` is an OpenAI-only role. DeepSeek's direct API doesn't accept it, so every request from a client that emits developer instructions (Codex-style agents, most notably) hard-failed.

## Fix

The gateway already has the machinery for this: `supportsDeveloperRole: false` on a provider mapping makes `prepareRequestBody` rewrite `developer` → `system` before the request goes upstream (`transformDeveloperRole`). `developer` is semantically a system instruction, so the downgrade is lossless here.

Set the flag on all three `providerId: "deepseek"` mappings — `deepseek-v4-pro`, `deepseek-v4-flash`, and the deactivated `deepseek-v3.2` one (the restriction is API-wide, not per model). Other providers serving the same models (deepinfra, runware, alibaba, …) are untouched and keep forwarding `developer` as-is.

## Verification

- Added unit tests to `prepare-request-body.spec.ts` covering the rewrite for both active DeepSeek mappings plus a negative case (`deepinfra/deepseek-v4-pro` still forwards `developer`).
- `pnpm vitest run packages/actions/src/prepare-request-body.spec.ts -t "developer role"` — 8 passed
- `pnpm vitest run packages/models` — 125 passed
- `pnpm build` and `pnpm format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for DeepSeek V3.2, V4 Pro, and V4 Flash by converting developer messages to system messages when required.
  * Preserved developer-role messages for supported DeepInfra configurations.
* **Tests**
  * Added coverage verifying correct developer-role handling across DeepSeek model variants and providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->