### PR TITLE
fix(actions): nested reasoning for embercloud

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -1103,6 +1103,51 @@ describe("prepareRequestBody - Moonshot thinking", () => {
 	});
 });
 
+describe("prepareRequestBody - embercloud reasoning shape", () => {
+	// embercloud's documented request body uses a nested `reasoning` object
+	// (reasoning.enabled + reasoning.effort) — the flat OpenAI-style
+	// `reasoning_effort` field is not documented and is silently ignored
+	// (https://embercloud.ai/docs/request-body).
+	async function prepare(effort: string) {
+		return (await prepareRequestBody(
+			"embercloud",
+			"glm-5.2",
+			null,
+			"glm-5.2",
+			[{ role: "user", content: "Hello!" }],
+			false, // stream
+			undefined, // temperature
+			undefined, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			undefined, // tools
+			undefined, // tool_choice
+			effort, // reasoning_effort
+			true, // supportsReasoning
+		)) as any;
+	}
+
+	test("builds the nested reasoning object instead of flat reasoning_effort", async () => {
+		const requestBody = await prepare("high");
+		expect(requestBody.reasoning).toEqual({
+			enabled: true,
+			effort: "high",
+		});
+		expect(requestBody.reasoning_effort).toBeUndefined();
+	});
+
+	test("forwards the top declared tier through the nested shape", async () => {
+		const requestBody = await prepare("max");
+		expect(requestBody.reasoning).toEqual({
+			enabled: true,
+			effort: "max",
+		});
+		expect(requestBody.reasoning_effort).toBeUndefined();
+	});
+});
+
 describe("prepareRequestBody - Alibaba thinking", () => {
 	async function prepare(options: {
 		model: string;

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -1108,7 +1108,9 @@ describe("prepareRequestBody - embercloud reasoning shape", () => {
 	// (reasoning.enabled + reasoning.effort) — the flat OpenAI-style
 	// `reasoning_effort` field is not documented and is silently ignored
 	// (https://embercloud.ai/docs/request-body).
-	async function prepare(effort: string) {
+	async function prepare(
+		effort: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max",
+	) {
 		return (await prepareRequestBody(
 			"embercloud",
 			"glm-5.2",

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -4082,7 +4082,21 @@ export async function prepareRequestBody(
 					supported.length === 0 ||
 					supported.includes("reasoning_effort")
 				) {
-					requestBody.reasoning_effort = reasoning_effort;
+					if (usedProvider === "embercloud") {
+						// embercloud's documented request body uses a nested
+						// `reasoning` object (`reasoning.enabled` +
+						// `reasoning.effort`) instead of the flat OpenAI-style
+						// `reasoning_effort` field, which it silently ignores
+						// (https://embercloud.ai/docs/request-body). "none"
+						// maps to enabled: false; any other tier enables
+						// reasoning at the requested effort.
+						requestBody.reasoning =
+							reasoning_effort === "none"
+								? { enabled: false }
+								: { enabled: true, effort: reasoning_effort };
+					} else {
+						requestBody.reasoning_effort = reasoning_effort;
+					}
 				}
 			}
 			// Hybrid models that keep thinking off by default (e.g. DeepSeek V3.2 on


### PR DESCRIPTION
Fixes #3444. Supersedes #3477 (rebased onto current `main`, plus a typecheck fix and live/e2e verification against the provider). Original change by @andyst-dev.

## Problem

EmberCloud does not accept the flat OpenAI-style `reasoning_effort` field — it silently ignores it. The gateway was forwarding that flat field for the reasoning-capable GLM mappings, so a declared effort never reached the provider and no reasoning was ever produced. Confirmed live against `api.embercloud.ai` on `glm-4.7`:

| request | result |
| --- | --- |
| `reasoning_effort: "high"` (before this PR) | 200, 2 completion tokens, **no reasoning** |
| no reasoning field at all | 200, 2 completion tokens, no reasoning |
| `reasoning: {enabled: true, effort: "high"}` | 200, 191 completion tokens, full `message.reasoning` |
| `reasoning: {enabled: false}` | 200, no reasoning |

`GET /v1/models` agrees: the reasoning-capable models advertise `reasoning` in `supported_parameters` and never `reasoning_effort`.

## Approach

`prepare-request-body.ts` builds the nested shape for `embercloud` only:

- an effort tier → `reasoning: { enabled: true, effort: "<tier>" }`
- `none` → `reasoning: { enabled: false }`
- every other provider keeps the flat `reasoning_effort` field unchanged

The `none` branch is currently unreachable — `none` is normalized to `undefined` for providers not in `handlesNoneNatively` before this point — and is kept for when a mapping-declared `none` opt-in lands.

## Things a reviewer would otherwise have to check

- **No new 4xx risk from effort tiers.** Every value the `reasoning_effort` union can emit (`minimal`/`low`/`medium`/`high`/`xhigh`/`max`) returns 200 upstream; the provider does not validate the enum at all (even a bogus string is accepted), so nothing regresses for tiers EmberCloud does not recognize.
- **No risk for non-reasoning mappings.** The nested object is tolerated by EmberCloud models that do not advertise reasoning (`kimi-k2.5`, `qwen3-coder-next` both 200), which covers mappings with an empty `supportedParameters`.
- **Streaming is fine.** With reasoning enabled the provider emits `delta.reasoning` chunks plus `completion_tokens_details.reasoning_tokens`; the existing streaming transform already normalizes `reasoning`/`reasoning_content`.
- **Provider coverage limits.** `glm-5.2`, `glm-4.6` and `glm-4.5-air` return 429 on every request and `glm-5.1` returns `400 "Temporary routing error"`, matching the `stability: "unstable"` comments already in the catalogue. Live coverage therefore rests on `glm-4.7` and `glm-5`.
- **Not changed here:** the "reasoning requests time out repeatedly in e2e" comments on the `glm-5` / `glm-4.7` mappings no longer reproduce (both suites ran green end to end), but revisiting those stability flags is a separate change.

## Verification

Merged onto `main` at f2056f9.

```
TEST_MODELS="embercloud/glm-4.7" FULL_MODE=true pnpm test:e2e
  Test Files  29 passed | 2 skipped (31)
       Tests  100 passed | 90 skipped (190)

TEST_MODELS="embercloud/glm-5" FULL_MODE=true pnpm test:e2e
  Test Files  29 passed | 2 skipped (31)
       Tests  98 passed | 90 skipped (188)

pnpm test:unit    4270 passed | 3 skipped
pnpm build        17/17
pnpm format       clean
```

Counter-check: reverting only the `prepare-request-body.ts` hunk fails exactly three e2e tests for `embercloud/glm-4.7` — `basic reasoning`, `reasoning + streaming`, `reasoning + tool calls`. The nested shape is what makes them pass.

The spec helper's `effort` parameter was typed `string`, which does not narrow to `prepareRequestBody`'s `reasoning_effort` union and failed `tsc` with TS2345, breaking `pnpm build`. It is now typed as the union, matching the other helpers in that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLDMLFqT6A7Lnk1i61eFCm

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLDMLFqT6A7Lnk1i61eFCm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reasoning controls for EmberCloud’s GLM-5.2 models.
  * “None” now correctly disables reasoning, while other effort levels are sent in the format required by the provider.
  * Reasoning settings for other providers remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->