### PR TITLE
feat: let orgs restrict BYOK keys to models

### DIFF
--- a/apps/api/src/lib/provider-key-allowed-models.ts
+++ b/apps/api/src/lib/provider-key-allowed-models.ts
@@ -1,0 +1,99 @@
+import { HTTPException } from "hono/http-exception";
+import { z } from "zod";
+
+import { getPinnedValidationModel } from "@llmgateway/actions";
+
+import type { ProviderKeyOptions } from "@llmgateway/db";
+import type { ProviderId } from "@llmgateway/models";
+
+/**
+ * Request shape for the `allowedModels` restriction, shared by the managed
+ * (admin) and organization (BYOK) provider-key APIs so both accept exactly the
+ * same input. `null` clears the restriction.
+ */
+export const allowedModelsSchema = z
+	.array(z.string().max(200))
+	.max(200)
+	.nullable()
+	.optional();
+
+/**
+ * Trims, deduplicates and drops blank entries so the stored list is exactly
+ * what routing compares model ids against. An emptied list becomes NULL — the
+ * canonical "no restriction" — because a key that can serve no model at all is
+ * only ever a misconfiguration.
+ */
+export function normalizeAllowedModels(
+	allowedModels: string[] | null | undefined,
+): string[] | null {
+	if (!allowedModels) {
+		return null;
+	}
+	const normalized = Array.from(
+		new Set(
+			allowedModels
+				.map((entry) => entry.trim())
+				.filter((entry) => entry !== ""),
+		),
+	);
+	return normalized.length > 0 ? normalized : null;
+}
+
+/**
+ * Every allowed model must be a catalogue model with a live mapping for this
+ * provider — the restriction narrows routing, so an id the provider could
+ * never serve anyway is a typo, and storing it would silently do nothing.
+ * The key's options/region travel in `validationOptions` so a region-scoped
+ * key is checked against the mapping it will actually use, the same way the
+ * save-time probe resolves it.
+ */
+export function validateAllowedModels(
+	provider: string,
+	allowedModels: string[] | null,
+	validationOptions?: ProviderKeyOptions,
+): void {
+	if (!allowedModels) {
+		return;
+	}
+	const unknown = allowedModels.filter(
+		(modelId) =>
+			getPinnedValidationModel(
+				provider as ProviderId,
+				modelId,
+				validationOptions,
+			) === null,
+	);
+	if (unknown.length > 0) {
+		throw new HTTPException(400, {
+			message: `Not available from ${provider} per the catalogue: ${unknown.join(", ")}`,
+		});
+	}
+}
+
+/**
+ * The allowed model a save-time probe should be sent to, or undefined when the
+ * key is unrestricted (probe the provider's default validation model) or when
+ * none of its allowed models can answer a chat completion.
+ *
+ * A restricted key is probed with one of its own models because the whole point
+ * of the restriction is that the upstream account may not have the provider's
+ * default validation model — probing that one would reject exactly the keys the
+ * restriction exists for.
+ */
+export function pickAllowedValidationModel(
+	provider: string,
+	allowedModels: string[] | null,
+	validationOptions?: ProviderKeyOptions,
+): string | undefined {
+	if (!allowedModels || allowedModels.length === 0) {
+		return undefined;
+	}
+	return allowedModels.find(
+		(modelId) =>
+			getPinnedValidationModel(
+				provider as ProviderId,
+				modelId,
+				validationOptions,
+			)?.chatCapable === true,
+	);
+}

