### PR TITLE
feat(api): master key usage & cost reporting

### DIFF
--- a/apps/api/src/lib/date-range.ts
+++ b/apps/api/src/lib/date-range.ts
@@ -1,0 +1,53 @@
+import { HTTPException } from "hono/http-exception";
+
+import { formatInTimeZone, zonedTimeToUtc } from "@/utils/timezone.js";
+
+// Daily buckets are padded one calendar day at a time, so cap the window to a
+// year to keep the response bounded and — crucially — to keep the returned
+// buckets covering exactly the same range the SQL totals do (no silent
+// truncation of an over-large span).
+export const MAX_ORG_ACTIVITY_RANGE_DAYS = 366;
+
+export function rangeDaysInclusive(fromStr: string, toStr: string): number {
+	const from = Date.parse(`${fromStr}T00:00:00Z`);
+	const to = Date.parse(`${toStr}T00:00:00Z`);
+	return Math.round((to - from) / 86_400_000) + 1;
+}
+
+// Resolve the query window and the local calendar day-labels used to pad the
+// series. from/to are interpreted as wall-clock days in the caller's timezone
+// (defaulting to UTC), so the returned fromStr/toStr always line up with the
+// day buckets the SQL produces.
+export function resolveDateRange(
+	from: string | undefined,
+	to: string | undefined,
+	timeZone: string,
+): {
+	startDate: Date;
+	endDate: Date;
+	fromStr: string;
+	toStr: string;
+} {
+	if (from && to) {
+		if (
+			Number.isNaN(Date.parse(from + "T00:00:00Z")) ||
+			Number.isNaN(Date.parse(to + "T00:00:00Z"))
+		) {
+			throw new HTTPException(400, {
+				message: "Invalid from/to date (expected YYYY-MM-DD)",
+			});
+		}
+		const startDate = zonedTimeToUtc(from + "T00:00:00.000", timeZone);
+		const endDate = zonedTimeToUtc(to + "T23:59:59.999", timeZone);
+		return { startDate, endDate, fromStr: from, toStr: to };
+	}
+	const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+	const endDate = new Date();
+	const startDate = new Date(endDate.getTime() - sevenDaysMs);
+	return {
+		startDate,
+		endDate,
+		fromStr: formatInTimeZone(startDate, timeZone, false),
+		toStr: formatInTimeZone(endDate, timeZone, false),
+	};
+}

--- a/apps/api/src/lib/org-projects.ts
+++ b/apps/api/src/lib/org-projects.ts
@@ -1,0 +1,23 @@
+import { and, db, eq, ne, tables } from "@llmgateway/db";
+
+/**
+ * Ids of every non-deleted project in an organization.
+ *
+ * Every usage rollup table is keyed on `projectId`, so this is the org scope
+ * filter for org-wide usage queries (dashboard analytics and the master API
+ * usage report alike).
+ */
+export async function getOrgProjectIds(
+	organizationId: string,
+): Promise<string[]> {
+	const projects = await db
+		.select({ id: tables.project.id })
+		.from(tables.project)
+		.where(
+			and(
+				eq(tables.project.organizationId, organizationId),
+				ne(tables.project.status, "deleted"),
+			),
+		);
+	return projects.map((p) => p.id);
+}

