### PR TITLE
fix(gateway): surface image size limit errors

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -4135,31 +4135,40 @@ describe("api", () => {
 		const requestId = "image-edit-oversized-request";
 		const oversizedImageDataUrl = `data:image/png;base64,${"A".repeat(28 * 1024 * 1024)}`;
 
-		const res = await app.request("/v1/images/edits", {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				Authorization: "Bearer real-token-image-edit-oversized",
-				"x-request-id": requestId,
-			},
-			body: JSON.stringify({
-				model: "gemini-3-pro-image-preview",
-				prompt: "Add a neon city reflection to this image",
-				images: [
-					{
-						image_url: oversizedImageDataUrl,
-					},
-					{
-						image_url: oversizedImageDataUrl,
-					},
-				],
-			}),
-		});
+		// Image edits use the caller's plan-based limit (the harness org is
+		// "pro"); lower it so this payload exceeds it without building a
+		// >100MB request body.
+		vi.stubEnv("IMAGE_SIZE_LIMIT_PRO_MB", "20");
+		let res: Response;
+		try {
+			res = await app.request("/v1/images/edits", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token-image-edit-oversized",
+					"x-request-id": requestId,
+				},
+				body: JSON.stringify({
+					model: "gemini-3-pro-image-preview",
+					prompt: "Add a neon city reflection to this image",
+					images: [
+						{
+							image_url: oversizedImageDataUrl,
+						},
+						{
+							image_url: oversizedImageDataUrl,
+						},
+					],
+				}),
+			});
+		} finally {
+			vi.unstubAllEnvs();
+		}
 
 		expect(res.status).toBe(400);
 		const json = await res.json();
 		expect(json.error.message).toContain("Image size");
-		expect(json.error.message).toContain("exceeds your current limit");
+		expect(json.error.message).toContain("exceeds your current limit of 20MB");
 
 		const log = await waitForLogByRequestId(requestId);
 		expect(log.finishReason).toBe("client_error");
