### PR TITLE
refactor(gateway): centralize service tier checks

### DIFF
--- a/apps/docs/content/features/service-tiers.mdx
+++ b/apps/docs/content/features/service-tiers.mdx
@@ -87,6 +87,38 @@ the exact tiers exposed by each provider card.
 	default) are always eligible.
 </Callout>
 
+## Retries and fallback never downgrade the tier
+
+A request can change provider or credential mid-flight: LLM Gateway falls back
+to another provider when one fails, and rotates to another key for the same
+provider when a credential returns a 429 or an auth error. A requested tier is
+carried through all of it.
+
+- Provider routing is narrowed to mappings that support the requested tier
+  **before** a provider is picked, so no fallback candidate can be one that
+  would serve the request as standard.
+- Key selection — BYOK keys, platform-managed credentials, and env credentials
+  alike — skips any credential that cannot carry the tier (a proxy base URL, or
+  a Vertex credential pinned to a regional endpoint), on the first attempt and
+  on every retry.
+- Every attempt re-resolves the tier against the provider, region and
+  credential it actually resolved to, and fails rather than sending at a lower
+  tier. If no eligible candidate is left, you get the upstream error instead of
+  a silently downgraded response.
+
+This applies to a tier you requested yourself. The optional coding-plan default
+tier is a cost preference rather than a requirement, so a request that cannot be
+served at that tier runs at standard instead of failing; `used_service_tier` in
+the response metadata always reports what was actually served.
+
+<Callout type="info">
+	Rotating to another key for the same provider is a separate upstream account
+	as far as prompt caching is concerned, so a retried request re-writes its
+	cached prefix rather than reading the original one. Send `x-no-fallback: true`
+	to have the original upstream error returned to you — note that this disables
+	cross-provider fallback, not key rotation within a provider.
+</Callout>
+
 ## Pricing uses multipliers
 
 Service tiers do not define separate model prices in LLM Gateway. They multiply

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -12,6 +12,7 @@ import {
 	resetKeyHealth,
 } from "./lib/api-key-health.js";
 import { createGatewayApiTestHarness } from "./test-utils/gateway-api-test-harness.js";
