### PR TITLE
fix(gateway): keep max_tokens above thinking budget

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -3790,7 +3790,7 @@ describe("prepareRequestBody - reasoning.max_tokens forwarding", () => {
 			[{ role: "user", content: "What is 2/3 + 1/4 + 5/6?" }],
 			false, // stream
 			undefined, // temperature
-			1024, // max_tokens (must exceed thinking budget)
+			1024, // max_tokens (raised by the gateway to clear the thinking budget)
 			undefined, // top_p
 			undefined, // frequency_penalty
 			undefined, // presence_penalty
@@ -3814,6 +3814,59 @@ describe("prepareRequestBody - reasoning.max_tokens forwarding", () => {
 			type: "enabled",
 			budget_tokens: budget,
 		});
+		expect(requestBody.max_tokens).toBeGreaterThan(budget);
+	});
+
+	test("anthropic raises max_tokens above a low-effort thinking budget", async () => {
+		const requestBody = (await prepareRequestBody(
+			"anthropic",
+			"claude-sonnet-4-6",
+			null,
+			"claude-sonnet-4-6",
+			[{ role: "user", content: "What is 2/3 + 1/4 + 5/6?" }],
+			false, // stream
+			undefined, // temperature
+			1024, // max_tokens (equal to the "low" budget — Anthropic 400s on this)
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			undefined, // tools
+			undefined, // tool_choice
+			"low", // reasoning_effort
+			true, // supportsReasoning
+			false, // isProd
+		)) as any;
+
+		expect(requestBody.thinking).toEqual({
+			type: "enabled",
+			budget_tokens: 1024,
+		});
+		expect(requestBody.max_tokens).toBe(2024);
+	});
+
+	test("anthropic leaves a max_tokens that already clears the budget", async () => {
+		const requestBody = (await prepareRequestBody(
+			"anthropic",
+			"claude-sonnet-4-6",
+			null,
+			"claude-sonnet-4-6",
+			[{ role: "user", content: "What is 2/3 + 1/4 + 5/6?" }],
+			false, // stream
+			undefined, // temperature
+			8000, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			undefined, // tools
+			undefined, // tool_choice
+			"low", // reasoning_effort
+			true, // supportsReasoning
+			false, // isProd
+		)) as any;
+
+		expect(requestBody.max_tokens).toBe(8000);
 	});
 
 	test("aws-bedrock forwards budget into additionalModelRequestFields.thinking.budget_tokens", async () => {

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -2870,6 +2870,16 @@ export async function prepareRequestBody(
 						type: "enabled",
 						budget_tokens: thinkingBudget,
 					};
+					// Anthropic rejects the request outright when `max_tokens` is not
+					// strictly greater than `thinking.budget_tokens`. The budget cannot
+					// be lowered to fit (1024 is Anthropic's minimum), so a caller-
+					// supplied max_tokens that leaves no room for a reply is raised to
+					// the budget plus a minimum response allowance — mirroring the
+					// aws-bedrock branch.
+					const reasoningFloor = thinkingBudget + 1000;
+					if (requestBody.max_tokens < reasoningFloor) {
+						requestBody.max_tokens = reasoningFloor;
+					}
 				}
 				// Anthropic requires temperature to be exactly 1 when thinking is
 				// enabled — but only for models that still accept temperature. The


### PR DESCRIPTION
## Problem

Production support chat was failing with:

```
`max_tokens` must be greater than `thinking.budget_tokens`.
```

The support-chat route (`apps/api/src/routes/public-chat-support.ts`) calls the gateway with `model: "auto"` and `maxOutputTokens: 1024`. When auto-routing lands on a reasoning-capable Anthropic model it sets `reasoning_effort = "low"`, which maps to a thinking budget of exactly 1024 — Anthropic's minimum. The direct `anthropic` / `vertex-anthropic` branch of `prepareRequestBody` then forwarded the caller's `max_tokens` verbatim, so the upstream request had `max_tokens == thinking.budget_tokens` and Anthropic 400s.

The `aws-bedrock` branch already guarded against this; the direct Anthropic branch did not, despite its comment claiming to ("Set max_tokens, ensuring it's higher than thinking budget"). It only enforced the floor on the *fallback* value used when the caller omitted `max_tokens`.

## Approach

Mirror the bedrock logic: when non-adaptive thinking is enabled, raise `max_tokens` to `thinking.budget_tokens + 1000` if the caller-supplied value doesn't clear it.

Raising `max_tokens` is the only possible fix — the budget can't be lowered to fit, since 1024 is Anthropic's floor for `budget_tokens`, so any `max_tokens <= 1024` is unsatisfiable without bumping it.

Adaptive models (Opus 4.7+) are untouched: they use `thinking: { type: "adaptive" }` with no `budget_tokens`, so the constraint doesn't apply.

## Verification

- New specs in `prepare-request-body.spec.ts` cover both the raise (1024 → 2024 at `reasoning_effort: "low"`) and the no-op case (an already-sufficient 8000 stays 8000).
- `packages/actions` unit suite: 581 passed.
- `pnpm format` and full `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Anthropic reasoning requests by ensuring the response token limit is always higher than the configured thinking budget.
  * Preserved caller-provided limits when they already meet the required threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->