### PR TITLE
chore: deactivate RanoAI provider mappings

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -683,6 +683,7 @@ export const deepseekModels = [
 				// `input_cache_read` rate /v1/models advertises.
 				providerId: "ranoai",
 				externalId: "deepseek-v4-flash",
+				deactivatedAt: new Date("2026-08-09"),
 				inputPrice: "0.15e-6",
 				outputPrice: "0.35e-6",
 				cachedInputPrice: "0.05e-6",

--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -2466,6 +2466,7 @@ export const googleModels = [
 				// input rate (verified 2026-08-05).
 				providerId: "ranoai",
 				externalId: "gemma-4-31b",
+				deactivatedAt: new Date("2026-08-09"),
 				inputPrice: "0.1e-6",
 				outputPrice: "0.3e-6",
 				cachedInputPrice: "0.05e-6",


### PR DESCRIPTION
## Summary

Deactivates all RanoAI provider mappings as of today (2026-08-09).

Both RanoAI mappings in the catalogue now carry `deactivatedAt: new Date("2026-08-09")`:

- `deepseek-v4-flash` (`packages/models/src/models/deepseek.ts`)
- `gemma-4-31b` (`packages/models/src/models/google.ts`)

Per the repo convention, the mappings are deactivated rather than removed so historical usage records and analytics lookups keep resolving.

## Testing

- `pnpm format`
- `pnpm build` — all 17 tasks pass
- `vitest run packages/models packages/shared packages/actions` — 952 tests pass
- `vitest run apps/gateway/src/lib/costs.spec.ts` — 76 tests pass (RanoAI cost cases still resolve pricing from the deactivated mappings)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDQ4Pe8PuXoDib8RP4bs7H)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Model Availability**
  * DeepSeek V4 Flash is scheduled to be deactivated on August 9, 2026.
  * Gemma 4 31B IT is scheduled to be deactivated on August 9, 2026.
  * These models may no longer be available after the listed date. Consider selecting an alternative model before deactivation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->