+import { resetFailOnceCounter } from "./test-utils/mock-openai-server.js";
 import {
 	readAll,
 	waitForLogByRequestId,
@@ -2291,6 +2292,188 @@ describe("api", () => {
 		expect(logs.length).toBe(1);
 		expect(logs[0].requestedServiceTier).toBe("priority");
 		expect(logs[0].usedServiceTier).toBe("priority");
+	});
+
+	test("/v1/chat/completions keeps the service tier when a retry rotates keys", async () => {
+		// The customer-visible failure this guards against: an upstream 429 on
+		// one key rotates the request onto another key for the same provider, and
+		// the second attempt is served (and billed) at the standard tier because
+		// the requested tier was rebuilt from the fallback context.
+		await db.insert(tables.apiKey).values({
+			id: "token-id-tier-key-rotation",
+			token: "real-token-tier-key-rotation",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values([
+			{
+				id: "provider-key-tier-rotation-primary",
+				token: "sk-primary-key",
+				provider: "openai",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			},
+			{
+				id: "provider-key-tier-rotation-secondary",
+				token: "sk-secondary-key",
+				provider: "openai",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			},
+		]);
+
+		resetFailOnceCounter();
+
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-tier-key-rotation",
+			},
+			body: JSON.stringify({
+				model: "openai/gpt-5.6-sol",
+				service_tier: "flex",
+				messages: [{ role: "user", content: "TRIGGER_FAIL_ONCE hello" }],
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		// Two attempts on the same provider with two different credentials.
+		expect(json.metadata.routing).toHaveLength(2);
+		expect(json.metadata.routing[0]).toMatchObject({
+			provider: "openai",
+			succeeded: false,
+		});
+		expect(json.metadata.routing[1]).toMatchObject({
+			provider: "openai",
+			succeeded: true,
+		});
+		expect(json.metadata.routing[0].apiKeyHash).not.toBe(
+			json.metadata.routing[1].apiKeyHash,
+		);
+		// The tier survived the rotation: the mock echoes back the tier it was
+		// sent, so a dropped `service_tier` would surface as a standard-tier
+		// response and a null usedServiceTier on the log.
+		expect(json.service_tier).toBe("flex");
+		expect(json.metadata?.used_service_tier).toBe("flex");
+
+		const logs = await waitForLogs(2);
+		const successLog = logs.find((log) => !log.hasError);
+		expect(successLog?.requestedServiceTier).toBe("flex");
+		expect(successLog?.usedServiceTier).toBe("flex");
+	});
+
+	test("/v1/chat/completions never routes a tier request to a provider without it", async () => {
+		// gpt-5.6-sol is served by openai (flex/priority), azure and aws-mantle.
+		// A flex request must stay on openai for every attempt — falling back to a
+		// provider with no premium tier would serve, and bill, standard silently.
+		await db.insert(tables.apiKey).values({
+			id: "token-id-tier-no-downgrade-fallback",
+			token: "real-token-tier-no-downgrade-fallback",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values([
+			{
+				id: "provider-key-tier-fallback-openai",
+				token: "sk-openai-test-key",
+				provider: "openai",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			},
+			{
+				id: "provider-key-tier-fallback-azure",
+				token: "azure-test-key",
+				provider: "azure",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			},
+		]);
+
+		resetFailOnceCounter();
+
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-tier-no-downgrade-fallback",
+			},
+			body: JSON.stringify({
+				// No provider prefix: routing is free to pick any mapping.
+				model: "gpt-5.6-sol",
+				service_tier: "flex",
+				messages: [{ role: "user", content: "TRIGGER_ERROR" }],
+			}),
+		});
+
+		// openai is the only flex-capable mapping, so the upstream failure is
+		// returned instead of being retried on azure at the standard tier.
+		expect(res.status).not.toBe(200);
+
+		const logs = await waitForLogs(1);
+		expect(logs.length).toBeGreaterThanOrEqual(1);
+		for (const log of logs) {
+			expect(log.usedProvider).toBe("openai");
+			expect(log.requestedServiceTier).toBe("flex");
+			expect(log.usedServiceTier).toBeNull();
+		}
+	});
+
+	test("/v1/chat/completions still falls back across providers without a tier", async () => {
+		// The control for the test above: the same failure without service_tier
+		// does reach azure, so the tier — not some unrelated routing constraint —
+		// is what keeps the request on openai.
+		await db.insert(tables.apiKey).values({
+			id: "token-id-tier-fallback-control",
+			token: "real-token-tier-fallback-control",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values([
+			{
+				id: "provider-key-tier-control-openai",
+				token: "sk-openai-test-key",
+				provider: "openai",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			},
+			{
+				id: "provider-key-tier-control-azure",
+				token: "azure-test-key",
+				provider: "azure",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			},
+		]);
+
+		resetFailOnceCounter();
+
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-tier-fallback-control",
+			},
+			body: JSON.stringify({
+				model: "gpt-5.6-sol",
+				messages: [{ role: "user", content: "TRIGGER_FAIL_ONCE hello" }],
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		expect(
+			json.metadata.routing.map(
+				(attempt: { provider: string }) => attempt.provider,
+			),
+		).toContain("azure");
 	});
 
 	test("/v1/chat/completions forwards generated request id upstream", async () => {
@@ -7669,6 +7852,8 @@ describe("api", () => {
 					baseUrl: mockServerUrl,
 				},
 			]);
+
+			resetFailOnceCounter();
 
 			const res = await app.request("/v1/chat/completions", {
 				method: "POST",

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -112,7 +112,6 @@ import {
 	getProviderEndpoint,
 	getProviderHeaders,
 	isPremiumServiceTier,
-	providerKeyBaseUrlSupportsServiceTier,
 	resolveServedServiceTier,
 	googleProviderSupportsAudioFormat,
 	hasProviderKey,
@@ -166,14 +165,11 @@ import {
 	providers,
 	resolveVertexTokenType,
 	type VertexTokenType,
-	supportsServiceTier,
 	type WebSearchTool,
 	expandAllProviderRegions,
-	type EnvVarVariant,
 	getOrganizationEnvVariant,
 	getProviderDefinition,
 	getRegionSpecificEnvVarName,
-	getProviderEnvValue,
 } from "@llmgateway/models";
 import {
 	detectCodingAgentFromReferer,
@@ -277,6 +273,12 @@ import {
 	shouldRetrySameKey,
 	shouldRetryRequest,
 } from "./tools/retry-with-fallback.js";
+import {
+	assertServiceTierHonored,
+	getForwardedServiceTier,
+	mappingSupportsRequestedServiceTier,
+	providerKeySupportsServiceTier,
+} from "./tools/service-tier.js";
 import {
 	encodeChatMessages,
 	messageContentToString,
@@ -871,39 +873,6 @@ function resolveOpenAIServiceTier(
 	return null;
 }
 
-function getForwardedServiceTier(
-	model: string,
-	provider: Provider,
-	region: string | undefined,
-	serviceTier: "auto" | "default" | "flex" | "priority" | undefined,
-	configIndex?: number,
-	variant?: EnvVarVariant,
-): "flex" | "priority" | undefined {
-	if (serviceTier !== "flex" && serviceTier !== "priority") {
-		return undefined;
-	}
-	const effectiveRegion =
-		provider === "google-vertex"
-			? (region ??
-				getProviderEnvValue(
-					"google-vertex",
-					"region",
-					configIndex,
-					"global",
-					variant,
-				) ??
-				"global")
-			: region;
-	return supportsServiceTier(
-		model,
-		provider,
-		serviceTier,
-		effectiveRegion ?? null,
-	)
-		? serviceTier
-		: undefined;
-}
-
 function isRequestedServiceTier(
 	serviceTier: "auto" | "default" | "flex" | "priority" | undefined,
 ): serviceTier is "flex" | "priority" {
@@ -918,33 +887,6 @@ function providerMatchesRequestedProvider(
 		!requestedProvider ||
 		requestedProvider === "llmgateway" ||
 		mapping.providerId === requestedProvider
-	);
-}
-
-function mappingSupportsRequestedServiceTier(
-	model: string,
-	mapping: ProviderModelMapping,
-	serviceTier: "flex" | "priority",
-	configIndex?: number,
-	variant?: EnvVarVariant,
-): boolean {
-	const effectiveRegion =
-		mapping.providerId === "google-vertex"
-			? (mapping.region ??
-				getProviderEnvValue(
-					"google-vertex",
-					"region",
-					configIndex,
-					"global",
-					variant,
-				) ??
-				"global")
-			: mapping.region;
-	return supportsServiceTier(
-		model,
-		mapping.providerId,
-		serviceTier,
-		effectiveRegion ?? null,
 	);
 }
 
@@ -2090,11 +2032,7 @@ chat.openapi(completions, async (c) => {
 		const providerHasEligibleTierCredential = (providerId: string): boolean => {
 			const hasCompliantDbKey = orgKeysForDefaultTier.some(
 				(key) =>
-					key.provider === providerId &&
-					providerKeyBaseUrlSupportsServiceTier(
-						providerId as Provider,
-						key.baseUrl,
-					),
+					key.provider === providerId && providerKeySupportsServiceTier(key),
 			);
 			if (project.mode === "api-keys") {
 				return hasCompliantDbKey;
@@ -2865,12 +2803,7 @@ chat.openapi(completions, async (c) => {
 		const dbKeys = (serviceTierOrgKeys ?? []).filter(
 			(key) => key.provider === providerId,
 		);
-		const hasCompliantDbKey = dbKeys.some((key) =>
-			providerKeyBaseUrlSupportsServiceTier(
-				providerId as Provider,
-				key.baseUrl,
-			),
-		);
+		const hasCompliantDbKey = dbKeys.some(providerKeySupportsServiceTier);
 		// An env credential is eligible only when at least one of its (possibly
 		// comma-indexed) base URLs targets the managed upstream — a custom base URL
 		// on every env index is just as ineligible as a custom DB key. In hybrid
@@ -4763,15 +4696,12 @@ chat.openapi(completions, async (c) => {
 	// and option resolution still use providerKey for BYOK base URLs/options.
 	let trackedKeyHealthId: string | undefined;
 	// Flex/Priority is only honored when the request reaches the provider's real
-	// upstream endpoint. Skip provider keys whose custom base URL (proxy) may
-	// silently drop the tier, so a compliant key (or the managed env credential
+	// upstream endpoint on a tier-capable location. Skip provider keys whose
+	// custom base URL (proxy) may silently drop the tier, and Vertex keys pinned
+	// to a regional endpoint, so a compliant key (or the managed env credential
 	// in hybrid mode) is used instead.
 	const serviceTierKeyFilter = isRequestedServiceTier(service_tier)
-		? (key: InferSelectModel<typeof tables.providerKey>) =>
-				providerKeyBaseUrlSupportsServiceTier(
-					key.provider as Provider,
-					key.baseUrl,
-				)
+		? providerKeySupportsServiceTier
 		: undefined;
 	if (
 		project.mode === "credits" &&
@@ -6292,6 +6222,26 @@ chat.openapi(completions, async (c) => {
 		}
 	}
 
+	// The tier this attempt will actually be sent at, resolved against the
+	// provider, region and credential that were finally selected. Asserted (not
+	// silently downgraded) so an explicitly requested tier can never be served —
+	// and billed — as standard without the caller knowing.
+	const initialForwardedServiceTier = getForwardedServiceTier(
+		usedInternalModel,
+		usedProvider,
+		usedRegion,
+		service_tier,
+		configIndex,
+		envVariant,
+	);
+	assertServiceTierHonored({
+		requestedServiceTier,
+		forwardedServiceTier: initialForwardedServiceTier,
+		provider: usedProvider,
+		model: usedInternalModel,
+		region: usedRegion,
+	});
+
 	let requestBody: ProviderRequestBody | FormData;
 	try {
 		requestBody = await prepareRequestBody(
@@ -6325,14 +6275,7 @@ chat.openapi(completions, async (c) => {
 			prompt_cache_retention,
 			providerCacheControlEnabled,
 			n,
-			getForwardedServiceTier(
-				usedInternalModel,
-				usedProvider,
-				usedRegion,
-				service_tier,
-				configIndex,
-				envVariant,
-			),
+			initialForwardedServiceTier,
 			verbosity,
 			prompt_cache_options,
 			sessionId,
@@ -6546,6 +6489,7 @@ chat.openapi(completions, async (c) => {
 				n,
 				providerCacheControlEnabled,
 				service_tier,
+				requestedServiceTier,
 				verbosity,
 			},
 		);
@@ -7147,19 +7091,32 @@ chat.openapi(completions, async (c) => {
 						}
 					}
 
+					// Resolved outside the try so an unhonorable tier surfaces as a
+					// request error instead of being caught below and retried as an
+					// upstream failure. resolveProviderContext already rejects
+					// fallback candidates that cannot carry the tier, so this only
+					// fires if some future routing path bypasses that filter.
+					const forwardedServiceTier = getForwardedServiceTier(
+						usedInternalModel,
+						usedProvider,
+						usedRegion,
+						service_tier,
+						configIndex,
+						envVariant,
+					);
+					assertServiceTierHonored({
+						requestedServiceTier,
+						forwardedServiceTier,
+						provider: usedProvider,
+						model: usedInternalModel,
+						region: usedRegion,
+					});
+
 					try {
 						// Clear any tier served by a previous attempt so a fallback
 						// that fails before fetch returns (timeout/connection error)
 						// logs no served tier instead of the prior provider's.
 						servedServiceTier = null;
-						const forwardedServiceTier = getForwardedServiceTier(
-							usedInternalModel,
-							usedProvider,
-							usedRegion,
-							service_tier,
-							configIndex,
-							envVariant,
-						);
 						const headers = getProviderHeaders(usedProvider, usedToken, {
 							requestId,
 							webSearchEnabled: !!webSearchTool,
@@ -11411,15 +11368,28 @@ chat.openapi(completions, async (c) => {
 		// instead of inheriting the prior provider's.
 		servedServiceTier = null;
 
+		// Resolved outside the try so an unhonorable tier surfaces as a request
+		// error instead of being caught below and retried as an upstream failure.
+		// resolveProviderContext already rejects fallback candidates that cannot
+		// carry the tier, so this only fires if some future routing path bypasses
+		// that filter.
+		const forwardedServiceTier = getForwardedServiceTier(
+			usedInternalModel,
+			usedProvider,
+			usedRegion,
+			service_tier,
+			configIndex,
+			envVariant,
+		);
+		assertServiceTierHonored({
+			requestedServiceTier,
+			forwardedServiceTier,
+			provider: usedProvider,
+			model: usedInternalModel,
+			region: usedRegion,
+		});
+
 		try {
-			const forwardedServiceTier = getForwardedServiceTier(
-				usedInternalModel,
-				usedProvider,
-				usedRegion,
-				service_tier,
-				configIndex,
-				envVariant,
-			);
 			const headers = getProviderHeaders(usedProvider, usedToken, {
 				requestId,
 				webSearchEnabled: !!webSearchTool,

--- a/apps/gateway/src/chat/tools/get-provider-env.ts
+++ b/apps/gateway/src/chat/tools/get-provider-env.ts
@@ -6,7 +6,7 @@ import {
 	peekRoundRobinValue,
 } from "@/lib/round-robin-env.js";
 
-import { providerKeyBaseUrlSupportsServiceTier } from "@llmgateway/actions";
+import { providerCredentialSupportsServiceTier } from "@llmgateway/actions";
 import {
 	type EnvVarVariant,
 	getProviderEnvValue,
@@ -54,29 +54,16 @@ function isServiceTierEligibleEnvIndex(
 	index: number,
 	variant?: EnvVarVariant,
 ): boolean {
-	const baseUrl = getProviderEnvValue(
-		provider,
-		"baseUrl",
-		index,
-		undefined,
-		variant,
-	);
-	if (!providerKeyBaseUrlSupportsServiceTier(provider, baseUrl)) {
-		return false;
-	}
-	if (provider === "google-vertex") {
-		const region = getProviderEnvValue(
+	return providerCredentialSupportsServiceTier(provider, {
+		baseUrl: getProviderEnvValue(
 			provider,
-			"region",
+			"baseUrl",
 			index,
-			"global",
+			undefined,
 			variant,
-		);
-		if (region !== "global") {
-			return false;
-		}
-	}
-	return true;
+		),
+		region: getProviderEnvValue(provider, "region", index, "global", variant),
+	});
 }
 
 /**

--- a/apps/gateway/src/chat/tools/resolve-platform-credential.ts
+++ b/apps/gateway/src/chat/tools/resolve-platform-credential.ts
@@ -1,9 +1,6 @@
 import { findManagedProviderKey } from "@/lib/cached-queries.js";
 
-import {
-	providerKeyBaseUrlSupportsServiceTier,
-	readProviderKey,
-} from "@llmgateway/actions";
+import { readProviderKey } from "@llmgateway/actions";
 import { providerKeyAllowsModel } from "@llmgateway/db";
 import { getProviderEnvValue } from "@llmgateway/models";
 
@@ -11,6 +8,7 @@ import {
 	getProviderEnv,
 	getServiceTierIneligibleEnvIndices,
 } from "./get-provider-env.js";
+import { providerKeySupportsServiceTier } from "./service-tier.js";
 
 import type { InferSelectModel, tables } from "@llmgateway/db";
 import type { EnvVarVariant, Provider } from "@llmgateway/models";
@@ -30,36 +28,6 @@ export interface PlatformCredential {
 	token: string;
 	configIndex: number;
 	envVarName: string | undefined;
-}
-
-/**
- * Base URL a managed credential routes through, which lives in its `config`
- * (the env-var replacement) rather than the `baseUrl` column BYOK keys use.
- */
-function managedBaseUrl(key: ProviderKeyRow): string | undefined {
-	return key.config?.baseUrl ?? key.baseUrl ?? undefined;
-}
-
-/**
- * Flex/Priority is only honored when the request reaches the provider's real
- * upstream endpoint, so managed credentials pointed at a proxy — and, for
- * Google Vertex, credentials pinned to a non-global region — are skipped for
- * premium service-tier requests. Mirrors the env-credential filtering in
- * getServiceTierIneligibleEnvIndices.
- */
-function supportsServiceTier(key: ProviderKeyRow): boolean {
-	if (
-		!providerKeyBaseUrlSupportsServiceTier(
-			key.provider as Provider,
-			managedBaseUrl(key) ?? null,
-		)
-	) {
-		return false;
-	}
-	if (key.provider === "google-vertex") {
-		return (key.config?.region ?? key.region ?? "global") === "global";
-	}
-	return true;
 }
 
 function combineFilters(
@@ -122,7 +90,7 @@ export async function resolvePlatformCredential(
 		excludedKeyIds: options.excludedProviderKeyIds,
 		filter: combineFilters(
 			options.filter,
-			options.requiresServiceTier ? supportsServiceTier : undefined,
+			options.requiresServiceTier ? providerKeySupportsServiceTier : undefined,
 			restrictedToModel !== undefined
 				? (key) => providerKeyAllowsModel(key.allowedModels, restrictedToModel)
 				: undefined,

--- a/apps/gateway/src/chat/tools/resolve-provider-context.ts
+++ b/apps/gateway/src/chat/tools/resolve-provider-context.ts
@@ -14,7 +14,6 @@ import {
 	isPremiumServiceTier,
 	managedCredentialOptions,
 	prepareRequestBody,
-	providerKeyBaseUrlSupportsServiceTier,
 	readProviderKey,
 	selectProviderMapping,
 } from "@llmgateway/actions";
@@ -47,6 +46,11 @@ import {
 
 import { clampTemperature } from "./clamp-temperature.js";
 import { resolvePlatformCredential } from "./resolve-platform-credential.js";
+import {
+	assertServiceTierHonored,
+	getForwardedServiceTier,
+	providerKeySupportsServiceTier,
+} from "./service-tier.js";
 
 import type { InferSelectModel, tables } from "@llmgateway/db";
 
@@ -158,6 +162,13 @@ export interface ProviderContextOptions {
 	n?: number;
 	providerCacheControlEnabled: boolean;
 	service_tier?: "auto" | "default" | "flex" | "priority";
+	/**
+	 * The premium tier the client asked for itself, or null when `service_tier`
+	 * only carries an org-level default. A client-requested tier is strict: a
+	 * candidate that cannot serve it is rejected rather than downgraded, so the
+	 * retry loop moves on instead of quietly serving standard.
+	 */
+	requestedServiceTier?: "flex" | "priority" | null;
 	verbosity?: "low" | "medium" | "high";
 }
 
@@ -470,15 +481,13 @@ export async function resolveProviderContext(
 	const envVariant = getOrganizationEnvVariant(organization);
 
 	// Flex/Priority is only honored when the request reaches the provider's real
-	// upstream endpoint. Skip provider keys whose custom base URL (proxy) may
-	// silently drop the tier, so a compliant key (or the managed env credential)
-	// is used instead.
+	// upstream endpoint on a tier-capable location. Skip provider keys whose
+	// custom base URL (proxy) may silently drop the tier, and Vertex keys pinned
+	// to a regional endpoint, so a compliant key (or the managed env credential)
+	// is used instead. This is what keeps an alternate-key retry from rotating a
+	// Flex request onto a credential that would serve it as standard.
 	const serviceTierKeyFilter = isPremiumServiceTier(options.service_tier)
-		? (key: InferSelectModel<typeof tables.providerKey>) =>
-				providerKeyBaseUrlSupportsServiceTier(
-					key.provider as Provider,
-					key.baseUrl,
-				)
+		? providerKeySupportsServiceTier
 		: undefined;
 
 	// Skip BYOK keys whose allowedModels restriction excludes the model being
@@ -626,6 +635,28 @@ export async function resolveProviderContext(
 			}
 		}
 	}
+
+	// The tier this attempt will actually be sent at. Resolved here — after the
+	// provider, region and credential are known — because a fallback attempt
+	// picks its own, and a mapping/credential that cannot carry the tier would
+	// otherwise be served (and billed) as standard without the caller knowing.
+	// Throwing rejects this candidate: the retry loop treats a context-resolution
+	// failure as "try the next provider/key".
+	const forwardedServiceTier = getForwardedServiceTier(
+		usedInternalModel,
+		usedProvider,
+		usedRegion,
+		options.service_tier,
+		configIndex,
+		envVariant,
+	);
+	assertServiceTierHonored({
+		requestedServiceTier: options.requestedServiceTier ?? null,
+		forwardedServiceTier,
+		provider: usedProvider,
+		model: usedInternalModel,
+		region: usedRegion,
+	});
 
 	const usedApiKeyHash = getApiKeyFingerprint(usedToken);
 
@@ -836,7 +867,7 @@ export async function resolveProviderContext(
 		options.prompt_cache_retention,
 		options.providerCacheControlEnabled,
 		options.n,
-		options.service_tier,
+		forwardedServiceTier,
 		options.verbosity,
 		options.prompt_cache_options,
 		options.session_id,

--- a/apps/gateway/src/chat/tools/service-tier.spec.ts
+++ b/apps/gateway/src/chat/tools/service-tier.spec.ts
@@ -1,0 +1,204 @@
+import { HTTPException } from "hono/http-exception";
+import { afterEach, describe, expect, test } from "vitest";
+
+import {
+	assertServiceTierHonored,
+	getForwardedServiceTier,
+	mappingSupportsRequestedServiceTier,
+	providerKeySupportsServiceTier,
+} from "./service-tier.js";
+
+import type { InferSelectModel, tables } from "@llmgateway/db";
+
+type ProviderKeyRow = InferSelectModel<typeof tables.providerKey>;
+
+function providerKey(overrides: Partial<ProviderKeyRow>): ProviderKeyRow {
+	return {
+		id: "key-id",
+		provider: "openai",
+		baseUrl: null,
+		options: null,
+		config: null,
+		region: null,
+		...overrides,
+	} as ProviderKeyRow;
+}
+
+describe("getForwardedServiceTier", () => {
+	test("forwards a tier the mapping supports", () => {
+		expect(
+			getForwardedServiceTier("gpt-5.5", "openai", undefined, "flex"),
+		).toBe("flex");
+	});
+
+	test("drops a tier the mapping does not support", () => {
+		expect(
+			getForwardedServiceTier("gpt-5.6-sol", "aws-mantle", undefined, "flex"),
+		).toBeUndefined();
+	});
+
+	test("is undefined for non-premium tiers", () => {
+		expect(
+			getForwardedServiceTier("gpt-5.5", "openai", undefined, "auto"),
+		).toBeUndefined();
+		expect(
+			getForwardedServiceTier("gpt-5.5", "openai", undefined, undefined),
+		).toBeUndefined();
+	});
+
+	describe("google-vertex region resolution", () => {
+		const originalRegion = process.env.LLM_GOOGLE_VERTEX_REGION;
+
+		afterEach(() => {
+			if (originalRegion === undefined) {
+				delete process.env.LLM_GOOGLE_VERTEX_REGION;
+			} else {
+				process.env.LLM_GOOGLE_VERTEX_REGION = originalRegion;
+			}
+		});
+
+		test("reads the credential's region when the mapping has none", () => {
+			process.env.LLM_GOOGLE_VERTEX_REGION = "us-central1";
+			expect(
+				getForwardedServiceTier(
+					"gemini-3.5-flash",
+					"google-vertex",
+					undefined,
+					"priority",
+				),
+			).toBeUndefined();
+
+			process.env.LLM_GOOGLE_VERTEX_REGION = "global";
+			expect(
+				getForwardedServiceTier(
+					"gemini-3.5-flash",
+					"google-vertex",
+					undefined,
+					"priority",
+				),
+			).toBe("priority");
+		});
+	});
+});
+
+describe("mappingSupportsRequestedServiceTier", () => {
+	test("keeps mappings that declare the tier and drops the rest", () => {
+		expect(
+			mappingSupportsRequestedServiceTier(
+				"gpt-5.6-sol",
+				{ providerId: "openai" },
+				"flex",
+			),
+		).toBe(true);
+		expect(
+			mappingSupportsRequestedServiceTier(
+				"gpt-5.6-sol",
+				{ providerId: "aws-mantle" },
+				"flex",
+			),
+		).toBe(false);
+	});
+});
+
+describe("providerKeySupportsServiceTier", () => {
+	test("accepts a key on the provider's own upstream", () => {
+		expect(providerKeySupportsServiceTier(providerKey({}))).toBe(true);
+	});
+
+	test("rejects a proxied key for upstream-only tier providers", () => {
+		expect(
+			providerKeySupportsServiceTier(
+				providerKey({
+					provider: "google-ai-studio",
+					baseUrl: "https://proxy.example.com",
+				}),
+			),
+		).toBe(false);
+	});
+
+	test("rejects a Vertex credential pinned to a regional endpoint", () => {
+		expect(
+			providerKeySupportsServiceTier(
+				providerKey({
+					provider: "google-vertex",
+					config: { region: "us-central1" },
+				}),
+			),
+		).toBe(false);
+		expect(
+			providerKeySupportsServiceTier(
+				providerKey({
+					provider: "google-vertex",
+					options: { env_config: { region: "europe-west4" } },
+				}),
+			),
+		).toBe(false);
+		expect(
+			providerKeySupportsServiceTier(
+				providerKey({ provider: "google-vertex", region: "us-east1" }),
+			),
+		).toBe(false);
+	});
+
+	test("accepts a Vertex credential on the global endpoint", () => {
+		expect(
+			providerKeySupportsServiceTier(
+				providerKey({
+					provider: "google-vertex",
+					config: { region: "global" },
+				}),
+			),
+		).toBe(true);
+		expect(
+			providerKeySupportsServiceTier(
+				providerKey({ provider: "google-vertex" }),
+			),
+		).toBe(true);
+	});
+});
+
+describe("assertServiceTierHonored", () => {
+	const base = {
+		provider: "openai",
+		model: "gpt-5.6-sol",
+		region: undefined,
+	};
+
+	test("throws when an explicitly requested tier cannot be forwarded", () => {
+		let thrown: unknown;
+		try {
+			assertServiceTierHonored({
+				...base,
+				requestedServiceTier: "flex",
+				forwardedServiceTier: undefined,
+			});
+		} catch (error) {
+			thrown = error;
+		}
+		expect(thrown).toBeInstanceOf(HTTPException);
+		expect((thrown as HTTPException).status).toBe(400);
+		expect((thrown as HTTPException).message).toContain(
+			"Service tier 'flex' is not available for openai/gpt-5.6-sol",
+		);
+	});
+
+	test("passes when the requested tier is forwarded", () => {
+		expect(() =>
+			assertServiceTierHonored({
+				...base,
+				requestedServiceTier: "flex",
+				forwardedServiceTier: "flex",
+			}),
+		).not.toThrow();
+	});
+
+	test("stays soft for an org-default tier the client did not request", () => {
+		expect(() =>
+			assertServiceTierHonored({
+				...base,
+				requestedServiceTier: null,
+				forwardedServiceTier: undefined,
+			}),
+		).not.toThrow();
+	});
+});

--- a/apps/gateway/src/chat/tools/service-tier.ts
+++ b/apps/gateway/src/chat/tools/service-tier.ts
@@ -1,0 +1,176 @@
+import { HTTPException } from "hono/http-exception";
+
+import {
+	isPremiumServiceTier,
+	providerCredentialSupportsServiceTier,
+} from "@llmgateway/actions";
+import {
+	type EnvVarVariant,
+	getProviderEnvValue,
+	type Provider,
+	type ProviderModelMapping,
+	supportsServiceTier,
+} from "@llmgateway/models";
+
+import type { InferSelectModel, tables } from "@llmgateway/db";
+
+type ProviderKeyRow = InferSelectModel<typeof tables.providerKey>;
+
+/**
+ * The region a service-tier decision must be evaluated against for a resolved
+ * attempt. Google Vertex mappings carry no region of their own — the endpoint's
+ * location comes from the credential (`LLM_GOOGLE_VERTEX_REGION` for the env
+ * path, `config.region` / `options.env_config.region` for a database-backed
+ * credential) — so the effective region has to be read from there. Every other
+ * provider uses the mapping's own region.
+ */
+export function resolveServiceTierRegion(
+	provider: Provider,
+	region: string | undefined,
+	configIndex?: number,
+	variant?: EnvVarVariant,
+): string | undefined {
+	if (provider !== "google-vertex") {
+		return region;
+	}
+	return (
+		region ??
+		getProviderEnvValue(
+			"google-vertex",
+			"region",
+			configIndex,
+			"global",
+			variant,
+		) ??
+		"global"
+	);
+}
+
+/**
+ * The tier to actually forward upstream for a resolved (model, provider,
+ * region, credential) attempt. Returns undefined when no premium tier was
+ * requested, or when the resolved mapping cannot serve the requested one.
+ *
+ * Callers must never treat an undefined result for a premium request as
+ * "send at standard": routing is pre-filtered to tier-capable mappings and
+ * credentials, so undefined means the attempt would be silently downgraded —
+ * see `assertServiceTierHonored`.
+ */
+export function getForwardedServiceTier(
+	model: string,
+	provider: Provider,
+	region: string | undefined,
+	serviceTier: "auto" | "default" | "flex" | "priority" | undefined,
+	configIndex?: number,
+	variant?: EnvVarVariant,
+): "flex" | "priority" | undefined {
+	if (!isPremiumServiceTier(serviceTier)) {
+		return undefined;
+	}
+	const effectiveRegion = resolveServiceTierRegion(
+		provider,
+		region,
+		configIndex,
+		variant,
+	);
+	return supportsServiceTier(
+		model,
+		provider,
+		serviceTier,
+		effectiveRegion ?? null,
+	)
+		? serviceTier
+		: undefined;
+}
+
+/**
+ * Whether a catalog mapping can serve the requested premium tier. Used to
+ * narrow the routing candidate set before a provider is picked, so neither the
+ * initial attempt nor any fallback can land on a mapping that would drop the
+ * tier.
+ */
+export function mappingSupportsRequestedServiceTier(
+	model: string,
+	mapping: Pick<ProviderModelMapping, "providerId" | "region">,
+	serviceTier: "flex" | "priority",
+	configIndex?: number,
+	variant?: EnvVarVariant,
+): boolean {
+	return (
+		getForwardedServiceTier(
+			model,
+			mapping.providerId as Provider,
+			mapping.region,
+			serviceTier,
+			configIndex,
+			variant,
+		) !== undefined
+	);
+}
+
+/**
+ * Fails an attempt that would reach the upstream at a lower tier than the
+ * client explicitly asked for.
+ *
+ * A dropped tier is invisible to the caller — the request succeeds, just slower
+ * or more expensive than the tier it was billed against — so every dispatch
+ * path asserts the invariant instead of falling back to standard. Routing and
+ * credential selection already exclude mappings and keys that cannot serve the
+ * tier; this is the backstop that keeps a provider/key/region resolved *after*
+ * those filters (a fallback provider, a rotated key) from quietly downgrading
+ * the request.
+ *
+ * Only applies to a tier the client requested itself. The dev-plan (DevPass)
+ * org-level default is deliberately soft: it is a cost preference, not a
+ * requirement, so an attempt that cannot serve it runs at standard instead of
+ * failing.
+ */
+export function assertServiceTierHonored(options: {
+	requestedServiceTier: "flex" | "priority" | null;
+	forwardedServiceTier: "flex" | "priority" | undefined;
+	provider: string;
+	model: string;
+	region: string | undefined;
+}): void {
+	if (!options.requestedServiceTier || options.forwardedServiceTier) {
+		return;
+	}
+	const target = options.region
+		? `${options.provider}/${options.model}:${options.region}`
+		: `${options.provider}/${options.model}`;
+	throw new HTTPException(400, {
+		message: `Service tier '${options.requestedServiceTier}' is not available for ${target}.`,
+		cause: "unsupported_service_tier",
+	});
+}
+
+/**
+ * The endpoint region a provider-key row routes through, mirroring what
+ * `getProviderEndpoint` reads. A platform-managed credential carries its
+ * settings in `config` — surfaced to the endpoint builder as `env_config`, and
+ * read here in both shapes so a row works whether or not it has been through
+ * `managedCredentialOptions` — plus the `region` scoping column. BYOK keys never
+ * set any of these for Vertex; their location comes from the environment, which
+ * `resolveServiceTierRegion` reads instead.
+ */
+function providerKeyRegion(key: ProviderKeyRow): string | undefined {
+	return (
+		key.config?.region ??
+		key.options?.env_config?.region ??
+		key.region ??
+		undefined
+	);
+}
+
+/**
+ * Whether a provider-key row (BYOK or platform-managed) can carry a
+ * Flex/Priority request. Shared by every key-selection path so a service-tier
+ * request cannot rotate onto a credential — on the first attempt or on a
+ * fallback — whose upstream would silently serve it as standard.
+ */
+export function providerKeySupportsServiceTier(key: ProviderKeyRow): boolean {
+	return providerCredentialSupportsServiceTier(key.provider as Provider, {
+		baseUrl: key.config?.baseUrl ?? key.baseUrl,
+		region: providerKeyRegion(key),
+	});
+}

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -637,6 +637,26 @@ mockOpenAIServer.post("/v1/responses", async (c) => {
 		c.status(500);
 		return c.json(sampleErrorResponse);
 	}
+
+	// Mirrors the chat-completions handler so retry/fallback behaviour can be
+	// exercised on the Responses API too (the surface OpenAI's newer models are
+	// served on). Shares the same module-level counter, so a test using it must
+	// call resetFailOnceCounter() first.
+	if (userMessage.includes("TRIGGER_FAIL_ONCE")) {
+		failOnceCounter++;
+		if (failOnceCounter === 1) {
+			c.status(500);
+			return c.json({
+				error: {
+					message: "Temporary server error (will succeed on retry)",
+					type: "server_error",
+					param: null,
+					code: "internal_server_error",
+				},
+			});
+		}
+	}
+
 	const shouldEndAfterDoneEvent = userMessage.includes(
 		"TRIGGER_RESPONSES_DONE_WITHOUT_COMPLETED",
 	);

--- a/packages/actions/src/apply-google-service-tier.spec.ts
+++ b/packages/actions/src/apply-google-service-tier.spec.ts
@@ -4,6 +4,7 @@ import {
 	applyGoogleServiceTier,
 	assumeServedServiceTier,
 	isPremiumServiceTier,
+	providerCredentialSupportsServiceTier,
 	providerKeyBaseUrlSupportsServiceTier,
 	resolveServedServiceTier,
 } from "./apply-google-service-tier.js";
@@ -228,5 +229,38 @@ describe("assumeServedServiceTier", () => {
 	it("returns null for providers that report their served tier", () => {
 		expect(assumeServedServiceTier("openai", "priority", true)).toBeNull();
 		expect(assumeServedServiceTier("google-vertex", "flex", true)).toBeNull();
+	});
+});
+
+describe("providerCredentialSupportsServiceTier", () => {
+	it("requires the global endpoint for google-vertex credentials", () => {
+		expect(
+			providerCredentialSupportsServiceTier("google-vertex", {
+				region: "global",
+			}),
+		).toBe(true);
+		expect(providerCredentialSupportsServiceTier("google-vertex", {})).toBe(
+			true,
+		);
+		expect(
+			providerCredentialSupportsServiceTier("google-vertex", {
+				region: "us-central1",
+			}),
+		).toBe(false);
+	});
+
+	it("still rejects a proxied base URL regardless of region", () => {
+		expect(
+			providerCredentialSupportsServiceTier("google-vertex", {
+				baseUrl: "https://my-proxy.example.com",
+				region: "global",
+			}),
+		).toBe(false);
+	});
+
+	it("ignores region for providers without an endpoint constraint", () => {
+		expect(
+			providerCredentialSupportsServiceTier("openai", { region: "us-east1" }),
+		).toBe(true);
 	});
 });

--- a/packages/actions/src/apply-google-service-tier.ts
+++ b/packages/actions/src/apply-google-service-tier.ts
@@ -95,6 +95,31 @@ export function providerKeyBaseUrlSupportsServiceTier(
 }
 
 /**
+ * Whether a credential (BYOK key, platform-managed key, or env-var index) can
+ * carry a Flex/Priority request, given the upstream it targets.
+ *
+ * Extends the base-URL rule with Google Vertex's endpoint constraint: Flex and
+ * Priority PayGo are only served on the `global` location, so a credential
+ * pinned to a regional endpoint would have its tier header dropped upstream and
+ * be served — and billed — as standard. Every credential-selection path (BYOK
+ * key filtering, managed-credential filtering, env round-robin) shares this
+ * predicate so a service-tier request can never rotate onto a credential that
+ * silently downgrades it.
+ */
+export function providerCredentialSupportsServiceTier(
+	provider: ProviderId,
+	credential: { baseUrl?: string | null; region?: string | null },
+): boolean {
+	if (!providerKeyBaseUrlSupportsServiceTier(provider, credential.baseUrl)) {
+		return false;
+	}
+	if (provider === "google-vertex") {
+		return (credential.region ?? "global") === "global";
+	}
+	return true;
+}
+
+/**
  * Resolve the processing tier the provider actually served from the upstream
  * response signals. Returns "flex" / "priority", or null for the standard tier
  * (including when Google downgraded an unsupported tier to standard).


### PR DESCRIPTION
## Background

A user on a coding plan reported that a `service_tier: "flex"` request to GPT-5.6 Sol got a 429 on one OpenAI key, was retried on another key, succeeded — and came back billed at standard rates. They asked for a way to strictly enforce the requested tier, or to disable alternate-key retry so they get the original 429 back.

**The investigation did not find a bug.** The tier survives both alternate-key rotation and cross-provider fallback today: routing is narrowed to tier-capable mappings before a provider is picked, and the retry context rebuilds the request body with the tier intact. The two integration tests added here pass on `main` unchanged. So the reported request was either served at standard by OpenAI itself, or never carried the tier upstream to begin with.

This PR is therefore **hardening and regression coverage, not a fix**. It is worth reviewing on that basis — if you'd rather not carry the guard, the tests and the filter dedup stand on their own.

## What's here

Roughly 800 added lines break down as ~420 lines of tests, ~170 lines of code *moved* out of `chat.ts`, ~30 lines of docs, and ~60 lines of genuinely new logic.

- **Regression tests for the reported scenario.** Three integration tests in `api.spec.ts`: key rotation preserves the tier through a 429/500 retry, a tier request never routes to a provider that lacks the tier, and a control proving the same request *does* fall back to that provider when no tier is requested. Plus unit coverage in a new `service-tier.spec.ts`.

- **One credential-eligibility predicate.** The rule for "can this credential carry a premium tier" existed in three hand-synced copies — the BYOK key filter, the managed-credential filter, and the env round-robin — and had already drifted: the BYOK copy was missing the Vertex global-endpoint rule the other two enforced. (Not reachable today, since BYOK Vertex keys take their region from the environment rather than key options, but it is one config option away from being a silent billing bug.) All three now share `providerCredentialSupportsServiceTier`.

- **A dispatch-time assert.** `getForwardedServiceTier` silently returns `undefined` when a resolved mapping or credential can't carry the tier, so "send it at standard anyway" is always one stray candidate away, and the resulting failure is invisible — the request succeeds and is billed at up to 2x what was asked for. `assertServiceTierHonored` turns that into a 400 `unsupported_service_tier`. In `resolveProviderContext` — the choke point every retry passes through, streaming and non-streaming — the throw is what both retry loops already treat as "try the next provider/key", so an ineligible candidate is skipped rather than downgraded.

- **Tier helpers extracted** from `chat.ts` into `apps/gateway/src/chat/tools/service-tier.ts` (`getForwardedServiceTier`, `mappingSupportsRequestedServiceTier`, and the Vertex region resolution each of them re-implemented inline).

Strictness applies only to a tier the client asked for itself. The coding-plan org default is a cost preference rather than a requirement, so an attempt that can't serve it still runs at standard — keyed off `serviceTierSource === "request"` from #3459.

## A caveat worth knowing about the guard

Syncing this branch with main hit exactly the failure mode the guard is meant to prevent, from the other direction. #3459 made `requestedServiceTier` mutable and now stamps it when the coding-plan default fires; the assert had been keying off that variable, so taking the merge naively would have made every DevPass flex request hard-fail where it used to run at standard. Caught in the merge and rewired, but it's a fair argument that the guard is itself a footgun if wired carelessly, where a plain regression test would not be.

## Not included

Two things the reporter asked for, out of scope here and worth deciding separately:

- **`no_key_fallback`** — `x-no-fallback` disables cross-provider fallback but deliberately still rotates keys within a provider (there is an existing test pinning that). Returning the original 429 to the client needs a new opt-out.
- **Prompt-cache locality across key rotation** — OpenAI's prompt cache is scoped to the upstream account, so a rotated key necessarily re-writes the prefix. Documented rather than fixed.

## Verification

- Post-merge with `origin/main`: 255 tests pass across `api.spec`, `fallback.spec`, `service-tier.spec`, `resolve-provider-context.spec` and the actions spec; before the merge the full `apps/gateway` + `packages/actions` run was 2663 passing.
- `pnpm format`, `pnpm lint`, `pnpm build` clean.

No UI surface changed. The only user-visible change is a new "Retries and fallback never downgrade the tier" section on the service-tiers docs page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
