### PR TITLE
fix(seo): complete Dataset schema on timeline

### DIFF
--- a/apps/code/src/app/data/[year]/page.tsx
+++ b/apps/code/src/app/data/[year]/page.tsx
@@ -176,6 +176,8 @@ export default async function CensusPage({
 			name: "LLM Gateway",
 			url: "https://llmgateway.io",
 		},
+		license: "https://llmgateway.io/legal/terms",
+		isAccessibleForFree: true,
 		temporalCoverage: `${year}`,
 		variableMeasured: [
 			"value for money (1-5)",

--- a/apps/ui/src/app/timeline/[year]/page.tsx
+++ b/apps/ui/src/app/timeline/[year]/page.tsx
@@ -13,11 +13,14 @@ import {
 	buildTimelineModels,
 	buildTimelineStats,
 	buildYearFaqs,
+	DATASET_CREATOR,
+	DATASET_LICENSE,
 	formatDate,
 	getTimelineYears,
 	getYearSummaries,
 	isoDate,
 	modelsForYear,
+	TIMELINE_DATASET_REF,
 } from "@/lib/timeline-data";
 
 import type { Metadata } from "next";
@@ -104,13 +107,22 @@ export default async function TimelineYearPage({ params }: YearPageProps) {
 	const datasetSchema = {
 		"@context": "https://schema.org",
 		"@type": "Dataset",
+		"@id": `${BASE_URL}/timeline/${year}#dataset`,
 		name: `LLM releases in ${year}`,
 		description: `Large language models released in ${year}, with provider release dates and the date each was added to LLM Gateway.`,
 		url: `${BASE_URL}/timeline/${year}`,
-		isPartOf: { "@type": "Dataset", "@id": `${BASE_URL}/timeline` },
+		isPartOf: TIMELINE_DATASET_REF,
 		temporalCoverage: `${year}-01-01/${year}-12-31`,
-		creator: { "@type": "Organization", name: "LLM Gateway", url: BASE_URL },
+		creator: DATASET_CREATOR,
+		license: DATASET_LICENSE,
 		isAccessibleForFree: true,
+		keywords: [
+			`LLMs released in ${year}`,
+			`AI models ${year}`,
+			`${year} model release dates`,
+			"LLM release timeline",
+		],
+		variableMeasured: ["Provider release date", "Date added to LLM Gateway"],
 		...(summary.latestInYearAt
 			? { dateModified: summary.latestInYearAt.slice(0, 10) }
 			: {}),

--- a/apps/ui/src/app/timeline/page.tsx
+++ b/apps/ui/src/app/timeline/page.tsx
@@ -12,11 +12,16 @@ import {
 	buildTimelineFaqs,
 	buildTimelineModels,
 	buildTimelineStats,
+	DATASET_CREATOR,
+	DATASET_LICENSE,
 	formatDate,
 	getMonthSummary,
 	getYearSummaries,
 	isoDate,
 	recentModels,
+	TIMELINE_DATASET_DESCRIPTION,
+	TIMELINE_DATASET_ID,
+	TIMELINE_DATASET_NAME,
 } from "@/lib/timeline-data";
 
 import type { TimelineMonthSummary } from "@/lib/timeline-data";
@@ -87,10 +92,11 @@ export default async function TimelinePage() {
 	const datasetSchema = {
 		"@context": "https://schema.org",
 		"@type": "Dataset",
-		name: "LLM Model Release Timeline",
-		description:
-			"A continuously updated dataset of large language model releases: the provider release date and the date each model was added to LLM Gateway.",
+		"@id": TIMELINE_DATASET_ID,
+		name: TIMELINE_DATASET_NAME,
+		description: TIMELINE_DATASET_DESCRIPTION,
 		url: `${BASE_URL}/timeline`,
+		license: DATASET_LICENSE,
 		keywords: [
 			"LLM release dates",
 			"AI model timeline",
@@ -99,11 +105,7 @@ export default async function TimelinePage() {
 			"Gemini release date",
 			"language model history",
 		],
-		creator: {
-			"@type": "Organization",
-			name: "LLM Gateway",
-			url: BASE_URL,
-		},
+		creator: DATASET_CREATOR,
 		isAccessibleForFree: true,
 		...(stats.firstYear
 			? {

--- a/apps/ui/src/lib/timeline-data.ts
+++ b/apps/ui/src/lib/timeline-data.ts
@@ -436,3 +436,37 @@ export function buildYearFaqs(
 
 	return faqs;
 }
+
+const TIMELINE_BASE_URL = "https://llmgateway.io";
+
+/**
+ * Google validates a nested Dataset node (the `isPartOf` reference on a year
+ * page) exactly like a top-level one, so every Dataset we emit — nested or not
+ * — has to carry its own name, description, url, creator and license.
+ */
+export const DATASET_CREATOR = {
+	"@type": "Organization",
+	name: "LLM Gateway",
+	url: TIMELINE_BASE_URL,
+};
+
+export const DATASET_LICENSE = `${TIMELINE_BASE_URL}/legal/terms`;
+
+export const TIMELINE_DATASET_ID = `${TIMELINE_BASE_URL}/timeline#dataset`;
+
+export const TIMELINE_DATASET_NAME = "LLM Model Release Timeline";
+
+export const TIMELINE_DATASET_DESCRIPTION =
+	"A continuously updated dataset of large language model releases: the provider release date and the date each model was added to LLM Gateway.";
+
+/** Fully-specified reference to the parent timeline dataset. */
+export const TIMELINE_DATASET_REF = {
+	"@type": "Dataset",
+	"@id": TIMELINE_DATASET_ID,
+	name: TIMELINE_DATASET_NAME,
+	description: TIMELINE_DATASET_DESCRIPTION,
+	url: `${TIMELINE_BASE_URL}/timeline`,
+	creator: DATASET_CREATOR,
+	license: DATASET_LICENSE,
+	isAccessibleForFree: true,
+};


### PR DESCRIPTION
## Problem

Search Console reported 4 Datasets structured data issues on `llmgateway.io`, sampled on `/timeline/2026`:

| Issue | Severity |
| --- | --- |
| Missing field `name` | Critical — item invalid |
| Missing field `description` | Critical — item invalid |
| Either `name` or `url` should be specified (in `isPartOf`) | Non-critical |
| Missing field `creator` | Non-critical |

All four came from a single node. `/timeline/[year]` linked back to the parent dataset with a bare reference:

```json
"isPartOf": { "@type": "Dataset", "@id": "https://llmgateway.io/timeline" }
```

Google validates a **nested** `Dataset` node exactly like a top-level one, so that stub counted as its own invalid Dataset item — hence the missing `name`/`description`/`creator`. The top-level Dataset on the page was already complete, which is why the page looked fine at a glance.

`Missing field "license"` (4 items, non-critical) was separate: the timeline Datasets and the DevPass census Dataset never set it.

## Approach

- Give the `isPartOf` reference every field Google wants — `name`, `description`, `url`, `creator`, `license`.
- Share that reference from `lib/timeline-data.ts` (`TIMELINE_DATASET_REF`) together with the name/description/`@id` constants, so the child's view of the parent dataset can't drift from what `/timeline` actually emits. Both nodes now agree on the `@id` `…/timeline#dataset`, which also makes the parent/child link resolvable rather than nominal.
- Add the recommended `license` to the Datasets missing it, and `@id` + `keywords` + `variableMeasured` to the year Dataset.

`license` points at `https://llmgateway.io/legal/terms`, matching the existing model-uptime Dataset. Verified it returns 200 in production.

## Verification

Built the UI and served it against the production public API, then extracted the emitted JSON-LD from `/timeline/2026`:

```json
{
  "@type": "Dataset",
  "@id": "https://llmgateway.io/timeline/2026#dataset",
  "name": "LLM releases in 2026",
  "description": "Large language models released in 2026, …",
  "url": "https://llmgateway.io/timeline/2026",
  "isPartOf": {
    "@type": "Dataset",
    "@id": "https://llmgateway.io/timeline#dataset",
    "name": "LLM Model Release Timeline",
    "description": "A continuously updated dataset of large language model releases: …",
    "url": "https://llmgateway.io/timeline",
    "creator": { "@type": "Organization", "name": "LLM Gateway", "url": "https://llmgateway.io" },
    "license": "https://llmgateway.io/legal/terms",
    "isAccessibleForFree": true
  },
  "creator": { "@type": "Organization", "name": "LLM Gateway", "url": "https://llmgateway.io" },
  "license": "https://llmgateway.io/legal/terms",
  …
}
```

Every field GSC flagged is present on the nested node. `/timeline` checked too. `pnpm build` and `pnpm lint` pass.

## Notes

- No screenshots: JSON-LD only, zero visual change, and none of the three dashboard UIs are touched.
- `apps/code`'s census Dataset is included because it had the same missing `license`. It's on `devpass.llmgateway.io`, so it only counts toward this report if the GSC property is domain-level — harmless either way.
- After deploy, hit **Validate Fix** on each of the issues in Search Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved dataset metadata across timeline and census pages.
  * Added clearer licensing information, including free-access details.
  * Added dataset identifiers, keywords, measured variables, descriptions, and creator information to structured metadata.
  * Standardized parent-dataset references across timeline pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->