### PR TITLE
feat(models): add Alibaba EU (Frankfurt) region

### DIFF
--- a/apps/api/src/routes/admin-provider-credentials.spec.ts
+++ b/apps/api/src/routes/admin-provider-credentials.spec.ts
@@ -19,6 +19,10 @@ import {
 	waitForSwrMirrorWrites,
 } from "@llmgateway/cache";
 import { and, asc, cdb, db, eq, getTableName, tables } from "@llmgateway/db";
+import {
+	getProviderDefinition,
+	getRegionEnvVarSuffix,
+} from "@llmgateway/models";
 import { getApiKeyFingerprint } from "@llmgateway/shared/api-key-hash";
 
 import type * as LlmGatewayActions from "@llmgateway/actions";
@@ -71,9 +75,13 @@ describe("admin provider credentials", () => {
 	 * ones it asserts on.
 	 */
 	function clearAlibabaEnvSlots() {
+		const regions =
+			getProviderDefinition("alibaba")?.regionConfig?.regions.map((r) =>
+				getRegionEnvVarSuffix(r.id),
+			) ?? [];
 		for (const variant of ["", "__ENTERPRISE", "__PLANS"]) {
 			vi.stubEnv(`LLM_ALIBABA_API_KEY${variant}`, "");
-			for (const region of ["SINGAPORE", "US_VIRGINIA", "CN_BEIJING"]) {
+			for (const region of regions) {
 				vi.stubEnv(`LLM_ALIBABA_API_KEY${variant}__${region}`, "");
 			}
 		}

--- a/apps/api/src/routes/keys-provider.e2e.ts
+++ b/apps/api/src/routes/keys-provider.e2e.ts
@@ -247,6 +247,94 @@ describe(
 			},
 		);
 
+		// A Model Studio credential comes in two shapes: a legacy account key and
+		// a newer workspace-scoped `sk-ws-…` key. Both must register through the
+		// same dialog, and the workspace id is only ever an optional upgrade.
+		describe("alibaba credential shapes", () => {
+			const legacyKey = process.env.LLM_ALIBABA_API_KEY;
+			const frankfurtKey = process.env.LLM_ALIBABA_API_KEY__EU_FRANKFURT;
+			const frankfurtWorkspaceId =
+				process.env.LLM_ALIBABA_WORKSPACE_ID__EU_FRANKFURT;
+
+			async function createAlibabaKey(
+				providerToken: string,
+				options?: Record<string, string>,
+			) {
+				const { token, orgId } = await setupTestData();
+				const res = await app.request("/keys/provider", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Cookie: token,
+					},
+					body: JSON.stringify({
+						provider: "alibaba",
+						token: providerToken,
+						organizationId: orgId,
+						...(options ? { options } : {}),
+					}),
+				});
+				return { res, orgId };
+			}
+
+			test("registers a key for a region with a shared DashScope host", async () => {
+				if (!legacyKey) {
+					console.log("Skipping - no LLM_ALIBABA_API_KEY provided");
+					return;
+				}
+				const { res } = await createAlibabaKey(legacyKey, {
+					alibaba_region: "singapore",
+				});
+				expect(await res.json()).toHaveProperty("providerKey");
+				expect(res.status).toBe(200);
+			});
+
+			test("registers a workspace-scoped key with its workspace id", async () => {
+				if (!frankfurtKey || !frankfurtWorkspaceId) {
+					console.log("Skipping - no Frankfurt key/workspace id provided");
+					return;
+				}
+				const { res, orgId } = await createAlibabaKey(frankfurtKey, {
+					alibaba_region: "eu-frankfurt",
+					alibaba_workspace_id: frankfurtWorkspaceId,
+				});
+				expect(res.status).toBe(200);
+
+				const providerKey = await db.query.providerKey.findFirst({
+					where: {
+						provider: { eq: "alibaba" },
+						organizationId: { eq: orgId },
+					},
+				});
+				expect(providerKey?.options?.alibaba_workspace_id).toBe(
+					frankfurtWorkspaceId,
+				);
+			});
+
+			test("registers a workspace-scoped key without a workspace id", async () => {
+				if (!frankfurtKey) {
+					console.log("Skipping - no Frankfurt key provided");
+					return;
+				}
+				const { res } = await createAlibabaKey(frankfurtKey, {
+					alibaba_region: "eu-frankfurt",
+				});
+				expect(res.status).toBe(200);
+			});
+
+			test("rejects a workspace id that is not a bare hostname label", async () => {
+				if (!frankfurtKey) {
+					console.log("Skipping - no Frankfurt key provided");
+					return;
+				}
+				const { res } = await createAlibabaKey(frankfurtKey, {
+					alibaba_region: "eu-frankfurt",
+					alibaba_workspace_id: "evil.example.com/x",
+				});
+				expect(res.status).toBe(400);
+			});
+		});
+
 		describe("SSRF protection at registration", () => {
 			const originalFlag = process.env.ALLOW_INSECURE_PROVIDER_URLS;
 

--- a/apps/api/src/routes/keys-provider.spec.ts
+++ b/apps/api/src/routes/keys-provider.spec.ts
@@ -239,6 +239,43 @@ describe("provider keys route", () => {
 		expect(res.status).toBe(400);
 	});
 
+	describe("POST /keys/provider workspace-scoped regions", () => {
+		const postAlibabaKey = (options: Record<string, string>) =>
+			app.request("/keys/provider", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Cookie: token,
+				},
+				body: JSON.stringify({
+					provider: "alibaba",
+					token: "sk-alibaba-test-key",
+					organizationId: "test-org-id",
+					options,
+				}),
+			});
+
+		// Frankfurt reaches a shared entry point without one, so the workspace id
+		// is an upgrade rather than a requirement.
+		test("accepts eu-frankfurt without a workspace id", async () => {
+			const res = await postAlibabaKey({ alibaba_region: "eu-frankfurt" });
+			expect(res.status).not.toBe(400);
+		});
+
+		test("rejects a workspace id that is not a bare hostname label", async () => {
+			const res = await postAlibabaKey({
+				alibaba_region: "eu-frankfurt",
+				alibaba_workspace_id: "evil.example.com/x",
+			});
+			expect(res.status).toBe(400);
+		});
+
+		test("accepts regions served by a shared host without a workspace id", async () => {
+			const res = await postAlibabaKey({ alibaba_region: "singapore" });
+			expect(res.status).not.toBe(400);
+		});
+	});
+
 	test("POST /keys/provider with invalid provider", async () => {
 		const res = await app.request("/keys/provider", {
 			method: "POST",

--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -34,7 +34,11 @@ import {
 	tables,
 } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
-import { isStealthProvider, providers } from "@llmgateway/models";
+import {
+	isStealthProvider,
+	providers,
+	regionEndpointRequiresWorkspaceId,
+} from "@llmgateway/models";
 import {
 	CUSTOM_PROVIDER_NAME_MESSAGE,
 	CUSTOM_PROVIDER_NAME_REGEX,
@@ -293,6 +297,36 @@ export function isValidProviderToken(value: string): boolean {
 	}
 }
 
+// The workspace id becomes a hostname label on the workspace-dedicated
+// endpoint, so it is restricted to what Model Studio issues rather than
+// accepted verbatim.
+const WORKSPACE_ID_REGEX = /^[a-zA-Z0-9-]{1,64}$/;
+const WORKSPACE_ID_MESSAGE =
+	"Workspace ID must be 1-64 characters of letters, digits, or hyphens";
+
+/**
+ * A workspace id is optional: a region whose endpoint is workspace-scoped
+ * still reaches a shared entry point without one. It is only mandatory for a
+ * region that has no such fallback, which is enforced here so a direct API
+ * client cannot store a key whose endpoint can never be built.
+ */
+function validateWorkspaceScopedRegion(
+	options: { alibaba_region?: string; alibaba_workspace_id?: string },
+	ctx: z.RefinementCtx,
+) {
+	const region = options.alibaba_region;
+	if (!region || !regionEndpointRequiresWorkspaceId("alibaba", region)) {
+		return;
+	}
+	if (!options.alibaba_workspace_id) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			path: ["alibaba_workspace_id"],
+			message: `The ${region} region has no shared endpoint, so a workspace ID is required.`,
+		});
+	}
+}
+
 const createProviderKeySchema = z.object({
 	provider: z
 		.string()
@@ -337,13 +371,17 @@ const createProviderKeySchema = z.object({
 			alibaba_region: z
 				.enum(["singapore", "eu-frankfurt", "us-virginia", "cn-beijing"])
 				.optional(),
-			alibaba_workspace_id: z.string().optional(),
+			alibaba_workspace_id: z
+				.string()
+				.regex(WORKSPACE_ID_REGEX, WORKSPACE_ID_MESSAGE)
+				.optional(),
 			aws_mantle_region: z
 				.enum(["us-east-1", "us-east-2", "us-west-2"])
 				.optional(),
 			google_vertex_project_id: z.string().optional(),
 			vertex_openai_project_id: z.string().optional(),
 		})
+		.superRefine(validateWorkspaceScopedRegion)
 		.optional(),
 	organizationId: z.string().min(1, "Organization ID is required"),
 	// Optional USD spend cap; the key auto-deactivates when its cumulative

--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -111,8 +111,9 @@ export const providerKeySchema = z.object({
 			azure_ai_foundry_resource: z.string().optional(),
 			azure_ai_foundry_api_version: z.string().optional(),
 			alibaba_region: z
-				.enum(["singapore", "us-virginia", "cn-beijing"])
+				.enum(["singapore", "eu-frankfurt", "us-virginia", "cn-beijing"])
 				.optional(),
+			alibaba_workspace_id: z.string().optional(),
 			aws_mantle_region: z
 				.enum(["us-east-1", "us-east-2", "us-west-2"])
 				.optional(),
@@ -334,8 +335,9 @@ const createProviderKeySchema = z.object({
 			azure_ai_foundry_resource: z.string().optional(),
 			azure_ai_foundry_api_version: z.string().optional(),
 			alibaba_region: z
-				.enum(["singapore", "us-virginia", "cn-beijing"])
+				.enum(["singapore", "eu-frankfurt", "us-virginia", "cn-beijing"])
 				.optional(),
+			alibaba_workspace_id: z.string().optional(),
 			aws_mantle_region: z
 				.enum(["us-east-1", "us-east-2", "us-west-2"])
 				.optional(),

--- a/apps/docs/content/features/routing.mdx
+++ b/apps/docs/content/features/routing.mdx
@@ -326,11 +326,12 @@ Routing metadata reflects this:
 </Callout>
 
 A few regions are served by an endpoint that belongs to your own account rather
-than a shared one — Alibaba Cloud's EU (Frankfurt) region is reachable only
-through your Model Studio workspace's dedicated host. Selecting such a region on
-a provider key also requires the workspace ID, which you copy from the API Host
-shown when you create the key. Until it is set, the region is skipped instead of
-routed to.
+than a shared one — Alibaba Cloud's EU (Frankfurt) region has no shared
+DashScope domain and is served by your Model Studio workspace's dedicated host.
+Such a region still works from an API key alone, via the provider's shared entry
+point, but that endpoint is rate-limited and carries no SLA. Set the workspace
+ID on the provider key (copy it from the API Host shown when you create the key)
+to route through your own endpoint instead.
 
 #### Low-Uptime Protection
 

--- a/apps/docs/content/features/routing.mdx
+++ b/apps/docs/content/features/routing.mdx
@@ -325,6 +325,13 @@ Routing metadata reflects this:
 	explicit provider-key region restricts the request to that region.
 </Callout>
 
+A few regions are served by an endpoint that belongs to your own account rather
+than a shared one — Alibaba Cloud's EU (Frankfurt) region is reachable only
+through your Model Studio workspace's dedicated host. Selecting such a region on
+a provider key also requires the workspace ID, which you copy from the API Host
+shown when you create the key. Until it is set, the region is skipped instead of
+routed to.
+
 #### Low-Uptime Protection
 
 When you specify a provider explicitly, LLMGateway checks the provider's recent uptime (from the time-decayed metrics window described above). If the uptime falls below 90%, the system automatically routes your request to the best available alternative provider to ensure reliability. This protects your application from providers experiencing temporary issues. The fallback threshold (default `90%`) is configurable.

--- a/apps/gateway/src/chat-helpers.e2e.ts
+++ b/apps/gateway/src/chat-helpers.e2e.ts
@@ -6,6 +6,7 @@ import {
 	type ModelDefinition,
 	getProviderDefinition,
 	getProviderEnvVar,
+	getRegionScopedProviderEnvValue,
 	getSupportedServiceTiers,
 	models,
 	type ProviderModelMapping,
@@ -1270,6 +1271,17 @@ function providerEnvOptionsForTests(
 ): ProviderKeyOptions | undefined {
 	if (providerId === "azure" && process.env.LLM_AZURE_RESOURCE) {
 		return { azure_resource: process.env.LLM_AZURE_RESOURCE };
+	}
+	if (providerId === "alibaba") {
+		// BYOK keys never read env vars at request time, so a workspace-scoped
+		// region (Frankfurt) is only reachable when the seeded key carries the
+		// workspace id the way a real credential would.
+		const workspaceId = getRegionScopedProviderEnvValue(
+			"alibaba",
+			"workspaceId",
+			"eu-frankfurt",
+		);
+		return workspaceId ? { alibaba_workspace_id: workspaceId } : undefined;
 	}
 	if (providerId === "azure-ai-foundry") {
 		const resource = process.env.LLM_AZURE_AI_FOUNDRY_RESOURCE;

--- a/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
+++ b/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
@@ -28,6 +28,7 @@ import { useApi } from "@/lib/fetch-client";
 import {
 	providers,
 	isStealthProvider,
+	regionEndpointRequiresWorkspaceId,
 	type ProviderDefinition,
 } from "@llmgateway/models";
 import { getProviderModelIds } from "@llmgateway/shared";
@@ -67,6 +68,7 @@ export function CreateProviderKeyDialog({
 	const [azureAiFoundryApiVersion, setAzureAiFoundryApiVersion] =
 		useState("2024-05-01-preview");
 	const [selectedRegion, setSelectedRegion] = useState("");
+	const [alibabaWorkspaceId, setAlibabaWorkspaceId] = useState("");
 	const [googleVertexProjectId, setGoogleVertexProjectId] = useState("");
 	const [vertexTokenType, setVertexTokenType] = useState<"api-key" | "oauth">(
 		"api-key",
@@ -108,6 +110,16 @@ export function CreateProviderKeyDialog({
 				? ANY_REGION
 				: selectedProviderDef?.regionConfig?.defaultRegion)) ??
 		"";
+
+	// Regions served only by a workspace-dedicated host (Alibaba Frankfurt)
+	// cannot be addressed by an API key alone, so the credential has to carry
+	// the workspace id that completes the hostname.
+	const requiresWorkspaceId = Boolean(
+		selectedProvider &&
+		effectiveRegion &&
+		effectiveRegion !== ANY_REGION &&
+		regionEndpointRequiresWorkspaceId(selectedProvider, effectiveRegion),
+	);
 
 	// Exclude the gateway itself and stealth providers (no default base URL):
 	// users can't configure a stealth provider key because the platform behind
@@ -223,6 +235,22 @@ export function CreateProviderKeyDialog({
 			payload.options = {
 				...payload.options,
 				[selectedProviderDef.regionConfig.optionsKey]: effectiveRegion,
+			};
+		}
+
+		if (requiresWorkspaceId) {
+			if (!/^[a-zA-Z0-9-]{1,64}$/.test(alibabaWorkspaceId)) {
+				toast({
+					title: "Error",
+					description:
+						"Workspace ID is required for this region and must be 1-64 characters of letters, numbers, and hyphens",
+					variant: "destructive",
+				});
+				return;
+			}
+			payload.options = {
+				...payload.options,
+				alibaba_workspace_id: alibabaWorkspaceId,
 			};
 		}
 
@@ -347,6 +375,7 @@ export function CreateProviderKeyDialog({
 			setAzureAiFoundryResource("");
 			setAzureAiFoundryApiVersion("2024-05-01-preview");
 			setSelectedRegion("");
+			setAlibabaWorkspaceId("");
 			setGoogleVertexProjectId("");
 			setVertexTokenType("api-key");
 			setUsageLimit("");
@@ -620,6 +649,25 @@ export function CreateProviderKeyDialog({
 								{regionOptional
 									? "One key works across every region. Leave this on “Any region” to let the gateway route across all of them; pick one to keep requests in a single region."
 									: "API keys are region-specific. Make sure your key matches the selected region."}
+							</p>
+						</div>
+					)}
+
+					{requiresWorkspaceId && (
+						<div className="space-y-2">
+							<Label htmlFor="provider-workspace-id">Workspace ID</Label>
+							<Input
+								id="provider-workspace-id"
+								type="text"
+								placeholder="llm-xxxxxxxxxxxxxxxx"
+								value={alibabaWorkspaceId}
+								onChange={(e) => setAlibabaWorkspaceId(e.target.value.trim())}
+								required
+							/>
+							<p className="text-sm text-muted-foreground">
+								This region is served only by your workspace&apos;s own
+								endpoint. Copy the workspace ID from the API Host shown on the
+								Model Studio workspace management page.
 							</p>
 						</div>
 					)}

--- a/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
+++ b/apps/ui/src/components/provider-keys/create-provider-key-dialog.tsx
@@ -29,6 +29,7 @@ import {
 	providers,
 	isStealthProvider,
 	regionEndpointRequiresWorkspaceId,
+	regionEndpointUsesWorkspaceId,
 	type ProviderDefinition,
 } from "@llmgateway/models";
 import { getProviderModelIds } from "@llmgateway/shared";
@@ -111,14 +112,20 @@ export function CreateProviderKeyDialog({
 				: selectedProviderDef?.regionConfig?.defaultRegion)) ??
 		"";
 
-	// Regions served only by a workspace-dedicated host (Alibaba Frankfurt)
-	// cannot be addressed by an API key alone, so the credential has to carry
-	// the workspace id that completes the hostname.
+	// Regions with a workspace-dedicated host (Alibaba Frankfurt) offer the
+	// field so a credential can use its own endpoint instead of the shared,
+	// trial-grade one. It is only mandatory where no shared host exists.
+	const workspaceIdRegion =
+		selectedProvider && effectiveRegion && effectiveRegion !== ANY_REGION
+			? effectiveRegion
+			: undefined;
+	const usesWorkspaceId = Boolean(
+		workspaceIdRegion &&
+		regionEndpointUsesWorkspaceId(selectedProvider, workspaceIdRegion),
+	);
 	const requiresWorkspaceId = Boolean(
-		selectedProvider &&
-		effectiveRegion &&
-		effectiveRegion !== ANY_REGION &&
-		regionEndpointRequiresWorkspaceId(selectedProvider, effectiveRegion),
+		workspaceIdRegion &&
+		regionEndpointRequiresWorkspaceId(selectedProvider, workspaceIdRegion),
 	);
 
 	// Exclude the gateway itself and stealth providers (no default base URL):
@@ -238,20 +245,33 @@ export function CreateProviderKeyDialog({
 			};
 		}
 
-		if (requiresWorkspaceId) {
-			if (!/^[a-zA-Z0-9-]{1,64}$/.test(alibabaWorkspaceId)) {
+		if (usesWorkspaceId) {
+			if (!alibabaWorkspaceId && requiresWorkspaceId) {
 				toast({
 					title: "Error",
-					description:
-						"Workspace ID is required for this region and must be 1-64 characters of letters, numbers, and hyphens",
+					description: "Workspace ID is required for this region",
 					variant: "destructive",
 				});
 				return;
 			}
-			payload.options = {
-				...payload.options,
-				alibaba_workspace_id: alibabaWorkspaceId,
-			};
+			if (
+				alibabaWorkspaceId &&
+				!/^[a-zA-Z0-9-]{1,64}$/.test(alibabaWorkspaceId)
+			) {
+				toast({
+					title: "Error",
+					description:
+						"Workspace ID must be 1-64 characters of letters, numbers, and hyphens",
+					variant: "destructive",
+				});
+				return;
+			}
+			if (alibabaWorkspaceId) {
+				payload.options = {
+					...payload.options,
+					alibaba_workspace_id: alibabaWorkspaceId,
+				};
+			}
 		}
 
 		if (selectedProvider === "azure") {
@@ -653,21 +673,23 @@ export function CreateProviderKeyDialog({
 						</div>
 					)}
 
-					{requiresWorkspaceId && (
+					{usesWorkspaceId && (
 						<div className="space-y-2">
-							<Label htmlFor="provider-workspace-id">Workspace ID</Label>
+							<Label htmlFor="provider-workspace-id">
+								Workspace ID{requiresWorkspaceId ? "" : " (optional)"}
+							</Label>
 							<Input
 								id="provider-workspace-id"
 								type="text"
-								placeholder="llm-xxxxxxxxxxxxxxxx"
+								placeholder="ws-xxxxxxxxxxxxxxxx"
 								value={alibabaWorkspaceId}
 								onChange={(e) => setAlibabaWorkspaceId(e.target.value.trim())}
-								required
+								required={requiresWorkspaceId}
 							/>
 							<p className="text-sm text-muted-foreground">
-								This region is served only by your workspace&apos;s own
-								endpoint. Copy the workspace ID from the API Host shown on the
-								Model Studio workspace management page.
+								{requiresWorkspaceId
+									? "This region is served only by your workspace's own endpoint. Copy the workspace ID from the API Host shown on the Model Studio workspace management page."
+									: "Without it, requests use the provider's shared endpoint, which is rate-limited and carries no SLA. Copy the workspace ID from the API Host shown on the Model Studio workspace management page to use your own."}
 							</p>
 						</div>
 					)}

--- a/apps/ui/src/components/provider-keys/provider-keys-list.tsx
+++ b/apps/ui/src/components/provider-keys/provider-keys-list.tsx
@@ -83,6 +83,8 @@ function formatOptionLabel(key: string, value: string): string {
 		azure_api_version: "API Version",
 		azure_deployment_type: "Deployment",
 		azure_validation_model: "Validation Model",
+		alibaba_region: "Region",
+		alibaba_workspace_id: "Workspace ID",
 	};
 
 	const label = labels[key] || key;

--- a/packages/actions/src/get-provider-endpoint.spec.ts
+++ b/packages/actions/src/get-provider-endpoint.spec.ts
@@ -19,6 +19,7 @@ const originalMantleRegion = process.env.LLM_AWS_MANTLE_REGION;
 
 afterEach(() => {
 	delete process.env.LLM_ALIBABA_WORKSPACE_ID__EU_FRANKFURT;
+	delete process.env.LLM_ALIBABA_WORKSPACE_ID__ENTERPRISE__EU_FRANKFURT;
 
 	if (originalAiStudioBaseUrl === undefined) {
 		delete process.env.LLM_GOOGLE_AI_STUDIO_BASE_URL;
@@ -886,9 +887,9 @@ describe("getProviderEndpoint", () => {
 			);
 		});
 
-		it("throws for eu-frankfurt without a workspace id", () => {
-			expect(() => callAlibaba("eu-frankfurt")).toThrow(
-				/workspace-dedicated endpoint/,
+		it("falls back to the shared entry point without a workspace id", () => {
+			expect(callAlibaba("eu-frankfurt")).toBe(
+				"https://trial.eu-central-1.maas.aliyuncs.com/compatible-mode/v1/chat/completions",
 			);
 		});
 
@@ -919,6 +920,57 @@ describe("getProviderEndpoint", () => {
 
 			expect(endpoint).toBe(
 				"https://llm-from-env.eu-central-1.maas.aliyuncs.com/compatible-mode/v1/chat/completions",
+			);
+		});
+
+		it("prefers the variant-regional workspace id for matching orgs", () => {
+			process.env.LLM_ALIBABA_WORKSPACE_ID__EU_FRANKFURT = "llm-shared";
+			process.env.LLM_ALIBABA_WORKSPACE_ID__ENTERPRISE__EU_FRANKFURT =
+				"llm-enterprise";
+
+			const endpoint = getProviderEndpoint(
+				"alibaba",
+				undefined,
+				"qwen3.7-max",
+				undefined,
+				false,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				"eu-frankfurt",
+				undefined,
+				undefined,
+				undefined,
+				"enterprise",
+			);
+
+			expect(endpoint).toBe(
+				"https://llm-enterprise.eu-central-1.maas.aliyuncs.com/compatible-mode/v1/chat/completions",
+			);
+		});
+
+		it("selects the regional workspace id matching configIndex", () => {
+			process.env.LLM_ALIBABA_WORKSPACE_ID__EU_FRANKFURT =
+				"llm-first,llm-second";
+
+			const endpoint = getProviderEndpoint(
+				"alibaba",
+				undefined,
+				"qwen3.7-max",
+				undefined,
+				false,
+				undefined,
+				undefined,
+				undefined,
+				1, // configIndex
+				undefined,
+				"eu-frankfurt",
+			);
+
+			expect(endpoint).toBe(
+				"https://llm-second.eu-central-1.maas.aliyuncs.com/compatible-mode/v1/chat/completions",
 			);
 		});
 	});

--- a/packages/actions/src/get-provider-endpoint.spec.ts
+++ b/packages/actions/src/get-provider-endpoint.spec.ts
@@ -18,6 +18,8 @@ const originalBedrockRegion = process.env.LLM_AWS_BEDROCK_REGION;
 const originalMantleRegion = process.env.LLM_AWS_MANTLE_REGION;
 
 afterEach(() => {
+	delete process.env.LLM_ALIBABA_WORKSPACE_ID__EU_FRANKFURT;
+
 	if (originalAiStudioBaseUrl === undefined) {
 		delete process.env.LLM_GOOGLE_AI_STUDIO_BASE_URL;
 	} else {
@@ -838,6 +840,85 @@ describe("getProviderEndpoint", () => {
 
 			expect(endpoint).toBe(
 				"https://bedrock-proxy.internal/openai/v1/chat/completions",
+			);
+		});
+	});
+
+	describe("alibaba regions", () => {
+		const callAlibaba = (
+			region: string | undefined,
+			providerKeyOptions?: Parameters<typeof getProviderEndpoint>[7],
+		) =>
+			getProviderEndpoint(
+				"alibaba",
+				undefined,
+				"qwen3.7-max",
+				undefined,
+				false,
+				undefined,
+				undefined,
+				providerKeyOptions,
+				undefined,
+				undefined,
+				region,
+				true, // skipEnvVars
+			);
+
+		it.each([
+			{
+				region: undefined,
+				host: "https://dashscope-intl.aliyuncs.com",
+			},
+			{ region: "singapore", host: "https://dashscope-intl.aliyuncs.com" },
+			{ region: "us-virginia", host: "https://dashscope-us.aliyuncs.com" },
+			{ region: "cn-beijing", host: "https://dashscope.aliyuncs.com" },
+		])("routes $region to its DashScope host", ({ region, host }) => {
+			expect(callAlibaba(region)).toBe(
+				`${host}/compatible-mode/v1/chat/completions`,
+			);
+		});
+
+		it("builds the workspace-dedicated host for eu-frankfurt", () => {
+			expect(
+				callAlibaba("eu-frankfurt", { alibaba_workspace_id: "llm-abc123" }),
+			).toBe(
+				"https://llm-abc123.eu-central-1.maas.aliyuncs.com/compatible-mode/v1/chat/completions",
+			);
+		});
+
+		it("throws for eu-frankfurt without a workspace id", () => {
+			expect(() => callAlibaba("eu-frankfurt")).toThrow(
+				/workspace-dedicated endpoint/,
+			);
+		});
+
+		it("rejects a workspace id that is not a bare hostname label", () => {
+			expect(() =>
+				callAlibaba("eu-frankfurt", {
+					alibaba_workspace_id: "evil.example.com/x",
+				}),
+			).toThrow(/workspace id is invalid/);
+		});
+
+		it("reads the workspace id from the region-specific env var", () => {
+			process.env.LLM_ALIBABA_WORKSPACE_ID__EU_FRANKFURT = "llm-from-env";
+
+			const endpoint = getProviderEndpoint(
+				"alibaba",
+				undefined,
+				"qwen3.7-max",
+				undefined,
+				false,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				"eu-frankfurt",
+			);
+
+			expect(endpoint).toBe(
+				"https://llm-from-env.eu-central-1.maas.aliyuncs.com/compatible-mode/v1/chat/completions",
 			);
 		});
 	});

--- a/packages/actions/src/get-provider-endpoint.ts
+++ b/packages/actions/src/get-provider-endpoint.ts
@@ -40,10 +40,11 @@ function getBedrockMantleBaseUrl(url: string, region?: string): string {
 }
 
 /**
- * Fill the workspace placeholder of a region endpoint that has no shared host
- * (Alibaba Frankfurt). The workspace id becomes part of the hostname, so it is
- * validated against the character set Model Studio issues (`llm-…`) rather
- * than interpolated blindly.
+ * Fill the workspace placeholder of a workspace-scoped region endpoint
+ * (Alibaba Frankfurt), falling back to the region's shared entry point when no
+ * workspace id is configured. The workspace id becomes part of the hostname,
+ * so it is validated against the character set Model Studio issues (`ws-…`)
+ * rather than interpolated blindly.
  */
 function resolveWorkspaceScopedEndpoint(
 	provider: ProviderId,
@@ -63,6 +64,17 @@ function resolveWorkspaceScopedEndpoint(
 			: workspaceEnvVar;
 
 	if (!workspaceId) {
+		// No workspace id: fall back to the region's shared entry point, which
+		// resolves the workspace from the API key. Only a region without such a
+		// host is unroutable.
+		const providerDef = providers.find((p) => p.id === provider) as
+			ProviderDefinition | undefined;
+		const fallback = region
+			? providerDef?.regionConfig?.endpointFallbackMap?.[region]
+			: undefined;
+		if (fallback) {
+			return fallback;
+		}
 		throw new Error(
 			`Provider ${provider} region ${region} is only reachable through a workspace-dedicated endpoint - set the workspace id on the provider key or via the ${regionalEnvVar} env var`,
 		);

--- a/packages/actions/src/get-provider-endpoint.ts
+++ b/packages/actions/src/get-provider-endpoint.ts
@@ -9,8 +9,11 @@ import {
 	type VertexTokenType,
 	getProviderEnvValue,
 	getProviderEnvConfig,
+	getRegionEnvVarSuffix,
+	getRegionScopedProviderEnvValue,
 	getVariantEnvVarNameFor,
 	resolveVertexTokenType,
+	REGION_WORKSPACE_ID_PLACEHOLDER,
 } from "@llmgateway/models";
 
 import type { ProviderKeyOptions } from "@llmgateway/db";
@@ -34,6 +37,43 @@ function getBedrockMantleBaseUrl(url: string, region?: string): string {
 		return `https://bedrock-mantle.${mantleRegion}.api.aws/openai/v1`;
 	}
 	return appendPath(url, "/openai/v1");
+}
+
+/**
+ * Fill the workspace placeholder of a region endpoint that has no shared host
+ * (Alibaba Frankfurt). The workspace id becomes part of the hostname, so it is
+ * validated against the character set Model Studio issues (`llm-…`) rather
+ * than interpolated blindly.
+ */
+function resolveWorkspaceScopedEndpoint(
+	provider: ProviderId,
+	baseUrl: string,
+	region: string | undefined,
+	workspaceId: string | undefined,
+): string {
+	if (!baseUrl.includes(REGION_WORKSPACE_ID_PLACEHOLDER)) {
+		return baseUrl;
+	}
+
+	const envConfig = getProviderEnvConfig(provider);
+	const workspaceEnvVar = envConfig?.optional?.workspaceId;
+	const regionalEnvVar =
+		workspaceEnvVar && region
+			? `${workspaceEnvVar}__${getRegionEnvVarSuffix(region)}`
+			: workspaceEnvVar;
+
+	if (!workspaceId) {
+		throw new Error(
+			`Provider ${provider} region ${region} is only reachable through a workspace-dedicated endpoint - set the workspace id on the provider key or via the ${regionalEnvVar} env var`,
+		);
+	}
+	if (!/^[a-zA-Z0-9-]{1,64}$/.test(workspaceId)) {
+		throw new Error(
+			`Provider ${provider} workspace id is invalid - must be 1-64 chars of letters, digits, or hyphens (set via provider options or the ${regionalEnvVar} env var)`,
+		);
+	}
+
+	return baseUrl.replace(REGION_WORKSPACE_ID_PLACEHOLDER, workspaceId);
 }
 
 function buildVertexCompatibleEndpoint(
@@ -374,8 +414,22 @@ export function getProviderEndpoint(
 				}
 				break;
 			case "alibaba": {
-				const alibabaBaseUrl =
-					regionBaseUrl ?? "https://dashscope-intl.aliyuncs.com";
+				const alibabaBaseUrl = resolveWorkspaceScopedEndpoint(
+					"alibaba",
+					regionBaseUrl ?? "https://dashscope-intl.aliyuncs.com",
+					region,
+					credentialConfig?.workspaceId ??
+						providerKeyOptions?.alibaba_workspace_id ??
+						(skipEnvVars
+							? undefined
+							: getRegionScopedProviderEnvValue(
+									"alibaba",
+									"workspaceId",
+									region,
+									configIndex,
+									variant,
+								)),
+				);
 				// Use different base URL for image generation vs chat completions
 				if (imageGenerations) {
 					url = alibabaBaseUrl;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1549,7 +1549,13 @@ export interface ProviderKeyOptions {
 	azure_deployment_name?: string;
 	azure_ai_foundry_resource?: string;
 	azure_ai_foundry_api_version?: string;
-	alibaba_region?: "singapore" | "us-virginia" | "cn-beijing";
+	alibaba_region?: "singapore" | "eu-frankfurt" | "us-virginia" | "cn-beijing";
+	/**
+	 * Model Studio workspace id, required for regions served only by the
+	 * workspace-dedicated `{WorkspaceId}.<region>.maas.aliyuncs.com` host
+	 * (Frankfurt). Ignored by regions that have a shared DashScope domain.
+	 */
+	alibaba_workspace_id?: string;
 	aws_mantle_region?: "us-east-1" | "us-east-2" | "us-west-2";
 	google_vertex_project_id?: string;
 	google_vertex_token_type?: "api-key" | "oauth";

--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -1375,6 +1375,17 @@ export const alibabaModels = [
 				cacheWriteInputPrice: "3.125e-6",
 				regions: [
 					{ id: "singapore" },
+					{
+						id: "eu-frankfurt",
+						inputPrice: "1.65e-6",
+						outputPrice: "4.951e-6",
+						cachedInputPrice: "0.33e-6",
+						cacheReadInputPrice: "0.165e-6",
+						cacheWriteInputPrice: "2.0625e-6",
+						// Frankfurt is served only through a workspace-dedicated endpoint,
+						// so there is no shared credential the e2e harness could use.
+						test: "skip",
+					},
 					{ id: "us-virginia" },
 					{
 						id: "cn-beijing",
@@ -1518,6 +1529,37 @@ export const alibabaModels = [
 				],
 				regions: [
 					{ id: "singapore" },
+					{
+						id: "eu-frankfurt",
+						inputPrice: "0.276e-6",
+						outputPrice: "1.101e-6",
+						cachedInputPrice: "0.0552e-6",
+						cacheReadInputPrice: "0.0276e-6",
+						cacheWriteInputPrice: "0.345e-6",
+						pricingTiers: [
+							{
+								name: "Up to 256K",
+								upToTokens: 256000,
+								inputPrice: "0.276e-6",
+								outputPrice: "1.101e-6",
+								cachedInputPrice: "0.0552e-6",
+								cacheReadInputPrice: "0.0276e-6",
+								cacheWriteInputPrice: "0.345e-6",
+							},
+							{
+								name: "Over 256K",
+								upToTokens: Infinity,
+								inputPrice: "0.826e-6",
+								outputPrice: "3.301e-6",
+								cachedInputPrice: "0.1652e-6",
+								cacheReadInputPrice: "0.0826e-6",
+								cacheWriteInputPrice: "1.0325e-6",
+							},
+						],
+						// Frankfurt is served only through a workspace-dedicated endpoint,
+						// so there is no shared credential the e2e harness could use.
+						test: "skip",
+					},
 					{ id: "us-virginia" },
 					{ id: "cn-beijing" },
 				],
@@ -3041,7 +3083,18 @@ export const alibabaModels = [
 				inputPrice: "0.5e-6",
 				outputPrice: "3e-6",
 				cachedInputPrice: "0.05e-6",
-				regions: [{ id: "singapore" }],
+				regions: [
+					{ id: "singapore" },
+					{
+						id: "eu-frankfurt",
+						inputPrice: "0.276e-6",
+						outputPrice: "1.651e-6",
+						cachedInputPrice: "0.0276e-6",
+						// Frankfurt is served only through a workspace-dedicated endpoint,
+						// so there is no shared credential the e2e harness could use.
+						test: "skip",
+					},
+				],
 				requestPrice: "0",
 				contextSize: 262144,
 				maxOutput: 65536,

--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -1382,9 +1382,6 @@ export const alibabaModels = [
 						cachedInputPrice: "0.33e-6",
 						cacheReadInputPrice: "0.165e-6",
 						cacheWriteInputPrice: "2.0625e-6",
-						// Frankfurt is served only through a workspace-dedicated endpoint,
-						// so there is no shared credential the e2e harness could use.
-						test: "skip",
 					},
 					{ id: "us-virginia" },
 					{
@@ -1556,9 +1553,6 @@ export const alibabaModels = [
 								cacheWriteInputPrice: "1.0325e-6",
 							},
 						],
-						// Frankfurt is served only through a workspace-dedicated endpoint,
-						// so there is no shared credential the e2e harness could use.
-						test: "skip",
 					},
 					{ id: "us-virginia" },
 					{ id: "cn-beijing" },
@@ -3090,9 +3084,6 @@ export const alibabaModels = [
 						inputPrice: "0.276e-6",
 						outputPrice: "1.651e-6",
 						cachedInputPrice: "0.0276e-6",
-						// Frankfurt is served only through a workspace-dedicated endpoint,
-						// so there is no shared credential the e2e harness could use.
-						test: "skip",
 					},
 				],
 				requestPrice: "0",

--- a/packages/models/src/provider.spec.ts
+++ b/packages/models/src/provider.spec.ts
@@ -6,6 +6,7 @@ import {
 	getProviderEnvExclusiveViolations,
 	getProviderEnvValue,
 	getRegionSpecificEnvVarName,
+	hasRegionSpecificEnvKey,
 	getVariantEnvVarName,
 	getVariantEnvVarNameFor,
 } from "./provider.js";
@@ -258,5 +259,43 @@ describe("exclusive provider env groups", () => {
 	it("leaves providers without exclusive groups unconstrained", () => {
 		expect(getProviderEnvExclusiveGroups("openai")).toEqual([]);
 		expect(getProviderEnvExclusiveViolations("openai", {})).toEqual([]);
+	});
+});
+
+describe("hasRegionSpecificEnvKey with workspace-scoped regions", () => {
+	const WORKSPACE = "LLM_ALIBABA_WORKSPACE_ID";
+	const WORKSPACE_REGIONAL = `${WORKSPACE}__EU_FRANKFURT`;
+	const FRANKFURT_KEY = `${BASE}__EU_FRANKFURT`;
+
+	beforeEach(() => {
+		for (const name of [BASE, FRANKFURT_KEY, WORKSPACE, WORKSPACE_REGIONAL]) {
+			vi.stubEnv(name, undefined);
+		}
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("does not consider Frankfurt available from an API key alone", () => {
+		vi.stubEnv(FRANKFURT_KEY, "sk-frankfurt");
+		expect(hasRegionSpecificEnvKey("alibaba", "eu-frankfurt")).toBe(false);
+	});
+
+	it("considers Frankfurt available once the workspace id is configured", () => {
+		vi.stubEnv(FRANKFURT_KEY, "sk-frankfurt");
+		vi.stubEnv(WORKSPACE_REGIONAL, "llm-abc123");
+		expect(hasRegionSpecificEnvKey("alibaba", "eu-frankfurt")).toBe(true);
+	});
+
+	it("still requires the regional API key when only the workspace id is set", () => {
+		vi.stubEnv(BASE, "sk-singapore");
+		vi.stubEnv(WORKSPACE, "llm-abc123");
+		expect(hasRegionSpecificEnvKey("alibaba", "eu-frankfurt")).toBe(false);
+	});
+
+	it("leaves regions with a shared host unaffected", () => {
+		vi.stubEnv(`${BASE}__US_VIRGINIA`, "sk-us");
+		expect(hasRegionSpecificEnvKey("alibaba", "us-virginia")).toBe(true);
 	});
 });

--- a/packages/models/src/provider.spec.ts
+++ b/packages/models/src/provider.spec.ts
@@ -277,20 +277,22 @@ describe("hasRegionSpecificEnvKey with workspace-scoped regions", () => {
 		vi.unstubAllEnvs();
 	});
 
-	it("does not consider Frankfurt available from an API key alone", () => {
+	// Frankfurt has a shared entry point, so the key alone makes it routable
+	// and the workspace id only upgrades which host is used.
+	it("considers Frankfurt available from the regional API key alone", () => {
 		vi.stubEnv(FRANKFURT_KEY, "sk-frankfurt");
-		expect(hasRegionSpecificEnvKey("alibaba", "eu-frankfurt")).toBe(false);
+		expect(hasRegionSpecificEnvKey("alibaba", "eu-frankfurt")).toBe(true);
 	});
 
-	it("considers Frankfurt available once the workspace id is configured", () => {
+	it("considers Frankfurt available with a workspace id too", () => {
 		vi.stubEnv(FRANKFURT_KEY, "sk-frankfurt");
-		vi.stubEnv(WORKSPACE_REGIONAL, "llm-abc123");
+		vi.stubEnv(WORKSPACE_REGIONAL, "ws-abc123");
 		expect(hasRegionSpecificEnvKey("alibaba", "eu-frankfurt")).toBe(true);
 	});
 
 	it("still requires the regional API key when only the workspace id is set", () => {
 		vi.stubEnv(BASE, "sk-singapore");
-		vi.stubEnv(WORKSPACE, "llm-abc123");
+		vi.stubEnv(WORKSPACE, "ws-abc123");
 		expect(hasRegionSpecificEnvKey("alibaba", "eu-frankfurt")).toBe(false);
 	});
 

--- a/packages/models/src/provider.ts
+++ b/packages/models/src/provider.ts
@@ -3,6 +3,7 @@ import {
 	type ProviderEnvConfig,
 	type ProviderEnvExclusiveGroup,
 	getProviderDefinition,
+	regionEndpointRequiresWorkspaceId,
 } from "./providers.js";
 
 import type { Provider } from "./index.js";
@@ -203,6 +204,25 @@ export function hasProviderEnvironmentToken(
 	return envVar ? Boolean(process.env[envVar]) : false;
 }
 
+/**
+ * Environment variable carrying a provider's setting for one logical env key
+ * (`apiKey`, `baseUrl`, `region`, `workspaceId`, …), or undefined when the
+ * provider does not declare that setting.
+ */
+export function getProviderEnvVarNameFor(
+	provider: Provider,
+	key: string,
+): string | undefined {
+	const config = getProviderEnvConfig(provider);
+	if (!config) {
+		return undefined;
+	}
+	if (key in config.required) {
+		return config.required[key as keyof typeof config.required];
+	}
+	return config.optional?.[key];
+}
+
 export function getProviderEnvValue(
 	provider: Provider,
 	key: string,
@@ -210,19 +230,11 @@ export function getProviderEnvValue(
 	defaultValue?: string,
 	variant?: EnvVarVariant,
 ): string | undefined {
-	const config = getProviderEnvConfig(provider);
-	if (!config) {
+	if (!getProviderEnvConfig(provider)) {
 		return undefined;
 	}
 
-	let envVarName: string | undefined;
-
-	// Check required vars first, then optional
-	if (key in config.required) {
-		envVarName = config.required[key as keyof typeof config.required];
-	} else if (config.optional && key in config.optional) {
-		envVarName = config.optional[key];
-	}
+	const envVarName = getProviderEnvVarNameFor(provider, key);
 
 	if (!envVarName) {
 		return defaultValue;
@@ -352,6 +364,32 @@ export function getRegionSpecificEnvValue(
 }
 
 /**
+ * Region-scoped read of any provider setting, not just the API key: checks
+ * `{ENV_VAR}__{REGION}` before falling back to the plain lookup. Settings that
+ * differ per region without being credentials — Alibaba's per-region Model
+ * Studio workspace id, for instance — are resolved through this so they follow
+ * the same naming as the regional keys they accompany.
+ */
+export function getRegionScopedProviderEnvValue(
+	provider: Provider,
+	key: string,
+	region: string | undefined,
+	configIndex?: number,
+	variant?: EnvVarVariant,
+): string | undefined {
+	if (region) {
+		const envVarName = getProviderEnvVarNameFor(provider, key);
+		const regionalValue = envVarName
+			? process.env[`${envVarName}__${getRegionEnvVarSuffix(region)}`]
+			: undefined;
+		if (regionalValue) {
+			return regionalValue;
+		}
+	}
+	return getProviderEnvValue(provider, key, configIndex, undefined, variant);
+}
+
+/**
  * Get the region-specific env var name only when that var is actually set.
  * Returns `{BASE_ENV_VAR}__{REGION}` when the regional override exists, else
  * undefined. Use this when you need to attribute health to the regional
@@ -385,6 +423,10 @@ export function getRegionSpecificEnvVarName(
  * Check whether an env var exists for a specific region.
  * Returns true if a region-specific env var (`{BASE_ENV_VAR}__{REGION}`) exists,
  * OR if the base env var exists and the queried region is the provider's default region.
+ *
+ * A region whose endpoint is workspace-scoped additionally needs its workspace
+ * id configured: the key alone cannot address the region, so treating it as
+ * available would route traffic to an endpoint that cannot be built.
  */
 export function hasRegionSpecificEnvKey(
 	provider: Provider,
@@ -392,6 +434,12 @@ export function hasRegionSpecificEnvKey(
 ): boolean {
 	const baseEnvVar = getProviderEnvVar(provider);
 	if (!baseEnvVar) {
+		return false;
+	}
+	if (
+		regionEndpointRequiresWorkspaceId(provider, region) &&
+		!getRegionScopedProviderEnvValue(provider, "workspaceId", region)
+	) {
 		return false;
 	}
 	const regionSuffix = getRegionEnvVarSuffix(region);

--- a/packages/models/src/provider.ts
+++ b/packages/models/src/provider.ts
@@ -244,8 +244,24 @@ export function getProviderEnvValue(
 	// its comma-separated list); an unset one falls back to the base var.
 	const effectiveEnvVarName =
 		getVariantEnvVarNameFor(envVarName, variant) ?? envVarName;
-	const envValue = process.env[effectiveEnvVarName];
+	return selectEnvListValue(
+		process.env[effectiveEnvVarName],
+		configIndex,
+		defaultValue,
+	);
+}
 
+/**
+ * Pick one entry out of a comma-separated env var. A deployment can rotate or
+ * shard a setting by listing several values; `configIndex` selects the one
+ * belonging to the credential in play, clamping to the last entry so a short
+ * list never leaves a credential without a value.
+ */
+function selectEnvListValue(
+	envValue: string | undefined,
+	configIndex?: number,
+	defaultValue?: string,
+): string | undefined {
 	if (!envValue) {
 		return defaultValue;
 	}
@@ -365,10 +381,11 @@ export function getRegionSpecificEnvValue(
 
 /**
  * Region-scoped read of any provider setting, not just the API key: checks
- * `{ENV_VAR}__{REGION}` before falling back to the plain lookup. Settings that
- * differ per region without being credentials — Alibaba's per-region Model
- * Studio workspace id, for instance — are resolved through this so they follow
- * the same naming as the regional keys they accompany.
+ * `{ENV_VAR}__{VARIANT}__{REGION}` and `{ENV_VAR}__{REGION}` before falling
+ * back to the plain lookup. Settings that differ per region without being
+ * credentials — Alibaba's per-region Model Studio workspace id, for instance —
+ * are resolved through this so they follow the same naming, variant precedence
+ * and comma-separated list selection as the regional keys they accompany.
  */
 export function getRegionScopedProviderEnvValue(
 	provider: Provider,
@@ -377,13 +394,19 @@ export function getRegionScopedProviderEnvValue(
 	configIndex?: number,
 	variant?: EnvVarVariant,
 ): string | undefined {
-	if (region) {
-		const envVarName = getProviderEnvVarNameFor(provider, key);
-		const regionalValue = envVarName
-			? process.env[`${envVarName}__${getRegionEnvVarSuffix(region)}`]
-			: undefined;
-		if (regionalValue) {
-			return regionalValue;
+	const envVarName = getProviderEnvVarNameFor(provider, key);
+	if (region && envVarName) {
+		const regionSuffix = getRegionEnvVarSuffix(region);
+		const candidates = variant
+			? [
+					`${envVarName}${ENV_VAR_VARIANT_SUFFIXES[variant]}__${regionSuffix}`,
+					`${envVarName}__${regionSuffix}`,
+				]
+			: [`${envVarName}__${regionSuffix}`];
+		for (const candidate of candidates) {
+			if (process.env[candidate]) {
+				return selectEnvListValue(process.env[candidate], configIndex);
+			}
 		}
 	}
 	return getProviderEnvValue(provider, key, configIndex, undefined, variant);

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -1,3 +1,13 @@
+/**
+ * Placeholder inside a `regionConfig.endpointMap` entry for a region whose
+ * host is not a fixed domain but is derived from a per-credential workspace
+ * identifier. Alibaba's Frankfurt region is only reachable through the
+ * workspace-dedicated `{WorkspaceId}.eu-central-1.maas.aliyuncs.com` host —
+ * it has no shared DashScope domain — so the endpoint can only be completed
+ * once the credential's workspace id is known.
+ */
+export const REGION_WORKSPACE_ID_PLACEHOLDER = "{workspaceId}";
+
 export interface ProviderEnvConfig {
 	required: {
 		apiKey?: string;
@@ -749,6 +759,7 @@ export const providers: ProviderDefinition[] = [
 			},
 			optional: {
 				region: "LLM_ALIBABA_REGION",
+				workspaceId: "LLM_ALIBABA_WORKSPACE_ID",
 			},
 		},
 		streaming: true,
@@ -762,11 +773,18 @@ export const providers: ProviderDefinition[] = [
 			defaultRegion: "singapore",
 			regions: [
 				{ id: "singapore", label: "Singapore (default)" },
+				{ id: "eu-frankfurt", label: "EU (Frankfurt)" },
 				{ id: "us-virginia", label: "US (Virginia)" },
 				{ id: "cn-beijing", label: "China (Beijing)" },
 			],
 			endpointMap: {
 				singapore: "https://dashscope-intl.aliyuncs.com",
+				// Frankfurt is the one Model Studio region with no shared DashScope
+				// domain: `dashscope-eu`/`dashscope-de` do not exist and aliasing
+				// another region's host would silently execute EU-designated traffic
+				// elsewhere. It is served only by the workspace-dedicated host, whose
+				// workspace id comes from the credential (see the placeholder docs).
+				"eu-frankfurt": `https://${REGION_WORKSPACE_ID_PLACEHOLDER}.eu-central-1.maas.aliyuncs.com`,
 				"us-virginia": "https://dashscope-us.aliyuncs.com",
 				"cn-beijing": "https://dashscope.aliyuncs.com",
 			},
@@ -1843,6 +1861,21 @@ export function getProviderDefinition(
 	providerId: ProviderId | string,
 ): ProviderDefinition | undefined {
 	return providers.find((p) => p.id === providerId);
+}
+
+/**
+ * Whether a region's endpoint can only be completed with a per-credential
+ * workspace id. Such a region is not routable from an API key alone, so both
+ * the endpoint builder and the platform-credential availability check consult
+ * this instead of hardcoding the provider.
+ */
+export function regionEndpointRequiresWorkspaceId(
+	providerId: ProviderId | string,
+	region: string,
+): boolean {
+	const endpoint =
+		getProviderDefinition(providerId)?.regionConfig?.endpointMap[region];
+	return Boolean(endpoint?.includes(REGION_WORKSPACE_ID_PLACEHOLDER));
 }
 
 /**

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -766,7 +766,10 @@ export const providers: ProviderDefinition[] = [
 				apiKey: "LLM_ALIBABA_API_KEY",
 			},
 			optional: {
-				region: "LLM_ALIBABA_REGION",
+				// No `region` key: the region comes from the model's `:region`
+				// suffix or the credential's own region binding, never from a
+				// provider-wide setting, so declaring one would only render a dead
+				// field on the credential form.
 				workspaceId: "LLM_ALIBABA_WORKSPACE_ID",
 			},
 		},

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -44,6 +44,14 @@ export interface ProviderRegionConfig {
 	/** Maps region id to its base URL */
 	endpointMap: Record<string, string>;
 	/**
+	 * Base URL to use for a workspace-scoped region when no workspace id is
+	 * configured. Alibaba's Frankfurt region has such a shared entry point, so
+	 * the region stays usable from an API key alone; the workspace-dedicated
+	 * host remains the better path because the shared one is documented as
+	 * trial-only (1000 RPM, no SLA, "not recommended for production").
+	 */
+	endpointFallbackMap?: Record<string, string>;
+	/**
 	 * Maps region id to a model-id prefix for providers where the upstream model
 	 * identifier varies per region (e.g. AWS Bedrock cross-region inference
 	 * profiles: `global.`, `us.`, `eu.`, `apac.`). When unset, no prefix is
@@ -787,6 +795,13 @@ export const providers: ProviderDefinition[] = [
 				"eu-frankfurt": `https://${REGION_WORKSPACE_ID_PLACEHOLDER}.eu-central-1.maas.aliyuncs.com`,
 				"us-virginia": "https://dashscope-us.aliyuncs.com",
 				"cn-beijing": "https://dashscope.aliyuncs.com",
+			},
+			endpointFallbackMap: {
+				// Resolves the workspace from the API key, so Frankfurt still works
+				// without one being configured. Alibaba caps it at 1000 RPM with no
+				// SLA and advises against production use, so a credential that
+				// supplies a workspace id gets the dedicated host instead.
+				"eu-frankfurt": "https://trial.eu-central-1.maas.aliyuncs.com",
 			},
 		},
 		termsUrl:
@@ -1864,18 +1879,33 @@ export function getProviderDefinition(
 }
 
 /**
- * Whether a region's endpoint can only be completed with a per-credential
- * workspace id. Such a region is not routable from an API key alone, so both
- * the endpoint builder and the platform-credential availability check consult
- * this instead of hardcoding the provider.
+ * Whether a region's preferred endpoint is completed with a per-credential
+ * workspace id. The workspace id is worth collecting for such a region even
+ * when a shared fallback exists, so the UI asks for it here.
  */
-export function regionEndpointRequiresWorkspaceId(
+export function regionEndpointUsesWorkspaceId(
 	providerId: ProviderId | string,
 	region: string,
 ): boolean {
 	const endpoint =
 		getProviderDefinition(providerId)?.regionConfig?.endpointMap[region];
 	return Boolean(endpoint?.includes(REGION_WORKSPACE_ID_PLACEHOLDER));
+}
+
+/**
+ * Whether a region is unreachable without a workspace id — true only when its
+ * endpoint is workspace-scoped and no shared fallback host exists. Routing
+ * consults this so a region it cannot build a URL for is never selected.
+ */
+export function regionEndpointRequiresWorkspaceId(
+	providerId: ProviderId | string,
+	region: string,
+): boolean {
+	if (!regionEndpointUsesWorkspaceId(providerId, region)) {
+		return false;
+	}
+	const regionConfig = getProviderDefinition(providerId)?.regionConfig;
+	return !regionConfig?.endpointFallbackMap?.[region];
 }
 
 /**


### PR DESCRIPTION
Adds Alibaba Cloud's **EU (Frankfurt)** region (`eu-frankfurt`).

## Why this needs more than an `endpointMap` entry

Frankfurt is the one Model Studio region with **no shared DashScope domain** — `dashscope-eu`, `dashscope-de` and `eu-central-1.dashscope` do not resolve at all. It is reachable two ways, both verified live against a real Frankfurt key:

| Host | Works | Notes |
| --- | --- | --- |
| `{WorkspaceId}.eu-central-1.maas.aliyuncs.com` | ✅ | Per-credential; full rate limits and SLA |
| `trial.eu-central-1.maas.aliyuncs.com` | ✅ | Shared; resolves the workspace from the API key |
| any other label (`foo.`, `dashscope.`, `api.`, …) | ❌ | `Workspace endpoint is invalid` |
| plain DashScope hosts | ❌ | Frankfurt has none |

An earlier attempt (48d088f, never merged) pointed `frankfurt` at `dashscope-intl`, which silently executed EU-designated traffic in Singapore. This does not alias any host.

## Design

The workspace ID is **optional**. Without one, Frankfurt uses the shared entry point, so an API key alone keeps working. With one, requests go to the credential's own endpoint — Alibaba caps the shared host at 1000 RPM with no SLA and documents it as *"not recommended for production environments"*.

- `endpointMap` entries may carry a `{workspaceId}` placeholder; `endpointFallbackMap` supplies the shared host to use when no ID is configured.
- Resolution order: managed credential → provider-key option → `LLM_ALIBABA_WORKSPACE_ID__EU_FRANKFURT` → base var → shared host. The ID is validated as a bare hostname label before interpolation.
- Regional env lookups honour the `__ENTERPRISE__`/`__PLANS__` variant names and comma-separated `configIndex` selection.
- Only a region with no fallback is gated out of routing, so an unbuildable endpoint is never selected.
- The dialog shows an optional **Workspace ID** field for regions that use one.

Other regions are untouched: they keep their plain DashScope hosts, which accept both legacy and workspace-scoped (`sk-ws-…`) keys.

## Pricing

Alibaba's published Frankfurt (Global-scope) list prices; all three models are Global-scope only there, so there is no deployment-scope ambiguity. Cache rates follow the documented model-level ratios (implicit 20%, explicit hit 10%, write 125%), which are region-independent.

| Model | Input | Output |
| --- | --- | --- |
| `qwen3.7-max` | $1.65 | $4.951 |
| `qwen3.7-plus` | $0.276 / $0.826 (>256K) | $1.101 / $3.301 |
| `qwen3.6-plus` | $0.276 | $1.651 |

`qwen3.8-max` is not offered in Frankfurt and is excluded.

## Testing

Real e2e against Frankfurt, both endpoint paths, `144 passed / 0 failed` each:

```
TEST_MODELS="alibaba/qwen3.7-max:eu-frankfurt,alibaba/qwen3.7-plus:eu-frankfurt,alibaba/qwen3.6-plus:eu-frankfurt" FULL_MODE=true pnpm test:e2e
```

27 named `:eu-frankfurt` cases ran (reasoning efforts `none`→`max`, reasoning + streaming) with `requestedRegion: "eu-frankfurt"`.

Provider-key registration verified through the real `POST /keys/provider` route with live keys: legacy key on a shared-host region, workspace-scoped key with its workspace ID, workspace-scoped key without one, and an invalid workspace ID rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Alibaba Cloud EU (Frankfurt) region support.
  * Added optional workspace ID configuration for account-specific Alibaba endpoints.
  * Added workspace ID validation, endpoint guidance, and display in provider key management.
  * Added shared-endpoint fallback where supported.
  * Added Frankfurt pricing for supported Qwen models.

* **Documentation**
  * Documented regional endpoint routing, workspace ID requirements, and shared endpoint availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->