### PR TITLE
feat(devpass): confirm before Reset Pass redeem

### DIFF
--- a/apps/code/src/app/dashboard/components/ResetPassCard.tsx
+++ b/apps/code/src/app/dashboard/components/ResetPassCard.tsx
@@ -280,32 +280,58 @@ export default function ResetPassCard({
 						)}
 					</p>
 					<div className="mt-3 flex flex-wrap items-center gap-2">
-						<Button
-							size="sm"
-							onClick={() => redeemMutation.mutate({})}
-							disabled={
-								available === 0 ||
-								nothingToReset ||
-								redeemBlocked ||
-								redeemMutation.isPending
-							}
-							title={
-								redeemBlocked
-									? "Over 90% of this cycle's credits are used — a reset would give you almost nothing. Your passes keep until your credits renew."
-									: available === 0
-										? "No passes held — buy one below"
-										: nothingToReset
-											? "Nothing to reset yet — your allowance is untouched"
-											: undefined
-							}
-						>
-							{redeemMutation.isPending ? (
-								<Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
-							) : (
-								<Stamp className="mr-1.5 h-4 w-4" />
-							)}
-							Use a pass
-						</Button>
+						<AlertDialog>
+							<AlertDialogTrigger asChild>
+								<Button
+									size="sm"
+									disabled={
+										available === 0 ||
+										nothingToReset ||
+										redeemBlocked ||
+										redeemMutation.isPending
+									}
+									title={
+										redeemBlocked
+											? "Over 90% of this cycle's credits are used — a reset would give you almost nothing. Your passes keep until your credits renew."
+											: available === 0
+												? "No passes held — buy one below"
+												: nothingToReset
+													? "Nothing to reset yet — your allowance is untouched"
+													: undefined
+									}
+								>
+									{redeemMutation.isPending ? (
+										<Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+									) : (
+										<Stamp className="mr-1.5 h-4 w-4" />
+									)}
+									Use a pass
+								</Button>
+							</AlertDialogTrigger>
+							<AlertDialogContent data-testid="redeem-pass-confirm">
+								<AlertDialogHeader>
+									<AlertDialogTitle>Stamp a Reset Pass now?</AlertDialogTitle>
+									<AlertDialogDescription>
+										This spends one of your{" "}
+										{`${available} pass${available === 1 ? "" : "es"}`} (
+										{includedRemaining > 0 ? "included" : "purchased"}) and
+										immediately lifts the weekly premium limit back to{" "}
+										{`$${premiumWeeklyLimit.toFixed(2)}`}. It doesn&apos;t add
+										credits — usage still draws from your monthly allowance, and
+										a spent pass can&apos;t be undone.
+									</AlertDialogDescription>
+								</AlertDialogHeader>
+								<AlertDialogFooter>
+									<AlertDialogCancel>Not now</AlertDialogCancel>
+									<AlertDialogAction
+										onClick={() => redeemMutation.mutate({})}
+										data-testid="redeem-pass-confirm-action"
+									>
+										Stamp the pass
+									</AlertDialogAction>
+								</AlertDialogFooter>
+							</AlertDialogContent>
+						</AlertDialog>
 						{price !== null && purchaseBlocked && (
 							<Button
 								size="sm"


### PR DESCRIPTION
## Problem

On the DevPass usage dashboard, **Use a pass** redeemed a Reset Pass on a single click — the mutation fired straight from `onClick` with no confirmation. Redeeming is irreversible: it spends one of a small, paid inventory (PRO includes 1 per cycle, extras are $29 each) and zeroes the weekly premium window. A stray click on a dashboard that also carries auto-opening dialogs costs the user a pass with nothing to undo it.

The neighbouring **Buy a pass** button already required a confirmation, so the destructive half of the pair was the unguarded one.

## Change

Wrap the redeem button in the same `AlertDialog` pattern already used for the purchase flow. The confirmation states what is actually at stake:

- which pass is spent (included vs purchased) and how many are left,
- that the weekly premium limit goes back to its full value,
- that it adds no credits — usage still draws from the monthly allowance,
- that a spent pass can't be undone.

The existing disabled/`title` logic is untouched, so the gated states (no passes held, nothing to reset, >90% cycle usage) still short-circuit before the dialog can open — a disabled trigger never fires.

## Screenshots

Reset Pass card, unchanged:

<img width="1100" alt="Reset Pass card on the DevPass usage dashboard" src="https://raw.githubusercontent.com/theopenco/llmgateway/9644c41b596a5559ef80dcbea9ae41158123f7c6/card-light.png" />

New confirmation, light and dark:

<img width="512" alt="Reset Pass confirmation dialog, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/9644c41b596a5559ef80dcbea9ae41158123f7c6/dialog-light.png" />

<img width="512" alt="Reset Pass confirmation dialog, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/9644c41b596a5559ef80dcbea9ae41158123f7c6/dialog-dark.png" />

## Verification

Ran the stack locally against an isolated worktree stack and drove the flow as `admin@example.com` on the seeded DevPass PRO org (premium week partially spent, 1 included + 1 purchased pass):

- Cancelling (**Not now**) leaves the org row untouched.
- Confirming (**Stamp the pass**) still redeems end-to-end: `dev_plan_premium_credits_used` → `0`, `dev_plan_premium_week_start` → `NULL`, `dev_plan_included_reset_passes_used` → `1`, and the "Allowance restored" stamp overlay plays.

`pnpm format`, `pnpm build`, and `pnpm vitest run apps/api/src/routes/dev-plans-reset-passes.spec.ts` (32 passed) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog before redeeming a pass.
  * The dialog explains pass consumption, allowance restoration, credit usage, and that the action cannot be undone.
  * Added Cancel and Confirm actions to control redemption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->