### PR TITLE
feat(gateway): wire up DashScope web search

### DIFF
--- a/apps/gateway/src/chat-websearch.e2e.ts
+++ b/apps/gateway/src/chat-websearch.e2e.ts
@@ -19,8 +19,15 @@ const testWebSearch = process.env.TEST_WEB_SEARCH;
 // Skip all tests if TEST_WEB_SEARCH is not set
 const describeWebSearch = testWebSearch ? describe : describe.skip;
 
+// DashScope's OpenAI-compatible protocol does not return search sources at all
+// (no `search_info`, regardless of enable_source/enable_citation), so the
+// providers backed by it can report that a search ran but never where it read.
+const providersWithoutWebSearchAnnotations = ["zai/", "alibaba/", "scx-ai-gp/"];
+
 const expectsWebSearchAnnotations = (model: string) =>
-	!model.startsWith("zai/");
+	!providersWithoutWebSearchAnnotations.some((prefix) =>
+		model.startsWith(prefix),
+	);
 
 describeWebSearch("e2e web search", getConcurrentTestOptions(), () => {
 	beforeAll(beforeAllHook);

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -8545,7 +8545,16 @@ chat.openapi(completions, async (c) => {
 				let streamingToolCalls = null;
 				let imageByteSize = 0; // Track total image data size for token estimation
 				let outputImageCount = 0; // Track number of output images for cost calculation
-				let webSearchCount = usedProvider === "zai" && webSearchTool ? 1 : 0; // Track web search calls for cost calculation
+				// Track web search calls for cost calculation. Providers that report
+				// no search metadata in the stream are counted up front: zai, and
+				// the DashScope-compatible endpoints where we force the search.
+				let webSearchCount =
+					webSearchTool &&
+					(usedProvider === "zai" ||
+						usedProvider === "alibaba" ||
+						usedProvider === "scx-ai-gp")
+						? 1
+						: 0;
 				const serverToolUseIndices = new Set<number>(); // Track Anthropic server_tool_use block indices
 				let sawUpstreamDoneSentinel = false;
 				let sawProviderTerminalEvent = false;

--- a/apps/gateway/src/chat/tools/parse-provider-response.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.ts
@@ -673,6 +673,13 @@ export function parseProviderResponse(
 					images = json.choices[0].message.images;
 				}
 			}
+			// DashScope's OpenAI-compatible protocol never returns `search_info`,
+			// so there is no per-response signal that a search ran. We only ever
+			// enable search together with `forced_search`, which guarantees one,
+			// so requesting it is the count.
+			if (webSearchRequested) {
+				webSearchCount = 1;
+			}
 			break;
 		}
 		default: // OpenAI format
@@ -1192,6 +1199,13 @@ export function parseProviderResponse(
 					} else if (webSearchRequested) {
 						webSearchCount = 1;
 					}
+				}
+
+				// SCX resells Qwen through DashScope, which returns no search
+				// metadata over the OpenAI-compatible protocol. See the `alibaba`
+				// case: forced_search guarantees the search ran.
+				if (usedProvider === "scx-ai-gp" && webSearchRequested) {
+					webSearchCount = 1;
 				}
 			}
 			break;

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -5752,3 +5752,69 @@ describe("prepareRequestBody - Sakana Fugu reasoning effort", () => {
 		}
 	});
 });
