### PR TITLE
fix(api): report unreachable provider endpoints

### DIFF
--- a/apps/api/src/routes/admin-provider-credentials.ts
+++ b/apps/api/src/routes/admin-provider-credentials.ts
@@ -393,6 +393,13 @@ async function validateCredentialToken(
 
 	const statusPart = result.statusCode ? ` (status ${result.statusCode})` : "";
 	const modelPart = result.model ? ` using model ${result.model}` : "";
+	// A connectivity failure says nothing about the credential — report it as
+	// what it is so the admin fixes the endpoint config, not the key.
+	if (result.unreachable) {
+		throw new HTTPException(400, {
+			message: `Could not reach ${provider} to validate the credential${modelPart}: ${errorMessage}. Pass skipValidation to store it anyway.`,
+		});
+	}
 	throw new HTTPException(400, {
 		message: `Credential rejected by ${provider}: ${errorMessage}${statusPart}${modelPart}. Pass skipValidation to store it anyway.`,
 	});

--- a/apps/api/src/routes/keys-provider.spec.ts
+++ b/apps/api/src/routes/keys-provider.spec.ts
@@ -320,6 +320,43 @@ describe("provider keys route", () => {
 			expect(json.message).toContain("status 429");
 			expect(json.message).toContain("try again later");
 		});
+
+		// A host that does not resolve (a mistyped Azure resource name, a custom
+		// base URL pointing nowhere) means the key was never judged at all, so
+		// the response must not claim the provider rejected it.
+		test("reports an unreachable endpoint as such", async () => {
+			vi.mocked(validateProviderKey).mockResolvedValueOnce({
+				valid: false,
+				model: "gpt-5.6-sol",
+				unreachable: true,
+				error:
+					"Could not resolve typo.openai.azure.com (DNS lookup failed: ENOTFOUND). Check the base URL / resource name configured for this credential.",
+			});
+
+			const res = await app.request("/keys/provider", {
+				method: "POST",
+				headers: { "Content-Type": "application/json", Cookie: token },
+				body: JSON.stringify({
+					provider: "azure",
+					token: "azure-test-token",
+					organizationId: "test-org-id",
+				}),
+			});
+
+			expect(res.status).toBe(400);
+			const json = await res.json();
+			expect(json.message).toContain("Could not reach provider azure");
+			expect(json.message).toContain("typo.openai.azure.com");
+			expect(json.message).not.toContain("rejected the key");
+			expect(json.message).not.toContain("Invalid API key");
+			// "fetch failed" is exactly the useless wording this replaces.
+			expect(json.message).not.toContain("fetch failed");
+
+			const stored = await db.query.providerKey.findFirst({
+				where: { provider: { eq: "azure" } },
+			});
+			expect(stored).toBeUndefined();
+		});
 	});
 
 	test("POST /keys/provider rejects stealth providers", async () => {

--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -563,6 +563,15 @@ keysProvider.openapi(create, async (c) => {
 		const modelPart = validationResult.model
 			? ` using model ${validationResult.model}`
 			: "";
+		// The provider never answered, so the key was never judged: saying it was
+		// rejected would send the user off replacing a perfectly good key. The
+		// endpoint is derived from the submitted base URL / options, so this is a
+		// problem with the request, hence 400 rather than a 5xx.
+		if (validationResult.unreachable) {
+			throw new HTTPException(400, {
+				message: `Could not reach provider ${provider}${modelPart}: ${errorMessage}`,
+			});
+		}
 		// A 401 is an auth or entitlement failure, so "try again later" is the
 		// wrong advice — the key will keep failing until it is replaced or the
 		// account is granted access. The provider's own message distinguishes the

--- a/packages/actions/src/provider-key/index.ts
+++ b/packages/actions/src/provider-key/index.ts
@@ -11,6 +11,8 @@ export {
 } from "./read.js";
 export type { ProviderKeyRowLike } from "./read.js";
 export { redactToken } from "./redact.js";
+export { describeNetworkFailure } from "./network-error.js";
+export type { NetworkFailure } from "./network-error.js";
 export {
 	managedCredentialOptions,
 	managedCredentialValidationOptions,

--- a/packages/actions/src/provider-key/network-error.spec.ts
+++ b/packages/actions/src/provider-key/network-error.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import { describeNetworkFailure } from "./network-error.js";
+
+/** The shape undici produces: an opaque TypeError wrapping the real reason. */
+function fetchFailed(cause: unknown): TypeError {
+	return new TypeError("fetch failed", { cause });
+}
+
+function errnoError(message: string, code: string): Error {
+	return Object.assign(new Error(message), { code });
+}
+
+describe("describeNetworkFailure", () => {
+	it("names the unresolvable host instead of reporting 'fetch failed'", () => {
+		const failure = describeNetworkFailure(
+			fetchFailed(
+				errnoError(
+					"getaddrinfo ENOTFOUND my-resource.openai.azure.com",
+					"ENOTFOUND",
+				),
+			),
+			"https://my-resource.openai.azure.com/openai/deployments/x/chat/completions?api-version=2024-10-21",
+		);
+
+		expect(failure?.code).toBe("ENOTFOUND");
+		expect(failure?.message).toContain("my-resource.openai.azure.com");
+		expect(failure?.message).toContain("DNS lookup failed");
+		expect(failure?.message).not.toContain("fetch failed");
+	});
+
+	// undici reports a connect failure across several resolved addresses as an
+	// AggregateError, which carries no `code` of its own.
+	it("digs the code out of an AggregateError", () => {
+		const aggregate = new AggregateError([
+			errnoError("connect ECONNREFUSED 10.0.0.1:443", "ECONNREFUSED"),
+		]);
+		const failure = describeNetworkFailure(
+			fetchFailed(aggregate),
+			"https://api.example.com/v1/chat/completions",
+		);
+
+		expect(failure?.code).toBe("ECONNREFUSED");
+		expect(failure?.message).toContain("api.example.com");
+		expect(failure?.message).toContain("refused the connection");
+	});
+
+	it.each([
+		["UND_ERR_CONNECT_TIMEOUT", "timed out"],
+		["ECONNRESET", "closed before a response arrived"],
+		["CERT_HAS_EXPIRED", "TLS handshake"],
+	])("classifies %s", (code, expected) => {
+		const failure = describeNetworkFailure(
+			fetchFailed(errnoError(code, code)),
+			"https://api.example.com/v1/chat/completions",
+		);
+
+		expect(failure?.code).toBe(code);
+		expect(failure?.message).toContain(expected);
+	});
+
+	it("explains an unfollowed redirect", () => {
+		const failure = describeNetworkFailure(
+			fetchFailed(new Error("unexpected redirect")),
+			"https://api.example.com/v1/chat/completions",
+		);
+
+		expect(failure?.code).toBe("UNEXPECTED_REDIRECT");
+		expect(failure?.message).toContain("redirect");
+	});
+
+	// The endpoint of an api-key-in-query-string provider must never reach an
+	// error message or a log line in full.
+	it("reports the host only, never the query string", () => {
+		const failure = describeNetworkFailure(
+			fetchFailed(errnoError("getaddrinfo EAI_AGAIN host", "EAI_AGAIN")),
+			"https://generativelanguage.googleapis.com/v1beta/models/x:generateContent?key=AIzaSySECRET",
+		);
+
+		expect(failure?.message).toContain("generativelanguage.googleapis.com");
+		expect(failure?.message).not.toContain("AIzaSySECRET");
+	});
+
+	it("still classifies an unknown fetch failure as unreachable", () => {
+		const failure = describeNetworkFailure(
+			fetchFailed(new Error("something went wrong at the socket layer")),
+			"https://api.example.com/v1/chat/completions",
+		);
+
+		expect(failure?.code).toBe("FETCH_FAILED");
+		expect(failure?.message).toContain("Could not reach api.example.com");
+	});
+
+	// Bugs on our side must keep their error-level treatment.
+	it("ignores errors that are not connectivity failures", () => {
+		expect(
+			describeNetworkFailure(
+				new Error("No suitable validation model found for provider openai"),
+				"https://api.openai.com/v1/chat/completions",
+			),
+		).toBeUndefined();
+		expect(describeNetworkFailure("not an error")).toBeUndefined();
+	});
+
+	it("falls back to a generic target when there is no endpoint", () => {
+		const failure = describeNetworkFailure(
+			fetchFailed(errnoError("getaddrinfo ENOTFOUND host", "ENOTFOUND")),
+		);
+
+		expect(failure?.message).toContain("the provider endpoint");
+	});
+});

--- a/packages/actions/src/provider-key/network-error.ts
+++ b/packages/actions/src/provider-key/network-error.ts
@@ -1,0 +1,170 @@
+/**
+ * A provider call that never produced an HTTP response: DNS, TCP, TLS or
+ * timeout failures. `fetch` reports every one of them as the same opaque
+ * `TypeError: fetch failed`, with the real reason buried in the `cause`
+ * chain, so callers that surface the raw message tell the user nothing.
+ */
+export interface NetworkFailure {
+	/** Node/undici error code, e.g. `ENOTFOUND`, `UND_ERR_CONNECT_TIMEOUT`. */
+	code: string;
+	/** Client-facing explanation of what could not be reached and why. */
+	message: string;
+	/** Underlying cause text, for logs only. */
+	detail: string;
+}
+
+const MAX_CAUSE_DEPTH = 5;
+
+const DNS_CODES = new Set(["ENOTFOUND", "EAI_AGAIN"]);
+const REFUSED_CODES = new Set(["ECONNREFUSED", "EHOSTUNREACH", "ENETUNREACH"]);
+const TIMEOUT_CODES = new Set([
+	"ETIMEDOUT",
+	"UND_ERR_CONNECT_TIMEOUT",
+	"UND_ERR_HEADERS_TIMEOUT",
+	"UND_ERR_BODY_TIMEOUT",
+]);
+const RESET_CODES = new Set(["ECONNRESET", "EPIPE", "UND_ERR_SOCKET"]);
+const TLS_CODE_PREFIXES = [
+	"CERT_",
+	"ERR_TLS_",
+	"DEPTH_ZERO_",
+	"SELF_SIGNED_",
+	"UNABLE_TO_",
+];
+
+/**
+ * The error plus its `cause` chain. An `AggregateError` (undici raises one
+ * when every resolved address fails to connect) hides the real code inside
+ * `errors`, so descend into its first entry as if it were the cause.
+ */
+function unwrapCauses(error: unknown): Error[] {
+	const chain: Error[] = [];
+	let current: unknown = error;
+	for (
+		let depth = 0;
+		depth < MAX_CAUSE_DEPTH && current instanceof Error;
+		depth++
+	) {
+		chain.push(current);
+		const aggregated = (current as AggregateError).errors;
+		current =
+			Array.isArray(aggregated) && aggregated.length > 0
+				? aggregated[0]
+				: (current as { cause?: unknown }).cause;
+	}
+	return chain;
+}
+
+function firstErrorCode(chain: Error[]): string | undefined {
+	for (const error of chain) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (typeof code === "string" && code) {
+			return code;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Host of the endpoint, never the full URL: Google AI Studio and Vertex in
+ * api-key mode carry the credential in the query string, so anything beyond
+ * the host would leak the token into error messages and logs.
+ */
+function endpointHost(endpoint: string | undefined): string | undefined {
+	if (!endpoint) {
+		return undefined;
+	}
+	try {
+		return new URL(endpoint).host || undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function isTlsCode(code: string): boolean {
+	return TLS_CODE_PREFIXES.some((prefix) => code.startsWith(prefix));
+}
+
+/**
+ * Classify a thrown provider-call error as a connectivity failure, or return
+ * `undefined` when it is a genuine bug on our side (a missing model, a broken
+ * payload) that deserves the usual error-level treatment.
+ */
+export function describeNetworkFailure(
+	error: unknown,
+	endpoint?: string,
+): NetworkFailure | undefined {
+	if (!(error instanceof Error)) {
+		return undefined;
+	}
+
+	const chain = unwrapCauses(error);
+	const code = firstErrorCode(chain);
+	const isFetchFailure =
+		error instanceof TypeError && /fetch failed/i.test(error.message);
+	if (!isFetchFailure && !code) {
+		return undefined;
+	}
+
+	const cause = chain[chain.length - 1];
+	const detail =
+		cause === error ? error.message : `${error.message}: ${cause.message}`;
+	const target = endpointHost(endpoint) ?? "the provider endpoint";
+
+	// `redirect: "error"` is deliberate (a tenant-supplied baseUrl must not be
+	// able to bounce the probe, and the token, at an internal host), so say so
+	// rather than reporting it as an unreachable host.
+	if (!code && /redirect/i.test(cause.message)) {
+		return {
+			code: "UNEXPECTED_REDIRECT",
+			message: `${target} answered with a redirect, which is not followed when validating a credential. Point the credential at the final URL instead.`,
+			detail,
+		};
+	}
+
+	if (code && DNS_CODES.has(code)) {
+		return {
+			code,
+			message: `Could not resolve ${target} (DNS lookup failed: ${code}). Check the base URL / resource name configured for this credential.`,
+			detail,
+		};
+	}
+
+	if (code && REFUSED_CODES.has(code)) {
+		return {
+			code,
+			message: `${target} refused the connection (${code}). Check the base URL / resource name configured for this credential.`,
+			detail,
+		};
+	}
+
+	if (code && TIMEOUT_CODES.has(code)) {
+		return {
+			code,
+			message: `The connection to ${target} timed out (${code}).`,
+			detail,
+		};
+	}
+
+	if (code && RESET_CODES.has(code)) {
+		return {
+			code,
+			message: `The connection to ${target} was closed before a response arrived (${code}).`,
+			detail,
+		};
+	}
+
+	if (code && isTlsCode(code)) {
+		return {
+			code,
+			message: `The TLS handshake with ${target} failed (${code}).`,
+			detail,
+		};
+	}
+
+	return {
+		code: code ?? "FETCH_FAILED",
+		message: `Could not reach ${target}: ${cause.message}`,
+		detail,
+	};
+}

--- a/packages/actions/src/validate-provider-key.spec.ts
+++ b/packages/actions/src/validate-provider-key.spec.ts
@@ -138,6 +138,36 @@ describe("validateProviderKey error reporting", () => {
 		expect(result.error).toBe("Rate limit exceeded");
 	});
 
+	// An Azure resource name that does not resolve is bad tenant input, not a
+	// gateway fault: it used to surface as a bare "fetch failed" and page us via
+	// an error-level log. It must read as an unreachable endpoint and log at warn.
+	it("explains a connectivity failure instead of 'fetch failed'", async () => {
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		vi.spyOn(globalThis, "fetch").mockRejectedValue(
+			new TypeError("fetch failed", {
+				cause: Object.assign(
+					new Error("getaddrinfo ENOTFOUND api.openai.com"),
+					{ code: "ENOTFOUND" },
+				),
+			}),
+		);
+
+		const result = await validateProviderKey(
+			"openai",
+			"sk-test",
+			undefined,
+			false,
+		);
+
+		expect(result.valid).toBe(false);
+		expect(result.unreachable).toBe(true);
+		expect(result.error).toContain("api.openai.com");
+		expect(result.error).not.toBe("fetch failed");
+		expect(errorSpy).not.toHaveBeenCalled();
+		expect(warnSpy).toHaveBeenCalled();
+	});
+
 	it("falls back to status text when the body carries no message", async () => {
 		vi.spyOn(globalThis, "fetch").mockResolvedValue(
 			new Response("not json", { status: 401, statusText: "Unauthorized" }),

--- a/packages/actions/src/validate-provider-key.ts
+++ b/packages/actions/src/validate-provider-key.ts
@@ -13,6 +13,7 @@ import { getGcpServiceAccountAccessToken } from "./gcp-access-token.js";
 import { getProviderEndpoint } from "./get-provider-endpoint.js";
 import { getProviderHeaders } from "./get-provider-headers.js";
 import { prepareRequestBody } from "./prepare-request-body.js";
+import { describeNetworkFailure } from "./provider-key/network-error.js";
 import { redactToken } from "./provider-key/redact.js";
 
 import type { ProviderKeyOptions } from "@llmgateway/db";
@@ -249,6 +250,8 @@ export async function validateProviderKey(
 	}
 
 	let validationModel: { modelId: string; externalId: string } | undefined;
+	// Hoisted so the catch can name the host that could not be reached.
+	let endpoint: string | undefined;
 
 	try {
 		validationModel = pinnedModelId
@@ -316,7 +319,7 @@ export async function validateProviderKey(
 			providerKeyOptions,
 		);
 
-		const endpoint = getProviderEndpoint(
+		endpoint = getProviderEndpoint(
 			provider,
 			baseUrl,
 			effectiveModelId, // Pass model ID for providers that need it in the URL (e.g., aws-bedrock, azure)
@@ -443,7 +446,35 @@ export async function validateProviderKey(
 	} catch (error) {
 		const rawMessage =
 			error instanceof Error ? error.message : "Unknown error occurred";
-		const safeErrorMessage = redactToken(rawMessage, token);
+		// `fetch` collapses every connectivity failure into "fetch failed", which
+		// is useless both to the caller and in logs — replace it with the actual
+		// reason (DNS, refused, timeout, TLS) whenever the error is one of those.
+		const networkFailure = describeNetworkFailure(error, endpoint);
+		const safeErrorMessage = redactToken(
+			networkFailure?.message ?? rawMessage,
+			token,
+		);
+
+		if (networkFailure) {
+			// Expected for a whole class of credentials: Azure resource names and
+			// custom base URLs are tenant-supplied, so a host that does not resolve
+			// or answer is bad input, not a gateway fault. Warn instead of error so
+			// it does not page anyone, and hand the reason back to the caller.
+			logger.warn("Provider key validation could not reach the provider", {
+				provider,
+				model: validationModel?.modelId,
+				errorCode: networkFailure.code,
+				error: safeErrorMessage,
+				detail: redactToken(networkFailure.detail, token),
+			});
+			return {
+				valid: false,
+				error: safeErrorMessage,
+				model: validationModel?.modelId,
+				unreachable: true,
+			};
+		}
+
 		const safeStack =
 			error instanceof Error
 				? redactToken(error.stack, token) || undefined

--- a/packages/models/src/types.ts
+++ b/packages/models/src/types.ts
@@ -460,6 +460,12 @@ export interface ProviderValidationResult {
 	error?: string;
 	statusCode?: number;
 	model?: string;
+	/**
+	 * The probe never got an HTTP response (DNS, connection, TLS or timeout
+	 * failure), so the credential itself was never judged. Callers should word
+	 * this as "could not reach the provider" rather than "key rejected".
+	 */
+	unreachable?: boolean;
 }
 
 // Model with pricing information


### PR DESCRIPTION
## Problem

Provider key validation reports every connectivity failure as `TypeError: fetch failed` — the opaque message `fetch` throws for DNS, TCP, TLS and timeout failures alike — and logs it at **error** level with a full stack:

```
"msg": "Provider key validation failed with exception",
"error": "fetch failed", "provider": "azure", "model": "gpt-5.6-sol", "level": 50
```

Neither half is right. The client gets a message that says nothing about what went wrong, and for providers whose endpoint is derived from tenant-supplied input — Azure resource names, custom base URLs — a host that does not resolve is expected input, not a gateway fault worth an error-level page.

Worse, the caller then words it as a rejection: `Credential rejected by azure: fetch failed`. The credential was never judged at all, so that sends people replacing a perfectly good key.

## Approach

New `describeNetworkFailure()` (`packages/actions/src/provider-key/network-error.ts`) walks the `cause` chain — including into an `AggregateError`, which is how undici reports a connect failure across several resolved addresses and which carries no `code` of its own — and classifies the result:

| code | message |
| --- | --- |
| `ENOTFOUND` / `EAI_AGAIN` | `Could not resolve my-resource.openai.azure.com (DNS lookup failed: ENOTFOUND). Check the base URL / resource name configured for this credential.` |
| `ECONNREFUSED` / `EHOSTUNREACH` / `ENETUNREACH` | `… refused the connection (ECONNREFUSED). …` |
| `ETIMEDOUT` / `UND_ERR_*_TIMEOUT` | `The connection to … timed out (…)` |
| `ECONNRESET` / `EPIPE` / `UND_ERR_SOCKET` | `The connection to … was closed before a response arrived (…)` |
| `CERT_*` / `ERR_TLS_*` / self-signed | `The TLS handshake with … failed (…)` |
| unfollowed redirect | explains that `redirect: "error"` is deliberate and to point the credential at the final URL |

`validateProviderKey` then logs these at **warn** instead of **error** and returns the new `unreachable: true` on `ProviderValidationResult`. Errors that are *not* connectivity failures (a missing validation model, a broken payload) keep their error-level treatment and stack.

Both callers word it accordingly instead of claiming the key was rejected:

- `POST /keys/provider` → `Could not reach provider azure using model gpt-5.6-sol: Could not resolve …`
- managed-credential save (`ee/admin`) → `Could not reach azure to validate the credential…`

Both stay **400**: the endpoint comes from the submitted base URL / options, so this is bad request input, not an upstream 5xx on our side.

## Notes for reviewers

- Only the **host** of the endpoint ever reaches a message or a log line. Google AI Studio and Vertex in api-key mode carry the credential in the query string, so anything beyond the host would leak the token — there is a test pinning this.
- The self-test and verify-models admin endpoints already pass `result.error` straight through, so they pick up the better wording without a schema change (no client regeneration needed).

## Verification

- `packages/actions/src/provider-key/network-error.spec.ts` (new, 10 tests) — classification, AggregateError unwrapping, token-free messages, and that non-network errors are left alone.
- `packages/actions/src/validate-provider-key.spec.ts` — end to end: `unreachable: true`, host named, `logger.error` not called and `logger.warn` called.
- `apps/api/src/routes/keys-provider.spec.ts` — the 400 says "Could not reach provider azure", never "rejected the key" / "Invalid API key" / "fetch failed", and no key is stored.
- `pnpm build` (17/17), `pnpm format`, plus full `keys-provider.spec.ts` (55) and `admin-provider-credentials.spec.ts` (62) against an isolated test database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)