### PR TITLE
test(gateway): port-agnostic e2e, opt-in ocr

### DIFF
--- a/apps/gateway/src/chat-helpers.e2e.ts
+++ b/apps/gateway/src/chat-helpers.e2e.ts
@@ -855,6 +855,91 @@ export const rerankModels = models
 		return testCases;
 	});
 
+// OCR models use the dedicated /v1/ocr endpoint, so they are excluded from
+// filteredModels above. Build a separate list for ocr.e2e.ts with the same
+// TEST_MODELS/TEST_PROVIDERS, deactivation, env-var, and stability filters as
+// rerankModels. The OCR mappings are marked test: "skip" in the catalogue, so
+// this list is empty unless TEST_MODELS names one of them.
+export const ocrModels = models
+	.filter((model) => !["custom", "auto"].includes(model.id))
+	.filter((model) =>
+		model.providers.some(
+			(provider: ProviderModelMapping) => provider.ocr === true,
+		),
+	)
+	// If any model has test: "only", only include those models
+	.filter((model) => {
+		if (hasOnlyModels) {
+			return model.providers.some(
+				(provider: ProviderModelMapping) => provider.test === "only",
+			);
+		}
+		return true;
+	})
+	.flatMap((model) => {
+		const testCases = [];
+		const expandedProviders = expandAllProviderRegions(
+			model.providers as ProviderModelMapping[],
+		);
+		for (const provider of expandedProviders) {
+			if (!provider.ocr) {
+				continue;
+			}
+
+			// Skip deactivated / deprecated provider mappings
+			if (provider.deactivatedAt && new Date() > provider.deactivatedAt) {
+				continue;
+			}
+			if (provider.deprecatedAt && new Date() > provider.deprecatedAt) {
+				continue;
+			}
+
+			if (specifiedModels || specifiedProviders) {
+				if (specifiedProviders) {
+					if (!specifiedProviders.includes(provider.providerId)) {
+						continue;
+					}
+				} else {
+					if (
+						!matchesTestModel(provider.providerId, model.id, provider.region)
+					) {
+						continue;
+					}
+				}
+			} else {
+				if (provider.test === "skip") {
+					continue;
+				}
+				if (
+					provider.test !== "only" &&
+					!hasAllRequiredProviderEnvVars(provider.providerId)
+				) {
+					continue;
+				}
+				if (
+					(provider.stability === "unstable" ||
+						provider.stability === "experimental") &&
+					!fullMode &&
+					provider.test !== "only"
+				) {
+					continue;
+				}
+			}
+
+			// If we have any "only" providers, skip those not marked as "only"
+			if (hasOnlyModels && provider.test !== "only") {
+				continue;
+			}
+
+			testCases.push({
+				model: `${provider.providerId}/${model.id}${provider.region ? `:${provider.region}` : ""}`,
+				provider,
+				originalModel: model.id,
+			});
+		}
+		return testCases;
+	});
+
 // Log the number of test models after filtering
 console.log(`Testing ${testModels.length} model configurations`);
 console.log(`Testing ${providerModels.length} provider model configurations`);
@@ -864,6 +949,7 @@ console.log(
 	`Testing ${transcriptionModels.length} transcription model configurations`,
 );
 console.log(`Testing ${rerankModels.length} rerank model configurations`);
