### PR TITLE
fix(analytics): count regional traffic once

### DIFF
--- a/apps/api/src/routes/admin-routing-analytics.spec.ts
+++ b/apps/api/src/routes/admin-routing-analytics.spec.ts
@@ -69,6 +69,7 @@ describe("admin routing analytics endpoint", () => {
 		await db.delete(tables.modelProviderMappingHistoryHourly);
 		await db.delete(tables.routingElectionHourly);
 		await db.delete(tables.routingExclusionHourly);
+		await db.delete(tables.modelProviderMapping);
 		await cdb.delete(tables.discount);
 		await deleteAll();
 	});
@@ -179,6 +180,75 @@ describe("admin routing analytics endpoint", () => {
 		);
 		expect(summaryA.requestCount).toBe(10);
 		expect(summaryA.uptime).toBe(80);
+	});
+
+	it("counts a mapping's regional traffic once", async () => {
+		const hour = currentHourStart();
+		// A mapping with regions is stored as a region-less root row plus one row
+		// per region, and the minute aggregator merges the regional traffic into
+		// the root row. Summing every row of the provider therefore reports double
+		// the requests that were actually served.
+		await db
+			.insert(tables.provider)
+			.values({ id: providerA, name: providerA, description: providerA })
+			.onConflictDoNothing();
+		await db
+			.insert(tables.model)
+			.values({ id: testModel.id, family: testModel.family })
+			.onConflictDoNothing();
+		await db.insert(tables.modelProviderMapping).values([
+			{
+				id: "routing-analytics-region-root",
+				modelId: testModel.id,
+				providerId: providerA,
+				externalId: testModel.id,
+			},
+			{
+				id: "routing-analytics-region-east",
+				modelId: testModel.id,
+				providerId: providerA,
+				externalId: testModel.id,
+				region: "us-east-1",
+			},
+		]);
+		await db.insert(tables.modelProviderMappingHistoryHourly).values([
+			{
+				id: "routing-analytics-region-root-hour",
+				modelId: testModel.id,
+				providerId: providerA,
+				modelProviderMappingId: "routing-analytics-region-root",
+				hourTimestamp: hour,
+				logsCount: 12,
+				serviceTierExplicitCount: 4,
+			},
+			{
+				id: "routing-analytics-region-east-hour",
+				modelId: testModel.id,
+				providerId: providerA,
+				modelProviderMappingId: "routing-analytics-region-east",
+				hourTimestamp: hour,
+				logsCount: 12,
+				serviceTierExplicitCount: 4,
+			},
+		]);
+
+		const res = await get(`?modelId=${testModel.id}&window=24h`, cookie);
+		const body = await res.json();
+
+		const summaryA = body.summary.find(
+			(s: { providerId: string }) => s.providerId === providerA,
+		);
+		expect(summaryA.requestCount).toBe(12);
+		expect(body.serviceTier.requestCount).toBe(12);
+		expect(body.serviceTier.explicit).toBe(4);
+
+		const trafficHour = body.hourly.find(
+			(h: { hour: string }) => h.hour === hour.toISOString(),
+		);
+		const entryA = trafficHour.providers.find(
+			(p: { providerId: string }) => p.providerId === providerA,
+		);
+		expect(entryA.requestCount).toBe(12);
 	});
 
 	it("reports election paths, eligibility and service-tier coverage", async () => {

--- a/apps/api/src/routes/admin-routing-analytics.ts
+++ b/apps/api/src/routes/admin-routing-analytics.ts
@@ -18,6 +18,7 @@ import {
 	db,
 	effectiveTtftTotals,
 	eq,
+	excludeRegionalMappingRows,
 	getEffectiveDiscount,
 	gte,
 	modelProviderMappingHistoryHourly,
@@ -537,6 +538,9 @@ adminRoutingAnalytics.openapi(getRoutingAnalytics, async (c) => {
 				and(
 					eq(modelProviderMappingHistoryHourly.modelId, model.id),
 					gte(modelProviderMappingHistoryHourly.hourTimestamp, windowStart),
+					// This view reports per provider, and the region-less root row
+					// already carries the provider's regional traffic.
+					excludeRegionalMappingRows(modelProviderMappingHistoryHourly),
 				),
 			),
 		db

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -43,6 +43,7 @@ import {
 	desc,
 	effectiveTtftTotals,
 	eq,
+	excludeRegionalMappingRows,
 	gte,
 	inArray,
 	isNotNull,
@@ -4844,7 +4845,13 @@ admin.openapi(getProviderStats, async (c) => {
 				...tokenBreakdownSums(mph),
 			})
 			.from(mph)
-			.where(and(gte(mphTs, startDate), lt(mphTs, endDateExclusive)))
+			.where(
+				and(
+					gte(mphTs, startDate),
+					lt(mphTs, endDateExclusive),
+					excludeRegionalMappingRows(mph),
+				),
+			)
 			.groupBy(mph.providerId)
 			.as("provider_stats_sub");
 
@@ -5868,7 +5875,13 @@ admin.openapi(getModelDetail, async (c) => {
 				...tokenBreakdownSums(mph),
 			})
 			.from(mph)
-			.where(and(eq(mph.modelId, modelId), gte(mphTs, startDate)))
+			.where(
+				and(
+					eq(mph.modelId, modelId),
+					gte(mphTs, startDate),
+					excludeRegionalMappingRows(mph),
+				),
+			)
 			.groupBy(mph.providerId),
 	]);
 
@@ -7325,6 +7338,9 @@ admin.openapi(getProviderHistory, async (c) => {
 				and(
 					eq(modelProviderMappingHistoryHourly.providerId, providerId),
 					gte(modelProviderMappingHistoryHourly.hourTimestamp, hourStartDate),
+					// Provider totals across models: the region-less root row already
+					// carries each mapping's regional traffic.
+					excludeRegionalMappingRows(modelProviderMappingHistoryHourly),
 				),
 			)
 			.groupBy(modelProviderMappingHistoryHourly.hourTimestamp)
@@ -7392,6 +7408,7 @@ admin.openapi(getProviderHistory, async (c) => {
 				and(
 					eq(modelProviderMappingHistory.providerId, providerId),
 					gte(modelProviderMappingHistory.minuteTimestamp, startDate),
+					excludeRegionalMappingRows(modelProviderMappingHistory),
 				),
 			)
 			.groupBy(modelProviderMappingHistory.minuteTimestamp)
@@ -7686,6 +7703,9 @@ admin.openapi(getMappingHistory, async (c) => {
 	// When a region is given, restrict the minute-level mapping history to the
 	// exact regional mapping(s). The hourly project rollups have no region
 	// dimension, so region scoping only applies to the minute-granularity source.
+	// Without a region the rows are summed across the mapping's variants, which
+	// means the regional rows have to be dropped — the region-less root row
+	// already includes their traffic.
 	const regionMappingFilter =
 		region !== undefined
 			? inArray(
@@ -7701,7 +7721,7 @@ admin.openapi(getMappingHistory, async (c) => {
 							),
 						),
 				)
-			: undefined;
+			: excludeRegionalMappingRows(modelProviderMappingHistory);
 
 	if (projectId) {
 		const rows = await db
@@ -7792,7 +7812,7 @@ admin.openapi(getMappingHistory, async (c) => {
 								),
 							),
 					)
-				: undefined;
+				: excludeRegionalMappingRows(modelProviderMappingHistoryHourly);
 
 		const rows = await db
 			.select({
@@ -8079,7 +8099,15 @@ admin.openapi(getProviderDetail, async (c) => {
 				...tokenBreakdownSums(mph),
 			})
 			.from(mph)
-			.where(and(eq(mph.providerId, providerId), gte(mphTs, startDate)))
+			.where(
+				and(
+					eq(mph.providerId, providerId),
+					gte(mphTs, startDate),
+					// Grouped per model, so the mapping's regional rows would be added
+					// on top of the root row that already contains them.
+					excludeRegionalMappingRows(mph),
+				),
+			)
 			.groupBy(mph.modelId),
 	]);
 

--- a/apps/api/src/routes/internal-models.ts
+++ b/apps/api/src/routes/internal-models.ts
@@ -10,6 +10,7 @@ import {
 	db,
 	effectiveTtftTotals,
 	eq,
+	excludeRegionalMappingRows,
 	gte,
 	isNull,
 	modelProviderMappingHistory,
@@ -514,6 +515,9 @@ internalModels.openapi(modelBenchmarksRoute, async (c) => {
 			and(
 				eq(modelProviderMappingHistory.modelId, modelId),
 				gte(modelProviderMappingHistory.minuteTimestamp, since),
+				// Per-provider totals: the region-less root row already includes the
+				// provider's regional traffic.
+				excludeRegionalMappingRows(modelProviderMappingHistory),
 			),
 		)
 		.groupBy(modelProviderMappingHistory.providerId, tables.provider.name);
@@ -737,6 +741,7 @@ internalModels.openapi(modelUptimeRoute, async (c) => {
 				and(
 					eq(modelProviderMappingHistory.modelId, modelId),
 					gte(modelProviderMappingHistory.minuteTimestamp, since),
+					excludeRegionalMappingRows(modelProviderMappingHistory),
 				),
 			)
 			.groupBy(

--- a/apps/api/src/routes/public-model-stats.ts
+++ b/apps/api/src/routes/public-model-stats.ts
@@ -7,7 +7,15 @@ import {
 	pickModelHistoryTable,
 } from "@/utils/history-window.js";
 
-import { and, cdb, gte, inArray, lt, sql } from "@llmgateway/db";
+import {
+	and,
+	cdb,
+	excludeRegionalMappingRows,
+	gte,
+	inArray,
+	lt,
+	sql,
+} from "@llmgateway/db";
 import {
 	models as modelDefinitions,
 	providers as providerDefinitions,
@@ -154,10 +162,12 @@ publicModelStats.openapi(listRoute, async (c) => {
 			totalRequests: sql<string>`COALESCE(SUM(${mph.logsCount}), 0)`,
 		})
 		.from(mph)
-		.where(and(gte(mphTs, startDate)))
+		// The region-less root row already carries a mapping's regional traffic,
+		// so summing every row per provider would count it twice.
+		.where(and(gte(mphTs, startDate), excludeRegionalMappingRows(mph)))
 		.groupBy(mph.providerId)
 		.$withCache({
-			tag: `publicModelStats:providers:v1:${window}`,
+			tag: `publicModelStats:providers:v2:${window}`,
 			autoInvalidate: false,
 			config: { ex: STATS_CACHE_TTL_SECONDS },
 		});

--- a/apps/api/src/routes/public-providers-stats.ts
+++ b/apps/api/src/routes/public-providers-stats.ts
@@ -6,7 +6,14 @@ import {
 	pickMappingHistoryTable,
 } from "@/utils/history-window.js";
 
-import { and, cdb, effectiveTtftTotals, gte, sql } from "@llmgateway/db";
+import {
+	and,
+	cdb,
+	effectiveTtftTotals,
+	excludeRegionalMappingRows,
+	gte,
+	sql,
+} from "@llmgateway/db";
 
 import type { ServerTypes } from "@/vars.js";
 
@@ -112,7 +119,9 @@ publicProvidersStats.openapi(listRoute, async (c) => {
 			updatedAt: sql<Date | null>`MAX(${mphTs})`,
 		})
 		.from(mph)
-		.where(and(gte(mphTs, startDate)))
+		// Grouped per provider, so the regional rows have to be dropped: the
+		// region-less root row of a mapping already includes their traffic.
+		.where(and(gte(mphTs, startDate), excludeRegionalMappingRows(mph)))
 		.groupBy(mph.providerId)
 		// Pin a stable, window-scoped cache tag. Without it Drizzle keys the
 		// cache on the rendered SQL + params, and `startDate` is derived from
@@ -123,7 +132,7 @@ publicProvidersStats.openapi(listRoute, async (c) => {
 		.$withCache({
 			// The version prefix is bumped whenever the selected columns change so
 			// a rolling deploy doesn't serve rows cached in the previous shape.
-			tag: `publicProviderStats:v4:${window}`,
+			tag: `publicProviderStats:v5:${window}`,
 			autoInvalidate: false,
 			config: { ex: STATS_CACHE_TTL_SECONDS },
 		});

--- a/ee/admin/src/app/routing-analytics/client.tsx
+++ b/ee/admin/src/app/routing-analytics/client.tsx
@@ -478,6 +478,24 @@ export function RoutingAnalyticsClient() {
 		[data],
 	);
 
+	// The election counts come from routing telemetry, a separate hourly rollup
+	// read from `log`, while every other count on this page comes from the
+	// mapping rollup. The two totals are therefore close but not identical — an
+	// hour whose telemetry never aggregated is simply missing from it — so the
+	// gap is stated rather than left for the reader to spot.
+	const telemetryCoverageHint = useMemo(() => {
+		if (!data || totalRequests <= 0) {
+			return undefined;
+		}
+		const missing = totalRequests - data.elections.requestCount;
+		if (missing === 0) {
+			return "routing telemetry on every request";
+		}
+		return missing > 0
+			? `${numberFormatter.format(missing)} requests without routing telemetry`
+			: `${numberFormatter.format(-missing)} decisions beyond the served requests`;
+	}, [data, totalRequests]);
+
 	const untieredRequests = data
 		? Math.max(
 				data.serviceTier.requestCount -
@@ -554,6 +572,7 @@ export function RoutingAnalyticsClient() {
 						<StatCard
 							label="Requests"
 							value={numberFormatter.format(totalRequests)}
+							hint="served, from the mapping rollup"
 						/>
 						<StatCard
 							label="Elected mapping"
@@ -566,6 +585,7 @@ export function RoutingAnalyticsClient() {
 									"—"
 								)
 							}
+							hint="lowest score, not the busiest"
 						/>
 						<StatCard
 							label="Routable mappings"
@@ -602,6 +622,7 @@ export function RoutingAnalyticsClient() {
 									</span>
 								</span>
 							}
+							hint={telemetryCoverageHint}
 						/>
 						<StatCard
 							label="Avg. candidates"
@@ -644,6 +665,7 @@ export function RoutingAnalyticsClient() {
 									<span className="text-muted-foreground">none</span>
 								)
 							}
+							hint="mapping drops, not requests"
 						/>
 					</section>
 

--- a/ee/admin/src/components/detail-stat-cards.tsx
+++ b/ee/admin/src/components/detail-stat-cards.tsx
@@ -131,10 +131,13 @@ export function DetailStatCards({
 export function StatCard({
 	label,
 	value,
+	hint,
 	loading,
 }: {
 	label: string;
 	value: React.ReactNode;
+	/** Optional line under the value, for the source or unit of the number. */
+	hint?: React.ReactNode;
 	loading?: boolean;
 }) {
 	return (
@@ -147,6 +150,9 @@ export function StatCard({
 			>
 				{value}
 			</p>
+			{hint ? (
+				<p className="mt-1 text-xs text-muted-foreground">{hint}</p>
+			) : null}
 		</div>
 	);
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -10,6 +10,7 @@ export * from "./email-recipients.js";
 export * from "./rate-limit-helpers.js";
 export * from "./schema.js";
 export * from "./log-payloads.js";
+export * from "./mapping-history-scope.js";
 export * from "./log-retention.js";
 export * from "./types.js";
 export * from "./migrate.js";

--- a/packages/db/src/mapping-history-scope.ts
+++ b/packages/db/src/mapping-history-scope.ts
@@ -1,0 +1,37 @@
+import { isNotNull, notInArray } from "drizzle-orm";
+
+import { db } from "./db.js";
+import { modelProviderMapping } from "./schema.js";
+
+import type { AnyColumn, SQL } from "drizzle-orm";
+
+/**
+ * Restrict mapping-history rows to the region-less root row of each mapping.
+ *
+ * A provider mapping with `regions` is expanded into a root entry plus one
+ * entry per region, and every one of them gets its own history row. The minute
+ * aggregator merges the regional traffic **into** the root row (see
+ * calculateMappingHistoryForMinute), so the root row is already the provider
+ * total for that model. Summing every row of a provider therefore counts
+ * regional traffic twice — a provider whose traffic is entirely regional
+ * reports exactly double its real request count.
+ *
+ * Any query that aggregates history across a provider's mappings has to apply
+ * this. Queries that deliberately scope to one regional mapping (by mapping id
+ * or region) must not.
+ *
+ * Rows whose mapping id no longer exists in `model_provider_mapping` are kept:
+ * the exclusion lists regional mapping ids rather than requiring a join, so
+ * orphaned history keeps contributing instead of silently disappearing.
+ */
+export function excludeRegionalMappingRows(table: {
+	modelProviderMappingId: AnyColumn;
+}): SQL {
+	return notInArray(
+		table.modelProviderMappingId,
+		db
+			.select({ id: modelProviderMapping.id })
+			.from(modelProviderMapping)
+			.where(isNotNull(modelProviderMapping.region)),
+	);
+}


### PR DESCRIPTION
## Problem

The admin **Routing Analytics** page shows a total that does not reconcile with the numbers next to it. Two separate causes:

**1. Regional mapping traffic is counted twice (a real data bug).**

A provider mapping with `regions` is expanded into a region-less root entry *plus* one entry per region, and every one of them gets its own history row. The minute aggregator deliberately merges the regional traffic **into** the root row (`calculateMappingHistoryForMinute`, asserted by `stats-calculator.spec.ts`), so the root row is already the provider total for that model. Every query that summed a provider's rows therefore double-counted regional traffic — a mapping whose traffic is entirely regional reported exactly 2× its real request count.

This was not confined to routing analytics. The same aggregation shape appears in:

- `admin/routing-analytics` — requests, share, service-tier coverage, requests-per-hour
- `admin/providers/{id}` history + detail, `admin/.../mappings/{...}` history when no region is given, the admin models list
- `internal/models/{id}` provider stats (public model page)
- `public/providers/stats` and `public/models/stats` provider rows

Ratio metrics (uptime, TTFT, throughput) were unaffected — the root row doubles numerator and denominator alike — and live routing is unaffected for the same reason, so this was purely a reporting defect.

**2. The page mixes two sources without saying so.**

Every count on the page comes from the mapping rollup, *except* the election counts, which come from routing telemetry — a separate hourly rollup read from `log`. The two totals are close but never identical (an hour whose telemetry never aggregated is simply missing from it), which is what makes "Requests 25,504" sit next to "of 24,895 routed".

## Approach

- New `excludeRegionalMappingRows()` in `@llmgateway/db`, applied wherever mapping history is aggregated **across** mappings. Queries that deliberately scope to one region keep their exact filter, and per-mapping queries are untouched. It excludes by regional mapping id rather than joining, so history rows whose mapping id no longer exists keep contributing instead of silently disappearing.
- Routing analytics stat cards now state their source: `Requests` is the mapping rollup, `Score-decided` reports how many requests carry no routing telemetry, `Excluded from elections` says it counts mapping drops rather than requests, and `Elected mapping` says it is the lowest score, not the busiest mapping.
- Bumped the two public stats cache tags so the corrected numbers do not wait out the TTL after deploy.

## Verification

New spec: a mapping with a root row and a regional row of 12 requests each must report 12, not 24 — it fails with `expected 24 to be 12` without the fix. `pnpm build`, `pnpm format`, and the routing-analytics / public-provider-stats / stats-calculator specs pass.

## Screenshots

Seeded 24 hours of `gpt-5.6-sol` traffic where `aws-mantle` serves 27 requests/hour split across `us-east-1` and `us-east-2`. Before, that provider reports 1,296 requests (5.0% share) and the page total is 26,160; after, 648 (2.5%) and 25,512.

**Light — before / after**

<img width="1440" alt="Routing analytics stat cards, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/643e48fd3ce743b52971fdb23f10a0b57d431ed4/before-light.png" />
<img width="1440" alt="Routing analytics stat cards, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/643e48fd3ce743b52971fdb23f10a0b57d431ed4/after-light.png" />

**Light, mappings table — before / after**

<img width="1440" alt="Mappings table, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/643e48fd3ce743b52971fdb23f10a0b57d431ed4/before-table-light.png" />
<img width="1440" alt="Mappings table, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/643e48fd3ce743b52971fdb23f10a0b57d431ed4/after-table-light.png" />

**Dark — before / after**

<img width="1440" alt="Routing analytics stat cards in dark mode, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/643e48fd3ce743b52971fdb23f10a0b57d431ed4/before-dark.png" />
<img width="1440" alt="Routing analytics stat cards in dark mode, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/643e48fd3ce743b52971fdb23f10a0b57d431ed4/after-dark.png" />

**Dark, mappings table — before / after**

<img width="1440" alt="Mappings table in dark mode, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/643e48fd3ce743b52971fdb23f10a0b57d431ed4/before-table-dark.png" />
<img width="1440" alt="Mappings table in dark mode, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/643e48fd3ce743b52971fdb23f10a0b57d431ed4/after-table-dark.png" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected routing, provider, model, benchmark, uptime, and public statistics to prevent regional traffic from being counted twice.
  * Preserved accurate results when filtering analytics by a specific region.

* **Improvements**
  * Added telemetry coverage messaging and clearer explanations for dashboard metrics.
  * Updated statistics caching to ensure corrected results are served.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->