--- a/apps/api/src/routes/admin-provider-credentials.ts
+++ b/apps/api/src/routes/admin-provider-credentials.ts
@@ -4,6 +4,12 @@ import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
 import {
+	allowedModelsSchema,
+	normalizeAllowedModels,
+	pickAllowedValidationModel,
+	validateAllowedModels,
+} from "@/lib/provider-key-allowed-models.js";
+import {
 	getBucketUnitForWindow,
 	getTokenWindowStartDate,
 	tokenWindowSchema,
@@ -40,18 +46,15 @@ import {
 	tables,
 } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
-import { getProviderEnvKeys, models, providers } from "@llmgateway/models";
+import { getProviderEnvKeys, providers } from "@llmgateway/models";
+import { getModelIdsByProvider } from "@llmgateway/shared";
 import { getApiKeyFingerprint } from "@llmgateway/shared/api-key-hash";
 import { maskToken } from "@llmgateway/shared/mask-token";
 import { assertSafeProviderUrl } from "@llmgateway/shared/url-safety-node";
 
 import type { ServerTypes } from "@/vars.js";
-import type { ProviderKeyOptions, ProviderKeyVariant } from "@llmgateway/db";
-import type {
-	ProviderDefinition,
-	ProviderId,
-	ProviderModelMapping,
-} from "@llmgateway/models";
+import type { ProviderKeyVariant } from "@llmgateway/db";
+import type { ProviderDefinition, ProviderId } from "@llmgateway/models";
 
 export const adminProviderCredentials = new OpenAPIHono<ServerTypes>();
 
@@ -251,59 +254,6 @@ async function validateConfig(
 }
 
 /**
- * Trims, deduplicates and drops blank entries so the stored list is exactly
- * what routing compares model ids against. An emptied list becomes NULL — the
- * canonical "no restriction" — because a credential that can serve no model at
- * all is only ever a misconfiguration.
- */
-function normalizeAllowedModels(
-	allowedModels: string[] | null | undefined,
-): string[] | null {
-	if (!allowedModels) {
-		return null;
-	}
-	const normalized = Array.from(
-		new Set(
-			allowedModels
-				.map((entry) => entry.trim())
-				.filter((entry) => entry !== ""),
-		),
-	);
-	return normalized.length > 0 ? normalized : null;
-}
-
-/**
- * Every allowed model must be a catalogue model with a live mapping for this
- * provider — the restriction narrows routing, so an id the provider could
- * never serve anyway is a typo, and storing it would silently do nothing.
- * The credential's config/region travel in `validationOptions` so a
- * region-scoped credential is checked against the mapping it will actually
- * use, the same way the save-time probe resolves it.
- */
-function validateAllowedModels(
-	provider: string,
-	allowedModels: string[] | null,
-	validationOptions: ProviderKeyOptions,
-): void {
-	if (!allowedModels) {
-		return;
-	}
-	const unknown = allowedModels.filter(
-		(modelId) =>
-			getPinnedValidationModel(
-				provider as ProviderId,
-				modelId,
-				validationOptions,
-			) === null,
-	);
-	if (unknown.length > 0) {
-		throw new HTTPException(400, {
-			message: `Not available from ${provider} per the catalogue: ${unknown.join(", ")}`,
-		});
-	}
-}
-
-/**
  * A credential's region selects which region's traffic it serves, so it only
  * means anything for a provider whose catalogue declares regions, and only for
  * a region that catalogue actually lists. Anything else would produce a
@@ -379,19 +329,13 @@ async function validateCredentialToken(
 		region,
 	);
 
-	let pinnedModelId: string | undefined;
-	if (allowedModels && allowedModels.length > 0) {
-		pinnedModelId = allowedModels.find(
-			(modelId) =>
-				getPinnedValidationModel(
-					provider as ProviderId,
-					modelId,
-					validationOptions,
-				)?.chatCapable === true,
-		);
-		if (!pinnedModelId) {
-			return;
-		}
+	const pinnedModelId = pickAllowedValidationModel(
+		provider,
+		allowedModels ?? null,
+		validationOptions,
+	);
+	if (allowedModels?.length && !pinnedModelId) {
+		return;
 	}
 
 	const result = await validateProviderKey(
@@ -462,21 +406,7 @@ const getCatalog = createRoute({
 
 adminProviderCredentials.openapi(getCatalog, async (c) => {
 	// Live catalogue models per provider, for the allowed-models picker.
-	const now = new Date();
-	const modelsByProvider = new Map<string, string[]>();
-	for (const model of models) {
-		for (const mapping of model.providers as readonly ProviderModelMapping[]) {
-			if (mapping.deactivatedAt && now >= mapping.deactivatedAt) {
-				continue;
-			}
-			const list = modelsByProvider.get(mapping.providerId);
-			if (!list) {
-				modelsByProvider.set(mapping.providerId, [model.id]);
-			} else if (!list.includes(model.id)) {
-				list.push(model.id);
-			}
-		}
-	}
+	const modelsByProvider = getModelIdsByProvider();
 
 	// Provider keys live on the gateway, which is a separate deployment: reading
 	// this process's own environment would report nothing at all in a split
@@ -930,11 +860,7 @@ const createCredential = createRoute({
 						region: z.string().max(64).optional(),
 						config: z.record(z.string(), z.string()).optional(),
 						usageLimit: createNullableLimitSchema("Usage limit").optional(),
-						allowedModels: z
-							.array(z.string().max(200))
-							.max(200)
-							.nullable()
-							.optional(),
+						allowedModels: allowedModelsSchema,
 						skipValidation: z.boolean().optional(),
 					}),
 				},
@@ -1031,11 +957,7 @@ const updateCredential = createRoute({
 						status: statusSchema.optional(),
 						config: z.record(z.string(), z.string()).optional(),
 						usageLimit: createNullableLimitSchema("Usage limit").optional(),
-						allowedModels: z
-							.array(z.string().max(200))
-							.max(200)
-							.nullable()
-							.optional(),
+						allowedModels: allowedModelsSchema,
 						skipValidation: z.boolean().optional(),
 					}),
 				},

--- a/apps/api/src/routes/keys-provider.spec.ts
+++ b/apps/api/src/routes/keys-provider.spec.ts
@@ -11,6 +11,7 @@ import {
 	waitForSwrMirrorWrites,
 } from "@llmgateway/cache";
 import { and, asc, cdb, db, eq, getTableName, tables } from "@llmgateway/db";
+import { getProviderModelIds } from "@llmgateway/shared";
 
 import type * as ActionsModule from "@llmgateway/actions";
 
@@ -506,6 +507,132 @@ describe("provider keys route", () => {
 			const json = await raised.json();
 			expect(json.providerKey.status).toBe("active");
 			expect(json.providerKey.usageLimit).toBe("50");
+		});
+	});
+
+	describe("allowed models", () => {
+		// Taken from the catalogue rather than hardcoded so the assertions do not
+		// rot when a model is retired.
+		const openaiModels = getProviderModelIds("openai");
+
+		async function createKey(body: Record<string, unknown>) {
+			return await app.request("/keys/provider", {
+				method: "POST",
+				headers: { "Content-Type": "application/json", Cookie: token },
+				body: JSON.stringify({
+					provider: "openai",
+					token: "sk-restricted",
+					organizationId: "test-org-id",
+					...body,
+				}),
+			});
+		}
+
+		async function patchKey(body: Record<string, unknown>) {
+			return await app.request("/keys/provider/test-provider-key-id", {
+				method: "PATCH",
+				headers: { "Content-Type": "application/json", Cookie: token },
+				body: JSON.stringify(body),
+			});
+		}
+
+		test("stores a normalized list on create and returns it", async () => {
+			const [first, second] = openaiModels;
+			const res = await createKey({
+				allowedModels: [` ${first} `, second, first, ""],
+			});
+			expect(res.status).toBe(200);
+			const json = await res.json();
+			expect(json.providerKey.allowedModels).toEqual([first, second]);
+
+			const stored = await db.query.providerKey.findFirst({
+				where: { id: { eq: json.providerKey.id } },
+			});
+			expect(stored?.allowedModels).toEqual([first, second]);
+		});
+
+		test("treats an empty list as no restriction", async () => {
+			const res = await createKey({ allowedModels: [] });
+			expect(res.status).toBe(200);
+			expect((await res.json()).providerKey.allowedModels).toBeNull();
+		});
+
+		test("rejects a model the provider does not serve", async () => {
+			const res = await createKey({
+				allowedModels: ["definitely-not-a-model"],
+			});
+			expect(res.status).toBe(400);
+			expect(await res.text()).toContain("definitely-not-a-model");
+		});
+
+		test("validates the key against one of its own allowed models", async () => {
+			const validate = vi.mocked(validateProviderKey);
+			validate.mockClear();
+
+			const res = await createKey({ allowedModels: [openaiModels[0]] });
+			expect(res.status).toBe(200);
+			// Sixth argument is the pinned model: a restricted key must not be
+			// probed with the provider's default validation model, which the
+			// upstream account may not have.
+			expect(validate.mock.calls[0]?.[5]).toBe(openaiModels[0]);
+		});
+
+		test("rejects allowed models on a custom provider key", async () => {
+			const res = await createKey({
+				provider: "custom",
+				name: "myprovider",
+				baseUrl: "https://api.example.com",
+				allowedModels: [openaiModels[0]],
+			});
+			expect(res.status).toBe(400);
+			expect(await res.text()).toContain("custom provider keys");
+		});
+
+		test("PATCH sets, lists and clears the restriction", async () => {
+			const set = await patchKey({ allowedModels: [openaiModels[0]] });
+			expect(set.status).toBe(200);
+			expect((await set.json()).providerKey.allowedModels).toEqual([
+				openaiModels[0],
+			]);
+
+			const listed = await app.request("/keys/provider", {
+				headers: { Cookie: token },
+			});
+			const listJson = await listed.json();
+			expect(
+				listJson.providerKeys.find(
+					(key: { id: string }) => key.id === "test-provider-key-id",
+				).allowedModels,
+			).toEqual([openaiModels[0]]);
+
+			const clear = await patchKey({ allowedModels: null });
+			expect(clear.status).toBe(200);
+			expect((await clear.json()).providerKey.allowedModels).toBeNull();
+		});
+
+		test("PATCH rejects a model the provider does not serve", async () => {
+			const res = await patchKey({ allowedModels: ["not-an-openai-model"] });
+			expect(res.status).toBe(400);
+			expect(await res.text()).toContain("not-an-openai-model");
+		});
+
+		test("PATCH audits the change", async () => {
+			const res = await patchKey({ allowedModels: [openaiModels[0]] });
+			expect(res.status).toBe(200);
+
+			const entry = await db.query.auditLog.findFirst({
+				where: {
+					resourceId: { eq: "test-provider-key-id" },
+					action: { eq: "provider_key.update" },
+				},
+			});
+			expect(
+				(
+					entry?.metadata as {
+						changes?: { allowedModels?: { new: string[] } };
+					}
+				)?.changes?.allowedModels?.new,
+			).toEqual([openaiModels[0]]);
 		});
 	});
 

--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -4,6 +4,12 @@ import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
 import { assertOrganizationProviderKey } from "@/lib/organization-provider-key.js";
+import {
+	allowedModelsSchema,
+	normalizeAllowedModels,
+	pickAllowedValidationModel,
+	validateAllowedModels,
+} from "@/lib/provider-key-allowed-models.js";
 import { createNullableLimitSchema } from "@/routes/keys-api.js";
 import {
 	getActiveUserOrganizationIds,
@@ -143,6 +149,12 @@ export const providerKeyPublicSchema = z.object({
 	/** Cumulative upstream spend (USD) attributed by the billing worker. */
 	usage: z.string(),
 	maskedToken: z.string(),
+	/**
+	 * Canonical model ids this key may serve; routing skips it for any other
+	 * model and (in hybrid mode) falls back to credits instead. Null means the
+	 * key serves the provider's full catalogue.
+	 */
+	allowedModels: z.array(z.string()).nullable(),
 });
 
 type ProviderKeyRow = typeof tables.providerKey.$inferSelect;
