### PR TITLE
fix(admin): make tall dialogs scrollable on mobile

### DIFF
--- a/ee/admin/src/components/ui/dialog.tsx
+++ b/ee/admin/src/components/ui/dialog.tsx
@@ -60,7 +60,7 @@ function DialogContent({
 			<DialogPrimitive.Content
 				data-slot="dialog-content"
 				className={cn(
-					"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+					"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
 					className,
 				)}
 				{...props}


### PR DESCRIPTION
## Problem

Tall dialogs in the admin app overflow the viewport on mobile with no way to scroll. Radix locks body scroll while a dialog is open and the admin `DialogContent` had no height cap or overflow handling, so on a phone the "Manage org" plan editor (plan term, enterprise trial, seat/API-key overrides) rendered ~1250px tall in an ~850px viewport — the header was cut off at the top and the Save/Cancel footer was unreachable at the bottom.

## Approach

Apply the same treatment the `apps/ui` and `apps/playground` dialog components already use: cap `DialogContent` at `max-h-[calc(100dvh-2rem)]` and add `overflow-y-auto`. One line in `ee/admin/src/components/ui/dialog.tsx`, fixing every admin dialog. Per-dialog `max-h-*` overrides that some admin dialogs already carry still win via `tailwind-merge`.

## Verification

Ran the stack locally and drove the admin app with Playwright at a 390×844 viewport: before, the dialog's scroll container reported `scrollHeight == clientHeight == 1256` with `scrollTop` stuck at 0 (unscrollable); after, it caps at `clientHeight: 810` and scrolls freely to the footer. `pnpm build` passes.

### Before (mobile)

Header cut off above, Save/Cancel unreachable below, no scrolling possible:

<img width="390" alt="Before: dialog overflows the mobile viewport and cannot scroll" src="https://raw.githubusercontent.com/theopenco/llmgateway/1bbc7bbc3c7e4843935b87ce0ca06408a0277600/before-scrolled.png" />

### After (mobile)

Dialog fits the viewport and scrolls; footer reachable:

| Light — top | Light — scrolled to footer | Dark |
| --- | --- | --- |
| <img width="260" alt="After: dialog top, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/1bbc7bbc3c7e4843935b87ce0ca06408a0277600/after-top.png" /> | <img width="260" alt="After: dialog scrolled to footer, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/1bbc7bbc3c7e4843935b87ce0ca06408a0277600/after-scrolled.png" /> | <img width="260" alt="After: dialog top, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/1bbc7bbc3c7e4843935b87ce0ca06408a0277600/after-dark-top.png" /> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dialog content now stays within the viewport height.
  * Long dialog content can be accessed by scrolling vertically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->