### PR TITLE
fix(gateway): raw finish_reason when not streaming

### DIFF
--- a/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
@@ -824,6 +824,68 @@ describe("parseProviderResponse", () => {
 
 			expect(result.finishReason).toBe("upstream_error");
 		});
+
+		it("maps 'end_turn' finish reason to 'stop' for groq", () => {
+			const json = {
+				choices: [
+					{
+						message: { content: "Hello", role: "assistant" },
+						finish_reason: "end_turn",
+					},
+				],
+				usage: {
+					prompt_tokens: 10,
+					completion_tokens: 5,
+					total_tokens: 15,
+				},
+			};
+
+			const result = parseProviderResponse(
+				"groq",
+				"llama-3.3-70b-versatile",
+				json,
+			);
+
+			expect(result.finishReason).toBe("stop");
+		});
+
+		it("maps 'tool_use' finish reason to 'tool_calls' for together-ai", () => {
+			const json = {
+				choices: [
+					{
+						message: {
+							role: "assistant",
+							content: null,
+							tool_calls: [
+								{
+									id: "call_1",
+									type: "function",
+									function: {
+										name: "get_weather",
+										arguments: '{"city":"San Francisco"}',
+									},
+								},
+							],
+						},
+						finish_reason: "tool_use",
+					},
+				],
+				usage: {
+					prompt_tokens: 10,
+					completion_tokens: 5,
+					total_tokens: 15,
+				},
+			};
+
+			const result = parseProviderResponse(
+				"together-ai",
+				"deepseek-ai/DeepSeek-V3",
+				json,
+			);
+
+			expect(result.finishReason).toBe("tool_calls");
+			expect(result.toolResults).toHaveLength(1);
+		});
 	});
 
 	describe("refusal finish reason", () => {

--- a/apps/gateway/src/chat/tools/parse-provider-response.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.ts
@@ -1074,7 +1074,10 @@ export function parseProviderResponse(
 				reasoningContent = hasReasoning ? aggregatedReasoning : null;
 				finishReason = allChoices[0]?.finish_reason ?? null;
 
-				if (finishReason === "abort") {
+				// Map non-standard finish reasons to OpenAI-compatible values
+				if (finishReason === "end_turn") {
+					finishReason = "stop";
+				} else if (finishReason === "abort") {
 					logger.warn("Upstream sent abort finish_reason", {
 						provider: usedProvider,
 						model: usedModel,
@@ -1087,6 +1090,8 @@ export function parseProviderResponse(
 					// "abort" is an upstream-initiated interruption, not a client
 					// cancellation, so it counts as an upstream error.
 					finishReason = "upstream_error";
+				} else if (finishReason === "tool_use") {
+					finishReason = "tool_calls";
 				}
 
 				// ZAI-specific fix for incorrect finish_reason in tool response scenarios


### PR DESCRIPTION
## Summary

Non-streaming chat completions leak provider-native `finish_reason` values
(`end_turn`, `tool_use`) to the client for the ~29 OpenAI-compatible providers
routed through the `default:` branch of `parseProviderResponse`
(`apps/gateway/src/chat/tools/parse-provider-response.ts`) — groq, deepseek,
xai, together-ai, fireworks, minimax, zai, … The streaming path canonicalizes
exactly that provider list (`transform-streaming-to-openai.ts`, the shared
`case` mapping `end_turn`→`stop`, `tool_use`→`tool_calls`,
`abort`→`upstream_error`), and the non-streaming path already does it for
`mistral`/`novita` — but not for the rest.

So the same request returns a **canonical** finish reason with `stream: true`
and a **non-canonical** one with `stream: false`. OpenAI-compatible clients key
behavior off the canonical set — the Vercel AI SDK only dispatches tool-call
handling on `finish_reason === "tool_calls"` — so a `tool_use` finish over
`stream: false` silently never runs the tool. This is the non-streaming mirror
of #2019, which fixed the same class in streaming for the same reason.

The `default:` branch already canonicalizes `abort`→`upstream_error` (#3053),
so this extends an existing, maintained mapping rather than adding a new
concept.

## Fix

Mirror the sibling `mistral`/`novita` branch in the `default:` branch: map
`end_turn`→`stop` and `tool_use`→`tool_calls` alongside the existing `abort`
handling. +6/−1 lines, additive only; providers with their own `case`
(`aws-bedrock`, `anthropic`, `google-*`, `mistral`, `novita`, `alibaba`) are
untouched.

Scope note: the branch serves 38 provider ids; for 29 of them the streaming
path already applies this exact mapping (the shared `case` list minus the
three with their own non-streaming branch), so this restores stream/non-stream
symmetry for those and extends the same canonicalization to the remaining
ones. Downstream per-provider fix-ups that key off the canonical values (the
`zai` and `scx-ai` blocks right below) now see the mapped value, which only
moves those paths towards more canonicalization. `alibaba` keeps its own
case and is deliberately out of scope.

## Tests

Two cases added to the existing
`describe("openai-format finish reason mapping")` block in
`parse-provider-response.spec.ts` (next to the minimax `abort` test):

- `tool_use` → `tool_calls` for `together-ai`, with the tool call payload
  passing through;
- `end_turn` → `stop` for `groq`.

## Verification

Every command below was run and its output captured verbatim. The record is
reproducible — the exact commands are included so you can re-run them yourself.

**red — new spec without the fix (only parse-provider-response.ts stashed)** (must fail without the fix)

```
$ pnpm exec vitest run apps/gateway/src/chat/tools/parse-provider-response.spec.ts
[…]
 FAIL  … > openai-format finish reason mapping > maps 'tool_use' finish reason to 'tool_calls' for together-ai
AssertionError: expected 'tool_use' to be 'tool_calls' // Object.is equality
Expected: "tool_calls"
Received: "tool_use"
[exit code 1]
```

**green — full spec with the fix** (must pass) — 3 runs, identical exit code

```
$ pnpm exec vitest run apps/gateway/src/chat/tools/parse-provider-response.spec.ts
 RUN  v4.1.8 ~/repos/llmgateway
 ✓ apps/gateway/src/chat/tools/parse-provider-response.spec.ts (39 tests) 13ms
 Test Files  1 passed (1)
      Tests  39 passed (39)
[exit code 0]
```

<details><summary>Environment and output hashes</summary>

```
so: Windows 11 (AMD64)
node --version: v24.14.1
pnpm --version: 10.28.1
base: d382119618a7cb76d8127e2cc61f6c21d2a8dc55 (origin/main)
sha256(red run 1) = e22553a1783c7250…  exit 1  5.77s
sha256(green run 1) = 742d459ce0ea616a…  exit 0  5.55s
sha256(green run 2) = d64c7ae54755f2f7…  exit 0  5.67s
sha256(green run 3) = fafa0810ba680141…  exit 0  5.59s
acta: 540b7b5e852a17e8
```

</details>

Gates (local, Windows): `tsc --noEmit` on `apps/gateway` ✅ · eslint ✅ on both
touched files · prettier ✅ on both touched files (LF form, as committed) ·
`git diff --check` clean · full `turbo run build --env-mode=loose` ✅ (17/17,
including the `gateway` typecheck). Area suite `vitest run
apps/gateway/src/chat`: 40/43 files, 601/634 tests ✅ — all 33 failures sit in
three service-harness specs (`chat-resilience`, `managed-credentials`,
`openai-content-filter`) that need Postgres/Redis and fail with
`ECONNREFUSED 127.0.0.1:6379` on this Docker-less machine; none of them
imports the touched module.

Not verified: a live round-trip against groq/together-ai (no provider keys on
this machine). The mapping itself is covered by the unit tests above, and the
affected provider list is the one the streaming branch already enumerates.

---

Disclosure: an AI coding assistant helped locate the asymmetry and draft the
test scaffolding. The reproduction, the red→green cycle and this write-up were
verified by running the code; I own the change and will follow up on review
comments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with provider responses by standardizing additional completion reasons.
  * Correctly preserves tool-call information when responses indicate tool usage.

* **Tests**
  * Added coverage for normalized completion reasons and preserved tool calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->