### PR TITLE
fix(actions): send nested reasoning object to embercloud instead of flat reasoning_effort

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -1103,6 +1103,51 @@ describe("prepareRequestBody - Moonshot thinking", () => {
 	});
 });
 
+describe("prepareRequestBody - embercloud reasoning shape", () => {
+	// embercloud's documented request body uses a nested `reasoning` object
+	// (reasoning.enabled + reasoning.effort) — the flat OpenAI-style
+	// `reasoning_effort` field is not documented and is silently ignored
+	// (https://embercloud.ai/docs/request-body).
+	async function prepare(effort: string) {
+		return (await prepareRequestBody(
+			"embercloud",
+			"glm-5.2",
+			null,
+			"glm-5.2",
+			[{ role: "user", content: "Hello!" }],
+			false, // stream
+			undefined, // temperature
+			undefined, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			undefined, // tools
+			undefined, // tool_choice
+			effort, // reasoning_effort
+			true, // supportsReasoning
+		)) as any;
+	}
+
+	test("builds the nested reasoning object instead of flat reasoning_effort", async () => {
+		const requestBody = await prepare("high");
+		expect(requestBody.reasoning).toEqual({
+			enabled: true,
+			effort: "high",
+		});
+		expect(requestBody.reasoning_effort).toBeUndefined();
+	});
+
+	test("forwards the top declared tier through the nested shape", async () => {
+		const requestBody = await prepare("max");
+		expect(requestBody.reasoning).toEqual({
+			enabled: true,
+			effort: "max",
+		});
+		expect(requestBody.reasoning_effort).toBeUndefined();
+	});
+});
+
 describe("prepareRequestBody - Alibaba thinking", () => {
 	async function prepare(options: {
 		model: string;

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -4082,7 +4082,21 @@ export async function prepareRequestBody(
 					supported.length === 0 ||
 					supported.includes("reasoning_effort")
 				) {
-					requestBody.reasoning_effort = reasoning_effort;
+					if (usedProvider === "embercloud") {
+						// embercloud's documented request body uses a nested
+						// `reasoning` object (`reasoning.enabled` +
+						// `reasoning.effort`) instead of the flat OpenAI-style
+						// `reasoning_effort` field, which it silently ignores
+						// (https://embercloud.ai/docs/request-body). "none"
+						// maps to enabled: false; any other tier enables
+						// reasoning at the requested effort.
+						requestBody.reasoning =
+							reasoning_effort === "none"
+								? { enabled: false }
+								: { enabled: true, effort: reasoning_effort };
+					} else {
+						requestBody.reasoning_effort = reasoning_effort;
+					}
 				}
 			}
 			// Hybrid models that keep thinking off by default (e.g. DeepSeek V3.2 on


### PR DESCRIPTION
Fixes #3444

## What

embercloud's documented request body uses a nested `reasoning` object (`reasoning.enabled` + `reasoning.effort`) — the flat OpenAI-style `reasoning_effort` field is not documented and is silently ignored. The gateway was forwarding the flat field for the 4 reasoning-capable GLM mappings (glm-5.2 / 5.1 / 5 / 4.7), so the declared effort never reached the provider.

This PR builds the nested shape for embercloud in `prepare-request-body.ts`:

- effort tier requested → `reasoning: { enabled: true, effort: "<tier>" }`
- `none` → `reasoning: { enabled: false }` (defensive — currently normalized away before this point, kept for after the mapping-declared `none` opt-in lands)
- every other provider keeps the flat `reasoning_effort` field unchanged

The mapping's `supportedParameters` already declares `"reasoning"`, so this aligns the sent body with the declared capability surface.

## Validation

Docs checked live at https://embercloud.ai/docs/request-body and https://embercloud.ai/docs/reasoning (nested shape confirmed; reasoning-capable models listed: glm-5.2, glm-5.1, glm-5, glm-4.7, minimax-m2.5).

```
pnpm exec vitest run --config vitest.config.mts packages/actions/src/prepare-request-body.spec.ts
Test Files  1 passed (1)
Tests       245 passed (245)
```

New regression tests assert the nested shape for `high`/`max` and the absence of the flat parameter. Prettier clean.

Note: live probing is not possible right now — embercloud rate-limits these models (429 on every request, per the catalog comments) — but the shape now matches their published request-body docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring reasoning levels for Embercloud requests, including disabled, high, and maximum effort options.

* **Bug Fixes**
  * Ensured Embercloud requests use the correct nested reasoning configuration format while preserving existing behavior for other providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->