### PR TITLE
feat(models): add Seedance 2.5 video model

### DIFF
--- a/.env.unified.example
+++ b/.env.unified.example
@@ -17,6 +17,11 @@ AUTH_SECRET=your-secret-key-here-must-be-32+
 # provider-key ciphertexts.
 GATEWAY_API_KEY_HASH_SECRET=your-api-key-hash-secret-here
 
+# Secret used to sign the short-lived playback URLs handed out for generated
+# videos. Required whenever video generation is enabled — without it completed
+# video jobs cannot hand back a playback link.
+LLM_VIDEO_CONTENT_JWT_SECRET=your-video-content-jwt-secret-here
+
 # =============================================================================
 # URLS (Update for your domain in production)
 # =============================================================================

--- a/apps/api/src/routes/video.spec.ts
+++ b/apps/api/src/routes/video.spec.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db, tables } from "@llmgateway/db";
+
+const SECRET_ENV = "LLM_VIDEO_CONTENT_JWT_SECRET";
+const ALLOW_DEV_ENV = "VIDEO_CONTENT_TOKEN_ALLOW_DEV";
+
+async function seedCompletedVideoJob() {
+	await db.insert(tables.organization).values({
+		id: "org-id",
+		name: "Test Organization",
+		billingEmail: "user",
+	});
+	await db.insert(tables.userOrganization).values({
+		id: "user-org-id",
+		userId: "test-user-id",
+		organizationId: "org-id",
+	});
+	await db.insert(tables.project).values({
+		id: "project-id",
+		name: "Test Project",
+		organizationId: "org-id",
+		mode: "credits",
+	});
+	await db.insert(tables.apiKey).values({
+		id: "api-key-id",
+		token: "real-token",
+		projectId: "project-id",
+		description: "Test API Key",
+		createdBy: "test-user-id",
+	});
+	await db.insert(tables.log).values({
+		id: "log-id",
+		requestId: "request-id",
+		organizationId: "org-id",
+		projectId: "project-id",
+		apiKeyId: "api-key-id",
+		duration: 1000,
+		requestedModel: "seedance-2-5",
+		usedModel: "dreamina-seedance-2-5-260628",
+		usedProvider: "bytedance",
+		responseSize: 0,
+		mode: "credits",
+		usedMode: "credits",
+	});
+	await db.insert(tables.videoJob).values({
+		id: "video-id",
+		requestId: "request-id",
+		logId: "log-id",
+		organizationId: "org-id",
+		projectId: "project-id",
+		apiKeyId: "api-key-id",
+		mode: "credits",
+		usedMode: "credits",
+		model: "seedance-2-5",
+		usedProvider: "bytedance",
+		usedModel: "dreamina-seedance-2-5-260628",
+		upstreamId: "upstream-id",
+		prompt: "a paper boat drifting down a rain puddle",
+		status: "completed",
+		progress: 100,
+	});
+}
+
+describe("GET /video/{videoId}", () => {
+	let token: string;
+
+	beforeEach(async () => {
+		token = await createTestUser();
+		await seedCompletedVideoJob();
+	});
+
+	afterEach(async () => {
+		vi.unstubAllEnvs();
+		await deleteAll();
+	});
+
+	test("returns a signed playback url for a completed job", async () => {
+		vi.stubEnv(SECRET_ENV, "video-content-secret");
+
+		const res = await app.request("/video/video-id", {
+			headers: { Cookie: token },
+		});
+
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		expect(json.status).toBe("completed");
+		expect(json.content[0].url).toContain("/v1/videos/logs/log-id/content");
+		expect(json.content[0].url).toContain("token=");
+	});
+
+	// A finished job is already generated and billed. Losing the ability to sign
+	// the playback url must not hide the terminal status from pollers, or the
+	// client spins on "in progress" forever and never persists the result.
+	test("still reports completion when the playback url cannot be signed", async () => {
+		vi.stubEnv(SECRET_ENV, undefined);
+		vi.stubEnv(ALLOW_DEV_ENV, undefined);
+
+		const res = await app.request("/video/video-id", {
+			headers: { Cookie: token },
+		});
+
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		expect(json.status).toBe("completed");
+		expect(json.progress).toBe(100);
+		expect(json.content).toBeUndefined();
+	});
+});

--- a/apps/api/src/routes/video.ts
+++ b/apps/api/src/routes/video.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { userHasOrganizationAccess } from "@/utils/authorization.js";
 
 import { db } from "@llmgateway/db";
+import { logger } from "@llmgateway/logger";
 import { buildSignedGatewayVideoLogContentUrl } from "@llmgateway/shared/video-access";
 
 import type { ServerTypes } from "@/vars.js";
