### PR TITLE
fix(gateway): return mapped finish_reason to client

### DIFF
--- a/apps/gateway/src/chat/tools/transform-response-to-openai.spec.ts
+++ b/apps/gateway/src/chat/tools/transform-response-to-openai.spec.ts
@@ -500,6 +500,141 @@ describe("transformResponseToOpenai", () => {
 		});
 	});
 
+	test("writes mapped finish_reason back for default-branch providers", () => {
+		const toolCalls = [
+			{
+				id: "call_1",
+				type: "function",
+				function: { name: "get_weather", arguments: '{"city":"Berlin"}' },
+			},
+		];
+		const response = transformResponseToOpenai(
+			"deepseek",
+			"deepseek-chat",
+			{
+				id: "chatcmpl-test",
+				object: "chat.completion",
+				created: 1,
+				model: "deepseek-chat",
+				choices: [
+					{
+						index: 0,
+						message: {
+							role: "assistant",
+							content: null,
+							tool_calls: toolCalls,
+						},
+						finish_reason: "tool_use",
+					},
+				],
+				usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+			},
+			null,
+			null,
+			"tool_calls",
+			10,
+			5,
+			15,
+			null,
+			null,
+			toolCalls,
+			[],
+			"deepseek/deepseek-chat",
+			"deepseek",
+			"deepseek-chat",
+			null,
+			false,
+			null,
+			null,
+			"req_finish_1",
+		);
+
+		expect(response.choices?.[0]?.finish_reason).toBe("tool_calls");
+		expect(response.choices?.[0]?.message?.tool_calls).toEqual(toolCalls);
+	});
+
+	test("writes 'upstream_error' finish_reason back for default-branch providers", () => {
+		const response = transformResponseToOpenai(
+			"fireworks",
+			"llama-v3p1-8b-instruct",
+			{
+				id: "chatcmpl-test",
+				object: "chat.completion",
+				created: 1,
+				model: "llama-v3p1-8b-instruct",
+				choices: [
+					{
+						index: 0,
+						message: { role: "assistant", content: "partial" },
+						finish_reason: "abort",
+					},
+				],
+				usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+			},
+			"partial",
+			null,
+			"upstream_error",
+			10,
+			5,
+			15,
+			null,
+			null,
+			null,
+			[],
+			"fireworks/llama-v3p1-8b-instruct",
+			"fireworks",
+			"llama-v3p1-8b-instruct",
+			null,
+			false,
+			null,
+			null,
+			"req_finish_2",
+		);
+
+		expect(response.choices?.[0]?.finish_reason).toBe("upstream_error");
+	});
+
+	test("keeps the upstream finish_reason when no mapped value exists", () => {
+		const response = transformResponseToOpenai(
+			"cerebras",
+			"llama3.3-70b",
+			{
+				id: "chatcmpl-test",
+				object: "chat.completion",
+				created: 1,
+				model: "llama3.3-70b",
+				choices: [
+					{
+						index: 0,
+						message: { role: "assistant", content: "hi" },
+						finish_reason: "stop",
+					},
+				],
+				usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+			},
+			"hi",
+			null,
+			null,
+			10,
+			5,
+			15,
+			null,
+			null,
+			null,
+			[],
+			"cerebras/llama3.3-70b",
+			"cerebras",
+			"llama3.3-70b",
+			null,
+			false,
+			null,
+			null,
+			"req_finish_3",
+		);
+
+		expect(response.choices?.[0]?.finish_reason).toBe("stop");
+	});
+
 	test("applyExtendedUsageFields defaults zeros when nothing is set", () => {
 		const usage: Record<string, any> = {
 			prompt_tokens: 5,

--- a/apps/gateway/src/chat/tools/transform-response-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-response-to-openai.ts
@@ -1428,6 +1428,13 @@ export function transformResponseToOpenai(
 						message.annotations = annotations;
 					}
 				}
+				// Update finish_reason with the mapped value so canonicalizations
+				// applied by parseProviderResponse (e.g. "abort" -> "upstream_error",
+				// "tool_use" -> "tool_calls") reach the client instead of the raw
+				// upstream value, matching the provider-specific cases above.
+				if (transformedResponse.choices?.[0] && finishReason !== null) {
+					transformedResponse.choices[0].finish_reason = finishReason;
+				}
 				transformedResponse.model = formatUsedModelForDisplay(
 					usedProvider,
 					baseModelName,


### PR DESCRIPTION
## Summary

Follow-up to #3492. That PR (and #3053 before it) canonicalizes non-standard finish reasons in `parseProviderResponse`'s `default:` branch — but for most providers the canonical value never reached the client. `transformResponseToOpenai` starts from the raw upstream JSON and only writes the parsed `finishReason` back inside provider-specific `case` blocks; its `default:` branch updates content, reasoning, annotations, model, metadata and usage, but **not** `finish_reason`.

So of the ~38 providers served by the parse `default:` branch, only the 14 with their own transform case (openai, groq, xai, aws-mantle, azure, zai, inference.net, together-ai, scx-ai, scx-ai-gp, bytedance, embercloud, meta, sakana) returned the mapped value. The other 24 (deepseek, fireworks, minimax, cerebras, moonshot, perplexity, nebius, deepinfra, canopywave, nanogpt, custom, …) fell through the transform `default:` and still leaked the raw upstream value — verified by running a `finish_reason: "tool_use"` payload through parse → transform: `together-ai` came out `tool_calls`, `deepseek`/`fireworks`/`minimax`/`cerebras` still `tool_use`.

19 of those 24 are in the streaming shared-case list that already canonicalizes (`transform-streaming-to-openai.ts`), so the stream/non-stream asymmetry #3492 targets persisted for them.

## Fix

Write the parsed `finishReason` back in the transform `default:` branch, exactly as the provider-specific cases already do:

```ts
if (transformedResponse.choices?.[0] && finishReason !== null) {
	transformedResponse.choices[0].finish_reason = finishReason;
}
```

Standalone this propagates the existing `abort` → `upstream_error` mapping (#3053) to those 24 providers; combined with #3492 it completes `end_turn` → `stop` / `tool_use` → `tool_calls` for all providers on the branch. When the upstream sends no finish reason at all, parse yields `null` and the guard leaves the response untouched.

## Tests

Three cases added to `transform-response-to-openai.spec.ts`:

- mapped `tool_calls` written back for `deepseek` (raw `tool_use` in the upstream JSON), tool calls preserved;
- mapped `upstream_error` written back for `fireworks` (raw `abort`);
- `null` parsed finishReason leaves the upstream value untouched (`cerebras`).

## Verification

- `vitest run` transform + parse specs: 50/50 ✅
- full `apps/gateway/src/chat/tools` suite: all specs pass
- `pnpm build`: 17/17 ✅
- `pnpm format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)