### PR TITLE
feat(gateway): block priority tier on dev plans

### DIFF
--- a/apps/docs/content/features/service-tiers.mdx
+++ b/apps/docs/content/features/service-tiers.mdx
@@ -43,6 +43,9 @@ The parameter works the same on the OpenAI-compatible **Responses API**
 (`/v1/responses`): the tier is forwarded to the provider and the response's
 `service_tier` field echoes the tier that was actually served.
 
+Coding (dev) plans are limited to `default`/`auto` and `flex` — the premium
+`priority` tier is not part of the plan and a request that asks for it returns a 403.
+
 ## Supported providers
 
 Service tiers are explicit per provider/model mapping. Check the model page for
@@ -111,7 +114,9 @@ carried through all of it.
 This applies to a tier you requested yourself. The optional coding-plan default
 tier is a cost preference rather than a requirement, so a request that cannot be
 served at that tier runs at standard instead of failing; `used_service_tier` in
-the response metadata always reports what was actually served.
+the response metadata always reports what was actually served. A tier sent on
+the request always takes precedence over that default, within the tiers the plan
+allows.
 
 <Callout type="info">
 	Rotating to another key for the same provider is a separate upstream account

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -2091,6 +2091,8 @@ describe("api", () => {
 
 		await harness.setDevPlan({ devPlan: "pro", serviceTier: "flex" });
 
+		// gpt-5.5 sells flex and the org defaults to it, so an explicit
+		// `default` is only honored if the request beats the org setting.
 		const res = await app.request("/v1/chat/completions", {
 			method: "POST",
 			headers: {
@@ -2099,16 +2101,56 @@ describe("api", () => {
 			},
 			body: JSON.stringify({
 				model: "gpt-5.5",
-				service_tier: "priority",
+				service_tier: "default",
 				messages: [{ role: "user", content: "Hello!" }],
 			}),
 		});
 
 		expect(res.status).toBe(200);
 		const json = await res.json();
-		expect(json.service_tier).toBe("priority");
-		expect(json.metadata?.requested_service_tier).toBe("priority");
-		expect(json.metadata?.used_service_tier).toBe("priority");
+		expect(json.metadata?.requested_service_tier).toBeUndefined();
+		expect(json.metadata?.used_service_tier).toBeUndefined();
+	});
+
+	test("/v1/chat/completions rejects an explicit priority service_tier on dev plans", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id-devplan-priority",
+			token: "real-token-devplan-priority",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-devplan-priority",
+			token: "sk-test-key",
+			provider: "openai",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		await harness.setDevPlan({ devPlan: "pro", serviceTier: "flex" });
+
+		// gpt-5.5 does sell priority — the rejection has to come from the plan
+		// restriction, not from the model lacking tier support.
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-devplan-priority",
+			},
+			body: JSON.stringify({
+				model: "gpt-5.5",
+				service_tier: "priority",
+				messages: [{ role: "user", content: "Hello!" }],
+			}),
+		});
+
+		expect(res.status).toBe(403);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain(
+			"Service tier 'priority' is not available on coding plans",
+		);
 	});
 
 	test("/v1/chat/completions skips the dev-plan flex default for models without flex support", async () => {

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2192,6 +2192,22 @@ chat.openapi(completions, async (c) => {
 		}
 	}
 
+	// Coding (dev) plans only sell the standard and flex tiers — the dashboard
+	// setting is limited to those, and this is the server-side half of that gate:
+	// without it a client could opt into priority per request and burn plan
+	// credits at the tier's premium multiplier (2.5x on OpenAI, 1.8x on Google),
+	// which dev-plan pricing does not account for. Rejected rather than silently
+	// clamped to standard, matching how an ineligible `routing` strategy is
+	// handled and the gateway's general rule that a requested tier is never
+	// quietly downgraded. Checked before the tier-narrowing block below so the
+	// error names the plan restriction instead of a model's missing tier support.
+	if (isDevPlan && service_tier === "priority") {
+		throw new HTTPException(403, {
+			message: `Service tier 'priority' is not available on coding plans. Use 'flex' or 'default'.`,
+			cause: "unsupported_service_tier",
+		});
+	}
+
 	if (isRequestedServiceTier(service_tier)) {
 		const serviceTierCandidateProviders = modelInfo.providers.filter(
 			(mapping) => providerMatchesRequestedProvider(mapping, requestedProvider),

--- a/apps/gateway/src/chat/schemas/completions.ts
+++ b/apps/gateway/src/chat/schemas/completions.ts
@@ -385,7 +385,7 @@ export const completionsRequestSchema = z.object({
 		.optional()
 		.openapi({
 			description:
-				"Processing tier for the request. `flex` and `priority` are forwarded only for provider/model mappings that explicitly support the requested tier, such as supported OpenAI and Google mappings. `auto`/`default` use the standard on-demand tier. Unsupported tier requests return a 400 `unsupported_service_tier` error.",
+				"Processing tier for the request. `flex` and `priority` are forwarded only for provider/model mappings that explicitly support the requested tier, such as supported OpenAI and Google mappings. `auto`/`default` use the standard on-demand tier. Unsupported tier requests return a 400 `unsupported_service_tier` error. On coding (dev) plans only `auto`, `default` and `flex` are allowed.",
 			example: "flex",
 		}),
 	routing: z


### PR DESCRIPTION
## Problem

The DevPass dashboard only offers `default` and `flex` for the org-level service tier, and both the API route (`apps/api/src/routes/dev-plans.ts`) and the DB column are enumed to those two values. But that limit was never enforced on the gateway.

The org-level default is applied only when the request omits `service_tier` (`apps/gateway/src/chat/chat.ts:2152`). Once a client sends the parameter itself, that block is skipped and the value flows into the generic service-tier path with **no dev-plan check anywhere** — so any DevPass user could send `"service_tier": "priority"` and have it honored, on `/v1/chat/completions` and `/v1/responses` alike.

That matters because priority is a price multiplier applied to every token cost in `apps/gateway/src/lib/costs.ts` — 2.5x on OpenAI, 1.8x on Google Vertex/AI Studio. Dev-plan orgs spend plan credits through the same cost path and have no per-request "promote to regular credits" escape, so an explicit priority request drained DevPass credits at up to 2.5x the rate the plan prices in.

Note the asymmetry this fixes: the sibling `routing` parameter *is* already gated for dev plans (`chat.ts:2382` — only `auto`/`price`, explicit ineligible request → 400). Service tier had no equivalent.

## Approach

Reject an explicit `priority` on coding plans with a 403, rather than silently clamping it to standard:

- Silent clamping contradicts the gateway's established rule that a requested tier is never quietly downgraded (`assertServiceTierHonored`, and the same reasoning documented in `chat/tools/service-tier.ts`).
- 403 matches the other coding-plan entitlement gates (direct provider routing, non-coding models), which all use 403.

The check sits **before** the tier-narrowing block so the error names the plan restriction, rather than bottoming out in a model's missing tier support and returning a misleading `unsupported_service_tier` 400 for a tier the model actually sells.

Deliberately unchanged: the `flex`/`default` side stays fully overridable per request. A DevPass user whose setting is `default` can still ask for `flex`, and vice versa — that's within what the plan sells and the request continues to win over the org default.

## Verification

- New spec asserts `priority` is rejected with 403 on a dev-plan org using `gpt-5.5`, which *does* sell priority — so the rejection provably comes from the plan gate, not from missing model support.
- Updated the existing "explicit service_tier wins over the dev-plan default" spec, which previously asserted priority succeeded on a DevPass org; it now covers the same precedence via an explicit `default` beating an org default of `flex`.
- `pnpm test:unit` — 260 files, 4361 passed, 0 failed.
- `pnpm build` and `pnpm format` clean.

Docs (`apps/docs/content/features/service-tiers.mdx`) and the OpenAPI description for `service_tier` both state the coding-plan restriction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

