### PR TITLE
feat(gateway): managed keys supersede env vars

### DIFF
--- a/apps/api/src/routes/admin-provider-credentials.ts
+++ b/apps/api/src/routes/admin-provider-credentials.ts
@@ -149,8 +149,9 @@ const catalogEntrySchema = z.object({
 	 * provider — the gateway's, or this process's own when no gateway has
 	 * published — across the base variable and its variant/region overrides.
 	 * These are read-only from the dashboard: they can only be changed by
-	 * redeploying, and once the provider has any active managed credential
-	 * covering an audience they stop being used for it.
+	 * redeploying, and once the provider has any active managed credential all
+	 * of them stop being used — managed credentials replace the environment for
+	 * their provider rather than taking precedence key by key.
 	 */
 	envCredentials: z.array(envCredentialSchema),
 	/**

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -20,7 +20,7 @@ import {
 import { resolveChatApiOrigin } from "@/lib/api-origin.js";
 import {
 	findApiKeyByToken,
-	findManagedProviderIds,
+	findManagedProviderAvailability,
 	findProjectById,
 	findOrganizationById,
 	findCustomProviderKey,
@@ -30,6 +30,7 @@ import {
 	findActiveProviderKeys,
 	findProviderKeysByProviders,
 	type CustomModel,
+	type ManagedProviderAvailability,
 } from "@/lib/cached-queries.js";
 import { raceClientAbort } from "@/lib/client-abort.js";
 import { getClientIpFromRequest } from "@/lib/client-ip.js";
@@ -219,8 +220,10 @@ import {
 import { hasMeaningfulAssistantOutput } from "./tools/has-meaningful-assistant-output.js";
 import { healJsonResponse } from "./tools/heal-json-response.js";
 import {
+	EMPTY_MANAGED_PROVIDER_AVAILABILITY,
 	getAvailableProvidersForProjectMode,
 	getRoutingCandidatesForProjectMode,
+	platformCredentialCoversRegion,
 	preferProvidersWithKeys,
 } from "./tools/hybrid-provider-routing.js";
 import { isModelTrulyFree } from "./tools/is-model-truly-free.js";
@@ -395,24 +398,40 @@ function customModelToProviderMapping(cm: CustomModel): ProviderModelMapping {
 
 function filterRegionsByAvailableKeys(
 	expandedProviders: ProviderModelMapping[],
+	managed: ManagedProviderAvailability,
 ): ProviderModelMapping[] {
-	return expandedProviders.filter((mapping) => {
-		if (!mapping.region) {
-			return true;
-		}
-		const providerDef = providers.find((p) => p.id === mapping.providerId) as
-			ProviderDefinition | undefined;
-		if (!providerDef?.regionConfig) {
-			return true;
-		}
-		if (mapping.region === providerDef.regionConfig.defaultRegion) {
-			return true;
-		}
-		return hasRegionSpecificEnvKey(
-			mapping.providerId as Provider,
-			mapping.region,
-		);
-	});
+	return expandedProviders.filter((mapping) =>
+		platformKeyCoversMappingRegion(mapping, managed),
+	);
+}
+
+/**
+ * Whether the platform's own credentials can serve this regional mapping.
+ * Mappings without a region, and providers the catalogue does not scope by
+ * region, are always kept — there is nothing to select against.
+ */
+function platformKeyCoversMappingRegion(
+	mapping: ProviderModelMapping,
+	managed: ManagedProviderAvailability,
+): boolean {
+	const region = mapping.region;
+	if (!region) {
+		return true;
+	}
+	const providerDef = providers.find((p) => p.id === mapping.providerId) as
+		ProviderDefinition | undefined;
+	const regionConfig = providerDef?.regionConfig;
+	if (!regionConfig) {
+		return true;
+	}
+	return platformCredentialCoversRegion(
+		mapping.providerId,
+		region,
+		managed,
+		() =>
+			region === regionConfig.defaultRegion ||
+			hasRegionSpecificEnvKey(mapping.providerId as Provider, region),
+	);
 }
 
 function preferConcreteRegionalMappings(
@@ -2023,48 +2042,48 @@ chat.openapi(completions, async (c) => {
 	let configIndex = 0; // Index for round-robin environment variables
 
 	// Filter region candidates based on available keys.
-	// - credits mode: only keep regions with env keys (base key → default region only)
+	// - credits mode: only keep regions a platform credential covers (a managed
+	//   credential pinned to the region, or — for providers with no managed
+	//   credential — the env key, whose base value covers the default region)
 	// - hybrid mode: providers with a DB key keep all regions (user chose their region);
 	//   providers without a DB key are filtered like credits mode
 	// - api-keys mode: no filtering (all regions available, user picks via DB key)
+	//
+	// Variant- and model-agnostic: this runs before the organization (and with
+	// it the env-var variant) is resolved, exactly like the env-var side.
+	const managedRegionAvailability =
+		project.mode === "api-keys"
+			? EMPTY_MANAGED_PROVIDER_AVAILABILITY
+			: await findManagedProviderAvailability();
 	if (project.mode === "credits") {
 		modelInfo = {
 			...modelInfo,
-			providers: filterRegionsByAvailableKeys(modelInfo.providers),
+			providers: filterRegionsByAvailableKeys(
+				modelInfo.providers,
+				managedRegionAvailability,
+			),
 		};
 		routingExpandedModelProviders = filterRegionsByAvailableKeys(
 			routingExpandedModelProviders,
+			managedRegionAvailability,
 		);
-		allModelProviders = filterRegionsByAvailableKeys(allModelProviders);
+		allModelProviders = filterRegionsByAvailableKeys(
+			allModelProviders,
+			managedRegionAvailability,
+		);
 	} else if (project.mode === "hybrid") {
 		const dbProviderKeys = await findActiveProviderKeys(project.organizationId);
 		const providersWithDbKeys = new Set(dbProviderKeys.map((k) => k.provider));
 		const filterHybridRegions = (
 			expanded: ProviderModelMapping[],
 		): ProviderModelMapping[] =>
-			expanded.filter((mapping) => {
-				// Providers with a DB key: keep all regions
-				if (providersWithDbKeys.has(mapping.providerId)) {
-					return true;
-				}
-				// Providers without a DB key: filter like credits mode
-				if (!mapping.region) {
-					return true;
-				}
-				const providerDef = providers.find(
-					(p) => p.id === mapping.providerId,
-				) as ProviderDefinition | undefined;
-				if (!providerDef?.regionConfig) {
-					return true;
-				}
-				if (mapping.region === providerDef.regionConfig.defaultRegion) {
-					return true;
-				}
-				return hasRegionSpecificEnvKey(
-					mapping.providerId as Provider,
-					mapping.region,
-				);
-			});
+			expanded.filter(
+				(mapping) =>
+					// Providers with a DB key: keep all regions
+					providersWithDbKeys.has(mapping.providerId) ||
+					// Providers without a DB key: filter like credits mode
+					platformKeyCoversMappingRegion(mapping, managedRegionAvailability),
+			);
 		modelInfo = {
 			...modelInfo,
 			providers: filterHybridRegions(modelInfo.providers),
@@ -3258,7 +3277,7 @@ chat.openapi(completions, async (c) => {
 						providerKeyAllowsModel(key.allowedModels, modelDef.id),
 					),
 					supportedProviderIds,
-					await findManagedProviderIds(envVariant, modelDef.id),
+					await findManagedProviderAvailability(envVariant, modelDef.id),
 				);
 
 			const candidateProviders = preferConcreteRegionalMappings(
@@ -3268,6 +3287,7 @@ chat.openapi(completions, async (c) => {
 								expandAllProviderRegions(
 									modelDef.providers as ProviderModelMapping[],
 								),
+								managedRegionAvailability,
 							)
 						: expandAllProviderRegions(
 								modelDef.providers as ProviderModelMapping[],
@@ -3785,7 +3805,7 @@ chat.openapi(completions, async (c) => {
 							providerKeyAllowsModel(key.allowedModels, baseModelId),
 						),
 						providerIds,
-						await findManagedProviderIds(envVariant, baseModelId),
+						await findManagedProviderAvailability(envVariant, baseModelId),
 					);
 
 				const availableModelProviders = preferConcreteRegionalMappings(
@@ -4007,7 +4027,7 @@ chat.openapi(completions, async (c) => {
 							providerKeyAllowsModel(key.allowedModels, baseModelId),
 						),
 						providerIds,
-						await findManagedProviderIds(envVariant, baseModelId),
+						await findManagedProviderAvailability(envVariant, baseModelId),
 					);
 
 				// Filter model providers to only those available (excluding the low-uptime one)
@@ -4235,7 +4255,7 @@ chat.openapi(completions, async (c) => {
 						providerKeyAllowsModel(key.allowedModels, routedModelId),
 					),
 					providerIds,
-					await findManagedProviderIds(envVariant, routedModelId),
+					await findManagedProviderAvailability(envVariant, routedModelId),
 				);
 
 			// Build a map of provider → locked region from DB provider keys.

--- a/apps/gateway/src/chat/managed-credentials.spec.ts
+++ b/apps/gateway/src/chat/managed-credentials.spec.ts
@@ -38,6 +38,8 @@ describe("managed provider credentials", () => {
 		token: string;
 		config?: Record<string, string>;
 		variant?: "default" | "enterprise" | "plans";
+		region?: string;
+		allowedModels?: string[];
 	}) {
 		await cdb.insert(tables.providerKey).values({
 			id: values.id,
@@ -47,6 +49,8 @@ describe("managed provider credentials", () => {
 			organizationId: null,
 			config: values.config,
 			variant: values.variant ?? "default",
+			region: values.region,
+			allowedModels: values.allowedModels,
 		});
 	}
 
@@ -390,6 +394,80 @@ describe("managed provider credentials", () => {
 		expect(new Set(seen)).toEqual(
 			new Set(["Bearer sk-managed-a", "Bearer sk-managed-b"]),
 		);
+	});
+
+	/**
+	 * Managed credentials replace the provider's `LLM_*` variables instead of
+	 * taking precedence over them: once the provider has one, the environment is
+	 * out of play for routing and for every fallback. Rotating onto an env key
+	 * after the managed fleet is exhausted would spend a credential the operator
+	 * has already retired on the admin dashboard.
+	 */
+	test("never rotates onto an env key when the managed credentials fail", async () => {
+		await seedApiKey();
+		await seedManagedCredential({
+			id: "managed-openai-lone",
+			provider: "openai",
+			token: "sk-managed-lone",
+		});
+
+		const previousEnvKey = process.env.LLM_OPENAI_API_KEY;
+		process.env.LLM_OPENAI_API_KEY = "sk-from-env";
+
+		const seen: (string | null)[] = [];
+		vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+			seen.push(new Headers(init?.headers).get("authorization"));
+			return new Response(
+				JSON.stringify({ error: { message: "Invalid API key" } }),
+				{ status: 401, headers: { "Content-Type": "application/json" } },
+			);
+		});
+
+		try {
+			await app.request("/v1/moderations", {
+				method: "POST",
+				headers: {
+					Authorization: "Bearer real-token",
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ input: "hello" }),
+			});
+		} finally {
+			if (previousEnvKey === undefined) {
+				delete process.env.LLM_OPENAI_API_KEY;
+			} else {
+				process.env.LLM_OPENAI_API_KEY = previousEnvKey;
+			}
+		}
+
+		expect(seen).toEqual(["Bearer sk-managed-lone"]);
+	});
+
+	test("fails instead of using the env key when no managed credential may serve the model", async () => {
+		await seedApiKey();
+		await seedManagedCredential({
+			id: "managed-openai-restricted",
+			provider: "openai",
+			token: "sk-managed-restricted",
+			allowedModels: ["gpt-4o"],
+		});
+
+		const previousEnvKey = process.env.LLM_OPENAI_API_KEY;
+		process.env.LLM_OPENAI_API_KEY = "sk-from-env";
+		const captured = captureUpstream(chatCompletion);
+
+		try {
+			const res = await completions("openai/gpt-4o-mini");
+			expect(res.status).not.toBe(200);
+		} finally {
+			if (previousEnvKey === undefined) {
+				delete process.env.LLM_OPENAI_API_KEY;
+			} else {
+				process.env.LLM_OPENAI_API_KEY = previousEnvKey;
+			}
+		}
+
+		expect(captured).toEqual([]);
 	});
 
 	test("routes a PAYG org to a default credential alongside a variant one", async () => {

--- a/apps/gateway/src/chat/tools/hybrid-provider-routing.spec.ts
+++ b/apps/gateway/src/chat/tools/hybrid-provider-routing.spec.ts
@@ -3,16 +3,42 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
 	getAvailableProvidersForProjectMode,
 	getRoutingCandidatesForProjectMode,
+	platformCredentialCoversRegion,
 	preferProvidersWithKeys,
 } from "./hybrid-provider-routing.js";
 
+import type { ManagedProviderAvailability } from "@/lib/cached-queries.js";
 import type { ProviderModelMapping } from "@llmgateway/models";
+
+function managedAvailability(values: {
+	configured?: string[];
+	usable?: string[];
+	pinnedRegions?: Record<string, string[]>;
+}): ManagedProviderAvailability {
+	return {
+		configured: new Set(values.configured ?? []),
+		usable: new Set(values.usable ?? []),
+		pinnedRegions: new Map(
+			Object.entries(values.pinnedRegions ?? {}).map(([provider, regions]) => [
+				provider,
+				new Set(regions),
+			]),
+		),
+	};
+}
 
 describe("hybrid-provider-routing", () => {
 	const originalOpenAIKey = process.env.LLM_OPENAI_API_KEY;
 	const originalGoogleVertexKey = process.env.LLM_GOOGLE_VERTEX_API_KEY;
+	const originalAlibabaKey = process.env.LLM_ALIBABA_API_KEY;
 
 	afterEach(() => {
+		if (originalAlibabaKey === undefined) {
+			delete process.env.LLM_ALIBABA_API_KEY;
+		} else {
+			process.env.LLM_ALIBABA_API_KEY = originalAlibabaKey;
+		}
+
 		if (originalOpenAIKey === undefined) {
 			delete process.env.LLM_OPENAI_API_KEY;
 		} else {
@@ -56,9 +82,78 @@ describe("hybrid-provider-routing", () => {
 			"credits",
 			[],
 			["google-vertex"],
-			new Set(["google-vertex"]),
+			managedAvailability({
+				configured: ["google-vertex"],
+				usable: ["google-vertex"],
+			}),
 		);
 		expect(withManaged.availableProviders).toEqual(["google-vertex"]);
+	});
+
+	/**
+	 * Managed credentials replace the environment rather than sitting in front
+	 * of it: a provider configured on the admin dashboard whose credentials
+	 * cannot serve this request must not silently fall back to the env key the
+	 * operator already superseded.
+	 */
+	it("drops a configured provider whose managed credentials cannot serve the request", () => {
+		process.env.LLM_GOOGLE_VERTEX_API_KEY = "vertex-env-key";
+
+		const result = getAvailableProvidersForProjectMode(
+			"credits",
+			[],
+			["google-vertex"],
+			// e.g. every credential is region-pinned, or restricted to other models.
+			managedAvailability({ configured: ["google-vertex"], usable: [] }),
+		);
+
+		expect(result.availableProviders).toEqual([]);
+	});
+
+	it("keeps reading the environment for providers with no managed credential", () => {
+		process.env.LLM_GOOGLE_VERTEX_API_KEY = "vertex-env-key";
+		process.env.LLM_OPENAI_API_KEY = "sk-openai";
+
+		const result = getAvailableProvidersForProjectMode(
+			"credits",
+			[],
+			["google-vertex", "openai"],
+			managedAvailability({ configured: ["openai"], usable: ["openai"] }),
+		);
+
+		expect(result.availableProviders).toEqual(["openai", "google-vertex"]);
+	});
+
+	it("reports region coverage from managed credentials only, once configured", () => {
+		process.env.LLM_ALIBABA_API_KEY = "alibaba-env-key";
+		const managed = managedAvailability({
+			configured: ["alibaba"],
+			usable: [],
+			pinnedRegions: { alibaba: ["us-virginia"] },
+		});
+
+		expect(
+			platformCredentialCoversRegion("alibaba", "us-virginia", managed, () => {
+				throw new Error("env must not be consulted for a configured provider");
+			}),
+		).toBe(true);
+		expect(
+			platformCredentialCoversRegion(
+				"alibaba",
+				"cn-beijing",
+				managed,
+				() => true,
+			),
+		).toBe(false);
+		// A provider with no managed credential still decides by its env vars.
+		expect(
+			platformCredentialCoversRegion(
+				"openai",
+				"us-virginia",
+				managed,
+				() => true,
+			),
+		).toBe(true);
 	});
 
 	it("prefers keyed providers over credits-backed providers in hybrid mode", () => {

--- a/apps/gateway/src/chat/tools/hybrid-provider-routing.ts
+++ b/apps/gateway/src/chat/tools/hybrid-provider-routing.ts
@@ -4,16 +4,65 @@ import {
 	providers,
 } from "@llmgateway/models";
 
+import type { ManagedProviderAvailability } from "@/lib/cached-queries.js";
+
 export type ProjectMode = "api-keys" | "credits" | "hybrid";
+
+/** A deployment with no managed credentials at all: every provider reads its env vars. */
+export const EMPTY_MANAGED_PROVIDER_AVAILABILITY: ManagedProviderAvailability =
+	{
+		configured: new Set(),
+		usable: new Set(),
+		pinnedRegions: new Map(),
+	};
+
+/**
+ * Whether the provider's `LLM_*` environment variables still count for
+ * routing. Managed credentials replace them rather than complement them: a
+ * provider configured on the admin dashboard is served only by those
+ * credentials, so its environment is ignored for routing and every fallback.
+ */
+export function environmentServesProvider(
+	providerId: string,
+	managed: ManagedProviderAvailability = EMPTY_MANAGED_PROVIDER_AVAILABILITY,
+): boolean {
+	return (
+		!managed.configured.has(providerId) &&
+		hasProviderEnvironmentToken(providerId as Provider)
+	);
+}
+
+/**
+ * Whether the platform holds a credential that can serve the provider in this
+ * region — a managed credential pinned to it (or a region-agnostic one, which
+ * `usable` already reports), or the provider's regional env var when no managed
+ * credential supersedes the environment.
+ */
+export function platformCredentialCoversRegion(
+	providerId: string,
+	region: string,
+	managed: ManagedProviderAvailability,
+	hasRegionalEnvKey: () => boolean,
+): boolean {
+	if (managed.configured.has(providerId)) {
+		return (
+			managed.usable.has(providerId) ||
+			Boolean(managed.pinnedRegions.get(providerId)?.has(region))
+		);
+	}
+	return hasRegionalEnvKey();
+}
 
 /**
  * Providers LLM Gateway can serve itself, i.e. the ones it holds a credential
  * for. A credential is either a managed provider-key row (the database-backed
- * configuration) or the provider's `LLM_*` environment variable, so a provider
- * migrated into the database stays routable once its env var is removed.
+ * configuration) or the provider's `LLM_*` environment variable — and once the
+ * provider has any managed credential the environment no longer counts, so a
+ * provider whose managed credentials cannot serve this request is dropped
+ * rather than silently served by the env var they superseded.
  */
 export function getPlatformBackedProviders(
-	managedProviderIds: ReadonlySet<string> = new Set(),
+	managed: ManagedProviderAvailability = EMPTY_MANAGED_PROVIDER_AVAILABILITY,
 	providerIds?: string[],
 ): string[] {
 	const candidateProviders = providerIds
@@ -24,8 +73,8 @@ export function getPlatformBackedProviders(
 		.filter((provider) => provider.id !== "llmgateway")
 		.filter(
 			(provider) =>
-				managedProviderIds.has(provider.id) ||
-				hasProviderEnvironmentToken(provider.id as Provider),
+				managed.usable.has(provider.id) ||
+				environmentServesProvider(provider.id, managed),
 		)
 		.map((provider) => provider.id);
 }
@@ -34,7 +83,7 @@ export function getAvailableProvidersForProjectMode(
 	projectMode: ProjectMode,
 	providerKeys: Array<{ provider: string }>,
 	providerIds?: string[],
-	managedProviderIds?: ReadonlySet<string>,
+	managed?: ManagedProviderAvailability,
 ): {
 	availableProviders: string[];
 	providersWithKeys: Set<string>;
@@ -48,10 +97,7 @@ export function getAvailableProvidersForProjectMode(
 		};
 	}
 
-	const platformProviders = getPlatformBackedProviders(
-		managedProviderIds,
-		providerIds,
-	);
+	const platformProviders = getPlatformBackedProviders(managed, providerIds);
 
 	if (projectMode === "credits") {
 		return {

--- a/apps/gateway/src/chat/tools/openai-content-filter.ts
+++ b/apps/gateway/src/chat/tools/openai-content-filter.ts
@@ -1,6 +1,10 @@
+import {
+	findManagedProviderKey,
+	hasManagedProviderCredential,
+} from "@/lib/cached-queries.js";
 import { isCancellationError, isTimeoutError } from "@/lib/timeout-config.js";
 
-import { getProviderHeaders } from "@llmgateway/actions";
+import { getProviderHeaders, readProviderKey } from "@llmgateway/actions";
 import { logger } from "@llmgateway/logger";
 
 import { extractErrorCause } from "./extract-error-cause.js";
@@ -348,6 +352,27 @@ function createFailedOpenAIContentFilterResult(
 	};
 }
 
+/**
+ * The OpenAI credential the moderation call runs on. A managed credential
+ * supersedes the env vars for its provider entirely, so once one exists the
+ * environment is never read — and a provider whose managed credentials cannot
+ * serve the call has no env key left to fall back to.
+ */
+async function resolveContentFilterToken(): Promise<string> {
+	if (await hasManagedProviderCredential("openai")) {
+		const managedKey = await findManagedProviderKey("openai", {
+			selectionScope: OPENAI_MODERATION_MODEL,
+		});
+		if (!managedKey) {
+			throw new Error(
+				"No managed credential available for provider: openai (content filter)",
+			);
+		}
+		return readProviderKey(managedKey);
+	}
+	return getProviderEnv("openai", { advanceRoundRobin: false }).token;
+}
+
 async function runOpenAIContentFilterRequest(
 	request: OpenAIModerationRequest,
 	context: GatewayContentFilterContext,
@@ -487,18 +512,14 @@ export async function checkOpenAIContentFilter(
 
 	try {
 		// Gateway-internal safety filter: always uses the base credential, never
-		// the enterprise-plan env override.
-		const providerEnv = getProviderEnv("openai", {
-			advanceRoundRobin: false,
-		});
+		// the enterprise-plan env override. Managed credentials replace the env
+		// vars for their provider, so once OpenAI has one the moderation call
+		// uses it and never reads `LLM_OPENAI_API_KEY`; when none can serve it,
+		// this throws and the filter fails open below.
+		const token = await resolveContentFilterToken();
 		const moderationResults = await Promise.all(
 			moderationRequests.map((request) =>
-				runOpenAIContentFilterRequest(
-					request,
-					context,
-					providerEnv.token,
-					signal,
-				),
+				runOpenAIContentFilterRequest(request, context, token, signal),
 			),
 		);
 

--- a/apps/gateway/src/chat/tools/resolve-platform-credential.ts
+++ b/apps/gateway/src/chat/tools/resolve-platform-credential.ts
@@ -1,4 +1,9 @@
-import { findManagedProviderKey } from "@/lib/cached-queries.js";
+import { HTTPException } from "hono/http-exception";
+
+import {
+	findManagedProviderKey,
+	hasManagedProviderCredential,
+} from "@/lib/cached-queries.js";
 
 import { readProviderKey } from "@llmgateway/actions";
 import { providerKeyAllowsModel } from "@llmgateway/db";
@@ -72,11 +77,14 @@ export interface ResolvePlatformCredentialOptions {
 /**
  * Resolve the platform's own credential for a provider.
  *
- * Managed provider-key rows win when any are configured for the provider:
- * they are the database-backed replacement for the `LLM_*` environment
- * variables and carry their own base URL, project, region and other settings.
- * Deployments that have not migrated (or providers with no managed credential
- * yet) keep reading the environment exactly as before.
+ * Managed provider-key rows replace the `LLM_*` environment variables for
+ * their provider — they are not tried before them. Once a provider has any
+ * managed credential, its environment is out of play: if no managed credential
+ * can serve this request (all excluded after failing, or none matching the
+ * variant, region, model restriction or requested service tier) the request
+ * fails rather than falling back to an env key the operator superseded.
+ * Providers with no managed credential yet keep reading the environment
+ * exactly as before, so migrating can be done a provider at a time.
  */
 export async function resolvePlatformCredential(
 	provider: Provider,
@@ -104,6 +112,12 @@ export async function resolvePlatformCredential(
 			configIndex: 0,
 			envVarName: undefined,
 		};
+	}
+
+	if (await hasManagedProviderCredential(provider)) {
+		throw new HTTPException(500, {
+			message: `No managed credential available for provider: ${provider}`,
+		});
 	}
 
 	const excludedIndices = options.requiresServiceTier

--- a/apps/gateway/src/lib/cached-queries-swr.spec.ts
+++ b/apps/gateway/src/lib/cached-queries-swr.spec.ts
@@ -26,7 +26,7 @@ import {
 	findActiveProviderKeys,
 	findApiKeyByToken,
 	findEffectiveDiscount,
-	findManagedProviderIds,
+	findManagedProviderAvailability,
 	findOrganizationById,
 	findProjectById,
 	findProviderKey,
@@ -334,7 +334,8 @@ describe("cached-queries SWR integration", () => {
 			// Prime once — the per-model narrowing happens in memory after the
 			// cached row fetch, so every model shares the same mirror entry.
 			expect(
-				await findManagedProviderIds(undefined, "special-model"),
+				(await findManagedProviderAvailability(undefined, "special-model"))
+					.usable,
 			).toContain("openai");
 			await waitForSwrMirrorWrites();
 			await flushDrizzleCache();
@@ -347,10 +348,12 @@ describe("cached-queries SWR integration", () => {
 			// JSON), so the restriction keeps filtering during the outage instead
 			// of failing open or erroring.
 			expect(
-				await findManagedProviderIds(undefined, "special-model"),
+				(await findManagedProviderAvailability(undefined, "special-model"))
+					.usable,
 			).toContain("openai");
 			expect(
-				await findManagedProviderIds(undefined, "some-other-model"),
+				(await findManagedProviderAvailability(undefined, "some-other-model"))
+					.usable,
 			).not.toContain("openai");
 
 			selectSpy.mockRestore();

--- a/apps/gateway/src/lib/cached-queries.ts
+++ b/apps/gateway/src/lib/cached-queries.ts
@@ -602,19 +602,15 @@ export interface FindManagedProviderKeyOptions {
 }
 
 /**
- * Find a platform-managed provider credential for credits-mode traffic
- * (cacheable). These rows are the database-backed replacement for the `LLM_*`
- * environment variables: they are not owned by any organization and carry
- * their own base URL, project, region and other provider settings.
- *
- * Returns undefined when no managed credential is configured for the provider,
- * which is the signal for callers to fall back to the environment variables.
+ * Every active platform-managed credential for a provider (cacheable). These
+ * rows are the database-backed replacement for the `LLM_*` environment
+ * variables: they are not owned by any organization and carry their own base
+ * URL, project, region and other provider settings.
  */
-export async function findManagedProviderKey(
+export async function listManagedProviderKeys(
 	provider: string,
-	options: FindManagedProviderKeyOptions = {},
-): Promise<ProviderKey | undefined> {
-	const results = await swrWrap(
+): Promise<ProviderKey[]> {
+	return await swrWrap(
 		`providerKey:managed:${provider}`,
 		[providerKeyTableName],
 		async () =>
@@ -638,6 +634,37 @@ export async function findManagedProviderKey(
 					asc(providerKeyTable.id),
 				),
 	);
+}
+
+/**
+ * Whether the provider has any active managed credential at all — regardless of
+ * variant, region or model restrictions.
+ *
+ * Managed credentials do not sit alongside the provider's `LLM_*` environment
+ * variables, they replace them: once a single one exists, the environment is
+ * ignored for that provider everywhere — routing, credential selection and
+ * every fallback. A request no managed credential can serve therefore fails
+ * instead of quietly spending an env key the operator has already superseded.
+ */
+export async function hasManagedProviderCredential(
+	provider: string,
+): Promise<boolean> {
+	return (await listManagedProviderKeys(provider)).length > 0;
+}
+
+/**
+ * Find a platform-managed provider credential for credits-mode traffic
+ * (cacheable).
+ *
+ * Returns undefined when no managed credential can serve the request. Callers
+ * must not read the environment in that case unless
+ * `hasManagedProviderCredential` is false — see its comment.
+ */
+export async function findManagedProviderKey(
+	provider: string,
+	options: FindManagedProviderKeyOptions = {},
+): Promise<ProviderKey | undefined> {
+	const results = await listManagedProviderKeys(provider);
 
 	const candidates = options.filter ? results.filter(options.filter) : results;
 	if (candidates.length === 0) {
@@ -667,19 +694,19 @@ export async function findManagedProviderKey(
 }
 
 /**
- * Providers holding an active managed credential this request could actually
- * use (cacheable).
+ * What the platform-managed credential fleet can serve, as routing needs it
+ * (cacheable).
  *
- * Routing uses this alongside the `LLM_*` environment variables to decide
- * which providers can serve credits-mode traffic, so a deployment that has
- * moved a provider into the database no longer needs its env var set for the
- * provider to be routable.
+ * `configured` is the authority on whether a provider still reads its `LLM_*`
+ * environment variables at all: any active managed credential supersedes them
+ * entirely, so routing must decide that provider purely from `usable` /
+ * `pinnedRegions` and never consult the environment for it.
  *
- * Mirrors how `findManagedProviderKey` selects, on both axes, because a
- * provider advertised here that then has no selectable credential fails the
- * request outright: `resolvePlatformCredential` falls through to
- * `getProviderEnv`, which throws a 500, and credential resolution happens
- * outside the provider-fallback loop so nothing recovers.
+ * `usable` mirrors how `findManagedProviderKey` selects, on both axes, because
+ * a provider advertised there that then has no selectable credential fails the
+ * request outright: `resolvePlatformCredential` has no environment to fall back
+ * to for a configured provider, and credential resolution happens outside the
+ * provider-fallback loop so nothing recovers.
  *
  * - Variant: an `enterprise`/`plans` request may fall back to a `default`
  *   credential, but a `default` request can never use a variant-scoped one,
@@ -690,16 +717,34 @@ export async function findManagedProviderKey(
  *   which `hasProviderEnvironmentToken` likewise ignores in favour of the base
  *   variable. A provider whose only credentials are region-pinned is therefore
  *   not advertised, the same as a deployment that sets only
- *   `LLM_X_API_KEY__US_EAST_1` and no `LLM_X_API_KEY`.
+ *   `LLM_X_API_KEY__US_EAST_1` and no `LLM_X_API_KEY`. Which regions those
+ *   credentials do cover is reported separately in `pinnedRegions`, for the
+ *   region filter that runs before a provider is chosen.
  * - Model: a credential restricted via `allowedModels` cannot serve any other
  *   model, so when the caller knows the model it is routing, credentials that
  *   exclude it are ignored — a provider whose every credential excludes the
- *   model is not advertised for it (unless its env var can still serve it).
+ *   model is not advertised for it.
  */
-export async function findManagedProviderIds(
+export interface ManagedProviderAvailability {
+	/**
+	 * Providers with at least one active managed credential, whatever its
+	 * variant, region or model restriction. Their `LLM_*` variables are ignored.
+	 */
+	configured: ReadonlySet<string>;
+	/** Providers a region-agnostic managed credential can serve for this request. */
+	usable: ReadonlySet<string>;
+	/**
+	 * Regions each provider has a region-pinned managed credential for. Variant-
+	 * and model-agnostic, matching how `hasRegionSpecificEnvKey` reads the
+	 * environment: the region filter runs before either is known.
+	 */
+	pinnedRegions: ReadonlyMap<string, ReadonlySet<string>>;
+}
+
+export async function findManagedProviderAvailability(
 	variant?: EnvVarVariant,
 	modelId?: string,
-): Promise<Set<string>> {
+): Promise<ManagedProviderAvailability> {
 	// Fetched whole and narrowed in memory so the request's variant stays out
 	// of the cache key, the same way findManagedProviderKey keeps variant,
 	// region and exclusions out of its own.
@@ -723,8 +768,19 @@ export async function findManagedProviderIds(
 				),
 	);
 
+	const configured = new Set<string>();
+	const pinnedRegions = new Map<string, Set<string>>();
 	const byProvider = new Map<string, typeof rows>();
 	for (const row of rows) {
+		configured.add(row.provider);
+		if (row.region) {
+			const regions = pinnedRegions.get(row.provider);
+			if (regions) {
+				regions.add(row.region);
+			} else {
+				pinnedRegions.set(row.provider, new Set([row.region]));
+			}
+		}
 		if (modelId && !providerKeyAllowsModel(row.allowedModels, modelId)) {
 			continue;
 		}
@@ -737,7 +793,7 @@ export async function findManagedProviderIds(
 	}
 
 	const effectiveVariant = variant ?? "default";
-	const available = new Set<string>();
+	const usable = new Set<string>();
 	for (const [provider, candidates] of byProvider) {
 		const variantMatches = candidates.filter(
 			(key) => key.variant === effectiveVariant,
@@ -748,10 +804,10 @@ export async function findManagedProviderIds(
 				: candidates.filter((key) => key.variant === "default");
 
 		if (byVariant.some((key) => !key.region)) {
-			available.add(provider);
+			usable.add(provider);
 		}
 	}
-	return available;
+	return { configured, usable, pinnedRegions };
 }
 
 /**

--- a/apps/gateway/src/lib/managed-provider-key.spec.ts
+++ b/apps/gateway/src/lib/managed-provider-key.spec.ts
@@ -20,9 +20,10 @@ import {
 	resetKeyHealth,
 } from "./api-key-health.js";
 import {
-	findManagedProviderIds,
+	findManagedProviderAvailability,
 	findManagedProviderKey,
 	findProviderKey,
+	hasManagedProviderCredential,
 } from "./cached-queries.js";
 
 const ORG_ID = "test-org-managed-keys";
@@ -170,12 +171,13 @@ describe("findManagedProviderKey", () => {
 
 /**
  * Routing consults this to decide which providers can serve credits-mode
- * traffic. It must answer "does this org have a usable credential here?", not
- * merely "does any credential exist?": advertising a provider whose only
- * credential belongs to another audience makes routing pick it, find nothing,
- * and fall through to an env var that a migrated deployment no longer sets.
+ * traffic. `usable` must answer "does this org have a usable credential here?",
+ * not merely "does any credential exist?": advertising a provider whose only
+ * credential belongs to another audience makes routing pick it and then fail
+ * the request, since a provider with managed credentials has no env var left
+ * to fall back to.
  */
-describe("findManagedProviderIds", () => {
+describe("findManagedProviderAvailability", () => {
 	beforeEach(async () => {
 		resetKeyHealth();
 		await waitForSwrMirrorWrites();
@@ -191,40 +193,59 @@ describe("findManagedProviderIds", () => {
 	it("offers a default credential to every audience", async () => {
 		await insertManaged({ id: "default-key", variant: "default" });
 
-		expect(await findManagedProviderIds()).toContain("openai");
-		expect(await findManagedProviderIds("enterprise")).toContain("openai");
-		expect(await findManagedProviderIds("plans")).toContain("openai");
+		expect((await findManagedProviderAvailability()).usable).toContain(
+			"openai",
+		);
+		expect(
+			(await findManagedProviderAvailability("enterprise")).usable,
+		).toContain("openai");
+		expect((await findManagedProviderAvailability("plans")).usable).toContain(
+			"openai",
+		);
 	});
 
 	it("hides a variant-scoped credential from other audiences", async () => {
 		await insertManaged({ id: "enterprise-key", variant: "enterprise" });
 
-		expect(await findManagedProviderIds("enterprise")).toContain("openai");
+		expect(
+			(await findManagedProviderAvailability("enterprise")).usable,
+		).toContain("openai");
 		// A PAYG org (no variant) and a plans org cannot use it.
-		expect(await findManagedProviderIds()).not.toContain("openai");
-		expect(await findManagedProviderIds("plans")).not.toContain("openai");
+		expect((await findManagedProviderAvailability()).usable).not.toContain(
+			"openai",
+		);
+		expect(
+			(await findManagedProviderAvailability("plans")).usable,
+		).not.toContain("openai");
 	});
 
 	it("offers the provider once any audience-usable credential exists", async () => {
 		await insertManaged({ id: "enterprise-key", variant: "enterprise" });
 		await insertManaged({ id: "default-key", variant: "default" });
 
-		expect(await findManagedProviderIds()).toContain("openai");
-		expect(await findManagedProviderIds("enterprise")).toContain("openai");
+		expect((await findManagedProviderAvailability()).usable).toContain(
+			"openai",
+		);
+		expect(
+			(await findManagedProviderAvailability("enterprise")).usable,
+		).toContain("openai");
 	});
 
 	it("ignores inactive credentials", async () => {
 		await insertManaged({ id: "inactive-key", status: "inactive" });
 
-		expect(await findManagedProviderIds()).not.toContain("openai");
+		expect((await findManagedProviderAvailability()).usable).not.toContain(
+			"openai",
+		);
 	});
 
 	/**
 	 * Routing picks a provider before a region is known, so a provider whose
 	 * only credentials are region-pinned cannot be guaranteed a match. Offering
 	 * it anyway means findManagedProviderKey returns nothing and
-	 * resolvePlatformCredential falls through to getProviderEnv, which 500s
-	 * outside the provider-fallback loop.
+	 * resolvePlatformCredential 500s — it has no environment to fall back to
+	 * for a provider with managed credentials — outside the provider-fallback
+	 * loop, where nothing recovers.
 	 */
 	it("does not offer a provider whose only credential is region-pinned", async () => {
 		await insertManaged({
@@ -233,10 +254,35 @@ describe("findManagedProviderIds", () => {
 			region: "eu-central-1",
 		});
 
-		expect(await findManagedProviderIds()).not.toContain("aws-bedrock");
+		expect((await findManagedProviderAvailability()).usable).not.toContain(
+			"aws-bedrock",
+		);
 		// The credential is still unusable for a region-less request, which is
 		// precisely why the provider must not be advertised.
 		expect(await findManagedProviderKey("aws-bedrock")).toBeUndefined();
+	});
+
+	/**
+	 * `configured` is what takes the provider's `LLM_*` vars out of play, so it
+	 * must report the provider even when nothing it holds can serve the request
+	 * — otherwise routing would quietly fall back to the superseded env key.
+	 */
+	it("reports a provider as configured even when no credential can serve it", async () => {
+		await insertManaged({
+			id: "region-pinned-only",
+			provider: "aws-bedrock",
+			region: "eu-central-1",
+		});
+
+		const availability = await findManagedProviderAvailability();
+		expect(availability.configured).toContain("aws-bedrock");
+		expect(availability.usable).not.toContain("aws-bedrock");
+		expect(availability.pinnedRegions.get("aws-bedrock")).toEqual(
+			new Set(["eu-central-1"]),
+		);
+
+		expect(await hasManagedProviderCredential("aws-bedrock")).toBe(true);
+		expect(await hasManagedProviderCredential("openai")).toBe(false);
 	});
 
 	it("offers the provider once a region-agnostic credential exists", async () => {
@@ -247,7 +293,9 @@ describe("findManagedProviderIds", () => {
 		});
 		await insertManaged({ id: "bedrock-any-region", provider: "aws-bedrock" });
 
-		expect(await findManagedProviderIds()).toContain("aws-bedrock");
+		expect((await findManagedProviderAvailability()).usable).toContain(
+			"aws-bedrock",
+		);
 		expect((await findManagedProviderKey("aws-bedrock"))?.id).toBe(
 			"bedrock-any-region",
 		);
@@ -269,12 +317,16 @@ describe("findManagedProviderIds", () => {
 		});
 		await insertManaged({ id: "default-any-region", variant: "default" });
 
-		expect(await findManagedProviderIds("enterprise")).not.toContain("openai");
+		expect(
+			(await findManagedProviderAvailability("enterprise")).usable,
+		).not.toContain("openai");
 		expect(
 			await findManagedProviderKey("openai", { variant: "enterprise" }),
 		).toBeUndefined();
 		// A PAYG org is unaffected: it uses the default credential.
-		expect(await findManagedProviderIds()).toContain("openai");
+		expect((await findManagedProviderAvailability()).usable).toContain(
+			"openai",
+		);
 	});
 });
 
@@ -310,22 +362,25 @@ describe("allowedModels restriction", () => {
 			allowedModels: ["gpt-5.2"],
 		});
 
-		expect(await findManagedProviderIds(undefined, "gpt-5.2")).toContain(
-			"openai",
-		);
 		expect(
-			await findManagedProviderIds(undefined, "some-other-model"),
+			(await findManagedProviderAvailability(undefined, "gpt-5.2")).usable,
+		).toContain("openai");
+		expect(
+			(await findManagedProviderAvailability(undefined, "some-other-model"))
+				.usable,
 		).not.toContain("openai");
 		// Callers that do not know the model yet keep the unfiltered answer.
-		expect(await findManagedProviderIds()).toContain("openai");
+		expect((await findManagedProviderAvailability()).usable).toContain(
+			"openai",
+		);
 	});
 
 	it("treats an unrestricted credential as serving every model", async () => {
 		await insertManaged({ id: "unrestricted-key" });
 
-		expect(await findManagedProviderIds(undefined, "any-model")).toContain(
-			"openai",
-		);
+		expect(
+			(await findManagedProviderAvailability(undefined, "any-model")).usable,
+		).toContain("openai");
 	});
 
 	it("advertises the provider when any credential allows the model", async () => {
@@ -336,7 +391,8 @@ describe("allowedModels restriction", () => {
 		await insertManaged({ id: "unrestricted-key" });
 
 		expect(
-			await findManagedProviderIds(undefined, "some-other-model"),
+			(await findManagedProviderAvailability(undefined, "some-other-model"))
+				.usable,
 		).toContain("openai");
 	});
 
@@ -353,7 +409,8 @@ describe("allowedModels restriction", () => {
 		await insertManaged({ id: "default-unrestricted" });
 
 		expect(
-			await findManagedProviderIds("enterprise", "some-other-model"),
+			(await findManagedProviderAvailability("enterprise", "some-other-model"))
+				.usable,
 		).toContain("openai");
 	});
 
@@ -383,23 +440,34 @@ describe("allowedModels restriction", () => {
 		expect(excluded.managedKey?.id).toBe("fallback-key");
 	});
 
-	it("falls through to the env credential when every managed key excludes the model", async () => {
+	it("fails rather than using the env key when every managed key excludes the model", async () => {
 		await insertManaged({
 			id: "restricted-key",
 			allowedModels: ["gpt-5.2"],
 		});
 
-		// With no selectable managed credential the env-var path takes over;
-		// whether an env key exists depends on the local environment, so only
-		// assert that no managed credential is chosen.
-		const result = await resolvePlatformCredential("openai", {
-			selectionScope: "some-other-model",
-			model: "some-other-model",
-			variant: undefined,
-			region: undefined,
-			requiresServiceTier: false,
-		}).catch(() => undefined);
-		expect(result?.managedKey).toBeUndefined();
+		// Managed credentials replace the provider's env vars: with none
+		// selectable there is nothing left to serve the request, and quietly
+		// spending the superseded env key would be worse than failing.
+		const previousEnvKey = process.env.LLM_OPENAI_API_KEY;
+		process.env.LLM_OPENAI_API_KEY = "sk-from-env";
+		try {
+			await expect(
+				resolvePlatformCredential("openai", {
+					selectionScope: "some-other-model",
+					model: "some-other-model",
+					variant: undefined,
+					region: undefined,
+					requiresServiceTier: false,
+				}),
+			).rejects.toThrow(/No managed credential available for provider: openai/);
+		} finally {
+			if (previousEnvKey === undefined) {
+				delete process.env.LLM_OPENAI_API_KEY;
+			} else {
+				process.env.LLM_OPENAI_API_KEY = previousEnvKey;
+			}
+		}
 	});
 
 	it("BYOK lookups skip keys excluded by the caller's model filter", async () => {
@@ -463,7 +531,9 @@ describe("managed credential cache invalidation", () => {
 	it("sees a credential written through cdb without a cache flush", async () => {
 		// Prime the cache with the empty answer.
 		expect(await findManagedProviderKey("openai")).toBeUndefined();
-		expect(await findManagedProviderIds()).not.toContain("openai");
+		expect((await findManagedProviderAvailability()).usable).not.toContain(
+			"openai",
+		);
 
 		await cdb.insert(providerKey).values({
 			id: "cdb-written-key",
@@ -477,7 +547,9 @@ describe("managed credential cache invalidation", () => {
 		expect((await findManagedProviderKey("openai"))?.id).toBe(
 			"cdb-written-key",
 		);
-		expect(await findManagedProviderIds()).toContain("openai");
+		expect((await findManagedProviderAvailability()).usable).toContain(
+			"openai",
+		);
 		expect((await findManagedProviderKeyById("cdb-written-key"))?.token).toBe(
 			"sk-written-through-cdb",
 		);
@@ -501,7 +573,9 @@ describe("managed credential cache invalidation", () => {
 		await waitForSwrMirrorWrites();
 
 		expect(await findManagedProviderKey("openai")).toBeUndefined();
-		expect(await findManagedProviderIds()).not.toContain("openai");
+		expect((await findManagedProviderAvailability()).usable).not.toContain(
+			"openai",
+		);
 	});
 });
 

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -24,6 +24,7 @@ import {
 	findOrganizationById,
 	findProjectById,
 	findProviderKey,
+	hasManagedProviderCredential,
 	type GatewayApiKey,
 } from "@/lib/cached-queries.js";
 import { getClientIpFromRequest } from "@/lib/client-ip.js";
@@ -1651,14 +1652,13 @@ async function resolveProviderContext(
 		return providerContext;
 	}
 
-	if (
-		!(await hasManagedVideoCredential(
-			providerId,
-			defaultBaseUrl,
-			envVariant,
-		)) &&
-		!hasProviderEnvironmentToken(providerId)
-	) {
+	// A provider with any managed credential is served only by those: its
+	// `LLM_*` vars are superseded and no longer count, even when no managed
+	// credential is video-eligible.
+	const platformCanServe = (await hasManagedProviderCredential(providerId))
+		? await hasManagedVideoCredential(providerId, defaultBaseUrl, envVariant)
+		: hasProviderEnvironmentToken(providerId);
+	if (!platformCanServe) {
 		throw new HTTPException(400, {
 			message: `No provider key or environment token set for provider: ${providerId}. Please add the provider key in the settings or switch the project mode to credits or hybrid.`,
 		});
@@ -1805,18 +1805,18 @@ async function hasVideoProviderConfiguration(
 
 /**
  * Whether LLM Gateway holds a credential of its own that can serve video
- * generation for the provider — a managed credential or the provider's env
- * vars. Either alone makes the provider routable.
+ * generation for the provider — a managed credential, or the provider's env
+ * vars when no managed credential has superseded them.
  */
 async function hasPlatformVideoConfiguration(
 	providerId: Provider,
 	defaultBaseUrl: string | null,
 	organizationId: string,
 ): Promise<boolean> {
-	const organization = await findOrganizationById(organizationId);
-	const variant = getOrganizationEnvVariant(organization);
-	if (await hasManagedVideoCredential(providerId, defaultBaseUrl, variant)) {
-		return true;
+	if (await hasManagedProviderCredential(providerId)) {
+		const organization = await findOrganizationById(organizationId);
+		const variant = getOrganizationEnvVariant(organization);
+		return await hasManagedVideoCredential(providerId, defaultBaseUrl, variant);
 	}
 	return hasVideoEnvConfiguration(providerId, defaultBaseUrl);
 }

--- a/ee/admin/src/components/provider-credentials-manager.tsx
+++ b/ee/admin/src/components/provider-credentials-manager.tsx
@@ -188,8 +188,9 @@ type EnvCredential = ProviderCredentialCatalogEntry["envCredentials"][number];
  * the managed credentials so an operator sees every key that can serve a
  * provider in one table. Read-only by nature: it can only be changed by
  * redeploying, so there is no edit/delete and it takes no part in reordering.
- * `superseded` marks it visibly unused once managed credentials cover its
- * audience — the gateway then ignores the variable entirely.
+ * `superseded` marks it visibly unused once the provider has any managed
+ * credential — the gateway then ignores every variable of that provider,
+ * whatever audience or region the credential is scoped to.
  */
 function EnvCredentialRow({
 	provider,
@@ -257,12 +258,12 @@ function EnvCredentialRow({
 					<Badge
 						variant="secondary"
 						className="text-muted-foreground"
-						title="Managed credentials cover this audience, so the gateway no longer reads this variable for it. Safe to remove on the next deploy."
+						title="This provider has a managed credential, so the gateway no longer reads any of its LLM_* variables. Safe to remove on the next deploy."
 					>
 						unused
 					</Badge>
 				) : (
-					<Badge title="No managed credential covers this audience yet, so this variable still serves its traffic.">
+					<Badge title="This provider has no managed credential yet, so this variable still serves its traffic.">
 						in use
 					</Badge>
 				)}
@@ -546,30 +547,22 @@ export function ProviderCredentialsManager({
 		[catalog],
 	);
 
-	// Audiences each provider has an ACTIVE managed credential for. An env key
-	// is unused for its audience once that audience is covered directly or via
-	// the `default` fallback — mirroring findManagedProviderKey's selection.
-	const managedCoverage = useMemo(() => {
-		const map = new Map<string, Set<string>>();
+	// Providers with an ACTIVE managed credential. The gateway stops reading a
+	// provider's environment the moment it has one — whatever that credential's
+	// audience or region — so every env key of such a provider is unused.
+	const managedProviders = useMemo(() => {
+		const set = new Set<string>();
 		for (const credential of credentials) {
-			if (credential.status !== "active") {
-				continue;
+			if (credential.status === "active") {
+				set.add(credential.provider);
 			}
-			const set = map.get(credential.provider) ?? new Set<string>();
-			set.add(credential.variant);
-			map.set(credential.provider, set);
 		}
-		return map;
+		return set;
 	}, [credentials]);
 
 	const isEnvSuperseded = useCallback(
-		(provider: string, variant: string) => {
-			const covered = managedCoverage.get(provider);
-			return Boolean(
-				covered && (covered.has(variant) || covered.has("default")),
-			);
-		},
-		[managedCoverage],
+		(provider: string) => managedProviders.has(provider),
+		[managedProviders],
 	);
 
 	// Providers whose only keys live in the environment get their own read-only
@@ -912,7 +905,7 @@ export function ProviderCredentialsManager({
 												key={`${entry.envVar}:${entry.index}`}
 												provider={provider}
 												entry={entry}
-												superseded={isEnvSuperseded(provider, entry.variant)}
+												superseded={isEnvSuperseded(provider)}
 											/>
 										))}
 									</ReorderableList>
@@ -924,7 +917,7 @@ export function ProviderCredentialsManager({
 												key={`${entry.envVar}:${entry.index}`}
 												provider={provider}
 												entry={entry}
-												superseded={isEnvSuperseded(provider, entry.variant)}
+												superseded={isEnvSuperseded(provider)}
 											/>
 										))}
 									</TableBody>


### PR DESCRIPTION
## Problem

Managed provider credentials — the ones set globally on the admin dashboard's **Provider Credentials** page — were treated as taking *precedence over* the provider's `LLM_*` environment variables rather than *replacing* them. The dashboard already promises the stronger rule ("A provider with managed credentials here ignores its `LLM_*` environment variables entirely"), but the gateway only honoured it on the happy path.

Whenever no managed credential matched, resolution silently fell through to `getProviderEnv`:

- a variant mismatch (an `enterprise`-only credential, a `default` request),
- a region mismatch (only region-pinned credentials configured),
- an `allowedModels` restriction that excludes the routed model,
- a flex/priority service-tier filter that no managed credential satisfies,
- **every managed credential already excluded after failing** — so alternate-key rotation ended on an env key.

Routing had the same hole: `getPlatformBackedProviders` advertised a provider if `managedProviderIds.has(id) || hasProviderEnvironmentToken(id)`, so a provider whose managed credentials could not serve the request stayed routable purely on the strength of the env var, and the credits-mode region filter decided regional availability from `LLM_*__{REGION}` even for fully-migrated providers.

Net effect: a key an operator had deliberately retired could still be spent.

## Approach

One invariant, enforced at every point that reads the environment: **if a provider has at least one active managed credential, its `LLM_*` variables are ignored — for routing, region selection, credential resolution and every fallback.** A provider with no managed credential keeps reading the environment exactly as before, so migrating stays a provider-at-a-time operation.

- `cached-queries.ts`: `listManagedProviderKeys` / `hasManagedProviderCredential` (same cache entry `findManagedProviderKey` already warms), and `findManagedProviderIds` becomes `findManagedProviderAvailability`, returning `{ configured, usable, pinnedRegions }`. `configured` is the authority on whether the environment counts at all; `usable` keeps the old variant/region/model semantics.
- `resolve-platform-credential.ts`: no managed credential selectable + provider is configured → 500 instead of an env fallback. Every alternate-key rotation path (chat, embeddings, speech, transcriptions, OCR, rerank, moderations, video) already catches resolution failures, so they stop rotating rather than reaching for an env key.
- `hybrid-provider-routing.ts`: availability is `usable.has(p) || (!configured.has(p) && hasProviderEnvironmentToken(p))`, plus `platformCredentialCoversRegion` for the region filter, which now reads managed `pinnedRegions` for configured providers and `hasRegionSpecificEnvKey` only for the rest.
- `videos.ts` and the gateway-internal OpenAI content filter follow the same rule.
- `ee/admin`: the env-key `unused` badge is now per provider rather than per audience, matching what the gateway does.

## Notes for reviewers

- **A configured-but-unservable provider now fails with a 500** rather than quietly succeeding on a superseded key. That is the intended trade — routing drops such providers up front (`usable`), so this is reachable mainly when every managed credential fails mid-request, where the alternative is billing traffic to a retired key.
- Region coverage is deliberately variant- and model-agnostic: the credits/hybrid region filter runs before the organization (and therefore the env-var variant) is resolved, exactly like the `hasRegionSpecificEnvKey` side it replaces.
- Video **job polling** still re-resolves env credentials for jobs created before a migration (`job.managedProviderKeyId` is null). Those jobs must keep polling with the credential that created them; it is neither routing nor fallback.

## Screenshots — admin Provider Credentials

An OpenAI credential scoped to **Enterprise plans**, alongside the deployment's `LLM_OPENAI_API_KEY` (audience *All organizations*). Before, the env key was only marked unused when its own audience was covered, so it still read **in use** — while the gateway, per this PR, no longer touches it. After, it reads **unused**, matching what actually happens.

| | Before | After |
| --- | --- | --- |
| Light | <img width="720" alt="Admin provider credentials, light theme, before: env key badged in use" src="https://raw.githubusercontent.com/theopenco/llmgateway/aad75257a8eefc5683aaac0eeb4d2828f2d9f31b/before-light.png" /> | <img width="720" alt="Admin provider credentials, light theme, after: env key badged unused" src="https://raw.githubusercontent.com/theopenco/llmgateway/aad75257a8eefc5683aaac0eeb4d2828f2d9f31b/after-light.png" /> |
| Dark | <img width="720" alt="Admin provider credentials, dark theme, before: env key badged in use" src="https://raw.githubusercontent.com/theopenco/llmgateway/aad75257a8eefc5683aaac0eeb4d2828f2d9f31b/before-dark.png" /> | <img width="720" alt="Admin provider credentials, dark theme, after: env key badged unused" src="https://raw.githubusercontent.com/theopenco/llmgateway/aad75257a8eefc5683aaac0eeb4d2828f2d9f31b/after-dark.png" /> |

## Verification

- `pnpm format`, `pnpm build` (full monorepo)
- `pnpm test:unit` — 249 files / 4199 passed, against an isolated per-worktree stack
- New coverage: no env rotation after the managed fleet fails, request failure instead of an env key when `allowedModels` excludes the model, `configured` vs `usable` for a region-pinned-only provider, and routing/region assertions in `hybrid-provider-routing.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Managed credentials now take precedence for an entire provider once configured.
  * Routing better respects credential availability by region and model, including hybrid and automatic routing.
  * Environment credentials remain available only when no managed credential is configured.
  * Requests no longer fall back to environment credentials when managed credentials are configured but unavailable or incompatible.
  * Provider credential status messaging now clearly indicates when environment credentials are superseded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
