### PR TITLE
fix(billing): report checkout top-ups fully

### DIFF
--- a/apps/api/src/credit-topup-checkout.spec.ts
+++ b/apps/api/src/credit-topup-checkout.spec.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { db, tables } from "@llmgateway/db";
+
+import { stripeRoutes } from "./stripe.js";
+import { deleteAll } from "./testing.js";
+
+import type * as PaymentsModule from "./routes/payments.js";
+import type * as EmailModule from "./utils/email.js";
+import type Stripe from "stripe";
+
+// discord.ts resolves DISCORD_NOTIFICATION_URL at module load, and the webhook
+// route needs a live signing secret, so both have to be set before the module
+// graph is imported.
+const DISCORD_URL = vi.hoisted(() => {
+	const url = "https://discord.test/webhook";
+	process.env.DISCORD_NOTIFICATION_URL = url;
+	process.env.STRIPE_WEBHOOK_SECRET = "whsec_test_secret";
+	process.env.FIRST_TIME_CREDIT_BONUS_MULTIPLIER = "0";
+	delete process.env.STRIPE_WEBHOOK_SECRET_TEST;
+	return url;
+});
+
+const stripeMock = vi.hoisted(() => ({
+	webhooks: { constructEvent: vi.fn() },
+	refunds: { list: vi.fn() },
+	invoices: { list: vi.fn() },
+	invoicePayments: { list: vi.fn() },
+	subscriptions: { retrieve: vi.fn(), cancel: vi.fn() },
+	paymentIntents: { retrieve: vi.fn() },
+	paymentMethods: { retrieve: vi.fn() },
+}));
+
+vi.mock("./routes/payments.js", async (importOriginal) => {
+	const original = await importOriginal<typeof PaymentsModule>();
+	return {
+		...original,
+		getStripe: () => stripeMock,
+	};
+});
+
+vi.mock("./posthog.js", () => ({
+	posthog: {
+		capture: vi.fn(),
+		groupIdentify: vi.fn(),
+	},
+}));
+
+vi.mock("./utils/invoice.js", () => ({
+	generateAndEmailInvoice: vi.fn(),
+}));
+
+vi.mock("./utils/email.js", async (importOriginal) => {
+	const original = await importOriginal<typeof EmailModule>();
+	return {
+		...original,
+		sendTransactionalEmail: vi.fn(),
+	};
+});
+
+const ORG_ID = "org-topup-checkout";
+const USER_ID = "user-topup-checkout";
+const USER_EMAIL = "buyer@acme.test";
+const CUSTOMER_ID = "cus_topup_checkout";
+const PAYMENT_INTENT_ID = "pi_topup_checkout";
+
+// $10 of credits plus the 3.5% platform fee the checkout page charges.
+const BASE_AMOUNT = 10;
+const TOTAL_AMOUNT = 10.35;
+
+const checkoutMetadata: Record<string, string> = {
+	organizationId: ORG_ID,
+	type: "credit_topup",
+	baseAmount: BASE_AMOUNT.toString(),
+	platformFee: "0.35",
+	internationalFee: "0",
+	totalAmount: TOTAL_AMOUNT.toString(),
+	userEmail: USER_EMAIL,
+	userId: USER_ID,
+};
+
+const fetchMock = vi.fn(
+	async (_url: string, _init?: { body?: string }) =>
+		new Response("{}", { status: 200 }),
+);
+
+function checkoutSessionCompletedEvent(
+	metadata: Record<string, string> = checkoutMetadata,
+): Stripe.Event {
+	return {
+		id: "evt_checkout_completed",
+		type: "checkout.session.completed",
+		data: {
+			object: {
+				id: "cs_topup_checkout",
+				mode: "payment",
+				customer: CUSTOMER_ID,
+				payment_status: "paid",
+				payment_intent: PAYMENT_INTENT_ID,
+				amount_total: Math.round(TOTAL_AMOUNT * 100),
+				currency: "usd",
+				subscription: null,
+				metadata,
+			},
+		},
+	} as unknown as Stripe.Event;
+}
+
+function paymentIntentEvent(
+	type: "payment_intent.succeeded" | "payment_intent.payment_failed",
+	metadata: Record<string, string>,
+): Stripe.Event {
+	return {
+		id: `evt_${type}`,
+		type,
+		data: {
+			object: {
+				id: PAYMENT_INTENT_ID,
+				customer: CUSTOMER_ID,
+				amount: Math.round(TOTAL_AMOUNT * 100),
+				currency: "usd",
+				last_payment_error: { message: "Your card was declined." },
+				metadata,
+			},
+		},
+	} as unknown as Stripe.Event;
+}
+
+async function deliver(event: Stripe.Event) {
+	stripeMock.webhooks.constructEvent.mockReturnValue(event);
+	const res = await stripeRoutes.request("/webhook", {
+		method: "POST",
+		headers: { "stripe-signature": "sig" },
+		body: JSON.stringify(event),
+	});
+	expect(res.status).toBe(200);
+}
+
+function discordNotification() {
+	const call = fetchMock.mock.calls.find(([url]) => url === DISCORD_URL);
+	if (!call) {
+		return null;
+	}
+	const payload = JSON.parse(String(call[1]?.body)) as {
+		embeds: { title: string; fields: { name: string; value: string }[] }[];
+	};
+	return {
+		title: payload.embeds[0].title,
+		fields: Object.fromEntries(
+			payload.embeds[0].fields.map((field) => [field.name, field.value]),
+		),
+	};
+}
+
+describe("credit top-up via Stripe Checkout", () => {
+	beforeEach(async () => {
+		await deleteAll();
+		fetchMock.mockClear();
+		vi.stubGlobal("fetch", fetchMock);
+		stripeMock.webhooks.constructEvent.mockReset();
+
+		await db.insert(tables.user).values({
+			id: USER_ID,
+			name: "Buyer Example",
+			email: USER_EMAIL,
+			emailVerified: true,
+		});
+		await db.insert(tables.organization).values({
+			id: ORG_ID,
+			name: "Acme Co",
+			billingEmail: "billing@acme.test",
+			stripeCustomerId: CUSTOMER_ID,
+			credits: "0",
+		});
+	});
+
+	afterEach(async () => {
+		vi.unstubAllGlobals();
+		await db.delete(tables.transaction);
+		await deleteAll();
+	});
+
+	test("credits the organization and reports the top-up to Discord", async () => {
+		await deliver(checkoutSessionCompletedEvent());
+
+		const org = await db.query.organization.findFirst({
+			where: { id: { eq: ORG_ID } },
+		});
+		expect(Number(org?.credits)).toBe(BASE_AMOUNT);
+
+		const transactions = await db.query.transaction.findMany({
+			where: { organizationId: { eq: ORG_ID } },
+		});
+		expect(transactions).toHaveLength(1);
+		expect(transactions[0].type).toBe("credit_topup");
+		expect(transactions[0].status).toBe("completed");
+		expect(transactions[0].stripePaymentIntentId).toBe(PAYMENT_INTENT_ID);
+
+		const notification = discordNotification();
+		expect(notification?.title).toBe("Credits Purchased");
+		expect(notification?.fields).toMatchObject({
+			Email: USER_EMAIL,
+			Name: "Buyer Example",
+			Credits: "$10.00",
+			Gross: "$10.35",
+			Fee: "$0.35",
+			Source: "Stripe Checkout",
+			Organization: `Acme Co (${ORG_ID})`,
+		});
+	});
+
+	test("reports the top-up even when the session carries no user email", async () => {
+		const { userEmail: _userEmail, ...metadata } = checkoutMetadata;
+
+		await deliver(checkoutSessionCompletedEvent(metadata));
+
+		const notification = discordNotification();
+		expect(notification?.title).toBe("Credits Purchased");
+		expect(notification?.fields.Email).toBe("billing@acme.test");
+	});
+
+	test("does not credit twice when the payment intent also succeeds", async () => {
+		await deliver(checkoutSessionCompletedEvent());
+		fetchMock.mockClear();
+
+		await deliver(
+			paymentIntentEvent("payment_intent.succeeded", {
+				...checkoutMetadata,
+				source: "stripe_checkout",
+			}),
+		);
+
+		const org = await db.query.organization.findFirst({
+			where: { id: { eq: ORG_ID } },
+		});
+		expect(Number(org?.credits)).toBe(BASE_AMOUNT);
+
+		const transactions = await db.query.transaction.findMany({
+			where: { organizationId: { eq: ORG_ID } },
+		});
+		expect(transactions).toHaveLength(1);
+		expect(discordNotification()).toBeNull();
+	});
+
+	test("does not record a failed transaction for a declined checkout attempt", async () => {
+		await deliver(
+			paymentIntentEvent("payment_intent.payment_failed", {
+				...checkoutMetadata,
+				source: "stripe_checkout",
+			}),
+		);
+
+		const transactions = await db.query.transaction.findMany({
+			where: { organizationId: { eq: ORG_ID } },
+		});
+		expect(transactions).toHaveLength(0);
+
+		// The decline itself is still tracked for the admin dashboard.
+		const failures = await db.query.paymentFailure.findMany({
+			where: { organizationId: { eq: ORG_ID } },
+		});
+		expect(failures).toHaveLength(1);
+	});
+});