@@ -169,7 +181,23 @@ export function toPublicProviderKey(row: ProviderKeyRow) {
 		usageLimit: row.usageLimit,
 		usage: row.usage,
 		maskedToken: row.tokenMasked ?? maskToken(row.token ?? ""),
+		allowedModels: row.allowedModels,
 	};
+}
+
+/**
+ * A custom provider serves models that exist only in the organization's own
+ * catalogue, so there is nothing for a canonical-model-id restriction to match
+ * against. Restricting which of a custom provider's models are served is what
+ * `customModelsOnly` plus the org's model list already does.
+ */
+function assertAllowedModelsSupported(provider: string) {
+	if (provider === "custom") {
+		throw new HTTPException(400, {
+			message:
+				"allowedModels cannot be set on custom provider keys. Manage a custom provider's models from its model list instead.",
+		});
+	}
 }
 
 // The custom provider name is the routing segment used in `custom/<name>/<model>`
@@ -312,12 +340,18 @@ const createProviderKeySchema = z.object({
 	// Optional USD spend cap; the key auto-deactivates when its cumulative
 	// attributed spend reaches it.
 	usageLimit: createNullableLimitSchema("Usage limit").optional(),
+	// Optional allowlist of canonical model ids this key may serve. Empty/null
+	// means the provider's full catalogue.
+	allowedModels: allowedModelsSchema,
 });
 
 // Schema for updating a provider key status / settings
 const updateProviderKeyStatusSchema = z
 	.object({
 		status: z.enum(["active", "inactive"]).optional(),
+		// Canonical model ids this key may serve; `null` (or an empty list)
+		// removes the restriction.
+		allowedModels: allowedModelsSchema,
 		// Custom providers only: renames the provider, which changes the model
 		// prefix used in requests (e.g. "myprovider/some-model").
 		name: customProviderNameSchema.optional(),
@@ -335,7 +369,8 @@ const updateProviderKeyStatusSchema = z
 			v.name !== undefined ||
 			v.customModelsOnly !== undefined ||
 			v.complianceAttestation !== undefined ||
-			v.usageLimit !== undefined,
+			v.usageLimit !== undefined ||
+			v.allowedModels !== undefined,
 		{
 			message: "No updatable fields provided",
 		},
@@ -384,7 +419,10 @@ keysProvider.openapi(create, async (c) => {
 		options,
 		organizationId,
 		usageLimit,
+		allowedModels: requestedAllowedModels,
 	} = c.req.valid("json");
+
+	const allowedModels = normalizeAllowedModels(requestedAllowedModels);
 
 	// Verify the user has access to this organization
 	const userOrgs = await db.query.userOrganization.findMany({
@@ -448,6 +486,24 @@ keysProvider.openapi(create, async (c) => {
 		await assertCustomProviderNameAvailable(organizationId, name);
 	}
 
+	if (allowedModels) {
+		assertAllowedModelsSupported(provider);
+		validateAllowedModels(provider, allowedModels, options);
+	}
+
+	// A restricted key is probed with one of its own allowed models instead of
+	// the provider's default validation model: users restrict a key precisely
+	// because the upstream account only has some models, so probing the default
+	// would reject exactly the keys the restriction exists for. When no allowed
+	// model can answer a chat completion (image/embedding-only lists) there is
+	// nothing to probe with, so the live check is skipped.
+	const pinnedValidationModel = pickAllowedValidationModel(
+		provider,
+		allowedModels,
+		options,
+	);
+	const skipLiveValidation = !!allowedModels && !pinnedValidationModel;
+
 	let validationResult;
 	try {
 		const isTestEnv =
@@ -458,7 +514,7 @@ keysProvider.openapi(create, async (c) => {
 		}
 
 		// Skip validation for custom providers as they don't have predefined models
-		if (provider === "custom") {
+		if (provider === "custom" || skipLiveValidation) {
 			validationResult = { valid: true };
 		} else {
 			validationResult = await validateProviderKey(
@@ -467,6 +523,7 @@ keysProvider.openapi(create, async (c) => {
 				baseUrl,
 				isTestEnv,
 				options,
+				pinnedValidationModel,
 			);
 		}
 	} catch (error) {
@@ -545,6 +602,7 @@ keysProvider.openapi(create, async (c) => {
 			baseUrl,
 			options,
 			usageLimit: usageLimit ?? null,
+			allowedModels,
 		})
 		.returning();
 
@@ -557,6 +615,7 @@ keysProvider.openapi(create, async (c) => {
 		metadata: {
 			provider,
 			hasCustomBaseUrl: !!baseUrl,
+			allowedModels,
 		},
 	});
 
@@ -841,8 +900,14 @@ keysProvider.openapi(updateStatus, async (c) => {
 	}
 
 	const { id } = c.req.param();
-	const { status, name, customModelsOnly, complianceAttestation, usageLimit } =
-		c.req.valid("json");
+	const {
+		status,
+		name,
+		customModelsOnly,
+		complianceAttestation,
+		usageLimit,
+		allowedModels: requestedAllowedModels,
+	} = c.req.valid("json");
 
 	// Get all active organization IDs the user has access to
 	const organizationIds = await getAdminOrganizationIds(user.id);
@@ -896,6 +961,24 @@ keysProvider.openapi(updateStatus, async (c) => {
 		}
 	}
 
+	// Only the catalogue is checked here, not the key upstream: a PATCH cannot
+	// change the token, and narrowing which models a key serves never makes an
+	// already-working key fail. Blocking the edit on a live probe would also
+	// stand in the way of the case the restriction exists for — a key whose
+	// account lost access to some models, which the user is fixing right now.
+	const allowedModels =
+		requestedAllowedModels === undefined
+			? undefined
+			: normalizeAllowedModels(requestedAllowedModels);
+	if (allowedModels) {
+		assertAllowedModelsSupported(providerKey.provider);
+		validateAllowedModels(
+			providerKey.provider,
+			allowedModels,
+			providerKey.options ?? undefined,
+		);
+	}
+
 	if (complianceAttestation !== undefined) {
 		if (providerKey.provider !== "custom") {
 			throw new HTTPException(400, {
@@ -933,9 +1016,13 @@ keysProvider.openapi(updateStatus, async (c) => {
 		customModelsOnly?: boolean;
 		complianceAttestation?: ProviderKeyComplianceAttestation | null;
 		usageLimit?: string | null;
+		allowedModels?: string[] | null;
 	} = {};
 	if (status !== undefined) {
 		updates.status = status;
+	}
+	if (allowedModels !== undefined) {
+		updates.allowedModels = allowedModels;
 	}
 	if (usageLimit !== undefined) {
 		updates.usageLimit = usageLimit;
@@ -984,6 +1071,16 @@ keysProvider.openapi(updateStatus, async (c) => {
 	}
 	if (usageLimit !== undefined && providerKey.usageLimit !== usageLimit) {
 		changes.usageLimit = { old: providerKey.usageLimit, new: usageLimit };
+	}
+	if (
+		allowedModels !== undefined &&
+		(providerKey.allowedModels ?? []).join(",") !==
+			(allowedModels ?? []).join(",")
+	) {
+		changes.allowedModels = {
+			old: providerKey.allowedModels,
+			new: allowedModels,
+		};
 	}
 
 	if (Object.keys(changes).length > 0) {

--- a/apps/docs/content/learn/provider-keys.mdx
+++ b/apps/docs/content/learn/provider-keys.mdx
@@ -19,6 +19,8 @@ Click **Add Provider Key** to configure a new key:
 - **Custom name** — An optional label to identify the key
 - **API key** — Your provider's API key
 - **Base URL** — Optional custom endpoint (useful for Azure OpenAI or custom deployments)
+- **Allowed models** — Optional allowlist restricting which models the key serves
+- **Max spend** — Optional USD cap; the key is disabled once the spend attributed to it reaches the limit
 
 ## Provider Keys List
 
@@ -37,8 +39,29 @@ Each configured key shows:
 For each provider key:
 
 - **Edit** — Update the key name, value, or base URL
+- **Restrict models** — Choose which models the key may serve
+- **Set spend limit** — Cap the spend attributed to the key
 - **Deactivate** — Temporarily disable the key without deleting it
 - **Delete** — Permanently remove the key
+
+## Restricting a Key to Specific Models
+
+Provider accounts often only have some of a provider's models enabled. Set
+**Allowed models** on a key to list exactly the models it may serve — routing
+then skips that key for anything else instead of sending a request the upstream
+account will reject. Leave the list empty to serve every model the provider
+offers.
+
+The restriction also decides how a key is checked when you save it: a restricted
+key is validated against one of its own allowed models rather than the
+provider's default validation model, so a key with partial model access still
+validates.
+
+<Callout type="info">
+	In hybrid mode, a model excluded by the restriction falls back to your credits
+	rather than failing, so restricting a key never takes a model away from your
+	projects.
+</Callout>
 
 <Callout type="info">
 	When you use your own provider keys, requests are routed directly to the

--- a/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
+++ b/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useQueryClient } from "@tanstack/react-query";
 import { usePostHog } from "posthog-js/react";
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 
 import { Button } from "@/lib/components/button";
 import {
@@ -30,6 +30,8 @@ import {
 	isStealthProvider,
 	type ProviderDefinition,
 } from "@llmgateway/models";
+import { getProviderModelIds } from "@llmgateway/shared";
+import { MultiModelIdSelector } from "@llmgateway/shared/components";
 
 import { ProviderSelect } from "./provider-select";
 
@@ -70,6 +72,7 @@ export function CreateProviderKeyDialog({
 		"api-key",
 	);
 	const [usageLimit, setUsageLimit] = useState("");
+	const [allowedModels, setAllowedModels] = useState<string[]>([]);
 	const [isValidating, setIsValidating] = useState(false);
 
 	const api = useApi();
@@ -81,6 +84,11 @@ export function CreateProviderKeyDialog({
 	const selectedProviderDef = providers.find(
 		(p) => p.id === selectedProvider,
 	) as ProviderDefinition | undefined;
+
+	const availableModelIds = useMemo(
+		() => (selectedProvider ? getProviderModelIds(selectedProvider) : []),
+		[selectedProvider],
+	);
 
 	// Sentinel for "let the gateway pick". Radix Select cannot hold an empty
 	// string value, so the no-preference choice needs its own id.
@@ -183,6 +191,7 @@ export function CreateProviderKeyDialog({
 			options?: Record<string, string | undefined>;
 			organizationId: string;
 			usageLimit?: string;
+			allowedModels?: string[];
 		} = {
 			provider: selectedProvider,
 			token: trimmedToken,
@@ -196,6 +205,12 @@ export function CreateProviderKeyDialog({
 		}
 		if (selectedProvider === "custom" && customName) {
 			payload.name = customName;
+		}
+		// A custom provider's models live in the organization's own catalogue, so
+		// there is nothing for a canonical-id restriction to match; the API rejects
+		// one, and the field is hidden for it.
+		if (selectedProvider !== "custom" && allowedModels.length > 0) {
+			payload.allowedModels = allowedModels;
 		}
 		// Include region in options for providers that support it. Storing a
 		// region locks routing to it (a data-residency guarantee), so the
@@ -335,6 +350,7 @@ export function CreateProviderKeyDialog({
 			setGoogleVertexProjectId("");
 			setVertexTokenType("api-key");
 			setUsageLimit("");
+			setAllowedModels([]);
 		}, 300);
 	};
 
@@ -364,6 +380,9 @@ export function CreateProviderKeyDialog({
 							onValueChange={(value) => {
 								setSelectedProvider(value);
 								setSelectedRegion("");
+								// Model ids are provider-specific, so a list picked for the
+								// previous provider would only ever be rejected on save.
+								setAllowedModels([]);
 							}}
 							value={selectedProvider}
 							providers={availableProviders}
@@ -634,6 +653,25 @@ export function CreateProviderKeyDialog({
 								/>
 							</div>
 						</>
+					)}
+
+					{selectedProvider && selectedProvider !== "custom" && (
+						<div className="space-y-2">
+							<Label htmlFor="provider-key-allowed-models">
+								Allowed models
+							</Label>
+							<MultiModelIdSelector
+								availableIds={availableModelIds}
+								value={allowedModels}
+								onChange={setAllowedModels}
+								placeholder="All models (no restriction)"
+							/>
+							<p className="text-sm text-muted-foreground">
+								{allowedModels.length === 0
+									? "Optional: leave empty to use this key for every model of the provider."
+									: "The key is validated against one of these models and routing only uses it for them. In hybrid mode, other models fall back to credits."}
+							</p>
+						</div>
 					)}
 
 					<div className="space-y-2">

--- a/apps/ui/src/components/provider-keys/provider-key-models-dialog.tsx
+++ b/apps/ui/src/components/provider-keys/provider-key-models-dialog.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+
+import { Button } from "@/lib/components/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/lib/components/dialog";
+import { toast } from "@/lib/components/use-toast";
+import { useApi } from "@/lib/fetch-client";
+
+import { getProviderModelIds } from "@llmgateway/shared";
+import { MultiModelIdSelector } from "@llmgateway/shared/components";
+
+export function ProviderKeyModelsDialog({
+	providerKeyId,
+	provider,
+	currentAllowedModels,
+	children,
+}: {
+	providerKeyId: string;
+	provider: string;
+	currentAllowedModels: string[] | null;
+	children: React.ReactNode;
+}) {
+	const api = useApi();
+	const queryClient = useQueryClient();
+	const [open, setOpen] = useState(false);
+	const [allowedModels, setAllowedModels] = useState<string[]>(
+		currentAllowedModels ?? [],
+	);
+
+	const queryKey = api.queryOptions("get", "/keys/provider").queryKey;
+	const updateMutation = api.useMutation("patch", "/keys/provider/{id}");
+
+	const availableIds = useMemo(() => getProviderModelIds(provider), [provider]);
+
+	const handleOpenChange = (next: boolean) => {
+		setOpen(next);
+		if (next) {
+			setAllowedModels(currentAllowedModels ?? []);
+		}
+	};
+
+	const handleSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
+
+		updateMutation.mutate(
+			{
+				params: { path: { id: providerKeyId } },
+				// An emptied list clears the restriction rather than storing a key
+				// that can serve nothing.
+				body: {
+					allowedModels: allowedModels.length > 0 ? allowedModels : null,
+				},
+			},
+			{
+				onSuccess: () => {
+					toast({
+						title: "Allowed models updated",
+						description:
+							allowedModels.length > 0
+								? `This key will only be used for ${allowedModels.length} model${allowedModels.length === 1 ? "" : "s"}.`
+								: "This key can now be used for every model of the provider.",
+					});
+					void queryClient.invalidateQueries({ queryKey });
+					setOpen(false);
+				},
+				onError: (error: unknown) =>
+					toast({
+						title: "Error",
+						// Surface the server's message: it names the model ids the
+						// provider's catalogue does not have.
+						description:
+							error instanceof Error
+								? error.message
+								: ((error as { message?: string } | undefined)?.message ??
+									"Failed to update allowed models"),
+						variant: "destructive",
+					}),
+			},
+		);
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={handleOpenChange}>
+			<DialogTrigger asChild>{children}</DialogTrigger>
+			<DialogContent className="sm:max-w-lg">
+				<form onSubmit={handleSubmit}>
+					<DialogHeader>
+						<DialogTitle>Allowed models</DialogTitle>
+						<DialogDescription>
+							Restrict this key to the models your provider account actually has
+							access to, so requests for anything else never reach it.
+						</DialogDescription>
+					</DialogHeader>
+					<div className="space-y-2 py-4">
+						<MultiModelIdSelector
+							availableIds={availableIds}
+							value={allowedModels}
+							onChange={setAllowedModels}
+							placeholder="All models (no restriction)"
+						/>
+						<p className="text-xs text-muted-foreground">
+							{allowedModels.length === 0
+								? "Empty means the key serves every model of this provider. Paste a comma-separated list to fill it quickly."
+								: `Routing only uses this key for the ${allowedModels.length === 1 ? "listed model" : `${allowedModels.length} listed models`}. In hybrid mode, other models fall back to credits instead of failing.`}
+						</p>
+					</div>
+					<DialogFooter>
+						<Button type="submit" disabled={updateMutation.isPending}>
+							{updateMutation.isPending ? "Saving..." : "Save"}
+						</Button>
+					</DialogFooter>
+				</form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/ui/src/components/provider-keys/provider-keys-list.tsx
+++ b/apps/ui/src/components/provider-keys/provider-keys-list.tsx
@@ -41,6 +41,7 @@ import {
 
 import { CreateProviderKeyDialog } from "./create-provider-key-dialog";
 import { ProviderKeyLimitDialog } from "./provider-key-limit-dialog";
+import { ProviderKeyModelsDialog } from "./provider-key-models-dialog";
 import { RenameProviderKeyDialog } from "./rename-provider-key-dialog";
 import { reorderProviderKeys } from "./reorder-provider-keys";
 
@@ -438,6 +439,19 @@ export function ProviderKeysList({
 																	<span className="max-w-[200px] truncate font-mono text-xs text-muted-foreground">
 																		{providerKey.maskedToken}
 																	</span>
+																	{providerKey.allowedModels &&
+																		providerKey.allowedModels.length > 0 && (
+																			<Badge
+																				variant="outline"
+																				className="text-xs"
+																				title={`Only used for: ${providerKey.allowedModels.join(", ")}`}
+																			>
+																				{providerKey.allowedModels.length} model
+																				{providerKey.allowedModels.length === 1
+																					? ""
+																					: "s"}
+																			</Badge>
+																		)}
 																	{providerKey.usageLimit !== null && (
 																		<Badge
 																			variant="outline"
@@ -511,6 +525,24 @@ export function ProviderKeysList({
 																					</Link>
 																				</DropdownMenuItem>
 																			</>
+																		)}
+																		{provider.id !== "custom" && (
+																			<ProviderKeyModelsDialog
+																				providerKeyId={providerKey.id}
+																				provider={provider.id}
+																				currentAllowedModels={
+																					providerKey.allowedModels
+																				}
+																			>
+																				<DropdownMenuItem
+																					onSelect={(e) => e.preventDefault()}
+																				>
+																					{providerKey.allowedModels &&
+																					providerKey.allowedModels.length > 0
+																						? "Edit allowed models"
+																						: "Restrict models"}
+																				</DropdownMenuItem>
+																			</ProviderKeyModelsDialog>
 																		)}
 																		<ProviderKeyLimitDialog
 																			providerKeyId={providerKey.id}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -147,6 +147,11 @@ export {
 	uniqueId,
 } from "./random.js";
 
+export {
+	getModelIdsByProvider,
+	getProviderModelIds,
+} from "./provider-model-ids.js";
+
 export { MARKETING_STATS, RUNWARE_PROMO } from "./marketing.js";
 
 export { isContentFilterErrorText } from "./content-filter.js";

--- a/packages/shared/src/provider-model-ids.ts
+++ b/packages/shared/src/provider-model-ids.ts
@@ -1,0 +1,53 @@
+import { models } from "@llmgateway/models";
+
+import type { ProviderModelMapping } from "@llmgateway/models";
+
+/**
+ * Canonical model ids the catalogue currently maps to each provider, keyed by
+ * provider id. Deactivated mappings are excluded: they can no longer serve a
+ * request, so offering them as a choice would only ever produce a restriction
+ * that matches nothing.
+ *
+ * Region is deliberately ignored — a provider key's allowed-models list is
+ * compared against canonical model ids, and a region-scoped mapping is still
+ * the same model.
+ */
+export function getModelIdsByProvider(now = new Date()): Map<string, string[]> {
+	const byProvider = new Map<string, string[]>();
+	for (const model of models) {
+		for (const mapping of model.providers as readonly ProviderModelMapping[]) {
+			if (mapping.deactivatedAt && now >= mapping.deactivatedAt) {
+				continue;
+			}
+			const list = byProvider.get(mapping.providerId);
+			if (!list) {
+				byProvider.set(mapping.providerId, [model.id]);
+			} else if (!list.includes(model.id)) {
+				list.push(model.id);
+			}
+		}
+	}
+	return byProvider;
+}
+
+/**
+ * Canonical model ids one provider currently serves, in catalogue order, for
+ * an allowed-models picker.
+ */
+export function getProviderModelIds(
+	providerId: string,
+	now = new Date(),
+): string[] {
+	const ids: string[] = [];
+	for (const model of models) {
+		const live = (model.providers as readonly ProviderModelMapping[]).some(
+			(mapping) =>
+				mapping.providerId === providerId &&
+				!(mapping.deactivatedAt && now >= mapping.deactivatedAt),
+		);
+		if (live) {
+			ids.push(model.id);
+		}
+	}
+	return ids;
+}


### PR DESCRIPTION
Follow-up to #3418, which added the `provider_key.allowedModels` restriction and wired gateway enforcement for both managed credentials and BYOK keys, but only exposed the editing surface in the `ee/admin` managed-credentials dashboard. Organizations had no way to set it on their own keys.

For BYOK the restriction is arguably more useful than for managed credentials: users commonly bring a key from an account that only has some models enabled, and today routing happily picks that key for a model the upstream account will reject.

## What changed

**API (`apps/api`)**

- `POST /keys/provider` and `PATCH /keys/provider/{id}` accept `allowedModels`; every provider-key response returns it.
- The normalize / catalogue-validate / pin-a-validation-model helpers move out of `admin-provider-credentials.ts` into `lib/provider-key-allowed-models.ts` and are shared by both routes, so managed and BYOK keys behave identically (trim + dedupe, empty list stored as `NULL`, unknown ids rejected with the offending id in the message).
- A restricted key is validated at save time against one of **its own** allowed models rather than the provider's default validation model — otherwise the keys the restriction exists for are exactly the ones that fail to save. When no allowed model can answer a chat probe (image/embedding-only lists) the live check is skipped, matching the admin route.
- `PATCH` validates against the catalogue only, no live probe: the token cannot change through it, narrowing the list can never break a working key, and a failing probe would block the edit a user makes *because* their account lost access to a model.
- Rejected for `custom` providers, whose models are not catalogue ids — the gateway already exempts them from this filter for the same reason.

**Dashboard (`apps/ui`)**

- Allowed-models picker in the add-key dialog and a per-key **Restrict models** dialog, both using the shared `MultiModelIdSelector` from #3418 (paste a comma-separated list, unknown ids flagged as chips).
- Restricted keys show a `N models` badge in the list.

**Shared (`packages/shared`)**

- `getProviderModelIds` / `getModelIdsByProvider`, replacing the inline catalogue walk in the admin catalog route and giving the dashboard the same provider→live-model-ids view without a round trip.

Nothing changed in the gateway: `resolveProviderContext`, the hybrid-mode credits fallback, and the per-model availability computation already filter org-owned keys through `providerKeyAllowsModel`. In hybrid mode an excluded model falls back to credits rather than failing, so restricting a key never takes a model away from a project.

## Screenshots

Row actions, before and after — the new **Restrict models** entry, and the `3 models` badge on the restricted key:

| Before | After |
| --- | --- |
| <img width="1440" alt="Provider key row menu before: Set spend limit, Deactivate, Delete" src="https://raw.githubusercontent.com/theopenco/llmgateway/a2b9f3a88dd3f6d052f5420624bd556001ea18cd/before-menu.png" /> | <img width="1440" alt="Provider key row menu after: Restrict models added, key shows a 3 models badge" src="https://raw.githubusercontent.com/theopenco/llmgateway/a2b9f3a88dd3f6d052f5420624bd556001ea18cd/after-menu.png" /> |

Allowed-models dialog (light / dark):

| Light | Dark |
| --- | --- |
| <img width="1440" alt="Allowed models dialog in light mode with three selected models" src="https://raw.githubusercontent.com/theopenco/llmgateway/a2b9f3a88dd3f6d052f5420624bd556001ea18cd/dialog-light.png" /> | <img width="1440" alt="Allowed models dialog in dark mode with three selected models" src="https://raw.githubusercontent.com/theopenco/llmgateway/a2b9f3a88dd3f6d052f5420624bd556001ea18cd/dialog-dark.png" /> |

Add-key dialog with the new field (light / dark):

| Light | Dark |
| --- | --- |
| <img width="1440" alt="Add provider key dialog in light mode showing the Allowed models field" src="https://raw.githubusercontent.com/theopenco/llmgateway/a2b9f3a88dd3f6d052f5420624bd556001ea18cd/add-key-light.png" /> | <img width="1440" alt="Add provider key dialog in dark mode showing the Allowed models field" src="https://raw.githubusercontent.com/theopenco/llmgateway/a2b9f3a88dd3f6d052f5420624bd556001ea18cd/add-key-dark.png" /> |

## Verification

- New specs in `keys-provider.spec.ts` cover normalization, the empty-list-is-no-restriction rule, unknown-model rejection on create and update, the pinned save-time probe, the custom-provider rejection, listing, clearing, and the audit entry. `keys-provider.spec.ts` (54) and `admin-provider-credentials.spec.ts` (62) both pass.
- `pnpm build` (17/17) and `pnpm format` clean.
- The screenshots were taken driving the real dashboard against a local stack: the restriction shown was applied through the dialog and persisted via the API, and the badge is read back from the list endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
