### PR TITLE
fix(gateway): collapse union types in Gemini tools

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -2894,6 +2894,153 @@ describe("prepareRequestBody - Google AI Studio", () => {
 		});
 	});
 
+	test("should collapse union type arrays in Google tool parameters", async () => {
+		// Google's `Schema` proto models `type` as a single enum, so the JSON
+		// Schema list form (`["string", "null"]`, which is how most generators
+		// spell an optional field) 400s the whole request with `Unknown name
+		// "type" … Proto field is not repeating, cannot start list.`
+		const toolsWithUnionTypes = [
+			{
+				type: "function" as const,
+				function: {
+					name: "create_memory",
+					description: "Test tool",
+					parameters: {
+						type: "object",
+						properties: {
+							extra: {
+								description: "Nullable string",
+								type: ["string", "null"],
+							},
+							sourceIds: {
+								items: { type: "string" },
+								type: ["array", "null"],
+							},
+							nested: {
+								type: "object",
+								properties: {
+									inner: { type: ["number", "null"] },
+								},
+							},
+							listed: {
+								type: "array",
+								items: {
+									type: ["object", "null"],
+									properties: {
+										flag: { type: ["boolean", "null"] },
+									},
+								},
+							},
+							multi: { type: ["string", "number"] },
+							onlyNull: { type: ["null"] },
+							contradictory: { type: ["string", "null"], nullable: false },
+						},
+					},
+				},
+			},
+		];
+
+		const requestBody = (await prepareRequestBody(
+			"google-ai-studio",
+			"gemini-2.0-flash",
+			null,
+			"gemini-2.0-flash",
+			[{ role: "user", content: "test" }],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			toolsWithUnionTypes,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+
+		const params = requestBody.tools[0].functionDeclarations[0].parameters;
+
+		expect(params.properties.extra).toEqual({
+			description: "Nullable string",
+			type: "string",
+			nullable: true,
+		});
+		expect(params.properties.sourceIds).toEqual({
+			items: { type: "string" },
+			type: "array",
+			nullable: true,
+		});
+		expect(params.properties.nested.properties.inner).toEqual({
+			type: "number",
+			nullable: true,
+		});
+		expect(params.properties.listed.items.type).toBe("object");
+		expect(params.properties.listed.items.nullable).toBe(true);
+		expect(params.properties.listed.items.properties.flag).toEqual({
+			type: "boolean",
+			nullable: true,
+		});
+		// A union with no `null` member keeps its first type and stays non-nullable
+		expect(params.properties.multi).toEqual({ type: "string" });
+		// Google's Type enum has no NULL member, so `["null"]` degrades to a
+		// nullable string rather than an unset type
+		expect(params.properties.onlyNull).toEqual({
+			type: "string",
+			nullable: true,
+		});
+		expect(params.properties.contradictory.nullable).toBe(true);
+	});
+
+	test("should collapse tuple-form items in Google tool parameters", async () => {
+		const toolsWithTupleItems = [
+			{
+				type: "function" as const,
+				function: {
+					name: "test_tool",
+					description: "Test tool",
+					parameters: {
+						type: "object",
+						properties: {
+							pair: {
+								type: "array",
+								items: [
+									{ type: "string", "x-vendor": true },
+									{ type: "number" },
+								],
+							},
+						},
+					},
+				},
+			},
+		];
+
+		const requestBody = (await prepareRequestBody(
+			"google-ai-studio",
+			"gemini-2.0-flash",
+			null,
+			"gemini-2.0-flash",
+			[{ role: "user", content: "test" }],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			toolsWithTupleItems,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as any;
+
+		const params = requestBody.tools[0].functionDeclarations[0].parameters;
+
+		expect(params.properties.pair.items).toEqual({ type: "string" });
+	});
+
 	test("should add additionalProperties: false to Cerebras tool parameters", async () => {
 		const toolsWithoutAdditionalProps = [
 			{

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -558,6 +558,44 @@ const GOOGLE_OPAQUE_SCHEMA_VALUE_KEYS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * JSON Schema lets `type` be a list of alternatives — `["string", "null"]` is
+ * how most schema generators express an optional field — but Google's `Schema`
+ * proto models `type` as a single enum. A list fails the entire request with
+ * `Invalid JSON payload received. Unknown name "type" at
+ * 'tools[0].function_declarations[N].parameters.properties[M].value': Proto
+ * field is not repeating, cannot start list.`, and since that is a 400 it
+ * classifies as `client_error`: no fallback, no retry.
+ *
+ * Collapse it the way the `response_format` path already does: `"null"` becomes
+ * `nullable: true` and the first remaining member becomes the type. Picking one
+ * member of a genuine multi-type union does lose information, but a single node
+ * cannot express the union in Google's schema, and a narrowed type still yields
+ * usable tool calls where the alternative is that every request carrying the
+ * tool fails.
+ */
+function normalizeGoogleSchemaType(type: unknown): {
+	type?: string;
+	nullable: boolean;
+} {
+	if (typeof type === "string") {
+		return { type, nullable: false };
+	}
+	if (!Array.isArray(type)) {
+		return { nullable: false };
+	}
+
+	const nullable = type.includes("null");
+	const firstNonNull = type.find(
+		(entry): entry is string => typeof entry === "string" && entry !== "null",
+	);
+	// `["null"]` on its own has no Google equivalent — its `Type` enum has no
+	// NULL member — so fall back to a nullable string.
+	const resolved = firstNonNull ?? (nullable ? "string" : undefined);
+
+	return { type: resolved, nullable };
+}
+
+/**
  * Recursively drops everything Google's schema parser does not accept and
  * expands $ref references inline, since Google supports neither $ref nor the
  * bulk of JSON Schema's validation vocabulary.
@@ -612,6 +650,7 @@ function stripUnsupportedSchemaProperties(
 	}
 
 	const cleaned: any = {};
+	let nullableFromType = false;
 
 	for (const [key, value] of Object.entries(schema)) {
 		if (!GOOGLE_SUPPORTED_SCHEMA_KEYS.has(key)) {
@@ -623,16 +662,23 @@ function stripUnsupportedSchemaProperties(
 			continue;
 		}
 
+		if (key === "type") {
+			const normalized = normalizeGoogleSchemaType(value);
+			if (normalized.type !== undefined) {
+				cleaned.type = normalized.type;
+			}
+			nullableFromType ||= normalized.nullable;
+			continue;
+		}
+
 		// For `properties` (a map of user-named fields to schemas), recurse into
 		// each value but do not filter the field names themselves — otherwise a
 		// tool parameter legitimately named `examples`, `prefill`, `const`, etc.
 		// would be silently dropped.
-		if (
-			key === "properties" &&
-			value &&
-			typeof value === "object" &&
-			!Array.isArray(value)
-		) {
+		if (key === "properties") {
+			if (!value || typeof value !== "object" || Array.isArray(value)) {
+				continue;
+			}
 			const cleanedProps: Record<string, any> = {};
 			for (const [propName, propSchema] of Object.entries(value)) {
 				cleanedProps[propName] = stripUnsupportedSchemaProperties(
@@ -645,12 +691,29 @@ function stripUnsupportedSchemaProperties(
 			continue;
 		}
 
+		// Draft-4 tuple validation puts a list in `items`, which hits the same
+		// "Proto field is not repeating" 400 as a list-valued `type`; Google's
+		// `items` is a single schema, so keep the first entry.
+		if (key === "items" && Array.isArray(value)) {
+			const [first] = value;
+			if (first && typeof first === "object") {
+				cleaned.items = stripUnsupportedSchemaProperties(first, defs, seenRefs);
+			}
+			continue;
+		}
+
 		// Recursively clean nested objects
 		if (value && typeof value === "object") {
 			cleaned[key] = stripUnsupportedSchemaProperties(value, defs, seenRefs);
 		} else {
 			cleaned[key] = value;
 		}
+	}
+
+	// Applied after the loop so it wins over an explicit `nullable: false` that
+	// contradicts a `"null"` member in the type list, whichever key came first.
+	if (nullableFromType) {
+		cleaned.nullable = true;
 	}
 
 	// Filter 'required' array to only include properties that exist in 'properties'


### PR DESCRIPTION
## Problem

Every tool-calling request from LobeChat to `google-ai-studio/gemini-3.6-flash` fails with a 400:

```
Invalid JSON payload received. Unknown name "type" at
'tools[0].function_declarations[29].parameters.properties[4].value':
Proto field is not repeating, cannot start list.
```

The tools contain the ordinary JSON Schema union form for an optional field:

```json
"sourceIds": { "items": { "type": "string" }, "type": ["array", "null"] }
```

Google's `Schema` proto models `type` as a **single** enum, so a list is rejected outright. Because it is a 400 the gateway classifies it as `client_error` — no fallback, no retry — so the request just dies, even though one property of one tool out of 47 carried the list.

`stripUnsupportedSchemaProperties` (the tool-schema path) allowlists `type` but forwards its value verbatim. The `response_format` path (`convertOpenAISchemaToGoogle`) has collapsed union types for a while; the tool path never did.

## Fix

Collapse the list on the tool path the same way: `"null"` becomes `nullable: true`, and the first remaining member becomes the type.

Picking one member of a genuine multi-type union (`["string", "number"]`) loses information, but a single Google schema node cannot express the union, and a narrowed type still produces usable tool calls — the alternative is that no request carrying the tool works at all. `["null"]` alone degrades to a nullable string, since Google's `Type` enum has no NULL member.

Two adjacent cases that trip the identical "Proto field is not repeating" 400 are handled while here:

- draft-4 tuple-form `items` (a list where Google expects one schema) keeps its first entry;
- a `properties` value that is not a plain object is dropped rather than recursed into as an array.

`nullable` is applied after the key loop so a `"null"` member wins over a contradictory explicit `nullable: false`, regardless of key order.

## Verification

- Two new unit tests in `prepare-request-body.spec.ts` covering nullable unions (top level, nested, inside `items`), non-null unions, `["null"]`, the `nullable: false` contradiction, and tuple-form `items`.
- Replayed the **exact 47-tool payload** from the failing request through `prepareRequestBody` against the live `gemini-3.6-flash` endpoint: previously 400, now **200** with a normal `STOP` completion.
- `pnpm format`, `pnpm build`, and the full `packages/actions` suite (581 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)