+console.log(`Testing ${ocrModels.length} ocr model configurations`);
 
 export const streamingModels = testModels.filter((m) =>
 	m.providers.some((p: ProviderModelMapping) => {

--- a/apps/gateway/src/ocr.e2e.ts
+++ b/apps/gateway/src/ocr.e2e.ts
@@ -11,6 +11,7 @@ import {
 	getConcurrentTestOptions,
 	getTestOptions,
 	logMode,
+	ocrModels,
 } from "@/chat-helpers.e2e.js";
 
 import { db, tables } from "@llmgateway/db";
@@ -32,10 +33,6 @@ function readFixtureImageDataUrl(): string {
 	const bytes = fs.readFileSync(FIXTURE_IMAGE_PATH);
 	return `data:image/png;base64,${bytes.toString("base64")}`;
 }
-
-// OCR resolves a real provider key from env vars (credits mode), so skip when
-// the Mistral key isn't configured rather than failing with an auth error.
-const hasMistralKey = Boolean(process.env.LLM_MISTRAL_API_KEY);
 
 async function ocrBeforeAllHook() {
 	await beforeAllHook();
@@ -72,10 +69,10 @@ describe("e2e ocr", getConcurrentTestOptions(), () => {
 		expect(true).toBe(true);
 	});
 
-	test.skipIf(!hasMistralKey)(
-		"/v1/ocr extracts a document via mistral-ocr-latest",
+	test.each(ocrModels)(
+		"/v1/ocr extracts a document via $model",
 		{ ...getTestOptions(), timeout: 120_000 },
-		async () => {
+		async ({ model }) => {
 			const res = await app.request("/v1/ocr", {
 				method: "POST",
 				headers: {
@@ -83,7 +80,7 @@ describe("e2e ocr", getConcurrentTestOptions(), () => {
 					Authorization: `Bearer ${OCR_API_KEY_TOKEN}`,
 				},
 				body: JSON.stringify({
-					model: "mistral-ocr-latest",
+					model,
 					document: {
 						type: "image_url",
 						image_url: readFixtureImageDataUrl(),
@@ -106,7 +103,9 @@ describe("e2e ocr", getConcurrentTestOptions(), () => {
 		},
 	);
 
-	test.skipIf(!hasMistralKey)(
+	// Pure request validation — rejected before any provider is contacted, so it
+	// needs no provider key and runs regardless of the OCR model selection.
+	test(
 		"/v1/ocr rejects an unknown model with 400",
 		getTestOptions(),
 		async () => {

--- a/apps/gateway/src/test-utils/gateway-api-test-harness.ts
+++ b/apps/gateway/src/test-utils/gateway-api-test-harness.ts
@@ -2,6 +2,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, expect } from "vitest";
 
 import { db, eq, pool, tables } from "@llmgateway/db";
 import { getProviderDefinition, models } from "@llmgateway/models";
+import { getGatewayPublicBaseUrl } from "@llmgateway/shared";
 import { verifyVideoContentAccessToken } from "@llmgateway/shared/video-access";
 
 import {
@@ -275,7 +276,7 @@ export function createGatewayApiTestHarness() {
 			const validAfterSixDays = 6 * 24 * 60 * 60 * 1000;
 			const expiredAfterEightDays = 8 * 24 * 60 * 60 * 1000;
 			const parsed = new URL(url);
-			expect(parsed.origin).toBe("http://localhost:4001");
+			expect(parsed.origin).toBe(new URL(getGatewayPublicBaseUrl()).origin);
 			expect(parsed.pathname).toBe(`/v1/videos/logs/${logId}/content`);
 			const token = parsed.searchParams.get("token");
 			expect(token).toBeTruthy();

--- a/apps/gateway/src/videos/videos.spec.ts
+++ b/apps/gateway/src/videos/videos.spec.ts
@@ -9,6 +9,7 @@ import {
 } from "@/test-utils/mock-openai-server.js";
 
 import { cdb, db, eq, tables } from "@llmgateway/db";
+import { buildGatewayVideoLogContentUrl } from "@llmgateway/shared";
 
 describe("videos", () => {
 	const harness = createGatewayApiTestHarness();
@@ -1510,9 +1511,7 @@ describe("videos", () => {
 		);
 
 		expect(logs[0].usedModelMapping).toBe("veo3_fast");
-		expect(logs[0].content).toBe(
-			`http://localhost:4001/v1/videos/logs/${logs[0].id}/content`,
-		);
+		expect(logs[0].content).toBe(buildGatewayVideoLogContentUrl(logs[0].id));
 		expect(logs[0].requestCost).toBe(0);
 		expect(logs[0].videoOutputCost).toBe(2.8);
 		expect(logs[0].cost).toBe(2.8);
@@ -1786,9 +1785,7 @@ describe("videos", () => {
 			);
 
 			expect(logs[0].usedModelMapping).toBe("veo-3.1-generate-001");
-			expect(logs[0].content).toBe(
-				`http://localhost:4001/v1/videos/logs/${logs[0].id}/content`,
-			);
+			expect(logs[0].content).toBe(buildGatewayVideoLogContentUrl(logs[0].id));
 			expect(logs[0].videoOutputCost).toBe(4.8);
 			expect(logs[0].cost).toBe(4.8);
 		} finally {

--- a/packages/models/src/models/mistral.ts
+++ b/packages/models/src/models/mistral.ts
@@ -237,6 +237,11 @@ export const mistralModels = [
 		output: ["ocr"],
 		providers: [
 			{
+				// OCR is billed per page and the Mistral key needs a separate OCR
+				// entitlement, so a key without it makes the suite fail with a 401
+				// that looks like a gateway bug. Opt in with
+				// TEST_MODELS="mistral/mistral-ocr-latest".
+				test: "skip",
 				providerId: "mistral",
 				externalId: "mistral-ocr-latest",
 				inputPrice: "0",


### PR DESCRIPTION
## Problem

Two unrelated ways a scoped test run reports failures that have nothing to do with the change under test. Both showed up while verifying #3492.

**1. Video log-content assertions hardcode `http://localhost:4001`.**

`gateway-api-test-harness.ts` and two `videos.spec.ts` assertions compare against a literal `http://localhost:4001`, but the gateway builds that URL from `getGatewayPublicBaseUrl()` (i.e. `GATEWAY_URL`). Any worktree following AGENTS.md's "isolated stack per worktree" guidance runs on an offset `GATEWAY_PORT`, so three video tests fail:

```
AssertionError: expected 'http://localhost:4801' to be 'http://localhost:4001'
 ❯ gateway-api-test-harness.ts:278
```

The tests were asserting the port, not the behaviour.

**2. `ocr.e2e.ts` runs unconditionally and hardcodes `mistral-ocr-latest`.**

It only skipped when `LLM_MISTRAL_API_KEY` was entirely absent, so a Mistral key *without* the separate OCR entitlement fails with an upstream `{"detail":"Invalid API Key"}` → 401 on **every** e2e run, including ones scoped to an unrelated model:

```
$ TEST_MODELS="together-ai/gpt-oss-20b" FULL_MODE=true pnpm test:e2e
 FAIL  apps/gateway/src/ocr.e2e.ts > /v1/ocr extracts a document via mistral-ocr-latest
 Tests  1 failed | 102 passed
```

OCR is also billed per page, so it should not run on every unrelated scoped run in the first place.

## Approach

**Port**: assert against the same helpers the gateway itself uses — `getGatewayPublicBaseUrl()` in the harness, `buildGatewayVideoLogContentUrl()` in `videos.spec.ts`. The tests now verify the URL matches what the app produces, on any port, and keep working on the `http://localhost:4001` default.

**OCR**: OCR models already live in the catalogue (`output: ["ocr"]`, `ocr: true`), so drive the suite from it like the rerank/speech/transcription suites do. Adds an `ocrModels` list to `chat-helpers.e2e.ts` mirroring `rerankModels` (same TEST_MODELS/TEST_PROVIDERS, deactivation, env-var and stability filters), and `ocr.e2e.ts` becomes `test.each(ocrModels)`.

The mapping is marked `test: "skip"`, which makes the suite opt-in — `TEST_MODELS` overrides `test: "skip"`, so it runs exactly when you ask for it:

```bash
TEST_MODELS="mistral/mistral-ocr-latest" pnpm test:e2e
```

The "rejects an unknown model with 400" case is pure request validation, rejected before any provider is contacted, so it no longer needs a key gate and runs always.

## Verification

`videos.spec.ts` — 50/50 pass on all three configurations (previously 3 failures on the first):

| `GATEWAY_URL` | before | after |
|---|---|---|
| `http://localhost:4801` (offset stack) | 3 failed | 50 passed |
| `http://localhost:4001` (explicit) | 50 passed | 50 passed |
| unset (falls back to :4001) | 50 passed | 50 passed |

`ocr.e2e.ts`:

```
$ pnpm test:e2e                                          # default
Testing 0 ocr model configurations
 ✓ /v1/ocr rejects an unknown model with 400
 Tests  3 passed

$ TEST_MODELS="mistral/mistral-ocr-latest" pnpm test:e2e # opt-in
Testing 1 ocr model configurations
 × /v1/ocr extracts a document via 'mistral/mistral-ocr-latest'   # this machine's key lacks the OCR entitlement
```

The scoped run that previously failed is now clean:

```
$ TEST_MODELS="together-ai/gpt-oss-20b" FULL_MODE=true pnpm test:e2e
 Test Files  29 passed | 2 skipped (31)
      Tests  102 passed | 88 skipped (190)
```

Gates: `pnpm build` 17/17 · `pnpm lint` 17/17 · `packages/models` 131/131 · full `apps/gateway` unit suite 2171 passed. One failure there — `openai-content-filter.spec.ts > logs missing moderation credentials` — reproduces identically on unmodified `main` with these changes stashed; it is the known local `.env` leakage (the spec assumes no OpenAI key is configured) and is untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded OCR extraction coverage across configured providers and models, including region-specific and selectively enabled test scenarios.
  * Added consistent validation for unknown OCR models, regardless of provider credentials.
  * Updated video log URL checks to work with configured gateway environments instead of relying on local addresses.

* **Chores**
  * Mistral OCR tests are now opt-in because they require separate OCR access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->