### PR TITLE
fix(gateway): allowlist Gemini tool schema keys

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -2583,6 +2583,169 @@ describe("prepareRequestBody - Google AI Studio", () => {
 		expect(params.required).toContain("prefill");
 	});
 
+	test("should strip unknown vendor extensions from Google tool parameters", async () => {
+		// Google's schema parser rejects any key it does not model, failing the
+		// whole request with `Unknown name "<key>" … Cannot find field.` — so a
+		// single `~optional` marker left in by a client's schema generator 400s
+		// every tool call. These keys are not enumerable in advance, which is why
+		// the filter is an allowlist.
+		const toolsWithVendorExtensions = [
+			{
+				type: "function" as const,
+				function: {
+					name: "test_tool",
+					description: "Test tool",
+					parameters: {
+						type: "object",
+						"~standard": { version: 1, vendor: "zod" },
+						properties: {
+							field_a: {
+								type: "string",
+								"~optional": true,
+							},
+							field_b: {
+								type: "string",
+								readOnly: true,
+								writeOnly: true,
+								deprecated: true,
+							},
+							field_c: {
+								type: "array",
+								items: { type: "string", "x-vendor-hint": "list" },
+								additionalItems: false,
+							},
+							field_d: {
+								type: "string",
+								enum: ["one"],
+								enumNames: ["One"],
+							},
+						},
+					},
+				},
+			},
+		];
+
+		const requestBody = (await prepareRequestBody(
+			"google-ai-studio",
+			"gemini-2.0-flash",
+			null,
+			"gemini-2.0-flash",
+			[{ role: "user", content: "test" }],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			toolsWithVendorExtensions,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+
+		const params = requestBody.tools[0].functionDeclarations[0].parameters;
+
+		expect(params["~standard"]).toBeUndefined();
+		expect(params.properties.field_a["~optional"]).toBeUndefined();
+		expect(params.properties.field_b.readOnly).toBeUndefined();
+		expect(params.properties.field_b.writeOnly).toBeUndefined();
+		expect(params.properties.field_b.deprecated).toBeUndefined();
+		expect(params.properties.field_c.additionalItems).toBeUndefined();
+		expect(params.properties.field_c.items["x-vendor-hint"]).toBeUndefined();
+		expect(params.properties.field_d.enumNames).toBeUndefined();
+
+		// The supported parts of each schema must survive untouched
+		expect(params.type).toBe("object");
+		expect(params.properties.field_a.type).toBe("string");
+		expect(params.properties.field_c.items.type).toBe("string");
+		expect(params.properties.field_d.enum).toEqual(["one"]);
+	});
+
+	test("should keep the schema keys Google supports in tool parameters", async () => {
+		const toolsWithSupportedKeys = [
+			{
+				type: "function" as const,
+				function: {
+					name: "test_tool",
+					description: "Test tool",
+					parameters: {
+						type: "object",
+						title: "Params",
+						description: "Parameters",
+						propertyOrdering: ["choice", "config"],
+						properties: {
+							choice: {
+								type: "string",
+								format: "enum",
+								nullable: true,
+								enum: ["a", "b"],
+								default: "a",
+								example: "b",
+							},
+							union: {
+								anyOf: [{ type: "string" }, { type: "number" }],
+							},
+							// An object-valued default must survive verbatim: it holds an
+							// instance value, not a subschema, so its own keys are not
+							// schema keywords and must not be filtered.
+							config: {
+								type: "object",
+								properties: { retries: { type: "number" } },
+								default: { retries: 3, mode: "fast" },
+							},
+						},
+						required: ["choice"],
+					},
+				},
+			},
+		];
+
+		const requestBody = (await prepareRequestBody(
+			"google-ai-studio",
+			"gemini-2.0-flash",
+			null,
+			"gemini-2.0-flash",
+			[{ role: "user", content: "test" }],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			toolsWithSupportedKeys,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+
+		const params = requestBody.tools[0].functionDeclarations[0].parameters;
+
+		expect(params.title).toBe("Params");
+		expect(params.description).toBe("Parameters");
+		expect(params.propertyOrdering).toEqual(["choice", "config"]);
+		expect(params.required).toEqual(["choice"]);
+		expect(params.properties.choice).toEqual({
+			type: "string",
+			format: "enum",
+			nullable: true,
+			enum: ["a", "b"],
+			default: "a",
+			example: "b",
+		});
+		expect(params.properties.union.anyOf).toEqual([
+			{ type: "string" },
+			{ type: "number" },
+		]);
+		expect(params.properties.config.default).toEqual({
+			retries: 3,
+			mode: "fast",
+		});
+	});
+
 	test("should add additionalProperties: false to Cerebras tool parameters", async () => {
 		const toolsWithoutAdditionalProps = [
 			{

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -467,8 +467,62 @@ function resolveRef(ref: string, rootDefs: Record<string, any>): any {
 }
 
 /**
- * Recursively strips unsupported properties and expands $ref references for Google
- * Google doesn't support $ref, additionalProperties, $schema, and some other JSON schema properties
+ * The only keys Google's `Schema` proto accepts inside a function
+ * declaration's `parameters`. Anything else — a JSON Schema keyword Google
+ * never modelled (`readOnly`, `additionalItems`, `const`, …) or a vendor
+ * extension a client's schema generator invented (`~optional`, `x-*`) —
+ * is rejected outright with `Invalid JSON payload received. Unknown name
+ * "<key>" at 'tools[0].function_declarations[N]…': Cannot find field.`,
+ * failing the entire request with a 400 even though only one property of one
+ * tool carried the key.
+ *
+ * This is an allowlist on purpose. The previous denylist could only ever be
+ * as complete as the last such outage: clients keep emitting new extension
+ * keys, and every unanticipated one is a hard failure rather than a
+ * degradation.
+ *
+ * Deliberately omitted even though Google does accept them: `minLength`,
+ * `maxLength`, `pattern`, `minimum`, `maximum`, `minItems`, `maxItems`,
+ * `minProperties`, `maxProperties` and `not`. The gateway has always stripped
+ * those, and forwarding them would change how models fill tool arguments, so
+ * restoring them is a separate behavioural change rather than part of this
+ * fix. `$ref` / `$defs` / `definitions` are absent because they are consumed
+ * by the inline expansion below instead of being forwarded.
+ */
+const GOOGLE_SUPPORTED_SCHEMA_KEYS: ReadonlySet<string> = new Set([
+	"type",
+	"format",
+	"title",
+	"description",
+	"nullable",
+	"enum",
+	"items",
+	"properties",
+	"required",
+	"default",
+	"anyOf",
+	"oneOf",
+	"allOf",
+	"propertyOrdering",
+	"example",
+]);
+
+/**
+ * Keys whose value is an instance value rather than a subschema. They are
+ * copied verbatim: recursing into them would apply the schema allowlist to the
+ * value's own fields, so an object-typed `default` or `example` would arrive
+ * at the provider emptied out.
+ */
+const GOOGLE_OPAQUE_SCHEMA_VALUE_KEYS: ReadonlySet<string> = new Set([
+	"default",
+	"example",
+	"enum",
+]);
+
+/**
+ * Recursively drops everything Google's schema parser does not accept and
+ * expands $ref references inline, since Google supports neither $ref nor the
+ * bulk of JSON Schema's validation vocabulary.
  */
 function stripUnsupportedSchemaProperties(
 	schema: any,
@@ -522,53 +576,12 @@ function stripUnsupportedSchemaProperties(
 	const cleaned: any = {};
 
 	for (const [key, value] of Object.entries(schema)) {
-		// Skip unsupported properties
-		// Google doesn't support many JSON Schema validation keywords
-		if (
-			key === "additionalProperties" ||
-			key === "$schema" ||
-			key === "$defs" ||
-			key === "definitions" ||
-			key === "$ref" ||
-			key === "ref" ||
-			key === "$id" ||
-			key === "$comment" ||
-			key === "$anchor" ||
-			key === "$dynamicAnchor" ||
-			key === "$dynamicRef" ||
-			key === "$vocabulary" ||
-			key === "examples" ||
-			key === "enumTitles" ||
-			key === "prefill" ||
-			key === "maxLength" ||
-			key === "minLength" ||
-			key === "minimum" ||
-			key === "maximum" ||
-			key === "exclusiveMinimum" ||
-			key === "exclusiveMaximum" ||
-			key === "pattern" ||
-			key === "propertyNames" ||
-			key === "const" ||
-			key === "not" ||
-			key === "if" ||
-			key === "then" ||
-			key === "else" ||
-			key === "multipleOf" ||
-			key === "minItems" ||
-			key === "maxItems" ||
-			key === "uniqueItems" ||
-			key === "minProperties" ||
-			key === "maxProperties" ||
-			key === "patternProperties" ||
-			key === "dependentRequired" ||
-			key === "dependentSchemas" ||
-			key === "unevaluatedProperties" ||
-			key === "unevaluatedItems" ||
-			key === "contentMediaType" ||
-			key === "contentEncoding" ||
-			key === "prefixItems" ||
-			key === "contains"
-		) {
+		if (!GOOGLE_SUPPORTED_SCHEMA_KEYS.has(key)) {
+			continue;
+		}
+
+		if (GOOGLE_OPAQUE_SCHEMA_VALUE_KEYS.has(key)) {
+			cleaned[key] = value;
 			continue;
 		}
 


### PR DESCRIPTION
## Problem

Any tool call to a `gemini-*` model 400s outright if a single property of a single tool carries a schema key Google doesn't model. Real production failure (log `KSq7eRFb1pyyIrJ3Bkgz`), where a client's schema generator left `~optional` markers on three properties across two of its tools:

```
Invalid JSON payload received. Unknown name "~optional" at
'tools[0].function_declarations[13].parameters.properties[1].value': Cannot find field.
... x3
```

Google's `Schema` proto rejects unknown keys rather than ignoring them, so one stray marker fails the entire request. Because the failure is a 400, it classifies as `client_error` — no provider fallback, no retry, and on stealth providers the real message is redacted out of the public log (it survives only in `internalErrorDetails`), so the user sees a bare `Upstream provider error (400 Bad Request)` with nothing to act on.

`stripUnsupportedSchemaProperties` was a denylist of ~35 hardcoded keywords. `~optional` was never going to be on it, and neither is the next one — clients keep inventing extension keys, and every unanticipated one is a hard failure rather than a degradation.

## Approach

Replace the denylist with an allowlist of the keys Google actually accepts.

I enumerated the accepted set empirically against the live API rather than from docs — 52 candidate keywords in one request, one function declaration each, reading back which indices came out as `Unknown name`. Accepted: `type, format, title, description, nullable, enum, items, properties, required, default, anyOf, oneOf, allOf, propertyOrdering, example, minLength, maxLength, pattern, minimum, maximum, minItems, maxItems, minProperties, maxProperties, not`.

The allowlist deliberately holds **only the keys that were both forwarded before and accepted upstream**, so no request that works today changes shape. `minLength`, `maxLength`, `pattern`, `minimum`, `maximum`, `minItems`, `maxItems`, `minProperties`, `maxProperties` and `not` are omitted even though Google accepts them: the gateway has always stripped those, and forwarding them would change how models fill tool arguments. Restoring them is a real improvement but a behavioural one, so it belongs in its own PR.

`default`, `example` and `enum` are now copied verbatim. They hold instance values rather than subschemas, so recursing into them would apply the schema allowlist to the value's own fields — an object-typed `default` would have arrived at the provider emptied out. The denylist happened not to hit this; an allowlist would have.

Not in scope: `convertOpenAISchemaToGoogle` (the `response_format: json_schema` path) is already allowlist-shaped by construction and was never affected.

## Verification

Verified end-to-end against the live provider, not just in unit tests — the same 15-tool payload built by `prepareRequestBody` and POSTed upstream:

| body | result |
|---|---|
| with `~optional` re-injected | **400**, `Unknown name "~optional" ... Cannot find field.` |
| as the gateway now builds it | **200** |

Also confirmed the diagnosis was exact before fixing: the raw upstream error body is 497 bytes, matching the failing log's recorded `responseSize` of 497 to the byte.

Not provider-specific — the same body goes to `google-ai-studio`, `google-vertex`, `glacier`, `iceberg` and `quartz`; session-sticky routing just happened to park this session on one of them.

`pnpm format`, full `pnpm build` (17/17), and `packages/actions` specs (537 passed) are green. Two regression tests added: one covering vendor extensions (`~optional`, `~standard`, `x-*`, `readOnly`/`writeOnly`/`deprecated`, `additionalItems`, `enumNames`), one pinning the supported keys — including that an object-valued `default` survives intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)