+
+describe("prepareRequestBody - DashScope web search", () => {
+	const prepare = (provider: string, model: string, webSearchTool?: any) =>
+		prepareRequestBody(
+			provider as any,
+			model,
+			null,
+			model,
+			[{ role: "user", content: "hi" }],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+			20,
+			null,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			webSearchTool,
+		) as Promise<any>;
+
+	test.each(["alibaba", "scx-ai-gp"])(
+		"%s pairs enable_search with forced_search",
+		async (provider) => {
+			const requestBody = await prepare(provider, "qwen3.8-max", {
+				type: "web_search",
+			});
+
+			// enable_search alone is a hint the model ignores; forced_search is what
+			// actually retrieves, so the two must always travel together.
+			expect(requestBody.enable_search).toBe(true);
+			expect(requestBody.search_options).toEqual({ forced_search: true });
+		},
+	);
+
+	test.each(["alibaba", "scx-ai-gp"])(
+		"%s omits search_strategy",
+		async (provider) => {
+			const requestBody = await prepare(provider, "qwen3.8-max", {
+				type: "web_search",
+			});
+
+			// The Qwen max models 400 on the documented "agent" policy.
+			expect(requestBody.search_options.search_strategy).toBeUndefined();
+		},
+	);
+
+	test.each(["alibaba", "scx-ai-gp"])(
+		"%s sends no search params without a web_search tool",
+		async (provider) => {
+			const requestBody = await prepare(provider, "qwen3.8-max");
+
+			expect(requestBody.enable_search).toBeUndefined();
+			expect(requestBody.search_options).toBeUndefined();
+		},
+	);
+});

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -273,6 +273,26 @@ function isFunctionTool(
 }
 
 /**
+ * Enables DashScope web search on an OpenAI-compatible request body.
+ *
+ * `enable_search` on its own is only a hint that the model is free to ignore,
+ * and in practice it always does: the prompt comes back the same size and the
+ * model answers that it has no live access. Pairing it with
+ * `search_options.forced_search` is what actually retrieves, so the two are
+ * always sent together and a search is guaranteed to have run.
+ *
+ * `search_strategy` is deliberately omitted. The documented "agent" and
+ * "agent_max" policies are rejected with a 400 ("The current model does not
+ * support the \"agent\" search strategy") by the Qwen max models mapped here,
+ * and the legacy turbo/standard/pro/max tiers only vary how many snippets get
+ * injected into the prompt.
+ */
+function applyDashScopeWebSearch(requestBody: Record<string, any>): void {
+	requestBody.enable_search = true;
+	requestBody.search_options = { forced_search: true };
+}
+
+/**
  * Ensures function-tool parameters form a valid JSON Schema object. Some
  * upstreams (e.g. DeepSeek) reject tools whose parameters omit `type` or set
  * it to null, which happens when SDKs serialize parameter-less tools.
@@ -2391,6 +2411,10 @@ export async function prepareRequestBody(
 				requestBody.response_format = response_format;
 			}
 
+			if (webSearchTool) {
+				applyDashScopeWebSearch(requestBody);
+			}
+
 			// Add optional parameters if they are provided
 			if (temperature !== undefined) {
 				requestBody.temperature = temperature;
@@ -3977,6 +4001,13 @@ export async function prepareRequestBody(
 			// already narrows to the tiers the catalog declares for this mapping.
 			if (usedProvider === "fireworks" && supportedServiceTier) {
 				requestBody.service_tier = supportedServiceTier;
+			}
+
+			// SCX resells Alibaba's Qwen models and passes DashScope's search
+			// parameters straight through, so its Qwen mappings take the same shape
+			// as the `alibaba` case above.
+			if (usedProvider === "scx-ai-gp" && webSearchTool) {
+				applyDashScopeWebSearch(requestBody);
 			}
 
 			// Vertex's OpenAI-compatible chat completions endpoint requires the

--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -1684,7 +1684,6 @@ export const alibabaModels = [
 			{
 				providerId: "scx-ai-gp",
 				externalId: "qwen3.8-max",
-				test: "skip",
 				inputPrice: "1.815e-6",
 				cachedInputPrice: "0.21e-6",
 				cacheReadInputPrice: "0.17e-6",


### PR DESCRIPTION
## Problem

Five `alibaba` mappings (`qwen3.7-max`, `qwen3.8-max`, `qwen35-397b-a17b`, `qwen3.6-plus`, `qwen3.6-35b-a3b`) and the `scx-ai-gp` Qwen mapping declare `webSearch: true` + `webSearchPrice`, but the gateway had **no request-side web search implementation for either provider**. The `case "alibaba"` block in `prepareRequestBody` never consumed `webSearchTool`, and `enable_search` did not exist anywhere in the source.

The flag was not merely inert. `provider-filter-reasons.ts` routes web-search requests *to* mappings that declare `webSearch: true`, so these mappings won the route, returned silently unsearched answers, and billed `webSearchCost` of `$0.00`. Every `chat-websearch` e2e case for them failed on `expect(log.webSearchCost).toBeGreaterThan(0)`.

## Approach

Send `enable_search: true` together with `search_options: { forced_search: true }`.

Both halves matter, verified live and reproducibly against DashScope:

| request | prompt_tokens | result |
|---|---|---|
| no params | 66 | *"I don't have real-time access"* |
| `enable_search: true` alone | 66 | *"I don't have live market access"* |
| `+ search_options.forced_search` | 5774 | correct live BTC price |

`enable_search` on its own is only a hint the model is free to ignore, and it always does. `search_strategy` is deliberately omitted: the documented `agent`/`agent_max` policies are rejected with a 400 (`The current model does not support the "agent" search strategy`) by the Qwen max models mapped here, and the legacy turbo/standard/pro/max tiers only vary how many snippets get injected.

SCX resells Qwen and passes the same parameters straight through (`prompt_tokens` 78 → 1430, same cited prices), so it gets the same shape.

## Counting and billing

DashScope's OpenAI-compatible protocol returns **no search metadata at all** — no `search_info`, regardless of `enable_source`/`enable_citation`. This is documented ("The OpenAI-compatible protocol does not support returning search sources in the response") and confirmed live at top level, in the choice, and in the message.

So there is no per-response signal that a search ran, and the count comes from the request, the way `zai` already does it. This is exact rather than approximate: we only ever enable search together with `forced_search`, which guarantees one happened.

The same limitation means these providers cannot emit `url_citation` annotations, so the e2e annotation assertion excludes them alongside `zai`.

## Pricing

`webSearchPrice: "0.01"` is correct and unchanged. Alibaba publishes $10.00 per 1,000 calls for the international deployment scope, which is the Singapore endpoint these mappings use. The retrieved snippets are appended to the prompt and already bill as ordinary input tokens via `prompt_tokens`.

Two things a reviewer should know rather than discover later:

- **The mainland rate is ~17x cheaper** — $0.573411 per 1,000 calls. `qwen3.7-max` and `qwen35-397b-a17b` carry `cn-beijing` regions that inherit the $0.01 mapping-level price. Region-level `webSearchPrice` overrides are supported, so this is a one-line fix per region, but I could not test those regions (see below) and did not want to change billing on an untested path.
- **The published per-call fee is attached to the `agent`/`agent_max` policies**, which these models reject. I could find no published per-call rate for the legacy strategies they actually use, and the docs' "incurs an additional fee per call" note appears only under `agent`. $0.01 is the only international figure Alibaba publishes, so it stays, but it is worth confirming against a real invoice.

Also unchanged, but noting it since it surfaced while tracing this: `chat.ts` passes `webSearchTool ? 1 : null` on the cancelled-request path, so a cancelled request bills $0.01 for a search that never ran.

## Verification

`TEST_WEB_SEARCH=1` scoped e2e, all three surfaces (non-streaming, streaming, Responses API), all green:

- `alibaba/qwen3.8-max` and `scx-ai-gp/qwen3.8-max` — 11/11 in one run
- `alibaba/qwen3.7-max:singapore` — 3/3
- `alibaba/qwen35-397b-a17b:singapore` — 3/3
- `alibaba/qwen3.6-plus:singapore` — 3/3
- `alibaba/qwen3.6-35b-a3b:singapore` — 3/3

Only `singapore` results are judged: the local BYOK key is Singapore-only, so `:cn-beijing` and `:us-virginia` variants 401 for environment reasons, as does the bare model id where cheapest-region routing picks Beijing. Running many mappings in one invocation also trips the harness's per-test re-seed under 16-way concurrency (`Invalid LLMGateway API token`), so the per-model runs above are the authoritative ones.

New unit tests cover the request shape for both providers: the paired parameters, the omitted `search_strategy`, and that nothing is sent without a `web_search` tool.

`pnpm format` and `pnpm build` clean.

## Supersedes #3442

#3442 dropped `webSearch` from the `scx-ai-gp` mapping on the conclusion that SCX's reseller endpoint could not do DashScope search. That was wrong — the gateway simply never sent the parameter, to either provider. SCX works identically to Alibaba once wired. This PR keeps the flag and instead makes it true, and carries over the one part of #3442 that holds up: dropping `test: "skip"`, since the deployment now serves the whole suite. **#3442 should be closed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)