### PR TITLE
fix(ui): hide providers without active mappings

### DIFF
--- a/apps/ui/src/app/providers/country/[country]/page.tsx
+++ b/apps/ui/src/app/providers/country/[country]/page.tsx
@@ -4,12 +4,9 @@ import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 import { ProvidersGrid } from "@/components/providers/providers-grid";
 import { JsonLd } from "@/components/seo/json-ld";
+import { activeModelCounts, listedProviders } from "@/lib/providers-catalog";
 
-import {
-	getProviderCountries,
-	models as modelDefinitions,
-	providers as providerDefinitions,
-} from "@llmgateway/models";
+import { getProviderCountries } from "@llmgateway/models";
 
 import type { Metadata } from "next";
 
@@ -24,18 +21,14 @@ function findCountry(code: string) {
 }
 
 function providersForCountry(code: string) {
-	return providerDefinitions.filter(
-		(provider) =>
-			provider.name !== "LLM Gateway" &&
-			provider.id !== "custom" &&
-			provider.headquarters === code,
-	);
+	return listedProviders.filter((provider) => provider.headquarters === code);
 }
 
-function modelCountForProviders(providerIds: Set<string>): number {
-	return modelDefinitions.filter((model) =>
-		model.providers.some((p) => providerIds.has(p.providerId)),
-	).length;
+function modelCountForProviders(providers: { id: string }[]): number {
+	return providers.reduce(
+		(sum, provider) => sum + (activeModelCounts[provider.id] ?? 0),
+		0,
+	);
 }
 
 export default async function ProviderCountryPage({
@@ -49,9 +42,7 @@ export default async function ProviderCountryPage({
 	}
 
 	const countryProviders = providersForCountry(country.code);
-	const modelCount = modelCountForProviders(
-		new Set(countryProviders.map((p) => p.id)),
-	);
+	const modelCount = modelCountForProviders(countryProviders);
 
 	const countryUrl = `https://llmgateway.io/providers/country/${country.code.toLowerCase()}`;
 

--- a/apps/ui/src/app/providers/page.tsx
+++ b/apps/ui/src/app/providers/page.tsx
@@ -2,8 +2,7 @@ import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 import { ProvidersGrid } from "@/components/providers/providers-grid";
 import { JsonLd } from "@/components/seo/json-ld";
-
-import { providers as providerDefinitions } from "@llmgateway/models";
+import { listedProviders } from "@/lib/providers-catalog";
 
 import type { Metadata } from "next";
 
@@ -20,10 +19,6 @@ export const metadata: Metadata = {
 		type: "website",
 	},
 };
-
-const listedProviders = providerDefinitions.filter(
-	(provider) => provider.name !== "LLM Gateway",
-);
 
 const collectionSchema = {
 	"@context": "https://schema.org",

--- a/apps/ui/src/components/providers/providers-grid.tsx
+++ b/apps/ui/src/components/providers/providers-grid.tsx
@@ -38,21 +38,16 @@ import {
 	MIN_REQUESTS_FOR_STATS,
 	type ProviderWindowStats,
 } from "@/lib/provider-stats";
+import { activeModelCounts, listedProviders } from "@/lib/providers-catalog";
 
 import {
 	countryCodeToFlag,
 	getProviderCountries,
 	isProviderCompliant,
-	models as modelDefinitions,
-	providers as providerDefinitions,
-	type ModelDefinition,
 	type ProviderCompliancePolicy,
 	type ProviderId,
 } from "@llmgateway/models";
-import {
-	isMappingDeactivated,
-	providerLogoUrls,
-} from "@llmgateway/shared/components";
+import { providerLogoUrls } from "@llmgateway/shared/components";
 
 type SortKey = "fastest" | "slowest" | "popular" | "name" | "uptime";
 
@@ -67,26 +62,6 @@ const getProviderLogo = (providerId: ProviderId) => {
 	}
 	return <div className="size-12 shrink-0 rounded-lg bg-muted" />;
 };
-
-const getModelsCountByProvider = (): Record<string, number> => {
-	const counts: Record<string, number> = {};
-	for (const model of modelDefinitions as readonly ModelDefinition[]) {
-		for (const providerMapping of model.providers) {
-			if (isMappingDeactivated(providerMapping)) {
-				continue;
-			}
-			const providerId = providerMapping.providerId;
-			counts[providerId] = (counts[providerId] || 0) + 1;
-		}
-	}
-	return counts;
-};
-
-const modelCounts = getModelsCountByProvider();
-
-const baseProviders = providerDefinitions.filter(
-	(p) => p.name !== "LLM Gateway" && p.id !== "custom",
-);
 
 const PROVIDER_COUNTRIES = getProviderCountries();
 
@@ -193,14 +168,14 @@ export function ProvidersGrid({
 	const visibleProviders = useMemo(
 		() =>
 			countryCode
-				? baseProviders.filter((p) => p.headquarters === countryCode)
-				: baseProviders,
+				? listedProviders.filter((p) => p.headquarters === countryCode)
+				: listedProviders,
 		[countryCode],
 	);
 
 	const totalProviders = visibleProviders.length;
 	const totalModels = visibleProviders.reduce(
-		(sum, p) => sum + (modelCounts[p.id] || 0),
+		(sum, p) => sum + (activeModelCounts[p.id] || 0),
 		0,
 	);
 
@@ -241,7 +216,7 @@ export function ProvidersGrid({
 			return {
 				...provider,
 				stats,
-				modelsCount: modelCounts[provider.id] || 0,
+				modelsCount: activeModelCounts[provider.id] || 0,
 			};
 		});
 

--- a/apps/ui/src/lib/providers-catalog.ts
+++ b/apps/ui/src/lib/providers-catalog.ts
@@ -1,0 +1,35 @@
+import {
+	models as modelDefinitions,
+	providers as providerDefinitions,
+	type ModelDefinition,
+} from "@llmgateway/models";
+import { isMappingDeactivated } from "@llmgateway/shared/components";
+
+function getActiveModelCountsByProvider(): Record<string, number> {
+	const counts: Record<string, number> = {};
+	for (const model of modelDefinitions as readonly ModelDefinition[]) {
+		for (const providerMapping of model.providers) {
+			if (isMappingDeactivated(providerMapping)) {
+				continue;
+			}
+			const providerId = providerMapping.providerId;
+			counts[providerId] = (counts[providerId] || 0) + 1;
+		}
+	}
+	return counts;
+}
+
+export const activeModelCounts = getActiveModelCountsByProvider();
+
+/**
+ * Providers shown in the public directory: everything except the gateway itself
+ * and the bring-your-own-endpoint entry, and only those that still have at
+ * least one routable model mapping — a provider whose every mapping is
+ * deactivated has nothing left to offer, so its card is hidden.
+ */
+export const listedProviders = providerDefinitions.filter(
+	(provider) =>
+		provider.name !== "LLM Gateway" &&
+		provider.id !== "custom" &&
+		(activeModelCounts[provider.id] ?? 0) > 0,
+);


### PR DESCRIPTION
## Problem

`/providers` rendered a card for every provider definition, including ones whose every model mapping is deactivated. Today that means **Reve** shows up as a card advertising "0 models" — clicking it leads to a provider page with nothing to offer, and the header count (47 providers) overstates what is actually routable.

## Approach

Added `apps/ui/src/lib/providers-catalog.ts` as the single source of truth for the public provider directory:

- `activeModelCounts` — per-provider count of non-deactivated model mappings (moved out of `providers-grid.tsx`, unchanged logic).
- `listedProviders` — provider definitions minus `LLM Gateway` and `custom`, and minus anything with zero active mappings.

Consumers now share it:

- `providers-grid.tsx` builds its cards and its header totals from `listedProviders` / `activeModelCounts`.
- `app/providers/page.tsx` uses the same list for the `CollectionPage` JSON-LD, so the structured data no longer advertises a provider the page doesn't render (it also picks up the `custom` exclusion the grid already had).
- `app/providers/country/[country]/page.tsx` renders the same grid, so its provider list and model count are derived from the shared helper too — otherwise its subheading would disagree with the grid's own stats row.

Deactivation uses the existing `isMappingDeactivated` helper, so a *scheduled* (future-dated) deactivation keeps a provider visible until the date passes.

Deliberately left alone: `/providers/[id]` pages and the sitemap still include these providers — a provider with only deactivated mappings still has a valid detail page behind the grid's "show deactivated" toggle, so removing the page would be a separate decision.

## Verification

- `turbo run build --filter=ui` passes.
- Ran the stack locally and captured the page in both themes.

### Provider card — searching "reve"

Before, the empty provider rendered a "0 models" card; after, it is filtered out and the provider count drops 47 → 46.

| Light | Dark |
| --- | --- |
| <img width="720" alt="Before, light: Reve card showing 0 models, 47 providers" src="https://raw.githubusercontent.com/theopenco/llmgateway/4829a18272ff245c78d05cdcf065b353f63af257/providers-search-light-before.png" /> | <img width="720" alt="Before, dark: Reve card showing 0 models, 47 providers" src="https://raw.githubusercontent.com/theopenco/llmgateway/4829a18272ff245c78d05cdcf065b353f63af257/providers-search-dark-before.png" /> |
| <img width="720" alt="After, light: no providers match reve, 46 providers" src="https://raw.githubusercontent.com/theopenco/llmgateway/4829a18272ff245c78d05cdcf065b353f63af257/providers-search-light-after.png" /> | <img width="720" alt="After, dark: no providers match reve, 46 providers" src="https://raw.githubusercontent.com/theopenco/llmgateway/4829a18272ff245c78d05cdcf065b353f63af257/providers-search-dark-after.png" /> |

### Full page after the change

| Light | Dark |
| --- | --- |
| <img width="720" alt="Providers page, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/4829a18272ff245c78d05cdcf065b353f63af257/providers-light-after.png" /> | <img width="720" alt="Providers page, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/4829a18272ff245c78d05cdcf065b353f63af257/providers-dark-after.png" /> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HtBGqgqXPYyLResMuyYqUW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider listings now show only providers with active models.
  * Provider cards display accurate active model counts.
  * Country provider pages use the updated provider catalog and model totals.
* **Bug Fixes**
  * Removed inactive providers and models from provider listings and counts.
  * Improved consistency between the main providers page, country pages, and provider cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->