### PR TITLE
fix(gateway): fix region-less managed credentials

### DIFF
--- a/apps/docs/content/self-host/docker-compose.mdx
+++ b/apps/docs/content/self-host/docker-compose.mdx
@@ -106,6 +106,15 @@ Managed credentials cover the same axes as the environment variables they replac
   Chat plans), mirroring the `__ENTERPRISE` and `__PLANS` suffixes below.
 - An optional region, mirroring the `{ENV_VAR}__{REGION}` overrides.
 
+A request that resolves no region is served from the provider's default region,
+so it is served by a region-agnostic credential or by one pinned to that default
+region. Providers whose keys are region-scoped — those with no global region, so
+every credential belongs to exactly one region — are therefore fully covered by
+one credential per region, with no region-agnostic credential needed. Providers
+whose key works across every region (AWS Bedrock) are stricter: a region on the
+credential scopes it to that region only, and a request for another region fails
+rather than borrowing it.
+
 Video generation pins the credential that created a job onto the job itself, so
 polling and content retrieval hours later go back through the same credential
 rather than re-selecting one.

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -171,6 +171,7 @@ import {
 	expandAllProviderRegions,
 	getOrganizationEnvVariant,
 	getProviderDefinition,
+	getRegionScopedDefaultRegion,
 	getRegionSpecificEnvVarName,
 } from "@llmgateway/models";
 import {
@@ -412,21 +413,25 @@ function filterRegionsByAvailableKeys(
 
 /**
  * Whether the platform's own credentials can serve this regional mapping.
- * Mappings without a region, and providers the catalogue does not scope by
- * region, are always kept — there is nothing to select against.
+ * Providers the catalogue does not scope by region are always kept — there is
+ * nothing to select against. A mapping without a region is served from the
+ * provider's default region, so for a provider whose credentials are
+ * region-scoped it is judged on that region; providers with a credential shared
+ * across regions (AWS Bedrock) keep the mapping unconditionally, as before.
  */
 function platformKeyCoversMappingRegion(
 	mapping: ProviderModelMapping,
 	managed: ManagedProviderAvailability,
 ): boolean {
-	const region = mapping.region;
-	if (!region) {
-		return true;
-	}
 	const providerDef = providers.find((p) => p.id === mapping.providerId) as
 		ProviderDefinition | undefined;
 	const regionConfig = providerDef?.regionConfig;
 	if (!regionConfig) {
+		return true;
+	}
+	const region =
+		mapping.region ?? getRegionScopedDefaultRegion(mapping.providerId);
+	if (!region) {
 		return true;
 	}
 	return platformCredentialCoversRegion(

--- a/apps/gateway/src/chat/managed-credentials.spec.ts
+++ b/apps/gateway/src/chat/managed-credentials.spec.ts
@@ -470,6 +470,66 @@ describe("managed provider credentials", () => {
 		expect(captured).toEqual([]);
 	});
 
+	/**
+	 * A provider whose regions each have their own credential (Alibaba has no
+	 * global region, so every managed credential is region-pinned) must still
+	 * serve a request that never resolved a region — it is sent to the
+	 * provider's default region, so the credential pinned to that region is the
+	 * one that serves it. Falling through to "no managed credential" 500s every
+	 * region-less request the moment the last region-agnostic credential goes
+	 * away.
+	 */
+	test("serves a region-less request from the default-region credential", async () => {
+		await seedApiKey();
+		await seedManagedCredential({
+			id: "managed-alibaba-singapore",
+			provider: "alibaba",
+			token: "sk-managed-singapore",
+			region: "singapore",
+		});
+		await seedManagedCredential({
+			id: "managed-alibaba-frankfurt",
+			provider: "alibaba",
+			token: "sk-managed-frankfurt",
+			region: "eu-frankfurt",
+		});
+
+		const captured = captureUpstream(chatCompletion);
+
+		// Bare model id: no provider prefix and no `:region` suffix.
+		const res = await completions("qwen3.7-plus");
+		expect(res.status).toBe(200);
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0].url).toContain("dashscope-intl.aliyuncs.com");
+		expect(captured[0].authorization).toBe("Bearer sk-managed-singapore");
+	});
+
+	test("serves each pinned region from its own credential", async () => {
+		await seedApiKey();
+		await seedManagedCredential({
+			id: "managed-alibaba-singapore",
+			provider: "alibaba",
+			token: "sk-managed-singapore",
+			region: "singapore",
+		});
+		await seedManagedCredential({
+			id: "managed-alibaba-frankfurt",
+			provider: "alibaba",
+			token: "sk-managed-frankfurt",
+			region: "eu-frankfurt",
+		});
+
+		const captured = captureUpstream(chatCompletion);
+
+		const res = await completions("alibaba/qwen3.7-plus:eu-frankfurt");
+		expect(res.status).toBe(200);
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0].url).toContain("eu-central-1.maas.aliyuncs.com");
+		expect(captured[0].authorization).toBe("Bearer sk-managed-frankfurt");
+	});
+
 	test("routes a PAYG org to a default credential alongside a variant one", async () => {
 		await seedApiKey();
 		await seedManagedCredential({

--- a/apps/gateway/src/chat/tools/hybrid-provider-routing.spec.ts
+++ b/apps/gateway/src/chat/tools/hybrid-provider-routing.spec.ts
@@ -13,11 +13,13 @@ import type { ProviderModelMapping } from "@llmgateway/models";
 function managedAvailability(values: {
 	configured?: string[];
 	usable?: string[];
+	defaultRegionUsable?: string[];
 	pinnedRegions?: Record<string, string[]>;
 }): ManagedProviderAvailability {
 	return {
 		configured: new Set(values.configured ?? []),
 		usable: new Set(values.usable ?? []),
+		defaultRegionUsable: new Set(values.defaultRegionUsable ?? []),
 		pinnedRegions: new Map(
 			Object.entries(values.pinnedRegions ?? {}).map(([provider, regions]) => [
 				provider,
@@ -108,6 +110,46 @@ describe("hybrid-provider-routing", () => {
 		);
 
 		expect(result.availableProviders).toEqual([]);
+	});
+
+	/**
+	 * A provider with no global region (Alibaba) can only ever hold region-pinned
+	 * credentials, and a region-less route is served from its default region — so
+	 * a credential pinned there backs the provider. It still covers no other
+	 * region: those stay gated behind their own pinned credential.
+	 */
+	it("backs a provider whose credential is pinned to its default region", () => {
+		const managed = managedAvailability({
+			configured: ["alibaba"],
+			usable: [],
+			defaultRegionUsable: ["alibaba"],
+			pinnedRegions: { alibaba: ["singapore", "eu-frankfurt"] },
+		});
+
+		const result = getAvailableProvidersForProjectMode(
+			"credits",
+			[],
+			["alibaba"],
+			managed,
+		);
+
+		expect(result.availableProviders).toEqual(["alibaba"]);
+		expect(
+			platformCredentialCoversRegion(
+				"alibaba",
+				"eu-frankfurt",
+				managed,
+				() => false,
+			),
+		).toBe(true);
+		expect(
+			platformCredentialCoversRegion(
+				"alibaba",
+				"cn-beijing",
+				managed,
+				() => true,
+			),
+		).toBe(false);
 	});
 
 	it("keeps reading the environment for providers with no managed credential", () => {

--- a/apps/gateway/src/chat/tools/hybrid-provider-routing.ts
+++ b/apps/gateway/src/chat/tools/hybrid-provider-routing.ts
@@ -13,6 +13,7 @@ export const EMPTY_MANAGED_PROVIDER_AVAILABILITY: ManagedProviderAvailability =
 	{
 		configured: new Set(),
 		usable: new Set(),
+		defaultRegionUsable: new Set(),
 		pinnedRegions: new Map(),
 	};
 
@@ -54,6 +55,25 @@ export function platformCredentialCoversRegion(
 }
 
 /**
+ * Whether the platform can serve the provider before a region is known. Such a
+ * request is sent to the provider's default region, so a credential pinned to
+ * that region serves it just as a region-agnostic one does — the only shape
+ * available for a provider with no global region, whose every credential is
+ * necessarily region-pinned (Alibaba). Providers whose credential is shared
+ * across regions (AWS Bedrock) are excluded from `defaultRegionUsable`, so for
+ * them this stays exactly `usable`.
+ */
+export function platformCredentialServesDefaultRegion(
+	providerId: string,
+	managed: ManagedProviderAvailability,
+): boolean {
+	return (
+		managed.usable.has(providerId) ||
+		managed.defaultRegionUsable.has(providerId)
+	);
+}
+
+/**
  * Providers LLM Gateway can serve itself, i.e. the ones it holds a credential
  * for. A credential is either a managed provider-key row (the database-backed
  * configuration) or the provider's `LLM_*` environment variable — and once the
@@ -73,7 +93,7 @@ export function getPlatformBackedProviders(
 		.filter((provider) => provider.id !== "llmgateway")
 		.filter(
 			(provider) =>
-				managed.usable.has(provider.id) ||
+				platformCredentialServesDefaultRegion(provider.id, managed) ||
 				environmentServesProvider(provider.id, managed),
 		)
 		.map((provider) => provider.id);

--- a/apps/gateway/src/chat/tools/resolve-platform-credential.ts
+++ b/apps/gateway/src/chat/tools/resolve-platform-credential.ts
@@ -115,8 +115,21 @@ export async function resolvePlatformCredential(
 	}
 
 	if (await hasManagedProviderCredential(provider)) {
+		// The scope is what makes this actionable: the fleet is never empty here,
+		// so the operator needs to know which axis excluded every credential.
+		const scope = [
+			`region: ${options.region ?? "default"}`,
+			`variant: ${options.variant ?? "default"}`,
+			...(restrictedToModel !== undefined
+				? [`model: ${restrictedToModel}`]
+				: []),
+			...(options.requiresServiceTier ? ["service tier: required"] : []),
+			...(options.excludedProviderKeyIds?.size
+				? [`excluded: ${options.excludedProviderKeyIds.size}`]
+				: []),
+		].join(", ");
 		throw new HTTPException(500, {
-			message: `No managed credential available for provider: ${provider}`,
+			message: `No managed credential available for provider: ${provider} (${scope})`,
 		});
 	}
 

--- a/apps/gateway/src/lib/cached-queries.ts
+++ b/apps/gateway/src/lib/cached-queries.ts
@@ -42,6 +42,7 @@ import {
 	userOrganization as userOrganizationTable,
 	wallet as walletTable,
 } from "@llmgateway/db";
+import { getRegionScopedDefaultRegion } from "@llmgateway/models";
 
 import { getApiKeyFingerprint } from "./api-key-fingerprint.js";
 import {
@@ -653,6 +654,43 @@ export async function hasManagedProviderCredential(
 }
 
 /**
+ * Narrow a provider's managed credentials to the ones that can serve this
+ * region.
+ *
+ * With a region in hand, a credential pinned to it wins and a region-agnostic
+ * one is the fallback — the same precedence `{ENV}__{REGION}` has over `{ENV}`.
+ *
+ * Without one, the request is sent to the provider's default region. A
+ * region-agnostic credential still serves it, and so does one pinned to that
+ * default region — which is all a provider with no global region can offer,
+ * since every one of its credentials is necessarily region-scoped (Alibaba).
+ * Providers whose credential works across regions (AWS Bedrock) are excluded
+ * from that last step by `getRegionScopedDefaultRegion`: a region on their
+ * credential is the operator scoping it deliberately, so the request fails
+ * rather than borrowing a credential meant for another region.
+ */
+function narrowManagedKeysToRegion(
+	keys: ProviderKey[],
+	provider: string,
+	region: string | undefined,
+): ProviderKey[] {
+	if (region) {
+		const pinned = keys.filter((key) => key.region === region);
+		return pinned.length > 0 ? pinned : keys.filter((key) => !key.region);
+	}
+
+	const regionAgnostic = keys.filter((key) => !key.region);
+	if (regionAgnostic.length > 0) {
+		return regionAgnostic;
+	}
+
+	const defaultRegion = getRegionScopedDefaultRegion(provider);
+	return defaultRegion
+		? keys.filter((key) => key.region === defaultRegion)
+		: [];
+}
+
+/**
  * Find a platform-managed provider credential for credits-mode traffic
  * (cacheable).
  *
@@ -678,13 +716,11 @@ export async function findManagedProviderKey(
 			? variantMatches
 			: candidates.filter((key) => key.variant === "default");
 
-	const regionMatches = options.region
-		? byVariant.filter((key) => key.region === options.region)
-		: [];
-	const byRegion =
-		regionMatches.length > 0
-			? regionMatches
-			: byVariant.filter((key) => !key.region);
+	const byRegion = narrowManagedKeysToRegion(
+		byVariant,
+		provider,
+		options.region,
+	);
 
 	return selectProviderKeyWithFailover(
 		byRegion,
@@ -711,15 +747,15 @@ export async function findManagedProviderKey(
  * - Variant: an `enterprise`/`plans` request may fall back to a `default`
  *   credential, but a `default` request can never use a variant-scoped one,
  *   and a variant that has its own credentials never falls back.
- * - Region: routing picks a provider before a region is known, so only a
- *   region-agnostic credential is guaranteed to serve the request. A
- *   region-pinned credential is an override — exactly like `{ENV}__{REGION}`,
- *   which `hasProviderEnvironmentToken` likewise ignores in favour of the base
- *   variable. A provider whose only credentials are region-pinned is therefore
- *   not advertised, the same as a deployment that sets only
- *   `LLM_X_API_KEY__US_EAST_1` and no `LLM_X_API_KEY`. Which regions those
- *   credentials do cover is reported separately in `pinnedRegions`, for the
- *   region filter that runs before a provider is chosen.
+ * - Region: routing picks a provider before a region is known, so a request
+ *   that resolves no region is served from the provider's default region. Both
+ *   a region-agnostic credential (`usable`) and one pinned to that default
+ *   region (`defaultRegionUsable`) can therefore serve it; a credential pinned
+ *   to any other region cannot, exactly like `{ENV}__{REGION}`, which
+ *   `hasProviderEnvironmentToken` ignores in favour of the base variable. Which
+ *   regions those credentials do cover is reported separately in
+ *   `pinnedRegions`, for the region filter that runs before a provider is
+ *   chosen.
  * - Model: a credential restricted via `allowedModels` cannot serve any other
  *   model, so when the caller knows the model it is routing, credentials that
  *   exclude it are ignored — a provider whose every credential excludes the
@@ -733,6 +769,13 @@ export interface ManagedProviderAvailability {
 	configured: ReadonlySet<string>;
 	/** Providers a region-agnostic managed credential can serve for this request. */
 	usable: ReadonlySet<string>;
+	/**
+	 * Providers whose credential for this request is pinned to their own default
+	 * region. They serve every request that resolves no region — which is what a
+	 * provider with no global region, such as Alibaba, can only ever offer — but,
+	 * unlike `usable`, they cover no other region.
+	 */
+	defaultRegionUsable: ReadonlySet<string>;
 	/**
 	 * Regions each provider has a region-pinned managed credential for. Variant-
 	 * and model-agnostic, matching how `hasRegionSpecificEnvKey` reads the
@@ -794,6 +837,7 @@ export async function findManagedProviderAvailability(
 
 	const effectiveVariant = variant ?? "default";
 	const usable = new Set<string>();
+	const defaultRegionUsable = new Set<string>();
 	for (const [provider, candidates] of byProvider) {
 		const variantMatches = candidates.filter(
 			(key) => key.variant === effectiveVariant,
@@ -806,8 +850,15 @@ export async function findManagedProviderAvailability(
 		if (byVariant.some((key) => !key.region)) {
 			usable.add(provider);
 		}
+		const defaultRegion = getRegionScopedDefaultRegion(provider);
+		if (
+			defaultRegion &&
+			byVariant.some((key) => key.region === defaultRegion)
+		) {
+			defaultRegionUsable.add(provider);
+		}
 	}
-	return { configured, usable, pinnedRegions };
+	return { configured, usable, defaultRegionUsable, pinnedRegions };
 }
 
 /**

--- a/apps/gateway/src/lib/managed-provider-key.spec.ts
+++ b/apps/gateway/src/lib/managed-provider-key.spec.ts
@@ -139,6 +139,77 @@ describe("findManagedProviderKey", () => {
 		).toBeUndefined();
 	});
 
+	/**
+	 * Alibaba has no global region, so every credential is necessarily pinned to
+	 * one. A request that resolved no region is sent to the provider's default
+	 * region, so the credential pinned there is the one that serves it —
+	 * otherwise a fully credentialed fleet fails every region-less request.
+	 */
+	it("serves a region-less request from the default-region credential", async () => {
+		await insertManaged({
+			id: "alibaba-singapore",
+			provider: "alibaba",
+			region: "singapore",
+		});
+		await insertManaged({
+			id: "alibaba-frankfurt",
+			provider: "alibaba",
+			region: "eu-frankfurt",
+		});
+
+		expect((await findManagedProviderKey("alibaba"))?.id).toBe(
+			"alibaba-singapore",
+		);
+		expect(
+			(await findManagedProviderKey("alibaba", { region: "eu-frankfurt" }))?.id,
+		).toBe("alibaba-frankfurt");
+
+		const availability = await findManagedProviderAvailability();
+		expect(availability.defaultRegionUsable).toContain("alibaba");
+		// Still not region-agnostic: it covers the default region, nothing else.
+		expect(availability.usable).not.toContain("alibaba");
+	});
+
+	it("does not serve a region-less request from a non-default region", async () => {
+		await insertManaged({
+			id: "alibaba-beijing",
+			provider: "alibaba",
+			region: "cn-beijing",
+		});
+
+		expect(await findManagedProviderKey("alibaba")).toBeUndefined();
+		expect(
+			(await findManagedProviderAvailability()).defaultRegionUsable,
+		).not.toContain("alibaba");
+	});
+
+	/**
+	 * A provider whose credential works in every region (AWS Bedrock's IAM-global
+	 * keys) is the opposite case: a region on the credential is the operator
+	 * deliberately scoping it, so it is never substituted for a request that
+	 * asked for another region — or for none — even when that region is the
+	 * provider's own default.
+	 */
+	it("keeps a provider with a cross-region credential region-strict", async () => {
+		await insertManaged({
+			id: "bedrock-global-pinned",
+			provider: "aws-bedrock",
+			region: "global",
+		});
+
+		expect(await findManagedProviderKey("aws-bedrock")).toBeUndefined();
+		expect(
+			await findManagedProviderKey("aws-bedrock", { region: "eu-central-1" }),
+		).toBeUndefined();
+		expect(
+			(await findManagedProviderKey("aws-bedrock", { region: "global" }))?.id,
+		).toBe("bedrock-global-pinned");
+
+		const availability = await findManagedProviderAvailability();
+		expect(availability.usable).not.toContain("aws-bedrock");
+		expect(availability.defaultRegionUsable).not.toContain("aws-bedrock");
+	});
+
 	it("excludes credentials that already failed this request", async () => {
 		await insertManaged({ id: "first-key" });
 		await insertManaged({ id: "second-key" });

--- a/packages/models/src/provider.spec.ts
+++ b/packages/models/src/provider.spec.ts
@@ -10,6 +10,7 @@ import {
 	getVariantEnvVarName,
 	getVariantEnvVarNameFor,
 } from "./provider.js";
+import { getRegionScopedDefaultRegion } from "./providers.js";
 
 const BASE = "LLM_ALIBABA_API_KEY";
 const ENTERPRISE = `${BASE}__ENTERPRISE`;
@@ -299,5 +300,24 @@ describe("hasRegionSpecificEnvKey with workspace-scoped regions", () => {
 	it("leaves regions with a shared host unaffected", () => {
 		vi.stubEnv(`${BASE}__US_VIRGINIA`, "sk-us");
 		expect(hasRegionSpecificEnvKey("alibaba", "us-virginia")).toBe(true);
+	});
+});
+
+describe("getRegionScopedDefaultRegion", () => {
+	// Alibaba has no global region, so a credential always belongs to exactly
+	// one region and the default one serves requests that resolved none.
+	it("reports the default region for a provider with region-scoped keys", () => {
+		expect(getRegionScopedDefaultRegion("alibaba")).toBe("singapore");
+	});
+
+	// AWS keys are IAM-global: a region on a credential is the operator scoping
+	// it, never a hint that it may stand in for the default region.
+	it("reports nothing for a provider whose key works across regions", () => {
+		expect(getRegionScopedDefaultRegion("aws-bedrock")).toBeUndefined();
+		expect(getRegionScopedDefaultRegion("aws-mantle")).toBeUndefined();
+	});
+
+	it("reports nothing for a provider without regions", () => {
+		expect(getRegionScopedDefaultRegion("openai")).toBeUndefined();
 	});
 });

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -1882,6 +1882,28 @@ export function getProviderDefinition(
 }
 
 /**
+ * The region a credential must be pinned to in order to serve a request that
+ * resolved no region — but only for providers whose credentials are
+ * region-scoped, i.e. those with no global region, where every credential is
+ * necessarily bound to one region (Alibaba).
+ *
+ * Undefined for providers not scoped by region at all, and deliberately
+ * undefined for providers with a credential shared across regions (AWS
+ * Bedrock, whose `global` is a real region): there a region-pinned credential
+ * is a deliberate scoping by the operator and must never be substituted for a
+ * region the request actually asked for — the request fails instead.
+ */
+export function getRegionScopedDefaultRegion(
+	providerId: ProviderId | string,
+): string | undefined {
+	const regionConfig = getProviderDefinition(providerId)?.regionConfig;
+	if (!regionConfig || regionConfig.sharedCredentialAcrossRegions) {
+		return undefined;
+	}
+	return regionConfig.defaultRegion;
+}
+
+/**
  * Whether a region's preferred endpoint is completed with a per-credential
  * workspace id. The workspace id is worth collecting for such a region even
  * when a shared fallback exists, so the UI asks for it here.


### PR DESCRIPTION
## Problem

Production 500s on Alibaba traffic:

```
No managed credential available for provider: alibaba
  at resolvePlatformCredential (/app/src/chat/tools/resolve-platform-credential.ts:118:9)
```

Every Alibaba region is credentialed on the admin dashboard, and every region works when requested explicitly — which is why the playground never reproduced it.

`findManagedProviderKey` narrowed candidates as: region on the request → credentials pinned to it, **otherwise region-agnostic credentials only**. Alibaba has no global region, so every credential is necessarily region-pinned and that last set is always empty. Any request that reached credential resolution without a resolved region therefore matched nothing, and because the provider *is* configured there is no env fallback — a hard 500 outside the provider-fallback loop, so nothing recovers.

Those are bare model ids: `{"model":"qwen3.7-plus"}`, with no `alibaba/` prefix and no `:region` suffix. A model whose only provider is Alibaba takes the single-provider shortcut, which reads the un-expanded mapping and leaves `usedRegion` undefined. `alibaba/qwen3.7-plus` and `…:eu-frankfurt` go through the expanded regional mappings and always carried a region, so they kept working throughout.

The same assumption had a second effect: `ManagedProviderAvailability.usable` also required a region-agnostic credential, so Alibaba was dropped from cross-provider routing entirely — a fully credentialed provider that could never win a route.

## Approach

A request with no region is sent to the provider's default region, so the credential pinned to that region is exactly the one that serves it.

- `getRegionScopedDefaultRegion()` (`packages/models`) returns the default region **only** for providers whose credentials are region-scoped.
- `findManagedProviderKey` falls back to that region's credentials, *after* region-agnostic ones — purely additive, no existing deployment changes behaviour.
- `defaultRegionUsable` on `ManagedProviderAvailability` makes such a provider routable again. `platformCredentialCoversRegion` is deliberately untouched: `cn-beijing` still requires a `cn-beijing` credential, so this never widens region coverage.
- The 500 now names the scope that excluded everything: `… (region: eu-frankfurt, variant: default, model: qwen3.7-plus)`.

## AWS is explicitly excluded

`aws-bedrock` and `aws-mantle` set `sharedCredentialAcrossRegions` (IAM-global keys, and `global` is a real region for them), so `getRegionScopedDefaultRegion` returns `undefined` for both and none of the above applies. A region on an AWS credential stays a deliberate scoping by the operator: it is never substituted for another region or for a missing one, and the request fails as it does today. Pinned by a test where a `global`-pinned Bedrock credential still refuses to serve a region-less request.

## Verification

- New regression test: with singapore + eu-frankfurt managed credentials and nothing region-agnostic, bare `qwen3.7-plus` failed with the production error before this change and now resolves the singapore credential and the `dashscope-intl` endpoint; `alibaba/qwen3.7-plus:eu-frankfurt` keeps resolving the Frankfurt credential and its workspace host.
- Unit coverage for credential selection (default-region hit, non-default-region miss, AWS strictness), routing availability, and `getRegionScopedDefaultRegion` itself.
- Full gateway unit suite: 110 files, 2183 passed.

## Not in scope

A bare model id served only by Alibaba still takes the base mapping and lands on singapore rather than price-routing to Frankfurt/Beijing the way `alibaba/qwen3.7-plus` does. Billing stays consistent (base prices equal singapore's), so it is a missed optimization rather than a defect — worth a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved regional credential selection for managed providers, including default-region fallback when requests do not specify a region.
  * Added stricter region matching for AWS Bedrock credentials.
  * Enhanced credential error messages with relevant scope and selection details.

* **Documentation**
  * Updated self-hosting documentation to explain regional credential selection and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->