@@ -102,16 +103,29 @@ video.openapi(getVideoStatus, async (c) => {
 		throw new HTTPException(404, { message: "Video not found" });
 	}
 
+	// Signing needs LLM_VIDEO_CONTENT_JWT_SECRET. If that is missing or invalid
+	// only playback is broken, so keep the failure scoped to `content` instead of
+	// failing the whole response: clients poll this endpoint to learn a job
+	// reached a terminal state, and a 500 here strands finished (already billed)
+	// generations on "in progress" forever.
 	let content:
 		{ type: "video"; url: string; mime_type?: string | null }[] | undefined;
 	if (job.status === "completed" && job.logId) {
-		content = [
-			{
-				type: "video" as const,
-				url: buildSignedGatewayVideoLogContentUrl(job.logId),
-				mime_type: job.contentType ?? null,
-			},
-		];
+		try {
+			content = [
+				{
+					type: "video" as const,
+					url: buildSignedGatewayVideoLogContentUrl(job.logId),
+					mime_type: job.contentType ?? null,
+				},
+			];
+		} catch (error) {
+			logger.error("Failed to sign video content URL", {
+				videoId: job.id,
+				logId: job.logId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
 	}
 
 	return c.json(

--- a/apps/docs/content/features/video-generation.mdx
+++ b/apps/docs/content/features/video-generation.mdx
@@ -13,6 +13,7 @@ LLMGateway supports asynchronous video generation through an OpenAI-compatible `
 Currently available models:
 
 - **Veo 3.1** through `avalanche` (1080p, 4k) and `google-vertex` (720p, 1080p, 4k)
+- **Seedance 2.5** through `bytedance` (480p, 720p, 1080p; clips up to 30 seconds)
 - **Seedance 2.0** and **Seedance 1.5 Pro** through `bytedance` (720p, 1080p), **Seedance 2.0 Fast** through `bytedance` (720p only)
 - **Seedance 2.0 Mini** through `bytedance` (480p, 720p)
 - **KLING v3.0** and **KLING v3.0 Turbo** through `atlascloud` (720p, 1080p; KLING v3.0 also 4k)
@@ -43,23 +44,24 @@ LLMGateway currently supports a focused subset of the OpenAI video API.
 | `last_frame`       | object  | no       | Optional ending frame when `image` is provided (see first/last frame inputs below)                                         |
 | `reference_images` | array   | no       | One to three provider-specific image inputs                                                                                |
 | `input_reference`  | object  | no       | Alias for one or more `reference_images`                                                                                   |
-| `reference_videos` | array   | no       | One to three reference video HTTPS URLs (Seedance 2.0 only, see below)                                                     |
-| `reference_audios` | array   | no       | One to three reference audio HTTPS URLs (Seedance 2.0 only, see below)                                                     |
+| `reference_videos` | array   | no       | One to three reference video HTTPS URLs (Seedance 2.x only, see below)                                                     |
+| `reference_audios` | array   | no       | One to three reference audio HTTPS URLs (Seedance 2.x only, see below)                                                     |
 | `callback_url`     | string  | no       | LLMGateway extension for completion webhooks                                                                               |
 | `callback_secret`  | string  | no       | LLMGateway extension used to sign webhook deliveries                                                                       |
 
 ### Sizes and durations by model
 
-| Model family      | Provider        | Supported sizes                                                            | Supported durations |
-| ----------------- | --------------- | -------------------------------------------------------------------------- | ------------------- |
-| Veo 3.1           | `google-vertex` | `1280x720`, `720x1280`, `1920x1080`, `1080x1920`, `3840x2160`, `2160x3840` | `4`, `6`, `8`, `10` |
-| Veo 3.1           | `avalanche`     | `1920x1080`, `1080x1920`, `3840x2160`, `2160x3840`                         | `8`                 |
-| Seedance 2.0      | `bytedance`     | `1280x720`, `720x1280`, `1920x1080`, `1080x1920`                           | `4`–`15`            |
-| Seedance 2.0 Fast | `bytedance`     | `1280x720`, `720x1280`                                                     | `4`–`15`            |
-| Seedance 2.0 Mini | `bytedance`     | `1280x720`, `720x1280`, `848x480`, `854x480`, `480x854`                    | `4`–`15`            |
-| Seedance 1.5 Pro  | `bytedance`     | `1280x720`, `720x1280`, `1920x1080`, `1080x1920`                           | `5`, `10`           |
-| KLING v3.0        | `atlascloud`    | `1280x720`, `720x1280`, `1920x1080`, `1080x1920`, `3840x2160`, `2160x3840` | `5`, `10`           |
-| KLING v3.0 Turbo  | `atlascloud`    | `1280x720`, `720x1280`, `1920x1080`, `1080x1920`                           | `5`, `10`           |
+| Model family      | Provider        | Supported sizes                                                                   | Supported durations |
+| ----------------- | --------------- | --------------------------------------------------------------------------------- | ------------------- |
+| Veo 3.1           | `google-vertex` | `1280x720`, `720x1280`, `1920x1080`, `1080x1920`, `3840x2160`, `2160x3840`        | `4`, `6`, `8`, `10` |
+| Veo 3.1           | `avalanche`     | `1920x1080`, `1080x1920`, `3840x2160`, `2160x3840`                                | `8`                 |
+| Seedance 2.5      | `bytedance`     | `848x480`, `854x480`, `480x854`, `1280x720`, `720x1280`, `1920x1080`, `1080x1920` | `4`–`30`            |
+| Seedance 2.0      | `bytedance`     | `1280x720`, `720x1280`, `1920x1080`, `1080x1920`                                  | `4`–`15`            |
+| Seedance 2.0 Fast | `bytedance`     | `1280x720`, `720x1280`                                                            | `4`–`15`            |
+| Seedance 2.0 Mini | `bytedance`     | `1280x720`, `720x1280`, `848x480`, `854x480`, `480x854`                           | `4`–`15`            |
+| Seedance 1.5 Pro  | `bytedance`     | `1280x720`, `720x1280`, `1920x1080`, `1080x1920`                                  | `5`, `10`           |
+| KLING v3.0        | `atlascloud`    | `1280x720`, `720x1280`, `1920x1080`, `1080x1920`, `3840x2160`, `2160x3840`        | `5`, `10`           |
+| KLING v3.0 Turbo  | `atlascloud`    | `1280x720`, `720x1280`, `1920x1080`, `1080x1920`                                  | `5`, `10`           |
 
 Requests return `400` when the selected provider cannot serve the requested `size` or `seconds`. Seedance and KLING v3.0 derive `aspect_ratio` from the requested `size` (16:9 for landscape, 9:16 for portrait).
 
@@ -71,12 +73,12 @@ Frame inputs interpolate a video between a starting frame and an optional ending
 
 | Field        | Required           | Accepted input                   | Available on                                                                                                                    |
 | ------------ | ------------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `image`      | for frame mode     | HTTPS URL **or** base64 data URL | **Seedance 2.0** (`bytedance`), **KLING v3.0 / Turbo** (`atlascloud`), Veo 3.1 (`google-vertex`, `avalanche`), `minimax`, `xai` |
-| `last_frame` | no (needs `image`) | HTTPS URL **or** base64 data URL | **Seedance 2.0** (`bytedance`), **KLING v3.0 / Turbo** (`atlascloud`), Veo 3.1 (`google-vertex`, `avalanche`)                   |
+| `image`      | for frame mode     | HTTPS URL **or** base64 data URL | **Seedance 2.x** (`bytedance`), **KLING v3.0 / Turbo** (`atlascloud`), Veo 3.1 (`google-vertex`, `avalanche`), `minimax`, `xai` |
+| `last_frame` | no (needs `image`) | HTTPS URL **or** base64 data URL | **Seedance 2.x** (`bytedance`), **KLING v3.0 / Turbo** (`atlascloud`), Veo 3.1 (`google-vertex`, `avalanche`)                   |
 
 #### Rules and limits
 
-- **Seedance scope.** Frame inputs are supported on **Seedance 2.0**, **Seedance 2.0 Fast**, and **Seedance 2.0 Mini** (`seedance-2-0`, `seedance-2-0-fast`, `seedance-2-0-mini`). Sending `image`/`last_frame` to Seedance 1.5 Pro or any other ByteDance model returns a `400`.
+- **Seedance scope.** Frame inputs are supported on **Seedance 2.5**, **Seedance 2.0**, **Seedance 2.0 Fast**, and **Seedance 2.0 Mini** (`seedance-2-5`, `seedance-2-0`, `seedance-2-0-fast`, `seedance-2-0-mini`). Sending `image`/`last_frame` to Seedance 1.5 Pro or any other ByteDance model returns a `400`.
 - **KLING scope.** Frame inputs are supported on **KLING v3.0** and **KLING v3.0 Turbo** (`kling-v3-0`, `kling-v3-0-turbo`). The gateway uploads base64 frames to AtlasCloud's media endpoint automatically, so both HTTPS URLs and base64 data URLs are accepted.
 - **`last_frame` requires `image`.** Providing `last_frame` without `image` returns a `400`.
 - **Not combinable with references.** First/last frame inputs (`image`, `last_frame`) cannot be combined with reference inputs (`reference_images`, `input_reference`, `reference_videos`, `reference_audios`).
@@ -112,15 +114,15 @@ curl -X POST "https://api.llmgateway.io/v1/videos" \
   }'
 ```
 
-### Reference-guided generation (Seedance 2.0)
+### Reference-guided generation (Seedance 2.x)
 
-Seedance 2.0 (`seedance-2-0`, `seedance-2-0-fast`, `seedance-2-0-mini`) can generate a video that is guided by reference **images**, **videos**, and **audio** — sometimes called omni-reference. You attach references as top-level fields in the same `POST /v1/videos` payload; the gateway forwards each one to the provider tagged with the correct role, so you don't set roles yourself.
+Seedance 2.x (`seedance-2-5`, `seedance-2-0`, `seedance-2-0-fast`, `seedance-2-0-mini`) can generate a video that is guided by reference **images**, **videos**, and **audio** — sometimes called omni-reference. You attach references as top-level fields in the same `POST /v1/videos` payload; the gateway forwards each one to the provider tagged with the correct role, so you don't set roles yourself.
 
 | Reference type | Payload field                                | Count | Accepted input                   | Available on                                         |
 | -------------- | -------------------------------------------- | ----- | -------------------------------- | ---------------------------------------------------- |
-| Image          | `reference_images` (`input_reference` alias) | 1–3   | HTTPS URL **or** base64 data URL | Seedance 2.0, Veo 3.1 (`google-vertex`, `avalanche`) |
-| Video          | `reference_videos`                           | 1–3   | HTTPS URL only                   | Seedance 2.0                                         |
-| Audio          | `reference_audios`                           | 1–3   | HTTPS URL only                   | Seedance 2.0                                         |
+| Image          | `reference_images` (`input_reference` alias) | 1–3   | HTTPS URL **or** base64 data URL | Seedance 2.x, Veo 3.1 (`google-vertex`, `avalanche`) |
+| Video          | `reference_videos`                           | 1–3   | HTTPS URL only                   | Seedance 2.x                                         |
+| Audio          | `reference_audios`                           | 1–3   | HTTPS URL only                   | Seedance 2.x                                         |
 
 Each list item accepts either a bare URL string or an object form:
 
@@ -135,7 +137,7 @@ You can mix all three reference types in one request. The `prompt` can be a ligh
 - **HTTPS only for video and audio.** `reference_videos` and `reference_audios` must be publicly reachable HTTPS URLs (the provider fetches them). base64 data URLs are rejected for video/audio; images may be HTTPS URLs or base64 data URLs.
 - **Reference video resolution.** Seedance requires reference video frames to be at least ~409,600 pixels (roughly 480p or larger). Low-resolution clips such as 360p are rejected with a `400`.
 - **Not combinable with frames.** Reference inputs (`reference_images`, `reference_videos`, `reference_audios`) cannot be combined with the first/last frame inputs (`image`, `last_frame`).
-- **Provider scope.** Reference videos and audio are only supported on Seedance 2.0 models; sending them to other models returns a `400`. **KLING v3.0** does not support any reference inputs (`reference_images`, `reference_videos`, `reference_audios`); use first/last frame inputs instead.
+- **Provider scope.** Reference videos and audio are only supported on Seedance 2.x models; sending them to other models returns a `400`. **KLING v3.0** does not support any reference inputs (`reference_images`, `reference_videos`, `reference_audios`); use first/last frame inputs instead.
 - **Moderation still applies.** The output is subject to the provider's content moderation. Blocked generations finish as `failed` and are logged with a `content_filter` finish reason.
 
 #### Examples
@@ -225,6 +227,9 @@ Seedance (ByteDance):
 
 | Model               | Provider    | Resolution | With audio          | Video only          |
 | ------------------- | ----------- | ---------- | ------------------- | ------------------- |
+| `seedance-2-5`      | `bytedance` | 480p       | `$0.1028 / second`  | `$0.1028 / second`  |
+| `seedance-2-5`      | `bytedance` | 720p       | `$0.2311 / second`  | `$0.2311 / second`  |
+| `seedance-2-5`      | `bytedance` | 1080p      | `$0.52 / second`    | `$0.52 / second`    |
 | `seedance-2-0`      | `bytedance` | 720p       | `$0.1512 / second`  | `$0.1512 / second`  |
 | `seedance-2-0`      | `bytedance` | 1080p      | `$0.3402 / second`  | `$0.3402 / second`  |
 | `seedance-2-0-fast` | `bytedance` | 720p       | `$0.121 / second`   | `$0.121 / second`   |

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -2198,6 +2198,27 @@ mockOpenAIServer.post("/contents/generations/tasks", async (c) => {
 		});
 	}
 
+	const referenceVideoUrls: string[] = [];
+	for (const entry of content) {
+		if (
+			!entry ||
+			typeof entry !== "object" ||
+			(entry as Record<string, unknown>).role !== "reference_video"
+		) {
+			continue;
+		}
+		const videoUrl = (entry as Record<string, unknown>).video_url;
+		const url =
+			typeof videoUrl === "object" &&
+			videoUrl !== null &&
+			typeof (videoUrl as Record<string, unknown>).url === "string"
+				? ((videoUrl as Record<string, unknown>).url as string)
+				: undefined;
+		if (url) {
+			referenceVideoUrls.push(url);
+		}
+	}
+
 	videoCounter++;
 	const id = `bytedance_task_${videoCounter}`;
 	const job: MockVideoJobState = {
@@ -2209,6 +2230,8 @@ mockOpenAIServer.post("/contents/generations/tasks", async (c) => {
 		firstFrame: parseFrameByRole("first_frame"),
 		lastFrame: parseFrameByRole("last_frame"),
 		referenceImages: referenceImages.length > 0 ? referenceImages : undefined,
+		referenceVideoUrls:
+			referenceVideoUrls.length > 0 ? referenceVideoUrls : undefined,
 		duration: typeof body.duration === "number" ? body.duration : undefined,
 		ratio: typeof body.ratio === "string" ? body.ratio : undefined,
 		resolution:

--- a/apps/gateway/src/videos/videos.spec.ts
+++ b/apps/gateway/src/videos/videos.spec.ts
@@ -872,7 +872,7 @@ describe("videos", () => {
 		expect(totalCosts[1]).toBeCloseTo(expectedCost, 6);
 	});
 
-	test("/v1/videos restricts reference inputs to Seedance 2.0 models", async () => {
+	test("/v1/videos restricts reference inputs to Seedance 2.x models", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id",
 			token: "real-token",
@@ -898,7 +898,7 @@ describe("videos", () => {
 
 		expect(res.status).toBe(400);
 		const json = await res.json();
-		expect(JSON.stringify(json)).toContain("Seedance 2.0");
+		expect(JSON.stringify(json)).toContain("Seedance 2.x");
 	});
 
 	test("/v1/videos forwards up to nine reference images to Seedance 2.0 Fast", async () => {
@@ -947,6 +947,105 @@ describe("videos", () => {
 
 		const mockVideo = getMockVideo(videoJob!.upstreamId);
 		expect(mockVideo?.referenceImages).toHaveLength(9);
+	});
+
+	test("/v1/videos routes Seedance 2.5 with its own resolution and duration range", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-bytedance-key",
+			provider: "bytedance",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const createRes = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "seedance-2-5",
+				prompt: "A long single-shot walk through a night market",
+				size: "848x480",
+				seconds: 30,
+				audio: false,
+				reference_videos: ["https://example.com/reference-motion.mp4"],
+			}),
+		});
+
+		expect(createRes.status).toBe(200);
+		const created = await createRes.json();
+
+		const videoJob = await db.query.videoJob.findFirst({
+			where: { id: { eq: created.id } },
+		});
+		expect(videoJob?.usedProvider).toBe("bytedance");
+		expect(videoJob?.usedModel).toBe("dreamina-seedance-2-5-260628");
+
+		const mockVideo = getMockVideo(videoJob!.upstreamId);
+		expect(mockVideo?.resolution).toBe("480p");
+		expect(mockVideo?.duration).toBe(30);
+		expect(mockVideo?.ratio).toBe("16:9");
+		expect(mockVideo?.referenceVideoUrls).toEqual([
+			"https://example.com/reference-motion.mp4",
+		]);
+	});
+
+	test("/v1/videos rejects 4K and over-30s durations on Seedance 2.5", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-bytedance-key",
+			provider: "bytedance",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const fourKRes = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "bytedance/seedance-2-5",
+				prompt: "A night market",
+				size: "3840x2160",
+				seconds: 4,
+			}),
+		});
+		expect(fourKRes.status).toBe(400);
+
+		const tooLongRes = await app.request("/v1/videos", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "bytedance/seedance-2-5",
+				prompt: "A night market",
+				size: "1280x720",
+				seconds: 31,
+			}),
+		});
+		expect(tooLongRes.status).toBe(400);
 	});
 
 	test("/v1/videos rejects more than nine reference images on Seedance 2.0 Fast", async () => {
@@ -2080,7 +2179,7 @@ describe("videos", () => {
 		expect(res.status).toBe(400);
 		const json = await res.json();
 		expect(JSON.stringify(json)).toContain(
-			"frame inputs are currently only supported on bytedance Seedance 2.0",
+			"frame inputs are currently only supported on bytedance Seedance 2.x",
 		);
 	});
 

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -359,7 +359,7 @@ const createVideoRequestSchema = z
 		image: videoImageInputSchema.optional(),
 		reference_images: videoReferenceImagesSchema.optional().openapi({
 			description:
-				"Reference images for provider-specific asset or material-guided video generation. ByteDance Seedance 2.0 models accept up to 9; other providers accept up to 3.",
+				"Reference images for provider-specific asset or material-guided video generation. ByteDance Seedance 2.x models accept up to 9; other providers accept up to 3.",
 			example: [
 				{
 					image_url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...",
@@ -368,7 +368,7 @@ const createVideoRequestSchema = z
 		}),
 		reference_videos: videoReferenceVideosSchema.optional().openapi({
 			description:
-				"One to three reference videos (HTTPS URLs) for omni-reference video generation. Currently only supported on ByteDance Seedance 2.0 models and can be combined with reference_images.",
+				"One to three reference videos (HTTPS URLs) for omni-reference video generation. Currently only supported on ByteDance Seedance 2.x models and can be combined with reference_images.",
 			example: [
 				{
 					video_url: "https://example.com/reference-motion.mp4",
@@ -377,7 +377,7 @@ const createVideoRequestSchema = z
 		}),
 		reference_audios: videoReferenceAudiosSchema.optional().openapi({
 			description:
-				"One to three reference audio clips (HTTPS URLs) for omni-reference video generation. Currently only supported on ByteDance Seedance 2.0 models and can be combined with reference_images and reference_videos.",
+				"One to three reference audio clips (HTTPS URLs) for omni-reference video generation. Currently only supported on ByteDance Seedance 2.x models and can be combined with reference_images and reference_videos.",
 			example: [
 				{
 					audio_url: "https://example.com/reference-track.mp3",
@@ -950,7 +950,8 @@ function isBytedanceSeedance2Model(externalId: string): boolean {
 	return (
 		externalId === "dreamina-seedance-2-0-260128" ||
 		externalId === "dreamina-seedance-2-0-fast-260128" ||
-		externalId === "dreamina-seedance-2-0-mini-260615"
+		externalId === "dreamina-seedance-2-0-mini-260615" ||
+		externalId === "dreamina-seedance-2-5-260628"
 	);
 }
 
@@ -1041,7 +1042,7 @@ function getVideoProviderConstraintReasons(
 		if (provider.providerId === "bytedance") {
 			if (!isBytedanceSeedance2Model(provider.externalId)) {
 				reasons.push(
-					"frame inputs are currently only supported on bytedance Seedance 2.0 (seedance-2-0, seedance-2-0-fast, seedance-2-0-mini)",
+					"frame inputs are currently only supported on bytedance Seedance 2.x (seedance-2-0, seedance-2-0-fast, seedance-2-0-mini, seedance-2-5)",
 				);
 			}
 		} else if (isAtlasCloudVideoProvider(provider.providerId)) {
@@ -1099,11 +1100,11 @@ function getVideoProviderConstraintReasons(
 		if (provider.providerId === "bytedance") {
 			if (!isBytedanceSeedance2Model(provider.externalId)) {
 				reasons.push(
-					"reference inputs are currently only supported on bytedance Seedance 2.0 (seedance-2-0, seedance-2-0-fast, seedance-2-0-mini)",
+					"reference inputs are currently only supported on bytedance Seedance 2.x (seedance-2-0, seedance-2-0-fast, seedance-2-0-mini, seedance-2-5)",
 				);
 			} else if (inputImageCount > SEEDANCE_2_MAX_REFERENCE_IMAGES) {
 				reasons.push(
-					`Seedance 2.0 supports at most ${SEEDANCE_2_MAX_REFERENCE_IMAGES} reference images`,
+					`Seedance 2.x supports at most ${SEEDANCE_2_MAX_REFERENCE_IMAGES} reference images`,
 				);
 			}
 
@@ -1112,13 +1113,13 @@ function getVideoProviderConstraintReasons(
 
 		if (referenceVideoCount > 0) {
 			reasons.push(
-				"reference videos are currently only supported on bytedance Seedance 2.0 models",
+				"reference videos are currently only supported on bytedance Seedance 2.x models",
 			);
 		}
 
 		if (referenceAudioCount > 0) {
 			reasons.push(
-				"reference audio is currently only supported on bytedance Seedance 2.0 models",
+				"reference audio is currently only supported on bytedance Seedance 2.x models",
 			);
 		}
 

--- a/apps/playground/src/lib/video-gen.spec.ts
+++ b/apps/playground/src/lib/video-gen.spec.ts
@@ -294,6 +294,43 @@ describe("Seedance 2.0 reference capabilities", () => {
 		expect(options.durations).toHaveLength(0);
 	});
 
+	test("Seedance 2.5 gets the same reference/frame capabilities as Seedance 2.0", () => {
+		expect(supportsVideoFrameInput("seedance-2-5")).toBe(true);
+		expect(supportsVideoFrameInput("bytedance/seedance-2-5")).toBe(true);
+		expect(supportsVideoReferenceInput("bytedance/seedance-2-5")).toBe(true);
+		expect(supportsVideoReferenceVideoInput("bytedance/seedance-2-5")).toBe(
+			true,
+		);
+		expect(supportsVideoReferenceAudioInput("bytedance/seedance-2-5")).toBe(
+			true,
+		);
+		expect(supportsVideoFrameInput("google-vertex/seedance-2-5")).toBe(false);
+	});
+
+	test("Seedance 2.5 offers 480p and durations beyond 15s", () => {
+		const model = makeModel(
+			[
+				makeSeedanceMapping({
+					modelId: "seedance-2-5",
+					externalId: "dreamina-seedance-2-5-260628",
+					supportedVideoSizes: ["848x480", "1280x720", "1920x1080"],
+					supportedVideoDurationsSeconds: [4, 8, 15, 20, 30],
+				}),
+			],
+			"seedance-2-5",
+		);
+		const options = getSupportedVideoRequestOptions(
+			[model],
+			["seedance-2-5"],
+			"none",
+		);
+
+		expect(options.sizes).toContain("848x480");
+		expect(options.sizes).not.toContain("3840x2160");
+		expect(options.durations).toContain(30);
+		expect(options.durations).not.toContain(5);
+	});
+
 	test("frame mode keeps size/duration options for Seedance 2.0", () => {
 		const model = makeModel([makeSeedanceMapping()], "seedance-2-0");
 		const options = getSupportedVideoRequestOptions(

--- a/apps/playground/src/lib/video-gen.ts
+++ b/apps/playground/src/lib/video-gen.ts
@@ -12,7 +12,34 @@ export type VideoSize =
 	| "3840x2160"
 	| "2160x3840";
 
-export type VideoDuration = 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15;
+export type VideoDuration =
+	| 4
+	| 5
+	| 6
+	| 7
+	| 8
+	| 9
+	| 10
+	| 11
+	| 12
+	| 13
+	| 14
+	| 15
+	| 16
+	| 17
+	| 18
+	| 19
+	| 20
+	| 21
+	| 22
+	| 23
+	| 24
+	| 25
+	| 26
+	| 27
+	| 28
+	| 29
+	| 30;
 
 export interface VideoInputImage {
 	dataUrl: string;
@@ -68,7 +95,8 @@ export interface VideoGalleryItem {
 export type VideoInputMode = "none" | "frames" | "reference";
 
 const VIDEO_DURATIONS: VideoDuration[] = [
-	4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+	4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+	25, 26, 27, 28, 29, 30,
 ];
 
 const VIDEO_SIZE_LABELS: Record<VideoSize, string> = {
@@ -130,7 +158,11 @@ export function supportsVideoFrameInput(modelId: string): boolean {
 }
 
 function isSeedance2ReferenceModel(rootModelId: string): boolean {
-	return rootModelId === "seedance-2-0" || rootModelId === "seedance-2-0-fast";
+	return (
+		rootModelId === "seedance-2-0" ||
+		rootModelId === "seedance-2-0-fast" ||
+		rootModelId === "seedance-2-5"
+	);
 }
 
 function isGrokImagineVideoModel(rootModelId: string): boolean {
@@ -243,10 +275,7 @@ function mappingSupportsVideoRequest(
 	if (inputMode === "frames") {
 		// Match by canonical root model id — never by the upstream externalId.
 		if (mapping.providerId === "bytedance") {
-			return (
-				mapping.modelId === "seedance-2-0" ||
-				mapping.modelId === "seedance-2-0-fast"
-			);
+			return isSeedance2ReferenceModel(mapping.modelId);
 		}
 
 		if (
@@ -263,10 +292,7 @@ function mappingSupportsVideoRequest(
 	if (inputMode === "reference") {
 		// Match by canonical root model id — never by the upstream externalId.
 		if (mapping.providerId === "bytedance") {
-			return (
-				mapping.modelId === "seedance-2-0" ||
-				mapping.modelId === "seedance-2-0-fast"
-			);
+			return isSeedance2ReferenceModel(mapping.modelId);
 		}
 
 		// Veo reference images are only supported on the veo-3.1 family.

--- a/packages/models/src/models/bytedance.ts
+++ b/packages/models/src/models/bytedance.ts
@@ -132,6 +132,58 @@ export const bytedanceModels = [
 		],
 	},
 	{
+		id: "seedance-2-5",
+		name: "Seedance 2.5",
+		description:
+			"ByteDance Seedance 2.5 video generation model with single-shot clips up to 30 seconds and omni-reference image/video/audio conditioning",
+		family: "bytedance",
+		output: ["video"],
+		maxVideoDurationSeconds: 30,
+		releasedAt: new Date("2026-08-08"),
+		providers: [
+			{
+				test: "skip",
+				providerId: "bytedance",
+				externalId: "dreamina-seedance-2-5-260628",
+				inputPrice: undefined,
+				outputPrice: undefined,
+				requestPrice: undefined,
+				perSecondPrice: {
+					default_audio: "0.2311",
+					default_video: "0.2311",
+					"480p_audio": "0.1028",
+					"480p_video": "0.1028",
+					"1080p_audio": "0.52",
+					"1080p_video": "0.52",
+				},
+				contextSize: 2000,
+				maxOutput: 1,
+				streaming: false,
+				vision: false,
+				tools: false,
+				jsonOutput: false,
+				videoGenerations: true,
+				// BytePlus rejects `2k` and `4k` on this deployment even though the
+				// console rate card lists a 4K tier, so 4K sizes stay off the mapping.
+				supportedVideoSizes: [
+					"848x480",
+					"854x480",
+					"480x854",
+					"1280x720",
+					"720x1280",
+					"1920x1080",
+					"1080x1920",
+				],
+				supportedVideoDurationsSeconds: [
+					4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+					23, 24, 25, 26, 27, 28, 29, 30,
+				],
+				supportsVideoAudio: true,
+				supportsVideoWithoutAudio: true,
+			},
+		],
+	},
+	{
 		id: "seedance-2-0",
 		name: "Seedance 2.0",
 		description:


### PR DESCRIPTION
## Problem

Two things, both hit through the video studio:

1. **Seedance 2.5 was missing.** ByteDance shipped `dreamina-seedance-2-5-260628` on 2026-08-08 — single-shot clips up to 30s and omni-reference (image/video/audio) conditioning.
2. **The video studio never finished a generation.** Every model — Veo 3.1, Seedance 2.0, AtlasCloud KLING — sat on `Generating… 50%` and then failed with a generic error. The clip was generated and billed upstream; the UI just never saw it, and because the save-to-history path only runs on a completed poll, the result was silently dropped.

The cause is in `GET /video/{videoId}` (`apps/api`): the handler mints a signed playback URL for completed jobs, and `buildSignedGatewayVideoLogContentUrl` **throws** when `LLM_VIDEO_CONTENT_JWT_SECRET` is unset. So the status endpoint 500s at exactly the moment a job reaches `completed` — never before. The playground poller treats 500 as transient, retries 10×, then gives up. `LLM_VIDEO_CONTENT_JWT_SECRET` is in `.env.example` but was missing from `.env.unified.example` and the self-host docs, so any deployment built from those hits this.

## Approach

**Seedance 2.5** — new mapping on `bytedance`. Sizes, durations and pricing were **probed against the live BytePlus ap-southeast deployment**, not copied from the console rate card:

| Probe | Result |
| --- | --- |
| `resolution` | `480p`, `720p`, `1080p` accepted; **`2k` and `4k` rejected** |
| `duration` | `4`–`30` accepted; `2`, `3`, `31`+ rejected |
| `ratio` | `16:9` and `9:16` both accepted |

The console rate card lists a 4K tier ($2.08/s) but the deployment 400s on it, so 4K sizes and the `4k_*` price keys are deliberately **off** the mapping (with a comment saying why, so nobody "fixes" it back). Per-second pricing: 480p `$0.1028`, 720p `$0.2311`, 1080p `$0.52`.

Seedance 2.5 joins the Seedance 2.x family everywhere the 2.0 ids were hardcoded — frame inputs, reference images/videos/audio, and the studio's capability checks. Studio duration options now run to 30s (they were capped at 15).

**Studio fix** — the signing step is wrapped so a failure is scoped to `content` and logged, instead of failing the whole status response. A completed job now reports `completed` even if playback can't be signed, so the poller terminates, history saves, and only playback degrades. `LLM_VIDEO_CONTENT_JWT_SECRET` added to `.env.unified.example`.

## Verification

Live against BytePlus with a real key (the model needed activating in the Ark Console first — `ModelNotOpen` until then):

- `POST /v1/videos` `bytedance/seedance-2-5` 480p/4s → completed, billed **$0.4112** (= 4 × $0.1028) ✅
- Same run through the video studio end to end → clip renders at 854×480 and persists to history ✅
- Regression-checked the models the studio was failing on: Seedance 2.0, Veo 3.1 and KLING v3.0 all complete again ✅

Tests: `videos.spec.ts` 50 passed (2 new — 2.5 routing/resolution/duration/reference-video forwarding, and 4K + `>30s` rejection), new `apps/api/src/routes/video.spec.ts` covering both signing outcomes, `video-gen.spec.ts` 22 passed. `pnpm build` and `pnpm format` clean.

**Not done:** e2e is `test: "skip"` on this mapping like every other video model — a run costs real money per clip.

## Screenshots

Video studio with a completed Seedance 2.5 generation — dark / light:

<img width="1440" alt="Seedance 2.5 in the video studio, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/f447993ac2335568af9b9c831720673f698ab0b2/studio-dark.png" />
<img width="1440" alt="Seedance 2.5 in the video studio, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/f447993ac2335568af9b9c831720673f698ab0b2/studio-light.png" />

Resolution menu — 480p/720p/1080p selectable, 4K greyed out because the deployment rejects it:

<img width="1440" alt="Resolution options, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/f447993ac2335568af9b9c831720673f698ab0b2/resolutions-dark.png" />
<img width="1440" alt="Resolution options, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/f447993ac2335568af9b9c831720673f698ab0b2/resolutions-light.png" />

Duration menu now reaching 30s:

<img width="1440" alt="Duration options, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/f447993ac2335568af9b9c831720673f698ab0b2/durations-dark.png" />
<img width="1440" alt="Duration options, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/f447993ac2335568af9b9c831720673f698ab0b2/durations-light.png" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Seedance 2.5 video-generation model.
  * Expanded video durations up to 30 seconds, with 480p–1080p resolution options.
  * Added support for audio, silent video, frame inputs, and reference media.
  * Added signed playback URLs for completed generated videos when configured.

* **Bug Fixes**
  * Completed video requests now remain available even if playback URL signing fails.

* **Documentation**
  * Updated video-generation guidance, capabilities, constraints, and pricing for Seedance 2.x.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->