--- a/apps/api/src/lib/usage-report.ts
+++ b/apps/api/src/lib/usage-report.ts
@@ -1,0 +1,392 @@
+import { z } from "zod";
+
+import {
+	mapModeSplit,
+	modeSplitFields,
+	modeSplitSchema,
+} from "@/lib/mode-split.js";
+import { bucketDate } from "@/utils/timezone.js";
+
+import {
+	and,
+	apiKeyHourlyModelStats,
+	db,
+	eq,
+	gte,
+	inArray,
+	lte,
+	sql,
+	tables,
+} from "@llmgateway/db";
+
+export const USAGE_DIMENSIONS = [
+	"user",
+	"model",
+	"provider",
+	"project",
+	"apiKey",
+] as const;
+export type UsageDimension = (typeof USAGE_DIMENSIONS)[number];
+
+export const USAGE_GRANULARITIES = ["hour", "day", "total"] as const;
+export type UsageGranularity = (typeof USAGE_GRANULARITIES)[number];
+
+export const usageReportRowSchema = z.object({
+	// null when granularity is "total"; otherwise a wall-clock bucket label in
+	// the requested timezone ("YYYY-MM-DD" or "YYYY-MM-DDTHH:mm:ss").
+	date: z.string().nullable(),
+	// Dimension fields are null unless the dimension was requested in groupBy,
+	// so the row shape stays stable for schema-driven consumers.
+	userId: z.string().nullable(),
+	userName: z.string().nullable(),
+	userEmail: z.string().nullable(),
+	projectId: z.string().nullable(),
+	projectName: z.string().nullable(),
+	apiKeyId: z.string().nullable(),
+	apiKeyName: z.string().nullable(),
+	model: z.string().nullable(),
+	provider: z.string().nullable(),
+	requestCount: z.number(),
+	errorCount: z.number(),
+	inputTokens: z.number(),
+	outputTokens: z.number(),
+	totalTokens: z.number(),
+	cachedTokens: z.number(),
+	reasoningTokens: z.number(),
+	cost: z.number(),
+	inputCost: z.number(),
+	outputCost: z.number(),
+	...modeSplitSchema,
+});
+
+export type UsageReportRow = z.infer<typeof usageReportRowSchema>;
+
+export interface UsageReportOptions {
+	/** Non-deleted project ids of the organization, already narrowed by any projectId filter. */
+	projectIds: string[];
+	startDate: Date;
+	endDate: Date;
+	timeZone: string;
+	granularity: UsageGranularity;
+	dimensions: UsageDimension[];
+	userId?: string;
+	apiKeyId?: string;
+	limit: number;
+	offset: number;
+}
+
+export interface UsageReportResult {
+	rows: UsageReportRow[];
+	hasMore: boolean;
+}
+
+/**
+ * Composable usage/cost cross-tab over the per-api-key hourly model rollups.
+ *
+ * Requests are attributed to whoever created the api key that made them
+ * (`api_key.created_by`) — the log table has no user column, so this join is the
+ * only link between traffic and a person. `end_user_customer` keys are included
+ * deliberately: their creator is the member who provisioned the platform key.
+ * Both rules mirror `getUserUsageBreakdown` so the master API and the dashboard
+ * can never report different numbers for the same window.
+ */
+export async function getUsageReport(
+	options: UsageReportOptions,
+): Promise<UsageReportResult> {
+	const {
+		projectIds,
+		startDate,
+		endDate,
+		timeZone,
+		granularity,
+		dimensions,
+		userId,
+		apiKeyId,
+		limit,
+		offset,
+	} = options;
+
+	if (!projectIds.length) {
+		return { rows: [], hasMore: false };
+	}
+
+	const wanted = new Set(dimensions);
+	const nullText = sql<string | null>`NULL::text`;
+
+	// Grouped expressions are referenced by SELECT position, because bucketDate
+	// binds the timezone as a parameter and repeating the expression in GROUP BY
+	// would make the two differ. Non-grouped dimensions select a NULL constant,
+	// which Postgres allows without a GROUP BY entry. Keep this list and the
+	// selection object in the same order.
+	const groupPositions: number[] = [];
+	if (granularity !== "total") {
+		groupPositions.push(1);
+	}
+	const dimensionPositions: Record<UsageDimension, number> = {
+		user: 2,
+		model: 3,
+		provider: 4,
+		project: 5,
+		apiKey: 6,
+	};
+	for (const dimension of USAGE_DIMENSIONS) {
+		if (wanted.has(dimension)) {
+			groupPositions.push(dimensionPositions[dimension]);
+		}
+	}
+
+	const selection = {
+		date:
+			granularity === "total"
+				? nullText
+				: bucketDate(
+						apiKeyHourlyModelStats.hourTimestamp,
+						timeZone,
+						granularity === "hour",
+					),
+		userId: wanted.has("user") ? tables.apiKey.createdBy : nullText,
+		model: wanted.has("model") ? apiKeyHourlyModelStats.usedModel : nullText,
+		provider: wanted.has("provider")
+			? apiKeyHourlyModelStats.usedProvider
+			: nullText,
+		projectId: wanted.has("project")
+			? apiKeyHourlyModelStats.projectId
+			: nullText,
+		apiKeyId: wanted.has("apiKey") ? apiKeyHourlyModelStats.apiKeyId : nullText,
+		requestCount:
+			sql<number>`COALESCE(SUM(${apiKeyHourlyModelStats.requestCount}), 0)`.as(
+				"requestCount",
+			),
+		errorCount:
+			sql<number>`COALESCE(SUM(${apiKeyHourlyModelStats.errorCount}), 0)`.as(
+				"errorCount",
+			),
+		inputTokens:
+			sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyModelStats.inputTokens} AS NUMERIC)), 0)`.as(
+				"inputTokens",
+			),
+		outputTokens:
+			sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyModelStats.outputTokens} AS NUMERIC)), 0)`.as(
+				"outputTokens",
+			),
+		totalTokens:
+			sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyModelStats.totalTokens} AS NUMERIC)), 0)`.as(
+				"totalTokens",
+			),
+		cachedTokens:
+			sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyModelStats.cachedTokens} AS NUMERIC)), 0)`.as(
+				"cachedTokens",
+			),
+		reasoningTokens:
+			sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyModelStats.reasoningTokens} AS NUMERIC)), 0)`.as(
+				"reasoningTokens",
+			),
+		cost: sql<number>`COALESCE(SUM(${apiKeyHourlyModelStats.cost}), 0)`.as(
+			"cost",
+		),
+		inputCost:
+			sql<number>`COALESCE(SUM(${apiKeyHourlyModelStats.inputCost}), 0)`.as(
+				"inputCost",
+			),
+		outputCost:
+			sql<number>`COALESCE(SUM(${apiKeyHourlyModelStats.outputCost}), 0)`.as(
+				"outputCost",
+			),
+		...modeSplitFields(apiKeyHourlyModelStats),
+	};
+
+	const filters = [
+		inArray(apiKeyHourlyModelStats.projectId, projectIds),
+		inArray(tables.apiKey.keyType, ["user", "end_user_customer"] as const),
+		gte(apiKeyHourlyModelStats.hourTimestamp, startDate),
+		lte(apiKeyHourlyModelStats.hourTimestamp, endDate),
+	];
+	if (userId) {
+		filters.push(eq(tables.apiKey.createdBy, userId));
+	}
+	if (apiKeyId) {
+		filters.push(eq(apiKeyHourlyModelStats.apiKeyId, apiKeyId));
+	}
+
+	let query = db
+		.select(selection)
+		.from(apiKeyHourlyModelStats)
+		.innerJoin(
+			tables.apiKey,
+			eq(tables.apiKey.id, apiKeyHourlyModelStats.apiKeyId),
+		)
+		.where(and(...filters))
+		.$dynamic();
+
+	if (groupPositions.length) {
+		const positions = sql.raw(groupPositions.join(", "));
+		query = query.groupBy(positions).orderBy(sql`${positions}`);
+	}
+
+	// One extra row tells us whether another page exists without a count query.
+	const raw = await query.limit(limit + 1).offset(offset);
+	const hasMore = raw.length > limit;
+	const page = hasMore ? raw.slice(0, limit) : raw;
+
+	const [userLabels, projectLabels, apiKeyLabels] = await Promise.all([
+		wanted.has("user")
+			? loadUserLabels(collectIds(page, "userId"))
+			: Promise.resolve(new Map<string, { name: string; email: string }>()),
+		wanted.has("project")
+			? loadProjectNames(collectIds(page, "projectId"))
+			: Promise.resolve(new Map<string, string>()),
+		wanted.has("apiKey")
+			? loadApiKeyNames(collectIds(page, "apiKeyId"))
+			: Promise.resolve(new Map<string, string>()),
+	]);
+
+	const rows = page.map((row): UsageReportRow => {
+		const user = row.userId ? userLabels.get(row.userId) : undefined;
+		return {
+			date: row.date === null ? null : String(row.date),
+			userId: row.userId,
+			userName: row.userId ? (user?.name ?? "Unknown user") : null,
+			userEmail: row.userId ? (user?.email ?? null) : null,
+			projectId: row.projectId,
+			projectName: row.projectId
+				? (projectLabels.get(row.projectId) ?? null)
+				: null,
+			apiKeyId: row.apiKeyId,
+			apiKeyName: row.apiKeyId
+				? (apiKeyLabels.get(row.apiKeyId) ?? null)
+				: null,
+			model: row.model,
+			provider: row.provider,
+			requestCount: Number(row.requestCount ?? 0),
+			errorCount: Number(row.errorCount ?? 0),
+			inputTokens: Number(row.inputTokens ?? 0),
+			outputTokens: Number(row.outputTokens ?? 0),
+			totalTokens: Number(row.totalTokens ?? 0),
+			cachedTokens: Number(row.cachedTokens ?? 0),
+			reasoningTokens: Number(row.reasoningTokens ?? 0),
+			cost: Number(row.cost ?? 0),
+			inputCost: Number(row.inputCost ?? 0),
+			outputCost: Number(row.outputCost ?? 0),
+			...mapModeSplit(row),
+		};
+	});
+
+	return { rows, hasMore };
+}
+
+function collectIds(
+	rows: {
+		userId: string | null;
+		projectId: string | null;
+		apiKeyId: string | null;
+	}[],
+	field: "userId" | "projectId" | "apiKeyId",
+): string[] {
+	const ids = new Set<string>();
+	for (const row of rows) {
+		const value = row[field];
+		if (value) {
+			ids.add(value);
+		}
+	}
+	return Array.from(ids);
+}
+
+async function loadUserLabels(ids: string[]) {
+	const labels = new Map<string, { name: string; email: string }>();
+	if (!ids.length) {
+		return labels;
+	}
+	const rows = await db
+		.select({
+			id: tables.user.id,
+			name: tables.user.name,
+			email: tables.user.email,
+		})
+		.from(tables.user)
+		.where(inArray(tables.user.id, ids));
+	for (const row of rows) {
+		labels.set(row.id, { name: row.name ?? row.email, email: row.email });
+	}
+	return labels;
+}
+
+async function loadProjectNames(ids: string[]) {
+	const names = new Map<string, string>();
+	if (!ids.length) {
+		return names;
+	}
+	const rows = await db
+		.select({ id: tables.project.id, name: tables.project.name })
+		.from(tables.project)
+		.where(inArray(tables.project.id, ids));
+	for (const row of rows) {
+		names.set(row.id, row.name);
+	}
+	return names;
+}
+
+async function loadApiKeyNames(ids: string[]) {
+	const names = new Map<string, string>();
+	if (!ids.length) {
+		return names;
+	}
+	const rows = await db
+		.select({
+			id: tables.apiKey.id,
+			description: tables.apiKey.description,
+		})
+		.from(tables.apiKey)
+		.where(inArray(tables.apiKey.id, ids));
+	for (const row of rows) {
+		names.set(row.id, row.description);
+	}
+	return names;
+}
+
+const CSV_COLUMNS = [
+	"date",
+	"userId",
+	"userName",
+	"userEmail",
+	"projectId",
+	"projectName",
+	"apiKeyId",
+	"apiKeyName",
+	"model",
+	"provider",
+	"requestCount",
+	"errorCount",
+	"inputTokens",
+	"outputTokens",
+	"totalTokens",
+	"cachedTokens",
+	"reasoningTokens",
+	"cost",
+	"inputCost",
+	"outputCost",
+	"creditsRequestCount",
+	"apiKeysRequestCount",
+	"creditsCost",
+	"apiKeysCost",
+] as const satisfies readonly (keyof UsageReportRow)[];
+
+function csvCell(value: string | number | null): string {
+	if (value === null) {
+		return "";
+	}
+	const text = String(value);
+	return /[",\r\n]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+}
+
+/**
+ * Flat CSV rendering of the report, with a fixed column set so a scheduled
+ * export keeps the same header regardless of which dimensions were requested.
+ */
+export function usageReportToCsv(rows: UsageReportRow[]): string {
+	const lines = [CSV_COLUMNS.join(",")];
+	for (const row of rows) {
+		lines.push(CSV_COLUMNS.map((column) => csvCell(row[column])).join(","));
+	}
+	return lines.join("\n") + "\n";
+}

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -3,19 +3,20 @@ import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
 import {
+	MAX_ORG_ACTIVITY_RANGE_DAYS,
+	rangeDaysInclusive,
+	resolveDateRange,
+} from "@/lib/date-range.js";
+import {
 	mapModeSplit,
 	modeSplitFields,
 	modeSplitSchema,
 } from "@/lib/mode-split.js";
+import { getOrgProjectIds } from "@/lib/org-projects.js";
 import { requireEnterpriseAdmin } from "@/lib/require-enterprise-admin.js";
 import { getUserUsageBreakdown } from "@/lib/user-usage-breakdown.js";
 import { userHasProjectAccess } from "@/utils/authorization.js";
-import {
-	bucketDate,
-	formatInTimeZone,
-	timezoneQueryField,
-	zonedTimeToUtc,
-} from "@/utils/timezone.js";
+import { bucketDate, timezoneQueryField } from "@/utils/timezone.js";
 
 import {
 	and,
@@ -27,7 +28,6 @@ import {
 	gte,
 	inArray,
 	lte,
-	ne,
 	projectHourlyModelStats,
 	projectHourlyStats,
 	sql,
@@ -47,57 +47,6 @@ const dateRangeQuery = {
 	to: z.string().optional(),
 	timezone: timezoneQueryField,
 };
-
-// Resolve the query window and the local calendar day-labels used to pad the
-// series. from/to are interpreted as wall-clock days in the caller's timezone
-// (defaulting to UTC), so the returned fromStr/toStr always line up with the
-// day buckets the SQL produces.
-function resolveDateRange(
-	from: string | undefined,
-	to: string | undefined,
-	timeZone: string,
-): {
-	startDate: Date;
-	endDate: Date;
-	fromStr: string;
-	toStr: string;
-} {
-	if (from && to) {
-		if (
-			Number.isNaN(Date.parse(from + "T00:00:00Z")) ||
-			Number.isNaN(Date.parse(to + "T00:00:00Z"))
-		) {
-			throw new HTTPException(400, {
-				message: "Invalid from/to date (expected YYYY-MM-DD)",
-			});
-		}
-		const startDate = zonedTimeToUtc(from + "T00:00:00.000", timeZone);
-		const endDate = zonedTimeToUtc(to + "T23:59:59.999", timeZone);
-		return { startDate, endDate, fromStr: from, toStr: to };
-	}
-	const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
-	const endDate = new Date();
-	const startDate = new Date(endDate.getTime() - sevenDaysMs);
-	return {
-		startDate,
-		endDate,
-		fromStr: formatInTimeZone(startDate, timeZone, false),
-		toStr: formatInTimeZone(endDate, timeZone, false),
-	};
-}
-
-async function getOrgProjectIds(organizationId: string): Promise<string[]> {
-	const projects = await db
-		.select({ id: tables.project.id })
-		.from(tables.project)
-		.where(
-			and(
-				eq(tables.project.organizationId, organizationId),
-				ne(tables.project.status, "deleted"),
-			),
-		);
-	return projects.map((p) => p.id);
-}
 
 const memberUsageSchema = z.object({
 	userId: z.string(),
@@ -918,18 +867,6 @@ function canonicalModelId(usedModel: string): string {
 		slashIdx === -1 ? usedModel : usedModel.slice(slashIdx + 1);
 	const colonIdx = withoutProvider.indexOf(":");
 	return colonIdx === -1 ? withoutProvider : withoutProvider.slice(0, colonIdx);
-}
-
-// Daily buckets are padded one calendar day at a time, so cap the window to a
-// year to keep the response bounded and — crucially — to keep the returned
-// buckets covering exactly the same range the SQL totals do (no silent
-// truncation of an over-large span).
-const MAX_ORG_ACTIVITY_RANGE_DAYS = 366;
-
-function rangeDaysInclusive(fromStr: string, toStr: string): number {
-	const from = Date.parse(`${fromStr}T00:00:00Z`);
-	const to = Date.parse(`${toStr}T00:00:00Z`);
-	return Math.round((to - from) / 86_400_000) + 1;
 }
 
 // Inclusive list of UTC calendar dates between two YYYY-MM-DD strings, used to

--- a/apps/api/src/routes/v1-master-usage.spec.ts
+++ b/apps/api/src/routes/v1-master-usage.spec.ts
@@ -1,0 +1,497 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { apiKeyHourlyModelStats, db, eq, tables } from "@llmgateway/db";
+import { getApiKeyFingerprint } from "@llmgateway/shared/api-key-hash";
+
+interface UsageRow {
+	date: string | null;
+	userId: string | null;
+	userName: string | null;
+	userEmail: string | null;
+	projectId: string | null;
+	projectName: string | null;
+	apiKeyId: string | null;
+	apiKeyName: string | null;
+	model: string | null;
+	provider: string | null;
+	requestCount: number;
+	errorCount: number;
+	totalTokens: number;
+	cost: number;
+}
+
+interface UsageResponse {
+	from: string;
+	to: string;
+	granularity: string;
+	groupBy: string[];
+	rows: UsageRow[];
+	pagination: { limit: number; offset: number; hasMore: boolean };
+}
+
+// Fixed window so the assertions never depend on the wall clock.
+const FROM = "2026-03-01";
+const TO = "2026-03-02";
+
+function statsRow(values: {
+	id: string;
+	apiKeyId: string;
+	projectId: string;
+	hour: string;
+	usedModel: string;
+	usedProvider: string;
+	requestCount: number;
+	cost: number;
+	totalTokens: number;
+}) {
+	return {
+		id: values.id,
+		apiKeyId: values.apiKeyId,
+		projectId: values.projectId,
+		hourTimestamp: new Date(values.hour),
+		usedModel: values.usedModel,
+		usedProvider: values.usedProvider,
+		requestCount: values.requestCount,
+		cost: values.cost,
+		creditsCost: values.cost,
+		creditsRequestCount: values.requestCount,
+		inputTokens: String(values.totalTokens),
+		totalTokens: String(values.totalTokens),
+	};
+}
+
+describe("GET /v1/master/usage", () => {
+	let masterToken: string;
+
+	beforeEach(async () => {
+		// createTestUser runs deleteAll and seeds test-user-id (admin@example.com).
+		await createTestUser();
+
+		await db.insert(tables.user).values({
+			id: "user-b-id",
+			name: "Second Member",
+			email: "second@example.com",
+			emailVerified: true,
+		});
+
+		await db.insert(tables.organization).values([
+			{
+				id: "test-org-id",
+				name: "Test Organization",
+				billingEmail: "test@example.com",
+				plan: "enterprise",
+			},
+			{
+				id: "other-org-id",
+				name: "Other Organization",
+				billingEmail: "other@example.com",
+				plan: "enterprise",
+			},
+		]);
+
+		await db.insert(tables.userOrganization).values([
+			{
+				id: "test-user-org-id",
+				userId: "test-user-id",
+				organizationId: "test-org-id",
+				role: "owner",
+			},
+			{
+				id: "user-b-org-id",
+				userId: "user-b-id",
+				organizationId: "test-org-id",
+				role: "developer",
+			},
+		]);
+
+		await db.insert(tables.project).values([
+			{
+				id: "project-1-id",
+				name: "Project One",
+				organizationId: "test-org-id",
+			},
+			{
+				id: "project-2-id",
+				name: "Project Two",
+				organizationId: "test-org-id",
+			},
+			{
+				id: "other-project-id",
+				name: "Other Project",
+				organizationId: "other-org-id",
+			},
+		]);
+
+		await db.insert(tables.apiKey).values([
+			{
+				id: "key-a",
+				token: "key-a-token",
+				projectId: "project-1-id",
+				description: "Key A",
+				createdBy: "test-user-id",
+			},
+			{
+				id: "key-b",
+				token: "key-b-token",
+				projectId: "project-1-id",
+				description: "Key B",
+				createdBy: "user-b-id",
+			},
+			{
+				id: "key-c",
+				token: "key-c-token",
+				projectId: "project-2-id",
+				description: "Key C",
+				createdBy: "test-user-id",
+			},
+			{
+				id: "other-key",
+				token: "other-key-token",
+				projectId: "other-project-id",
+				description: "Other Key",
+				createdBy: "user-b-id",
+			},
+		]);
+
+		await db.insert(apiKeyHourlyModelStats).values([
+			statsRow({
+				id: "stat-1",
+				apiKeyId: "key-a",
+				projectId: "project-1-id",
+				hour: "2026-03-01T10:00:00.000Z",
+				usedModel: "gpt-5.6",
+				usedProvider: "openai",
+				requestCount: 2,
+				cost: 1,
+				totalTokens: 150,
+			}),
+			statsRow({
+				id: "stat-2",
+				apiKeyId: "key-a",
+				projectId: "project-1-id",
+				hour: "2026-03-01T11:00:00.000Z",
+				usedModel: "claude-sonnet-5",
+				usedProvider: "anthropic",
+				requestCount: 1,
+				cost: 2,
+				totalTokens: 15,
+			}),
+			statsRow({
+				id: "stat-3",
+				apiKeyId: "key-a",
+				projectId: "project-1-id",
+				hour: "2026-03-02T10:00:00.000Z",
+				usedModel: "gpt-5.6",
+				usedProvider: "openai",
+				requestCount: 3,
+				cost: 4,
+				totalTokens: 300,
+			}),
+			statsRow({
+				id: "stat-4",
+				apiKeyId: "key-b",
+				projectId: "project-1-id",
+				hour: "2026-03-01T10:00:00.000Z",
+				usedModel: "gpt-5.6",
+				usedProvider: "openai",
+				requestCount: 5,
+				cost: 8,
+				totalTokens: 3,
+			}),
+			statsRow({
+				id: "stat-5",
+				apiKeyId: "key-c",
+				projectId: "project-2-id",
+				hour: "2026-03-01T10:00:00.000Z",
+				usedModel: "gpt-5.6",
+				usedProvider: "openai",
+				requestCount: 7,
+				cost: 16,
+				totalTokens: 70,
+			}),
+			// Negative control: another organization's traffic must never appear.
+			statsRow({
+				id: "stat-other",
+				apiKeyId: "other-key",
+				projectId: "other-project-id",
+				hour: "2026-03-01T10:00:00.000Z",
+				usedModel: "gpt-5.6",
+				usedProvider: "openai",
+				requestCount: 100,
+				cost: 1000,
+				totalTokens: 9999,
+			}),
+		]);
+
+		masterToken = `mk-${crypto.randomUUID()}`;
+		await db.insert(tables.masterKey).values({
+			id: "test-master-key-id",
+			tokenHash: getApiKeyFingerprint(masterToken),
+			maskedToken: "mk-****",
+			description: "Test Master Key",
+			status: "active",
+			organizationId: "test-org-id",
+			createdBy: "test-user-id",
+		});
+	});
+
+	afterEach(async () => {
+		// deleteAll does not target masterKey, but deleting the organization
+		// cascades it (masterKey.organizationId ON DELETE cascade).
+		await deleteAll();
+	});
+
+	async function fetchUsage(
+		query: string,
+		token = masterToken,
+	): Promise<Response> {
+		return await app.request(
+			`/v1/master/usage?from=${FROM}&to=${TO}&${query}`,
+			{ headers: { Authorization: `Bearer ${token}` } },
+		);
+	}
+
+	async function fetchJson(query: string): Promise<UsageResponse> {
+		const res = await fetchUsage(query);
+		expect(res.status).toBe(200);
+		return (await res.json()) as UsageResponse;
+	}
+
+	test("rejects a request without a master key", async () => {
+		const res = await app.request("/v1/master/usage");
+		expect(res.status).toBe(401);
+	});
+
+	test("rejects a master key on a non-enterprise organization", async () => {
+		await db
+			.update(tables.organization)
+			.set({ plan: "pro" })
+			.where(eq(tables.organization.id, "test-org-id"));
+
+		const res = await fetchUsage("granularity=total&groupBy=user");
+		expect(res.status).toBe(403);
+	});
+
+	test("groups by user across the whole organization", async () => {
+		const body = await fetchJson("granularity=total&groupBy=user");
+
+		expect(body.granularity).toBe("total");
+		expect(body.groupBy).toEqual(["user"]);
+		expect(body.pagination).toEqual({
+			limit: 1000,
+			offset: 0,
+			hasMore: false,
+		});
+
+		const byUser = indexBy(body.rows, (row) => row.userId!);
+		// key-a (2 + 1 + 3) + key-c (7); the other org's 100 requests are excluded.
+		expect(byUser.get("test-user-id")).toMatchObject({
+			date: null,
+			requestCount: 13,
+			cost: 23,
+			userName: "Test User",
+			userEmail: "admin@example.com",
+			model: null,
+			projectId: null,
+		});
+		expect(byUser.get("user-b-id")).toMatchObject({
+			requestCount: 5,
+			cost: 8,
+			userName: "Second Member",
+		});
+		expect(body.rows).toHaveLength(2);
+	});
+
+	test("cross-tabs user by model", async () => {
+		const body = await fetchJson("granularity=total&groupBy=user,model");
+
+		const byCell = indexBy(body.rows, (row) => `${row.userId}|${row.model}`);
+		expect(byCell.get("test-user-id|gpt-5.6")).toMatchObject({
+			requestCount: 12,
+			cost: 21,
+			totalTokens: 520,
+		});
+		expect(byCell.get("test-user-id|claude-sonnet-5")).toMatchObject({
+			requestCount: 1,
+			cost: 2,
+		});
+		expect(byCell.get("user-b-id|gpt-5.6")).toMatchObject({
+			requestCount: 5,
+			cost: 8,
+		});
+		expect(body.rows).toHaveLength(3);
+	});
+
+	test("buckets by local day and labels providers", async () => {
+		const body = await fetchJson("granularity=day&groupBy=user,provider");
+
+		const byCell = indexBy(
+			body.rows,
+			(row) => `${row.date}|${row.userId}|${row.provider}`,
+		);
+		expect(byCell.get("2026-03-01|test-user-id|openai")).toMatchObject({
+			requestCount: 9,
+			cost: 17,
+		});
+		expect(byCell.get("2026-03-01|test-user-id|anthropic")).toMatchObject({
+			requestCount: 1,
+			cost: 2,
+		});
+		expect(byCell.get("2026-03-02|test-user-id|openai")).toMatchObject({
+			requestCount: 3,
+			cost: 4,
+		});
+		expect(byCell.get("2026-03-01|user-b-id|openai")).toMatchObject({
+			requestCount: 5,
+			cost: 8,
+		});
+		// Rows are ordered by bucket, so the series is already chart-ready.
+		expect(body.rows[0].date).toBe("2026-03-01");
+		expect(body.rows.at(-1)!.date).toBe("2026-03-02");
+	});
+
+	test("buckets in the caller's timezone", async () => {
+		// 02:00 UTC on 03-02 is still 03-01 in New York.
+		await db.insert(apiKeyHourlyModelStats).values(
+			statsRow({
+				id: "stat-tz",
+				apiKeyId: "key-a",
+				projectId: "project-1-id",
+				hour: "2026-03-02T02:00:00.000Z",
+				usedModel: "gpt-5.6",
+				usedProvider: "openai",
+				requestCount: 11,
+				cost: 32,
+				totalTokens: 1,
+			}),
+		);
+
+		const utc = await fetchJson(
+			"granularity=day&groupBy=user&userId=test-user-id",
+		);
+		const utcByDate = indexBy(utc.rows, (row) => row.date!);
+		expect(utcByDate.get("2026-03-01")!.requestCount).toBe(10);
+		expect(utcByDate.get("2026-03-02")!.requestCount).toBe(3 + 11);
+
+		const ny = await fetchJson(
+			"granularity=day&groupBy=user&userId=test-user-id&timezone=America%2FNew_York",
+		);
+		const nyByDate = indexBy(ny.rows, (row) => row.date!);
+		expect(nyByDate.get("2026-03-01")!.requestCount).toBe(10 + 11);
+		expect(nyByDate.get("2026-03-02")!.requestCount).toBe(3);
+	});
+
+	test("filters by project, user and api key", async () => {
+		const byProject = await fetchJson(
+			"granularity=total&groupBy=user&projectId=project-1-id",
+		);
+		const projectRows = indexBy(byProject.rows, (row) => row.userId!);
+		expect(projectRows.get("test-user-id")).toMatchObject({
+			requestCount: 6,
+			cost: 7,
+		});
+		expect(projectRows.get("user-b-id")).toMatchObject({ requestCount: 5 });
+
+		const byUser = await fetchJson(
+			"granularity=total&groupBy=user&userId=user-b-id",
+		);
+		expect(byUser.rows).toHaveLength(1);
+		expect(byUser.rows[0]).toMatchObject({ userId: "user-b-id", cost: 8 });
+
+		const byKey = await fetchJson(
+			"granularity=total&groupBy=apiKey&apiKeyId=key-c",
+		);
+		expect(byKey.rows).toHaveLength(1);
+		expect(byKey.rows[0]).toMatchObject({
+			apiKeyId: "key-c",
+			apiKeyName: "Key C",
+			cost: 16,
+		});
+	});
+
+	test("labels projects when grouping by project", async () => {
+		const body = await fetchJson("granularity=total&groupBy=project");
+		const byProject = indexBy(body.rows, (row) => row.projectId!);
+		expect(byProject.get("project-1-id")).toMatchObject({
+			projectName: "Project One",
+			requestCount: 11,
+			cost: 15,
+		});
+		expect(byProject.get("project-2-id")).toMatchObject({
+			projectName: "Project Two",
+			requestCount: 7,
+		});
+		expect(body.rows).toHaveLength(2);
+	});
+
+	test("returns a single total row when no dimensions are requested", async () => {
+		const body = await fetchJson("granularity=total&groupBy=");
+		expect(body.rows).toHaveLength(1);
+		expect(body.rows[0]).toMatchObject({
+			date: null,
+			userId: null,
+			model: null,
+			requestCount: 18,
+			cost: 31,
+		});
+	});
+
+	test("pages with limit and offset", async () => {
+		const first = await fetchJson(
+			"granularity=total&groupBy=user,model&limit=2",
+		);
+		expect(first.rows).toHaveLength(2);
+		expect(first.pagination.hasMore).toBe(true);
+
+		const second = await fetchJson(
+			"granularity=total&groupBy=user,model&limit=2&offset=2",
+		);
+		expect(second.rows).toHaveLength(1);
+		expect(second.pagination.hasMore).toBe(false);
+	});
+
+	test("rejects an unknown groupBy dimension", async () => {
+		const res = await fetchUsage("groupBy=user,department");
+		expect(res.status).toBe(400);
+	});
+
+	test("rejects over-long ranges", async () => {
+		const tooLong = await app.request(
+			"/v1/master/usage?from=2024-01-01&to=2026-03-02",
+			{ headers: { Authorization: `Bearer ${masterToken}` } },
+		);
+		expect(tooLong.status).toBe(400);
+
+		const tooLongHourly = await app.request(
+			"/v1/master/usage?from=2026-01-01&to=2026-03-02&granularity=hour",
+			{ headers: { Authorization: `Bearer ${masterToken}` } },
+		);
+		expect(tooLongHourly.status).toBe(400);
+	});
+
+	test("404s on a project outside the organization", async () => {
+		const res = await fetchUsage("projectId=other-project-id");
+		expect(res.status).toBe(404);
+	});
+
+	test("renders CSV", async () => {
+		const res = await fetchUsage("granularity=total&groupBy=user&format=csv");
+		expect(res.status).toBe(200);
+		expect(res.headers.get("content-type")).toContain("text/csv");
+		expect(res.headers.get("content-disposition")).toContain(
+			`usage-${FROM}-to-${TO}.csv`,
+		);
+
+		const lines = (await res.text()).trim().split("\n");
+		expect(lines[0].split(",")).toContain("userEmail");
+		expect(lines).toHaveLength(3);
+		expect(lines.some((line) => line.includes("admin@example.com"))).toBe(true);
+	});
+});
+
+function indexBy<T>(rows: T[], key: (row: T) => string): Map<string, T> {
+	return new Map(rows.map((row) => [key(row), row]));
+}

--- a/apps/api/src/routes/v1-master.ts
+++ b/apps/api/src/routes/v1-master.ts
@@ -3,13 +3,27 @@ import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
 import {
+	MAX_ORG_ACTIVITY_RANGE_DAYS,
+	rangeDaysInclusive,
+	resolveDateRange,
+} from "@/lib/date-range.js";
+import {
 	createIamRuleSchema,
 	iamRuleStatusEnum,
 	iamRuleTypeEnum,
 	iamRuleValueSchema,
 	validateIamRuleInput,
 } from "@/lib/iam-rules.js";
+import { getOrgProjectIds } from "@/lib/org-projects.js";
 import { assertOrganizationProviderKey } from "@/lib/organization-provider-key.js";
+import {
+	getUsageReport,
+	USAGE_DIMENSIONS,
+	USAGE_GRANULARITIES,
+	usageReportRowSchema,
+	usageReportToCsv,
+	type UsageDimension,
+} from "@/lib/usage-report.js";
 import {
 	applyCustomModelUpdate,
 	createCustomModelSchema,
@@ -40,6 +54,7 @@ import {
 } from "@/routes/keys-provider.js";
 import { createProjectForOrg } from "@/routes/projects.js";
 import { memberIamRuleSchema } from "@/routes/team.js";
+import { timezoneQueryField } from "@/utils/timezone.js";
 
 import { encryptProviderKey, readProviderKey } from "@llmgateway/actions";
 import { logAuditEvent } from "@llmgateway/audit";
@@ -2043,6 +2058,150 @@ v1Master.openapi(deleteCustomModel, async (c) => {
 	await softDeleteCustomModel(existing, masterKey.createdBy);
 
 	return c.json({ message: "Custom model deleted successfully" });
+});
+
+// Hourly buckets over a long window explode the row count (a year is ~8800
+// buckets before any dimension fan-out), so hourly granularity gets a much
+// tighter cap than the daily one.
+const MAX_HOURLY_USAGE_RANGE_DAYS = 31;
+
+const usageQuery = z.object({
+	from: z.string().optional(),
+	to: z.string().optional(),
+	timezone: timezoneQueryField,
+	granularity: z.enum(USAGE_GRANULARITIES).optional(),
+	groupBy: z.string().optional(),
+	projectId: z.string().min(1).optional(),
+	userId: z.string().min(1).optional(),
+	apiKeyId: z.string().min(1).optional(),
+	limit: z.coerce.number().int().min(1).max(10000).optional(),
+	offset: z.coerce.number().int().min(0).optional(),
+	format: z.enum(["json", "csv"]).optional(),
+});
+
+const usageResponseSchema = z.object({
+	from: z.string(),
+	to: z.string(),
+	granularity: z.enum(USAGE_GRANULARITIES),
+	groupBy: z.array(z.enum(USAGE_DIMENSIONS)),
+	rows: z.array(usageReportRowSchema),
+	pagination: z.object({
+		limit: z.number(),
+		offset: z.number(),
+		hasMore: z.boolean(),
+	}),
+});
+
+function parseGroupBy(raw: string | undefined): UsageDimension[] {
+	if (raw === undefined) {
+		return ["user", "model"];
+	}
+	const seen = new Set<UsageDimension>();
+	for (const part of raw.split(",")) {
+		const value = part.trim();
+		if (!value) {
+			continue;
+		}
+		if (!(USAGE_DIMENSIONS as readonly string[]).includes(value)) {
+			throw new HTTPException(400, {
+				message: `Invalid groupBy dimension "${value}" (expected any of: ${USAGE_DIMENSIONS.join(", ")})`,
+			});
+		}
+		seen.add(value as UsageDimension);
+	}
+	return Array.from(seen);
+}
+
+const getUsage = createRoute({
+	method: "get",
+	path: "/usage",
+	request: {
+		query: usageQuery,
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: usageResponseSchema.openapi({}),
+				},
+				"text/csv": {
+					schema: z.any().openapi({ type: "string" }),
+				},
+			},
+			description:
+				"Usage and cost for the master key's organization, grouped by any combination of user, model, provider, project and API key, bucketed hourly, daily or not at all. Returns JSON, or CSV when format=csv.",
+		},
+	},
+});
+
+v1Master.openapi(getUsage, async (c) => {
+	const masterKey = c.get("masterKey");
+	if (!masterKey) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const query = c.req.valid("query");
+	const timeZone = query.timezone || "UTC";
+	const granularity = query.granularity ?? "day";
+	const dimensions = parseGroupBy(query.groupBy);
+	const limit = query.limit ?? 1000;
+	const offset = query.offset ?? 0;
+
+	const { startDate, endDate, fromStr, toStr } = resolveDateRange(
+		query.from,
+		query.to,
+		timeZone,
+	);
+
+	const rangeDays = rangeDaysInclusive(fromStr, toStr);
+	if (rangeDays > MAX_ORG_ACTIVITY_RANGE_DAYS) {
+		throw new HTTPException(400, {
+			message: `Date range too large (max ${MAX_ORG_ACTIVITY_RANGE_DAYS} days)`,
+		});
+	}
+	if (granularity === "hour" && rangeDays > MAX_HOURLY_USAGE_RANGE_DAYS) {
+		throw new HTTPException(400, {
+			message: `Date range too large for hourly granularity (max ${MAX_HOURLY_USAGE_RANGE_DAYS} days)`,
+		});
+	}
+
+	const orgProjectIds = await getOrgProjectIds(masterKey.organizationId);
+	if (query.projectId && !orgProjectIds.includes(query.projectId)) {
+		throw new HTTPException(404, {
+			message: "Project not found in this organization",
+		});
+	}
+
+	const { rows, hasMore } = await getUsageReport({
+		projectIds: query.projectId ? [query.projectId] : orgProjectIds,
+		startDate,
+		endDate,
+		timeZone,
+		granularity,
+		dimensions,
+		userId: query.userId,
+		apiKeyId: query.apiKeyId,
+		limit,
+		offset,
+	});
+
+	if (query.format === "csv") {
+		c.header("Content-Type", "text/csv; charset=utf-8");
+		c.header(
+			"Content-Disposition",
+			`attachment; filename="usage-${fromStr}-to-${toStr}.csv"`,
+		);
+		return c.body(usageReportToCsv(rows));
+	}
+
+	return c.json({
+		from: fromStr,
+		to: toStr,
+		granularity,
+		groupBy: dimensions,
+		rows,
+		pagination: { limit, offset, hasMore },
+	});
 });
 
 export default v1Master;

--- a/apps/docs/content/features/master-keys.mdx
+++ b/apps/docs/content/features/master-keys.mdx
@@ -353,6 +353,11 @@ Response (200):
 
 Returns usage and cost for the master key's organization as a flat list of rows, grouped by any combination of member, model, provider, project, and API key, and bucketed hourly, daily, or not at all. This is the endpoint to point an internal reporting tool, data warehouse, or chargeback job at — it is the only usage surface that authenticates with a token rather than a dashboard session.
 
+<Callout type="info">
+	Like every `/v1/master/*` endpoint, this requires an **Enterprise** plan. A
+	master key on any other plan receives a `403`.
+</Callout>
+
 ```bash
 # Cost per member for a month
 curl -G https://internal.llmgateway.io/v1/master/usage \

--- a/apps/docs/content/features/master-keys.mdx
+++ b/apps/docs/content/features/master-keys.mdx
@@ -1,6 +1,6 @@
 ---
 title: Master Keys
-description: Provision projects, gateway API keys, and custom providers/models programmatically with org-scoped bearer tokens (Enterprise only)
+description: Provision projects, gateway API keys, and custom providers/models — and pull per-member usage and cost data — programmatically with org-scoped bearer tokens (Enterprise only)
 icon: KeyRound
 ---
 
@@ -9,6 +9,8 @@ import { Callout } from "fumadocs-ui/components/callout";
 # Master Keys
 
 Master keys are org-scoped bearer tokens that let you create projects, gateway API keys, IAM rules (both per key and per organization member), and your organization's custom providers and custom models programmatically — without going through the dashboard. They are intended for server-to-server provisioning (e.g. multi-tenant onboarding from your own backend).
+
+They also expose [usage and cost reporting](#usage-and-cost-reporting), so you can pull per-member and per-model spend into your own dashboards, data warehouse, or chargeback process.
 
 <Callout type="info">
 	Master keys are available on the **Enterprise** plan only. Contact us at
@@ -344,6 +346,114 @@ Response (200):
 	The auto-generated Lounge (playground) API key cannot be deleted via the
 	master API.
 </Callout>
+
+## Usage and cost reporting
+
+`GET /v1/master/usage`
+
+Returns usage and cost for the master key's organization as a flat list of rows, grouped by any combination of member, model, provider, project, and API key, and bucketed hourly, daily, or not at all. This is the endpoint to point an internal reporting tool, data warehouse, or chargeback job at — it is the only usage surface that authenticates with a token rather than a dashboard session.
+
+```bash
+# Cost per member for a month
+curl -G https://internal.llmgateway.io/v1/master/usage \
+  -H "Authorization: Bearer $MASTER_KEY" \
+  -d from=2026-07-01 -d to=2026-07-31 \
+  -d granularity=total -d groupBy=user
+```
+
+Query parameters:
+
+| Param         | Type                                                              | Default      | Description                                                                              |
+| ------------- | ----------------------------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------- |
+| `from`, `to`  | `YYYY-MM-DD`                                                      | last 7 days  | Inclusive window, interpreted as wall-clock days in `timezone`. Max 366 days             |
+| `timezone`    | IANA timezone                                                     | `UTC`        | Timezone the day/hour buckets are labelled in                                            |
+| `granularity` | `hour` \| `day` \| `total`                                        | `day`        | Time bucket. `total` collapses the window into one row per group. `hour` caps at 31 days |
+| `groupBy`     | comma-separated: `user`, `model`, `provider`, `project`, `apiKey` | `user,model` | Dimensions to break down by. Pass an empty value for organization-wide totals            |
+| `projectId`   | string                                                            | —            | Restrict to one project. `404` if it is not in this organization                         |
+| `userId`      | string                                                            | —            | Restrict to one member                                                                   |
+| `apiKeyId`    | string                                                            | —            | Restrict to one gateway API key                                                          |
+| `limit`       | 1–10000                                                           | `1000`       | Rows per page                                                                            |
+| `offset`      | ≥ 0                                                               | `0`          | Row offset for paging                                                                    |
+| `format`      | `json` \| `csv`                                                   | `json`       | `csv` returns a `text/csv` attachment with a fixed header                                |
+
+Response (200):
+
+```json
+{
+	"from": "2026-07-01",
+	"to": "2026-07-31",
+	"granularity": "day",
+	"groupBy": ["user", "model"],
+	"rows": [
+		{
+			"date": "2026-07-01",
+			"userId": "usr_...",
+			"userName": "Ada Lovelace",
+			"userEmail": "ada@example.com",
+			"projectId": null,
+			"projectName": null,
+			"apiKeyId": null,
+			"apiKeyName": null,
+			"model": "gpt-5.6",
+			"provider": "openai",
+			"requestCount": 128,
+			"errorCount": 2,
+			"inputTokens": 481203,
+			"outputTokens": 92844,
+			"totalTokens": 574047,
+			"cachedTokens": 120000,
+			"reasoningTokens": 18320,
+			"cost": 3.4127,
+			"inputCost": 2.1,
+			"outputCost": 1.3127,
+			"creditsRequestCount": 128,
+			"apiKeysRequestCount": 0,
+			"creditsCost": 3.4127,
+			"apiKeysCost": 0
+		}
+	],
+	"pagination": { "limit": 1000, "offset": 0, "hasMore": false }
+}
+```
+
+Every row carries the full column set. Dimension fields you did not group by are `null`, and `date` is `null` when `granularity=total`, so the row shape stays stable for a schema-driven consumer. `creditsCost` / `apiKeysCost` split the blended `cost` into credit-billed and BYOK traffic.
+
+### Per-member, per-model breakdown
+
+Combine the two dimensions to get the cross-tab most reporting tools want — one row per member, model, and day:
+
+```bash
+curl -G https://internal.llmgateway.io/v1/master/usage \
+  -H "Authorization: Bearer $MASTER_KEY" \
+  -d from=2026-07-01 -d to=2026-07-31 \
+  -d granularity=day -d groupBy=user,model \
+  -d timezone=Europe/Berlin
+```
+
+### CSV export
+
+```bash
+curl -G https://internal.llmgateway.io/v1/master/usage \
+  -H "Authorization: Bearer $MASTER_KEY" \
+  -d from=2026-07-01 -d to=2026-07-31 \
+  -d granularity=day -d groupBy=user,model -d format=csv \
+  -o usage-july.csv
+```
+
+The CSV header is the same fixed column set regardless of the dimensions requested, so a scheduled export never changes shape.
+
+<Callout type="warn">
+	**Usage is attributed to the member who created the API key** (there is no
+	per-caller identity on an inference request). A key shared by several people
+	reports entirely under its creator. For accurate per-person reporting, issue
+	one gateway API key per member — the per-member key limit under **Organization
+	→ Members** is the lever that enforces it.
+</Callout>
+
+Two more things worth knowing:
+
+- These figures come from hourly rollups, not the request log, so they are **not** affected by your [data retention](/features/data-retention) setting — per-member and per-model history stays available even with retention turned off.
+- Traffic from [embeddable payments](/features/embeddable-payments) end-user keys rolls up to the member who provisioned the platform key.
 
 ## IAM rules
 


### PR DESCRIPTION
## Problem

Customers want to pull per-user usage and cost data — broken down per model — into their own reporting tools (intranet portals, warehouses, chargeback jobs).

The data and the queries already existed, but nothing could reach them programmatically:

- `/analytics/members/{userId}`, `/analytics/activity`, `/activity?groupBy=user` and `/logs` all sit behind the Better Auth session guard (`apps/api/src/routes/index.ts`), and no bearer/apiKey plugin is registered. A machine-to-machine job would have to replay a dashboard session cookie.
- `/v1/master/*` — the one org-scoped bearer-token surface — had **no** usage endpoints. The only usage it exposed was the cumulative `usage` / `currentPeriodUsage` counters on `GET /v1/master/keys`: no model dimension, no time series, no token counts.

## What this adds

`GET /v1/master/usage` — a composable usage/cost cross-tab, authenticated with a master key (Enterprise, same middleware and gates as the rest of `/v1/master`).

| Param | Notes |
| --- | --- |
| `from` / `to` | `YYYY-MM-DD`, wall-clock days in `timezone`, max 366 days |
| `timezone` | IANA, default `UTC` |
| `granularity` | `hour` \| `day` \| `total` (default `day`; `hour` caps at 31 days) |
| `groupBy` | any combination of `user`, `model`, `provider`, `project`, `apiKey` (default `user,model`) |
| `projectId` / `userId` / `apiKeyId` | filters; unknown `projectId` in another org 404s |
| `limit` / `offset` | 1–10000, default 1000 |
| `format` | `json` \| `csv` |

`groupBy=user,model` is the case that motivated this — the dashboard can only give per-user **or** per-model in one call, and only crosses the two one user at a time.

Every row carries the full column set (requests, errors, input/output/cached/reasoning tokens, cost with the credits-vs-BYOK split). Dimensions not grouped by are `null`, and `date` is `null` for `granularity=total`, so the row shape is stable for a schema-driven consumer. The CSV header is fixed for the same reason.

## Approach

- No schema change: `api_key_hourly_model_stats` already has the `(apiKey, hour, model, provider)` grain, and denormalises `projectId` for org scoping.
- `apps/api/src/lib/usage-report.ts` builds the query. Attribution (`api_key.created_by`) and the `keyType IN ('user','end_user_customer')` filter deliberately mirror `getUserUsageBreakdown`, so the master API and the dashboard can never drift apart on the same window.
- Grouped expressions are referenced by SELECT **position**, per the constraint documented on `bucketDate` — repeating the expression would rebind the timezone parameter and make GROUP BY differ from SELECT. Non-grouped dimensions select a `NULL` constant, which needs no GROUP BY entry.
- `getOrgProjectIds` and the date-range helpers (`resolveDateRange`, `rangeDaysInclusive`, `MAX_ORG_ACTIVITY_RANGE_DAYS`) moved out of `analytics.ts` into `lib/org-projects.ts` and `lib/date-range.ts` so both callers share one implementation. `analytics.ts` behaviour is unchanged.

## Deliberately not in scope

True per-caller attribution. Usage is attributed to the **creator** of the API key, so a key shared by several people reports entirely under its creator. Making this exact needs a `log.userId` column plus a `user_hourly_stats` rollup (migration + worker changes); we kept the existing semantics and documented the caveat prominently instead.

## Docs

`apps/docs/content/features/master-keys.mdx` gains a **Usage and cost reporting** section: full parameter table, response shape, three curl examples (monthly cost per member, daily user×model, CSV export), the attribution caveat, and two notes — these figures come from rollups so data retention does not prune them, and embeddable-payments end-user traffic rolls up to the member who provisioned the platform key.

## Verification

- New `apps/api/src/routes/v1-master-usage.spec.ts` — 14 tests: auth (401 / non-enterprise 403), per-user totals, the user×model cross-tab, daily bucketing, timezone bucket shifting, project/user/apiKey filters, project labelling, dimensionless totals, paging + `hasMore`, invalid `groupBy`, both range caps, cross-org 404, and CSV output.
- Cross-org isolation is asserted with a second organization's traffic seeded as a negative control.
- `analytics.spec.ts`, `activity.spec.ts`, `v1-master.spec.ts`, `v1-master-custom-catalog.spec.ts` re-run for the helper extraction — 116 tests pass (sequentially; these specs share the test DB).
- `pnpm format` and a full `pnpm build` pass.
- Smoke-tested against a real `node dist/serve.js` on an isolated stack, not just in-process `app.request` — both the JSON and CSV paths, including the `Content-Type` / `Content-Disposition` headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added master-key usage and cost reporting with date, timezone, granularity, grouping, filtering, pagination, and JSON/CSV export options.
  * Added reporting by organization, user, project, API key, model, and provider.
  * Added validation for date ranges, project ownership, and access permissions.

* **Documentation**
  * Added comprehensive API documentation, examples, response details, and reporting behavior for master-key usage analytics.

* **Tests**
  * Added integration coverage for authorization, filtering, grouping, timezone-aware buckets, pagination, validation, and CSV output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->