### PR TITLE
fix(gateway): don't guess content_filter on empty body

### DIFF
--- a/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
@@ -365,14 +365,14 @@ describe("parseProviderResponse", () => {
 			expect(result.finishReason).toBe("PROHIBITED_CONTENT");
 		});
 
-		it("falls back to content_filter when google gives no reason at all", () => {
+		it("reports no finish reason when google gives none at all", () => {
 			const result = parseProviderResponse(
 				"google-ai-studio",
 				"gemini-3-pro-image-preview",
 				{ candidates: [] },
 			);
 
-			expect(result.finishReason).toBe("content_filter");
+			expect(result.finishReason).toBeNull();
 		});
 
 		it("retains NO_IMAGE rather than reporting it as a content filter", () => {

--- a/apps/gateway/src/chat/tools/parse-provider-response.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.ts
@@ -318,11 +318,13 @@ export function parseProviderResponse(
 		case "iceberg":
 		case "google-vertex":
 		case "quartz": {
-			// A response with no candidates is only assumed to be a content filter
-			// when Google gave no reason of its own. Setting `finishReason` here
-			// unconditionally used to win over the `promptFeedback.blockReason`
-			// assignment below, so every such response was logged as the generic
-			// "content_filter" and the actual Google reason was lost.
+			// A response with no candidates used to be assigned "content_filter"
+			// here, which won over the `promptFeedback.blockReason` assignment
+			// below, so every such response was logged as the generic
+			// "content_filter" and the actual Google reason was lost. When Google
+			// reports no reason at all the finish reason is left unset (logged as
+			// "unknown") rather than guessing at a block — the warning below
+			// carries the full response for diagnosis.
 			const missingCandidates =
 				!json.candidates || json.candidates.length === 0;
 			if (missingCandidates && !json.promptFeedback?.blockReason) {
@@ -455,8 +457,6 @@ export function parseProviderResponse(
 					finishReason = promptBlockReason;
 				} else if (googleFinishReason) {
 					finishReason = googleFinishReason;
-				} else if (missingCandidates) {
-					finishReason = "content_filter";
 				}
 			}
 


### PR DESCRIPTION
Follow-up to #3516.

That PR stopped the generic `content_filter` label from overwriting the reason Google actually returned, but it kept a fallback: when a Google response has no candidates, no `promptFeedback.blockReason` and no candidate finish reason, it still recorded `content_filter`.

That is the same guess the rest of the change removes, made with even less evidence — Google reported nothing at all, so there is nothing to suggest a policy block. The finish reason is now left unset, which `getUnifiedFinishReason` already maps to `unknown`.

No other behaviour changes:

- The existing `logger.warn` for this case still fires and carries the full response body.
- `hasEmptyNonStreamingResponse` is gated on a truthy finish reason, so an empty response here is treated exactly as before (`content_filter` was explicitly excluded from that check).
- The "Unknown finish reason encountered" error log is gated on a truthy finish reason, so it does not fire.

The only client-visible difference is that `finish_reason` becomes `stop` instead of `content_filter` for a response that carried no information at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of blocked Google responses when no candidates or block reason are provided.
  * Finish reasons now accurately reflect available response information instead of defaulting to a content-filter status.
  * Diagnostic warnings remain available for affected responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->