--- a/apps/api/src/routes/payments.ts
+++ b/apps/api/src/routes/payments.ts
@@ -697,9 +697,11 @@ payments.openapi(topUpWithSavedMethod, async (c) => {
 			off_session: true,
 			metadata: {
 				organizationId: userOrganization.organization.id,
+				type: "credit_topup",
 				baseAmount: amount.toString(),
 				platformFee: feeBreakdown.platformFee.toString(),
 				internationalFee: feeBreakdown.internationalFee.toString(),
+				totalAmount: feeBreakdown.totalAmount.toString(),
 				isInternational: isInternational.toString(),
 				userEmail: user.email,
 				userId: user.id,
@@ -878,11 +880,25 @@ payments.openapi(createCheckoutSession, async (c) => {
 		cancelUrl = `${defaultBillingUrl}?canceled=true`;
 	}
 
-	// IMPORTANT: Metadata is intentionally set on the session only, NOT via
-	// payment_intent_data.metadata. This prevents handlePaymentIntentSucceeded
-	// from also processing this payment (it returns early when baseAmount is
-	// missing from the PaymentIntent metadata). Adding payment_intent_data.metadata
-	// here would cause double-crediting. See handleCreditTopUpCheckout in stripe.ts.
+	// The same metadata goes on the Checkout Session and on its PaymentIntent so
+	// the charge is attributable in the Stripe dashboard (organization, credits,
+	// gross, fees) instead of showing up bare. `source: "stripe_checkout"` marks
+	// the PaymentIntent as owned by the checkout.session.completed webhook:
+	// handlePaymentIntentSucceeded returns early on it, so the top-up is credited
+	// exactly once. See handleCreditTopUpCheckout in stripe.ts.
+	const topUpMetadata = {
+		organizationId,
+		type: "credit_topup",
+		baseAmount: amount.toString(),
+		platformFee: feeBreakdown.platformFee.toString(),
+		// Always 0 here: the checkout page collects the card itself, so the
+		// international-card fee is unknown up front and is not charged on this path.
+		internationalFee: feeBreakdown.internationalFee.toString(),
+		totalAmount: feeBreakdown.totalAmount.toString(),
+		userEmail: user.email,
+		userId: user.id,
+	};
+
 	const session = await getStripe().checkout.sessions.create({
 		customer: stripeCustomerId,
 		mode: "payment",
@@ -901,13 +917,13 @@ payments.openapi(createCheckoutSession, async (c) => {
 		],
 		success_url: successUrl,
 		cancel_url: cancelUrl,
-		metadata: {
-			organizationId,
-			type: "credit_topup",
-			baseAmount: amount.toString(),
-			platformFee: feeBreakdown.platformFee.toString(),
-			userEmail: user.email,
-			userId: user.id,
+		metadata: topUpMetadata,
+		payment_intent_data: {
+			description: `Credit purchase for ${amount} USD (including fees)`,
+			metadata: {
+				...topUpMetadata,
+				source: "stripe_checkout",
+			},
 		},
 	});
 

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -2049,9 +2049,17 @@ async function handleCreditTopUpCheckout(session: Stripe.Checkout.Session) {
 		purchaserUserId: resolvedUser?.id ?? null,
 	});
 
-	if (userEmail) {
-		await notifyCreditsPurchased(userEmail, resolvedUser?.name, creditAmount);
-	}
+	await notifyCreditsPurchased({
+		email: userEmail ?? organization.billingEmail,
+		name: resolvedUser?.name,
+		creditAmount,
+		bonusAmount,
+		grossAmount: totalAmountInDollars,
+		currency: (session.currency ?? "USD").toUpperCase(),
+		organizationId,
+		organizationName: organization.name,
+		source: "stripe_checkout",
+	});
 
 	logger.info(
 		`Added ${finalCreditAmount} credits to organization ${organizationId} via Stripe Checkout (paid $${totalAmountInDollars} including fees)`,
@@ -2689,6 +2697,14 @@ async function handlePaymentIntentSucceeded(
 		return;
 	}
 
+	// Credit top-ups paid through Stripe Checkout are fulfilled by
+	// checkout.session.completed (handleCreditTopUpCheckout). Their PaymentIntent
+	// carries the same metadata only so the charge is attributable in the Stripe
+	// dashboard — crediting it here as well would double-credit the organization.
+	if (paymentIntent.metadata.source === "stripe_checkout") {
+		return;
+	}
+
 	// payment_intent.succeeded also fires for subscription invoice payments;
 	// only credit top-up payment intents set baseAmount in metadata.
 	if (paymentIntent.metadata.baseAmount === undefined) {
@@ -2903,9 +2919,17 @@ async function handlePaymentIntentSucceeded(
 		});
 	}
 
-	if (userEmail) {
-		await notifyCreditsPurchased(userEmail, resolvedUser?.name, creditAmount);
-	}
+	await notifyCreditsPurchased({
+		email: userEmail ?? organization.billingEmail,
+		name: resolvedUser?.name,
+		creditAmount,
+		bonusAmount,
+		grossAmount: totalAmountInDollars,
+		currency: paymentIntent.currency.toUpperCase(),
+		organizationId,
+		organizationName: organization.name,
+		source: transactionId ? "auto_topup" : "payment_intent",
+	});
 
 	logger.info(
 		`Added credits to organization ${organizationId} (paid ${totalAmountInDollars} including fees)`,
@@ -2994,9 +3018,14 @@ export async function handlePaymentIntentFailed(
 	// subscription invoice intents carry neither. Failure tracking above
 	// (paymentFailure row + dunning email) still runs for subscription invoices,
 	// and dev/chat plan credit freezes are handled in handleInvoicePaymentFailed.
+	// Checkout-sourced top-ups are excluded as well: the Stripe-hosted page lets
+	// the customer retry a declined card on the same PaymentIntent, so recording a
+	// row per failure would spam the billing history, and no transaction exists
+	// until checkout.session.completed fulfils the payment.
 	const transactionId = metadata?.transactionId;
 	const isCreditTopup =
-		metadata?.baseAmount !== undefined || transactionId !== undefined;
+		(metadata?.baseAmount !== undefined || transactionId !== undefined) &&
+		metadata?.source !== "stripe_checkout";
 	if (isCreditTopup) {
 		if (transactionId) {
 			// Update existing pending transaction to failed

--- a/apps/api/src/utils/discord.ts
+++ b/apps/api/src/utils/discord.ts
@@ -98,12 +98,40 @@ export async function notifyUserSignup(
 	});
 }
 
-export async function notifyCreditsPurchased(
-	email: string,
-	name: string | null | undefined,
-	creditAmount: number,
-): Promise<void> {
-	const displayName = name ?? "Unknown";
+const creditTopUpSourceLabels = {
+	stripe_checkout: "Stripe Checkout",
+	payment_intent: "Saved card",
+	auto_topup: "Auto top-up",
+} as const;
+
+export type CreditTopUpSource = keyof typeof creditTopUpSourceLabels;
+
+export async function notifyCreditsPurchased(args: {
+	email?: string | null;
+	name?: string | null;
+	/** Credits bought, excluding any bonus — the amount the customer paid for. */
+	creditAmount: number;
+	bonusAmount?: number;
+	/** Total charged by Stripe, including platform and international card fees. */
+	grossAmount: number;
+	currency?: string;
+	organizationId: string;
+	organizationName?: string | null;
+	source: CreditTopUpSource;
+}): Promise<void> {
+	const {
+		email,
+		name,
+		creditAmount,
+		bonusAmount = 0,
+		grossAmount,
+		currency = "USD",
+		organizationId,
+		organizationName,
+		source,
+	} = args;
+
+	const fee = Math.max(0, grossAmount - creditAmount);
 
 	await sendDiscordNotification({
 		embeds: [
@@ -113,18 +141,49 @@ export async function notifyCreditsPurchased(
 				fields: [
 					{
 						name: "Email",
-						value: email,
+						value: email || "Unknown",
 						inline: true,
 					},
 					{
 						name: "Name",
-						value: displayName,
+						value: name ?? "Unknown",
 						inline: true,
 					},
 					{
 						name: "Credits",
-						value: `$${creditAmount.toFixed(2)}`,
+						value: formatAmount(creditAmount, currency),
 						inline: true,
+					},
+					...(bonusAmount > 0
+						? [
+								{
+									name: "Bonus",
+									value: formatAmount(bonusAmount, currency),
+									inline: true,
+								},
+							]
+						: []),
+					{
+						name: "Gross",
+						value: formatAmount(grossAmount, currency),
+						inline: true,
+					},
+					{
+						name: "Fee",
+						value: formatAmount(fee, currency),
+						inline: true,
+					},
+					{
+						name: "Source",
+						value: creditTopUpSourceLabels[source],
+						inline: true,
+					},
+					{
+						name: "Organization",
+						value: organizationName
+							? `${organizationName} (${organizationId})`
+							: organizationId,
+						inline: false,
 					},
 				],
 				timestamp: new Date().toISOString(),

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -649,11 +649,13 @@ export async function processAutoTopUp(): Promise<void> {
 						off_session: true,
 						metadata: {
 							organizationId: org.id,
+							type: "credit_topup",
 							autoTopUp: "true",
 							transactionId: pendingTransaction.id,
 							baseAmount: feeBreakdown.baseAmount.toString(),
 							platformFee: feeBreakdown.platformFee.toString(),
 							internationalFee: feeBreakdown.internationalFee.toString(),
+							totalAmount: feeBreakdown.totalAmount.toString(),
 							isInternational: isInternational.toString(),
 							...(orgUser?.user?.email && { userEmail: orgUser.user.email }),
 						},


### PR DESCRIPTION
## Problem

Credit top-ups paid through Stripe Checkout on the credits page are credited and recorded as a `credit_topup` transaction correctly, but two things around them were incomplete:

1. **The Stripe charge has no metadata.** `create-checkout-session` set metadata on the Checkout Session only — deliberately, because adding `payment_intent_data.metadata` used to make `handlePaymentIntentSucceeded` fulfil the same payment a second time. The consequence is that the PaymentIntent and its charge show up bare in the Stripe dashboard: no organization id, no credit amount, no gross, no fee. Every other top-up path (saved card, auto top-up) carries that metadata.
2. **The Discord notification was silently skipped** whenever the session metadata carried no `userEmail` — `notifyCreditsPurchased` was gated behind `if (userEmail)`. And when it did fire it only reported email, name and credits, so a top-up was indistinguishable from any other and carried none of the amounts.

## Approach

**Stripe metadata.** The Checkout Session and its PaymentIntent now get the same metadata (`organizationId`, `type`, `baseAmount`, `platformFee`, `internationalFee`, `totalAmount`, `userEmail`, `userId`), plus a `description` on the PaymentIntent matching the saved-card path. The PaymentIntent copy is marked `source: "stripe_checkout"`, which replaces the old "just don't set any metadata" trick as the double-credit guard:

- `handlePaymentIntentSucceeded` returns early on that marker, so `checkout.session.completed` remains the single fulfilment path.
- `handlePaymentIntentFailed` skips the failed-`credit_topup`-row branch for the same marker. The Stripe-hosted page lets a customer retry a declined card on the same PaymentIntent, so recording a row per decline would spam the billing history, and no transaction exists yet at that point. The `paymentFailure` row and dunning email still fire, exactly as before.

`internationalFee` is always `0` on this path — the checkout page collects the card itself, so the international-card fee is unknown up front and is not charged. It is included anyway so the metadata shape matches the other paths.

**Discord.** `notifyCreditsPurchased` takes an options object and now reports credits, bonus (when non-zero), gross, fee (gross − credits), source and organization. Both call sites pass the organization's billing email as a fallback so a missing `userEmail` no longer swallows the notification. Source is reported as `Stripe Checkout`, `Saved card` or `Auto top-up`, distinguishing the three ways credits get bought.

`totalAmount` and `type: "credit_topup"` were also added to the saved-card and auto top-up PaymentIntent metadata so all three paths carry an identical shape.

## Verification

New `apps/api/src/credit-topup-checkout.spec.ts` drives real webhook events through the `/webhook` route and covers: the checkout top-up credits the org and posts a Discord embed with the right credits/gross/fee/source/organization; the notification still fires with the billing email when the session has no `userEmail`; a following `payment_intent.succeeded` carrying the checkout metadata does not credit twice or re-notify; a declined checkout attempt records a `paymentFailure` but no failed transaction row.

`pnpm format`, `pnpm build`, and the full `apps/api` (849) and `apps/worker` (106) unit suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ku5DD6b3KNZQk8AC2Y7vQi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ku5DD6b3KNZQk8AC2Y7vQi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Credit top-ups now retain detailed payment information, including fees, totals, organization, and purchase source.
  - Purchase notifications include richer details such as credits, bonuses, charges, currency, and organization information.
  - Automatic top-ups now record the total amount charged.

- **Bug Fixes**
  - Prevented duplicate crediting and duplicate failure records for Stripe Checkout payments.
  - Improved handling of declined payments while preserving payment-failure tracking.
  - Added billing-email fallback support for credit top-ups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->