@@ -4192,19 +4201,27 @@ describe("api", () => {
 		const requestId = "image-edit-retention-none-request";
 		const oversizedImageDataUrl = `data:image/png;base64,${"A".repeat(28 * 1024 * 1024)}`;
 
-		const res = await app.request("/v1/images/edits", {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				Authorization: "Bearer real-token-image-edit-retention-none",
-				"x-request-id": requestId,
-			},
-			body: JSON.stringify({
-				model: "gemini-3-pro-image-preview",
-				prompt: "secret retention payload",
-				images: [{ image_url: oversizedImageDataUrl }],
-			}),
-		});
+		// See the oversized-input test above: shrink the pro plan limit so
+		// this payload is rejected as oversized.
+		vi.stubEnv("IMAGE_SIZE_LIMIT_PRO_MB", "20");
+		let res: Response;
+		try {
+			res = await app.request("/v1/images/edits", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token-image-edit-retention-none",
+					"x-request-id": requestId,
+				},
+				body: JSON.stringify({
+					model: "gemini-3-pro-image-preview",
+					prompt: "secret retention payload",
+					images: [{ image_url: oversizedImageDataUrl }],
+				}),
+			});
+		} finally {
+			vi.unstubAllEnvs();
+		}
 
 		expect(res.status).toBe(400);
 

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -111,6 +111,7 @@ import {
 	getCheapestFromAvailableProviders,
 	getDiscountedProviderSelectionPrice,
 	getGcpServiceAccountAccessToken,
+	getPlanImageSizeLimitMB,
 	getProviderEndpoint,
 	getProviderHeaders,
 	isPremiumServiceTier,
@@ -2793,13 +2794,9 @@ chat.openapi(completions, async (c) => {
 	let usedRegion: string | undefined = requestedRegion;
 	let routingMetadata: RoutingMetadata | undefined;
 
-	// Get image size limits from environment variables or use defaults
-	const freeLimitMB = Number(process.env.IMAGE_SIZE_LIMIT_FREE_MB) || 50;
-	const proLimitMB = Number(process.env.IMAGE_SIZE_LIMIT_PRO_MB) || 100;
-
 	// Determine max image size based on plan
 	const userPlan = organization?.plan ?? "free";
-	const maxImageSizeMB = userPlan === "pro" ? proLimitMB : freeLimitMB;
+	const maxImageSizeMB = getPlanImageSizeLimitMB(userPlan);
 
 	// Validate IAM rules for model access
 	// Pass modelInfo (with deactivated providers already filtered) so IAM validation

--- a/apps/gateway/src/images/images.ts
+++ b/apps/gateway/src/images/images.ts
@@ -14,7 +14,11 @@ import { parseApiToken } from "@/lib/extract-api-token.js";
 import { calculateDataStorageCost, insertLog } from "@/lib/logs.js";
 import { validateModelOutput } from "@/lib/validate-model-output.js";
 
-import { parseDataUrl, processImageUrl } from "@llmgateway/actions";
+import {
+	getPlanImageSizeLimitMB,
+	parseDataUrl,
+	processImageUrl,
+} from "@llmgateway/actions";
 import { shortid } from "@llmgateway/db";
 import { logger, toError } from "@llmgateway/logger";
 import { models } from "@llmgateway/models";
@@ -87,6 +91,7 @@ interface ImageClientErrorLogContext {
 	project: NonNullable<Awaited<ReturnType<typeof findProjectById>>>;
 	requestId: string;
 	retentionLevel: "retain" | "none";
+	organizationPlan: "free" | "pro" | "enterprise" | null;
 }
 
 const imageGenerationsResponseSchema = z.object({
@@ -462,6 +467,7 @@ async function resolveImageClientErrorLogContext(
 		project,
 		requestId,
 		retentionLevel: organization?.retentionLevel ?? "none",
+		organizationPlan: organization?.plan ?? null,
 	};
 }
 
@@ -1066,10 +1072,20 @@ async function processImageEdit(
 			}
 
 			const isProd = process.env.NODE_ENV === "production";
+			// Use the caller's plan-based limit so the pre-check here matches the
+			// limit the forwarded chat-completions request will enforce, and the
+			// surfaced size message states the caller's actual limit. Without a
+			// resolvable key context the request will fail auth downstream, so
+			// the conservative default cap is fine.
+			const logContext = await getLogContext();
+			const userPlan = logContext?.organizationPlan ?? null;
+			const maxImageSizeMB = logContext
+				? getPlanImageSizeLimitMB(userPlan)
+				: undefined;
 			const imageResults = await Promise.all(
 				imageUrls.map(async (url, index) => {
 					try {
-						return await processImageUrl(url, isProd);
+						return await processImageUrl(url, isProd, maxImageSizeMB, userPlan);
 					} catch (error) {
 						const errorMessage =
 							error instanceof Error

--- a/apps/gateway/src/videos/videos.spec.ts
+++ b/apps/gateway/src/videos/videos.spec.ts
@@ -407,7 +407,9 @@ describe("videos", () => {
 		const json = await res.json();
 		expect(json.error.message).toContain("Invalid image input");
 		expect(json.error.message).toContain("Image size");
-		expect(json.error.message).toContain("exceeds your current limit");
+		// Video image inputs use a fixed cap rather than a plan limit, so the
+		// message must not present it as a plan entitlement.
+		expect(json.error.message).toContain("exceeds the maximum allowed size");
 
 		const logs = await db.query.log.findMany({
 			where: { requestId: { eq: requestId } },

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -4271,6 +4271,11 @@ async function processVideoImageInput(
 	}
 
 	try {
+		// Fixed cap for video image inputs, not the plan-based chat limit: the
+		// same inputs are re-processed by provider upload helpers that carry no
+		// org context, so the limit must be identical everywhere in the video
+		// flow. The null plan keeps the size error message neutral instead of
+		// presenting this cap as the caller's plan limit.
 		const { data, mimeType } = await processImageUrl(
 			imageUrl,
 			process.env.NODE_ENV === "production",

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -3265,6 +3265,13 @@ export async function prepareRequestBody(
 									},
 								});
 							} catch (error) {
+								// A typed client error (e.g. image over the plan size
+								// limit) must fail the request instead of degrading to a
+								// placeholder, which would silently drop the image while
+								// still billing the request.
+								if (error instanceof RequestError) {
+									throw error;
+								}
 								logger.error("Failed to process image for Bedrock", {
 									err:
 										error instanceof Error ? error : new Error(String(error)),

--- a/packages/actions/src/process-image-url.spec.ts
+++ b/packages/actions/src/process-image-url.spec.ts
@@ -1,14 +1,18 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ImageSizeLimitError, processImageUrl } from "./process-image-url.js";
 
+const MB = 1024 * 1024;
 const MAX_SIZE_MB = 1;
 const REMOTE_URL = "https://example.com/huge.png";
 
-function imageResponseWithContentLength(bytes: number): Response {
+function responseWithContentLength(
+	bytes: number,
+	contentType = "image/png",
+): Response {
 	return new Response(new Uint8Array(0), {
 		headers: {
-			"content-type": "image/png",
+			"content-type": contentType,
 			"content-length": String(bytes),
 		},
 	});
@@ -26,79 +30,110 @@ function imageResponseWithBody(bytes: number): Response {
 	return new Response(stream, { headers: { "content-type": "image/png" } });
 }
 
+async function rejectionOf(promise: Promise<unknown>): Promise<unknown> {
+	return await promise.then(
+		() => null,
+		(err: unknown) => err,
+	);
+}
+
 // The SSRF guard is a no-op under vitest (the global setup sets
 // ALLOW_INSECURE_PROVIDER_URLS), so these exercise the default validateSsrf
 // path without DNS or network access.
 describe("processImageUrl size limits", () => {
+	beforeEach(() => {
+		// getImageSizeErrorMessage appends an upsell sentence when HOSTED and
+		// PAID_MODE are both "true"; pin them so exact-message assertions do
+		// not depend on ambient env.
+		vi.stubEnv("HOSTED", "false");
+		vi.stubEnv("PAID_MODE", "false");
+	});
+
 	afterEach(() => {
+		vi.unstubAllEnvs();
 		vi.restoreAllMocks();
 	});
 
-	// The catch block used to sniff for "Image size exceeds", which the generated
-	// message ("Image size (32.0MB) exceeds your current limit of 1MB.") never
-	// contains, so every remote-URL size rejection surfaced as the generic
-	// "Failed to process image from URL" and users were never told why.
-	it("surfaces the size message when Content-Length exceeds the limit", async () => {
+	it("surfaces a 400 size error when Content-Length exceeds the limit", async () => {
 		vi.spyOn(globalThis, "fetch").mockResolvedValue(
-			imageResponseWithContentLength(32 * 1024 * 1024),
+			responseWithContentLength(32 * MB),
 		);
 
-		try {
-			await processImageUrl(REMOTE_URL, false, MAX_SIZE_MB);
-			throw new Error("expected throw");
-		} catch (err) {
-			// The message is asserted before the type on purpose: this is the line
-			// that fails on the unfixed code, and it fails for the reason the user
-			// experiences ("Failed to process image from URL") rather than because
-			// a new export is missing.
-			expect((err as Error).message).toContain(
-				"Image size (32.0MB) exceeds your current limit of 1MB.",
-			);
-			expect(err).toBeInstanceOf(ImageSizeLimitError);
-		}
-	});
-
-	it("surfaces the size message when the downloaded body exceeds the limit", async () => {
-		vi.spyOn(globalThis, "fetch").mockResolvedValue(
-			imageResponseWithBody(2 * 1024 * 1024),
+		const err = await rejectionOf(
+			processImageUrl(REMOTE_URL, false, MAX_SIZE_MB),
 		);
 
-		try {
-			await processImageUrl(REMOTE_URL, false, MAX_SIZE_MB);
-			throw new Error("expected throw");
-		} catch (err) {
-			expect((err as Error).message).toContain(
-				"Image size (2.0MB) exceeds your current limit of 1MB.",
-			);
-			expect(err).toBeInstanceOf(ImageSizeLimitError);
-		}
+		expect(err).toBeInstanceOf(ImageSizeLimitError);
+		expect((err as ImageSizeLimitError).statusCode).toBe(400);
+		// No plan passed: the limit is a fixed cap, so the message must not
+		// present it as a plan entitlement.
+		expect((err as Error).message).toBe(
+			"Image size (32.0MB) exceeds the maximum allowed size of 1MB.",
+		);
 	});
 
-	// The data URL branch throws from outside the try block, so it always
-	// surfaced the real message. Remote URLs must report the same way.
+	it("surfaces the plan limit message when the downloaded body exceeds it", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			imageResponseWithBody(2 * MB),
+		);
+
+		const err = await rejectionOf(
+			processImageUrl(REMOTE_URL, false, MAX_SIZE_MB, "free"),
+		);
+
+		expect(err).toBeInstanceOf(ImageSizeLimitError);
+		expect((err as Error).message).toBe(
+			"Image size (2.0MB) exceeds your current limit of 1MB.",
+		);
+	});
+
 	it("reports data URL and remote URL rejections the same way", async () => {
 		vi.spyOn(globalThis, "fetch").mockResolvedValue(
-			imageResponseWithContentLength(2 * 1024 * 1024),
+			responseWithContentLength(2 * MB),
 		);
 
-		const remote = await processImageUrl(REMOTE_URL, false, MAX_SIZE_MB).catch(
-			(err: unknown) => err,
+		const remote = await rejectionOf(
+			processImageUrl(REMOTE_URL, false, MAX_SIZE_MB, "pro"),
 		);
-		const dataUrl = await processImageUrl(
-			`data:image/png;base64,${"A".repeat(2 * 1024 * 1024)}`,
-			false,
-			MAX_SIZE_MB,
-		).catch((err: unknown) => err);
+		const dataUrl = await rejectionOf(
+			processImageUrl(
+				`data:image/png;base64,${"A".repeat(2 * MB)}`,
+				false,
+				MAX_SIZE_MB,
+				"pro",
+			),
+		);
 
 		const sizeMessage =
 			/^Image size \(\d+\.\d+MB\) exceeds your current limit of 1MB\.$/;
-		// Data URLs already reported correctly (they throw outside the try), so
-		// this asymmetry is the whole bug: same rejection, two different answers
-		// depending on how the image arrived.
-		expect((dataUrl as Error).message).toMatch(sizeMessage);
-		expect((remote as Error).message).toMatch(sizeMessage);
 		expect(remote).toBeInstanceOf(ImageSizeLimitError);
 		expect(dataUrl).toBeInstanceOf(ImageSizeLimitError);
+		expect((remote as Error).message).toMatch(sizeMessage);
+		expect((dataUrl as Error).message).toMatch(sizeMessage);
+	});
+
+	it("rounds the reported size up so it never equals the limit", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			responseWithContentLength(MB + 1),
+		);
+
+		const err = await rejectionOf(
+			processImageUrl(REMOTE_URL, false, MAX_SIZE_MB, "free"),
+		);
+
+		expect((err as Error).message).toBe(
+			"Image size (1.1MB) exceeds your current limit of 1MB.",
+		);
+	});
+
+	it("reports an oversized non-image as invalid, not as a size rejection", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			responseWithContentLength(32 * MB, "application/pdf"),
+		);
+
+		await expect(
+			processImageUrl(REMOTE_URL, false, MAX_SIZE_MB),
+		).rejects.toThrow("URL does not point to a valid image");
 	});
 
 	// The passthrough must stay narrow: anything that is not a size rejection is

--- a/packages/actions/src/process-image-url.spec.ts
+++ b/packages/actions/src/process-image-url.spec.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ImageSizeLimitError, processImageUrl } from "./process-image-url.js";
+
+const MAX_SIZE_MB = 1;
+const REMOTE_URL = "https://example.com/huge.png";
+
+function imageResponseWithContentLength(bytes: number): Response {
+	return new Response(new Uint8Array(0), {
+		headers: {
+			"content-type": "image/png",
+			"content-length": String(bytes),
+		},
+	});
+}
+
+function imageResponseWithBody(bytes: number): Response {
+	// A stream body carries no Content-Length, so the pre-check is skipped and
+	// the post-download size check is the one that rejects.
+	const stream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(new Uint8Array(bytes));
+			controller.close();
+		},
+	});
+	return new Response(stream, { headers: { "content-type": "image/png" } });
+}
+
+// The SSRF guard is a no-op under vitest (the global setup sets
+// ALLOW_INSECURE_PROVIDER_URLS), so these exercise the default validateSsrf
+// path without DNS or network access.
+describe("processImageUrl size limits", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	// The catch block used to sniff for "Image size exceeds", which the generated
+	// message ("Image size (32.0MB) exceeds your current limit of 1MB.") never
+	// contains, so every remote-URL size rejection surfaced as the generic
+	// "Failed to process image from URL" and users were never told why.
+	it("surfaces the size message when Content-Length exceeds the limit", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			imageResponseWithContentLength(32 * 1024 * 1024),
+		);
+
+		try {
+			await processImageUrl(REMOTE_URL, false, MAX_SIZE_MB);
+			throw new Error("expected throw");
+		} catch (err) {
+			// The message is asserted before the type on purpose: this is the line
+			// that fails on the unfixed code, and it fails for the reason the user
+			// experiences ("Failed to process image from URL") rather than because
+			// a new export is missing.
+			expect((err as Error).message).toContain(
+				"Image size (32.0MB) exceeds your current limit of 1MB.",
+			);
+			expect(err).toBeInstanceOf(ImageSizeLimitError);
+		}
+	});
+
+	it("surfaces the size message when the downloaded body exceeds the limit", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			imageResponseWithBody(2 * 1024 * 1024),
+		);
+
+		try {
+			await processImageUrl(REMOTE_URL, false, MAX_SIZE_MB);
+			throw new Error("expected throw");
+		} catch (err) {
+			expect((err as Error).message).toContain(
+				"Image size (2.0MB) exceeds your current limit of 1MB.",
+			);
+			expect(err).toBeInstanceOf(ImageSizeLimitError);
+		}
+	});
+
+	// The data URL branch throws from outside the try block, so it always
+	// surfaced the real message. Remote URLs must report the same way.
+	it("reports data URL and remote URL rejections the same way", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			imageResponseWithContentLength(2 * 1024 * 1024),
+		);
+
+		const remote = await processImageUrl(REMOTE_URL, false, MAX_SIZE_MB).catch(
+			(err: unknown) => err,
+		);
+		const dataUrl = await processImageUrl(
+			`data:image/png;base64,${"A".repeat(2 * 1024 * 1024)}`,
+			false,
+			MAX_SIZE_MB,
+		).catch((err: unknown) => err);
+
+		const sizeMessage =
+			/^Image size \(\d+\.\d+MB\) exceeds your current limit of 1MB\.$/;
+		// Data URLs already reported correctly (they throw outside the try), so
+		// this asymmetry is the whole bug: same rejection, two different answers
+		// depending on how the image arrived.
+		expect((dataUrl as Error).message).toMatch(sizeMessage);
+		expect((remote as Error).message).toMatch(sizeMessage);
+		expect(remote).toBeInstanceOf(ImageSizeLimitError);
+		expect(dataUrl).toBeInstanceOf(ImageSizeLimitError);
+	});
+
+	// The passthrough must stay narrow: anything that is not a size rejection is
+	// still sanitized so upstream/network detail does not leak to the caller.
+	it("still sanitizes non-size failures", async () => {
+		vi.spyOn(globalThis, "fetch").mockRejectedValue(
+			new Error("connect ECONNREFUSED 10.0.0.1:443"),
+		);
+
+		await expect(
+			processImageUrl(REMOTE_URL, false, MAX_SIZE_MB),
+		).rejects.toThrow("Failed to process image from URL");
+	});
+});

--- a/packages/actions/src/process-image-url.ts
+++ b/packages/actions/src/process-image-url.ts
@@ -5,18 +5,30 @@ import { parseDataUrl } from "./parse-data-url.js";
 import { RequestError } from "./request-error.js";
 
 /**
- * Thrown when an image exceeds the caller's size limit. Typed so the catch
- * block in `processImageUrl` can re-throw it as-is: the previous check sniffed
- * the message for "Image size exceeds", which never matched the generated text
- * ("Image size (32.0MB) exceeds your current limit of 1MB."), so every remote
- * URL size rejection was flattened into the generic "Failed to process image
- * from URL" and users were never told their image was too big.
+ * Extends RequestError so the gateway maps an oversized image to a 400 with
+ * the size message and a client_error log row instead of an unhandled 500.
+ * The distinct type also lets the catch block in `processImageUrl` re-throw
+ * size rejections past the generic sanitization without message sniffing.
  */
-export class ImageSizeLimitError extends Error {
+export class ImageSizeLimitError extends RequestError {
 	public constructor(message: string) {
-		super(message);
+		super(message, 400);
 		this.name = "ImageSizeLimitError";
 	}
+}
+
+/**
+ * Resolves the plan-based max image size. Enterprise plans get at least the
+ * pro limit so they are not bucketed into the free cap.
+ */
+export function getPlanImageSizeLimitMB(
+	userPlan: "free" | "pro" | "enterprise" | null,
+): number {
+	const freeLimitMB = Number(process.env.IMAGE_SIZE_LIMIT_FREE_MB) || 50;
+	const proLimitMB = Number(process.env.IMAGE_SIZE_LIMIT_PRO_MB) || 100;
+	return userPlan === "pro" || userPlan === "enterprise"
+		? proLimitMB
+		: freeLimitMB;
 }
 
 /**
@@ -30,7 +42,18 @@ function getImageSizeErrorMessage(
 	const isHosted = process.env.HOSTED === "true";
 	const isPaidMode = process.env.PAID_MODE === "true";
 
-	let message = `Image size (${actualSizeMB.toFixed(1)}MB) exceeds your current limit of ${maxSizeMB}MB.`;
+	// Round the reported size up so a value just over the threshold cannot
+	// print as equal to the limit ("Image size (1.0MB) exceeds ... 1MB.").
+	const displaySizeMB = (Math.ceil(actualSizeMB * 10) / 10).toFixed(1);
+
+	// A null plan means the limit is a fixed endpoint cap rather than a plan
+	// entitlement, so don't present it as the caller's "current limit" or
+	// upsell a plan change.
+	if (userPlan === null) {
+		return `Image size (${displaySizeMB}MB) exceeds the maximum allowed size of ${maxSizeMB}MB.`;
+	}
+
+	let message = `Image size (${displaySizeMB}MB) exceeds your current limit of ${maxSizeMB}MB.`;
 
 	if (isHosted && isPaidMode) {
 		if (userPlan === "enterprise") {
@@ -129,6 +152,18 @@ export async function processImageUrl(
 			throw new Error(`Failed to fetch image: HTTP ${response.status}`);
 		}
 
+		// Check content type before size so an oversized non-image is reported
+		// as "not an image" rather than sent away to shrink a file that would
+		// be rejected anyway.
+		const contentType = response.headers.get("content-type");
+		if (!contentType || !contentType.startsWith("image/")) {
+			logger.warn("Invalid content type for image URL", {
+				contentType,
+				url: url.substring(0, 50) + "...",
+			});
+			throw new Error("URL does not point to a valid image");
+		}
+
 		// Calculate max size in bytes once
 		const maxSizeBytes = maxSizeMB * 1024 * 1024;
 
@@ -144,15 +179,6 @@ export async function processImageUrl(
 			throw new ImageSizeLimitError(
 				getImageSizeErrorMessage(maxSizeMB, actualSizeMB, userPlan),
 			);
-		}
-
-		const contentType = response.headers.get("content-type");
-		if (!contentType || !contentType.startsWith("image/")) {
-			logger.warn("Invalid content type for image URL", {
-				contentType,
-				url: url.substring(0, 50) + "...",
-			});
-			throw new Error("URL does not point to a valid image");
 		}
 
 		const arrayBuffer = await response.arrayBuffer();
@@ -182,12 +208,6 @@ export async function processImageUrl(
 			mimeType: contentType,
 		};
 	} catch (error) {
-		// Log the full error internally but sanitize the thrown error
-		logger.error("Error processing image URL", {
-			err: error instanceof Error ? error : new Error(String(error)),
-			url: url.substring(0, 50) + "...",
-		});
-
 		if (error instanceof ImageSizeLimitError) {
 			throw error; // Re-throw size limit errors as-is
 		}
@@ -203,6 +223,15 @@ export async function processImageUrl(
 		) {
 			throw error; // Re-throw content type errors as-is
 		}
+
+		// Log the full error internally but sanitize the thrown error. The
+		// re-thrown cases above are ordinary client rejections and already
+		// logged at warn where they throw, so only unexpected failures land
+		// in the error log.
+		logger.error("Error processing image URL", {
+			err: error instanceof Error ? error : new Error(String(error)),
+			url: url.substring(0, 50) + "...",
+		});
 
 		// Generic error for all other cases
 		throw new Error("Failed to process image from URL");

--- a/packages/actions/src/process-image-url.ts
+++ b/packages/actions/src/process-image-url.ts
@@ -5,6 +5,21 @@ import { parseDataUrl } from "./parse-data-url.js";
 import { RequestError } from "./request-error.js";
 
 /**
+ * Thrown when an image exceeds the caller's size limit. Typed so the catch
+ * block in `processImageUrl` can re-throw it as-is: the previous check sniffed
+ * the message for "Image size exceeds", which never matched the generated text
+ * ("Image size (32.0MB) exceeds your current limit of 1MB."), so every remote
+ * URL size rejection was flattened into the generic "Failed to process image
+ * from URL" and users were never told their image was too big.
+ */
+export class ImageSizeLimitError extends Error {
+	public constructor(message: string) {
+		super(message);
+		this.name = "ImageSizeLimitError";
+	}
+}
+
+/**
  * Generates a user-friendly error message for image size limits
  */
 function getImageSizeErrorMessage(
@@ -74,7 +89,7 @@ export async function processImageUrl(
 				maxSizeMB,
 				actualSizeMB,
 			});
-			throw new Error(
+			throw new ImageSizeLimitError(
 				getImageSizeErrorMessage(maxSizeMB, actualSizeMB, userPlan),
 			);
 		}
@@ -126,7 +141,7 @@ export async function processImageUrl(
 				maxSizeMB,
 				actualSizeMB,
 			});
-			throw new Error(
+			throw new ImageSizeLimitError(
 				getImageSizeErrorMessage(maxSizeMB, actualSizeMB, userPlan),
 			);
 		}
@@ -150,7 +165,7 @@ export async function processImageUrl(
 				maxSizeMB,
 				actualSizeMB,
 			});
-			throw new Error(
+			throw new ImageSizeLimitError(
 				getImageSizeErrorMessage(maxSizeMB, actualSizeMB, userPlan),
 			);
 		}
@@ -173,10 +188,7 @@ export async function processImageUrl(
 			url: url.substring(0, 50) + "...",
 		});
 
-		if (
-			error instanceof Error &&
-			error.message.includes("Image size exceeds")
-		) {
+		if (error instanceof ImageSizeLimitError) {
 			throw error; // Re-throw size limit errors as-is
 		}
 		if (

--- a/packages/actions/src/transform-anthropic-messages.ts
+++ b/packages/actions/src/transform-anthropic-messages.ts
@@ -12,6 +12,7 @@ import {
 
 import { parseToolCallArguments } from "./parse-tool-call-arguments.js";
 import { processImageUrl } from "./process-image-url.js";
+import { RequestError } from "./request-error.js";
 
 /**
  * Transforms Anthropic messages
@@ -116,6 +117,13 @@ export async function transformAnthropicMessages(
 								},
 							};
 						} catch (error) {
+							// A typed client error (e.g. image over the plan size limit)
+							// must fail the request: degrading it to placeholder text
+							// would return a 200 with the image silently dropped and the
+							// user billed without ever learning why it was ignored.
+							if (error instanceof RequestError) {
+								throw error;
+							}
 							logger.error(`Failed to fetch image ${part.image_url.url}`, {
 								err: error instanceof Error ? error : new Error(String(error)),
 							});


### PR DESCRIPTION
## Problem

`processImageUrl()` never told a caller their image was too big. The size-limit passthrough in its `catch` sniffed the message for `"Image size exceeds"`, which never matches the generated text (`Image size (32.0MB) exceeds your current limit of 1MB.`), so every remote-URL size rejection was flattened into the generic `Failed to process image from URL` — while data URLs (which throw outside the `try`) reported the real message.

#3447 (@pacocartones) fixed the dead branch with a typed `ImageSizeLimitError`. This PR carries that commit and additionally addresses the [review findings](https://github.com/theopenco/llmgateway/pull/3447#pullrequestreview-4888762751): as originally written, the typed error only reached users on `/v1/images` and `/v1/videos` — on chat completions it still surfaced as an opaque 500, on Anthropic/Bedrock it was silently swallowed into a placeholder, and the newly visible message could state a limit the caller doesn't have.

## Approach

- **`ImageSizeLimitError extends RequestError` (status 400).** Chat completions now return the size message as a 400 `client_error` with a log row instead of an unhandled 500: the Google transform preserves `RequestError`s, the chat handler's typed-error branch matches, and the `aws-mantle` inlining path (no try/catch) is covered by the same change.
- **Anthropic and Bedrock re-throw typed client errors** instead of degrading them to `[Image failed to load]` placeholders that silently drop the image while still billing the request. Other failures (HTTP errors, network) still degrade gracefully as before.
- **Shared `getPlanImageSizeLimitMB()`** resolves plan limits in one place and gives enterprise orgs at least the pro limit instead of bucketing them into the free cap.
- **`/v1/images` edits use the caller's plan-based limit**, matching what the forwarded chat-completions request enforces, so a pro org is no longer told about a 20MB limit it doesn't have.
- **Video image inputs keep their fixed 20MB cap** — the same inputs are re-processed by provider upload helpers that carry no org context, so the limit must be uniform across the video flow — but a null plan now produces a neutral `exceeds the maximum allowed size of 20MB` message instead of presenting the cap as a plan entitlement (with an upsell).
- **Content type is checked before size**, so an oversized non-image reports `URL does not point to a valid image` instead of a misleading size rejection.
- **The reported size rounds up** so it can never print equal to the limit (`Image size (1.0MB) exceeds your current limit of 1MB.`), and ordinary size rejections no longer land in the error log — they are already warn-logged at the throw sites, so `logger.error` now fires only for unexpected failures.

## Tests

`packages/actions/src/process-image-url.spec.ts` (from #3447, reworked): pins `HOSTED`/`PAID_MODE` so exact-message assertions don't depend on ambient env, replaces the throw-inside-its-own-`try` assertions with a rejection-capture helper, asserts `statusCode: 400`, and adds cases for the rounding and content-type-ordering behavior (6 tests).

Two existing integration tests were updated: the `/v1/images/edits` oversized tests stub `IMAGE_SIZE_LIMIT_PRO_MB=20` (the harness org is plan `pro`, so the 28MB payload would otherwise pass the new plan-based limit), and the `/v1/videos` oversized test asserts the new neutral wording.

## Verification

- `pnpm build` — all 17 tasks pass
- `pnpm exec vitest run packages/actions` — 19 files, 565 tests pass (also green with `HOSTED=true PAID_MODE=true`)
- `pnpm exec vitest run apps/gateway --no-file-parallelism` — 110 files, 2166 tests pass against local Postgres/Redis
- `pnpm format` — clean

Supersedes #3447.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dg9Dp62WCAEP7dAmhWsESQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dg9Dp62WCAEP7dAmhWsESQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image uploads and edits now enforce the correct size limits for each plan.
  * Oversized images display clearer, consistent limit messages.
  * Invalid image types and expected request errors are handled more reliably.
  * Image-processing errors now surface appropriately instead of being replaced with placeholder text.
* **Tests**
  * Expanded coverage for remote images, data URLs, streamed downloads, size rounding, and plan-specific limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->