### PR TITLE
fix(admin): show the real credential test error

### DIFF
--- a/ee/admin/src/components/provider-credentials-manager.tsx
+++ b/ee/admin/src/components/provider-credentials-manager.tsx
@@ -47,6 +47,7 @@ import {
 } from "@/components/ui/table";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import { thrownErrorMessage } from "@/lib/api-error";
 import { formatUsd, isInRotation } from "@/lib/provider-key-spend";
 import { cn } from "@/lib/utils";
 
@@ -1051,6 +1052,26 @@ const nonNegativeDecimalPattern = /^\d+(?:\.\d+)?$/;
 type ModelVerificationEntry =
 	ProviderCredentialModelVerification["results"][number];
 
+interface SelfTestOutcome {
+	result?: ProviderCredentialSelfTestResult;
+	error?: string;
+}
+
+/**
+ * Why the self-test failed, in the order the reason is most specific: the
+ * gateway could not run the probe at all, the provider explained itself, or it
+ * only answered with a status. The generic sentence is the last resort — it is
+ * all the admin gets, so nothing more specific may be dropped on the way here.
+ */
+function selfTestFailureReason(outcome: SelfTestOutcome): string {
+	const statusCode = outcome.result?.statusCode;
+	const suffix = statusCode ? ` (HTTP ${statusCode})` : "";
+	const reason = outcome.error ?? outcome.result?.error;
+	return reason
+		? `${reason}${suffix}`
+		: `the provider rejected the request${suffix}`;
+}
+
 function CredentialDialog({
 	catalog,
 	credential,
@@ -1103,7 +1124,7 @@ function CredentialDialog({
 	// cleared whenever an input that changes what the probe would send changes.
 	const [selfTestLoading, setSelfTestLoading] = useState(false);
 	const [selfTestOutcome, setSelfTestOutcome] = useState<
-		{ result?: ProviderCredentialSelfTestResult; error?: string } | undefined
+		SelfTestOutcome | undefined
 	>();
 	const [verifyLoading, setVerifyLoading] = useState(false);
 	const [verifyOutcome, setVerifyOutcome] = useState<
@@ -1140,8 +1161,10 @@ function CredentialDialog({
 					? { result: outcome.result }
 					: { error: outcome.error ?? "Failed to test credential" },
 			);
-		} catch {
-			setSelfTestOutcome({ error: "Failed to test credential" });
+		} catch (cause) {
+			setSelfTestOutcome({
+				error: thrownErrorMessage(cause, "Failed to test credential"),
+			});
 		} finally {
 			setSelfTestLoading(false);
 		}
@@ -1160,8 +1183,10 @@ function CredentialDialog({
 					? { result: outcome.result }
 					: { error: outcome.error ?? "Failed to verify models" },
 			);
-		} catch {
-			setVerifyOutcome({ error: "Failed to verify models" });
+		} catch (cause) {
+			setVerifyOutcome({
+				error: thrownErrorMessage(cause, "Failed to verify models"),
+			});
 		} finally {
 			setVerifyLoading(false);
 		}
@@ -1622,10 +1647,7 @@ function CredentialDialog({
 										{selfTestOutcome.result?.model
 											? ` (probed ${selfTestOutcome.result.model})`
 											: ""}
-										:{" "}
-										{selfTestOutcome.error ??
-											selfTestOutcome.result?.error ??
-											"the provider rejected the request"}
+										: {selfTestFailureReason(selfTestOutcome)}
 									</p>
 								) : (
 									<p className="flex items-center gap-1 text-sm text-green-600">

--- a/ee/admin/src/lib/admin-provider-credentials.ts
+++ b/ee/admin/src/lib/admin-provider-credentials.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { apiErrorMessage, thrownErrorMessage } from "./api-error";
 import { createServerApiClient } from "./server-api";
 
 import type { paths } from "./api/v1";
@@ -46,8 +47,38 @@ interface MutationResult {
 	error?: string;
 }
 
-function toErrorMessage(error: unknown, fallback: string): string {
-	return (error as { message?: string } | undefined)?.message ?? fallback;
+interface FetchOutcome<T> {
+	data?: T;
+	error?: unknown;
+	response: Response;
+}
+
+/**
+ * Runs one API call and reduces it to `{ success, error?, result? }`, keeping
+ * hold of the reason it failed. Both halves matter to the caller: an error
+ * response carries its message in one of several envelopes, and a request that
+ * throws would otherwise leave the server action with an opaque failure.
+ */
+async function request<T>(
+	fallback: string,
+	call: () => Promise<FetchOutcome<T>>,
+	isSuccess: (data: T) => boolean = () => true,
+): Promise<MutationResult & { result?: T }> {
+	let outcome: FetchOutcome<T>;
+	try {
+		outcome = await call();
+	} catch (cause) {
+		return { success: false, error: thrownErrorMessage(cause, fallback) };
+	}
+
+	const { data, error, response } = outcome;
+	if (error || !data || !isSuccess(data)) {
+		return {
+			success: false,
+			error: apiErrorMessage(error, fallback, response),
+		};
+	}
+	return { success: true, result: data };
 }
 
 export async function getProviderCredentials() {
@@ -66,16 +97,10 @@ export async function createProviderCredential(
 	body: CredentialInput,
 ): Promise<MutationResult> {
 	const $api = await createServerApiClient();
-	const { data, error } = await $api.POST("/admin/provider-credentials", {
-		body,
-	});
-	if (error || !data) {
-		return {
-			success: false,
-			error: toErrorMessage(error, "Failed to create credential"),
-		};
-	}
-	return { success: true };
+	const { success, error } = await request("Failed to create credential", () =>
+		$api.POST("/admin/provider-credentials", { body }),
+	);
+	return { success, error };
 }
 
 export async function updateProviderCredential(
@@ -93,36 +118,28 @@ export async function updateProviderCredential(
 	},
 ): Promise<MutationResult> {
 	const $api = await createServerApiClient();
-	const { data, error } = await $api.PATCH("/admin/provider-credentials/{id}", {
-		params: { path: { id } },
-		body,
-	});
-	if (error || !data) {
-		return {
-			success: false,
-			error: toErrorMessage(error, "Failed to update credential"),
-		};
-	}
-	return { success: true };
+	const { success, error } = await request("Failed to update credential", () =>
+		$api.PATCH("/admin/provider-credentials/{id}", {
+			params: { path: { id } },
+			body,
+		}),
+	);
+	return { success, error };
 }
 
 export async function deleteProviderCredential(
 	id: string,
 ): Promise<MutationResult> {
 	const $api = await createServerApiClient();
-	const { data, error } = await $api.DELETE(
-		"/admin/provider-credentials/{id}",
-		{
-			params: { path: { id } },
-		},
+	const { success, error } = await request(
+		"Failed to delete credential",
+		() =>
+			$api.DELETE("/admin/provider-credentials/{id}", {
+				params: { path: { id } },
+			}),
+		(data) => data.success,
 	);
-	if (error || !data?.success) {
-		return {
-			success: false,
-			error: toErrorMessage(error, "Failed to delete credential"),
-		};
-	}
-	return { success: true };
+	return { success, error };
 }
 
 /**
@@ -133,17 +150,9 @@ export async function selfTestProviderCredential(
 	body: CredentialTestInput,
 ): Promise<MutationResult & { result?: ProviderCredentialSelfTestResult }> {
 	const $api = await createServerApiClient();
-	const { data, error } = await $api.POST(
-		"/admin/provider-credentials/self-test",
-		{ body },
+	return await request("Failed to test credential", () =>
+		$api.POST("/admin/provider-credentials/self-test", { body }),
 	);
-	if (error || !data) {
-		return {
-			success: false,
-			error: toErrorMessage(error, "Failed to test credential"),
-		};
-	}
-	return { success: true, result: data };
 }
 
 /**
@@ -154,17 +163,9 @@ export async function verifyProviderCredentialModels(
 	body: CredentialTestInput & { models: string[] },
 ): Promise<MutationResult & { result?: ProviderCredentialModelVerification }> {
 	const $api = await createServerApiClient();
-	const { data, error } = await $api.POST(
-		"/admin/provider-credentials/verify-models",
-		{ body },
+	return await request("Failed to verify models", () =>
+		$api.POST("/admin/provider-credentials/verify-models", { body }),
 	);
-	if (error || !data) {
-		return {
-			success: false,
-			error: toErrorMessage(error, "Failed to verify models"),
-		};
-	}
-	return { success: true, result: data };
 }
 
 /**
@@ -176,14 +177,12 @@ export async function reorderProviderCredentials(
 	credentialIds: string[],
 ): Promise<MutationResult> {
 	const $api = await createServerApiClient();
-	const { data, error } = await $api.PUT("/admin/provider-credentials/order", {
-		body: { provider, credentialIds },
-	});
-	if (error || !data) {
-		return {
-			success: false,
-			error: toErrorMessage(error, "Failed to save credential order"),
-		};
-	}
-	return { success: true };
+	const { success, error } = await request(
+		"Failed to save credential order",
+		() =>
+			$api.PUT("/admin/provider-credentials/order", {
+				body: { provider, credentialIds },
+			}),
+	);
+	return { success, error };
 }

--- a/ee/admin/src/lib/api-error.spec.ts
+++ b/ee/admin/src/lib/api-error.spec.ts
@@ -88,6 +88,22 @@ describe("apiErrorMessage", () => {
 			apiErrorMessage({ message: "   " }, "fallback", jsonResponse(500)),
 		).toBe("fallback (HTTP 500)");
 	});
+
+	test("prefers the status over a proxy's HTML error page", () => {
+		expect(
+			apiErrorMessage(
+				"<html><head><title>502 Bad Gateway</title></head></html>",
+				"Failed to test credential",
+				jsonResponse(502),
+			),
+		).toBe("Failed to test credential (HTTP 502)");
+	});
+
+	test("truncates a message too long for a dialog", () => {
+		const message = apiErrorMessage({ message: "x".repeat(1000) }, "fallback");
+		expect(message).toHaveLength(401);
+		expect(message.endsWith("…")).toBe(true);
+	});
 });
 
 describe("thrownErrorMessage", () => {

--- a/ee/admin/src/lib/api-error.spec.ts
+++ b/ee/admin/src/lib/api-error.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "vitest";
+
+import { apiErrorMessage, thrownErrorMessage } from "./api-error";
+
+function jsonResponse(status: number): Response {
+	return new Response(null, { status });
+}
+
+describe("apiErrorMessage", () => {
+	test("reads the message of the global HTTPException envelope", () => {
+		expect(
+			apiErrorMessage(
+				{ error: true, status: 400, message: "Unknown provider: nope" },
+				"Failed to test credential",
+			),
+		).toBe("Unknown provider: nope");
+	});
+
+	test("describes zod-openapi request validation failures", () => {
+		expect(
+			apiErrorMessage(
+				{
+					success: false,
+					error: {
+						name: "ZodError",
+						issues: [
+							{
+								code: "too_big",
+								path: ["region"],
+								message: "String must contain at most 64 character(s)",
+							},
+						],
+					},
+				},
+				"Failed to test credential",
+			),
+		).toBe("region: String must contain at most 64 character(s)");
+	});
+
+	test("joins multiple validation issues", () => {
+		expect(
+			apiErrorMessage(
+				{
+					success: false,
+					error: {
+						issues: [
+							{ path: ["config", "region"], message: "Expected string" },
+							{ path: [], message: "Invalid input" },
+						],
+					},
+				},
+				"fallback",
+			),
+		).toBe("config.region: Expected string; Invalid input");
+	});
+
+	test("unwraps a nested provider error object", () => {
+		expect(
+			apiErrorMessage(
+				{ error: { message: "Incorrect API key provided" } },
+				"fallback",
+			),
+		).toBe("Incorrect API key provided");
+	});
+
+	test("accepts a bare string body", () => {
+		expect(apiErrorMessage("Bad Gateway\n", "fallback")).toBe("Bad Gateway");
+	});
+
+	test("falls back with the status when the body carries no reason", () => {
+		expect(
+			apiErrorMessage(
+				undefined,
+				"Failed to test credential",
+				jsonResponse(502),
+			),
+		).toBe("Failed to test credential (HTTP 502)");
+	});
+
+	test("falls back verbatim when there is no response either", () => {
+		expect(apiErrorMessage({}, "Failed to test credential")).toBe(
+			"Failed to test credential",
+		);
+	});
+
+	test("ignores a blank message rather than showing an empty reason", () => {
+		expect(
+			apiErrorMessage({ message: "   " }, "fallback", jsonResponse(500)),
+		).toBe("fallback (HTTP 500)");
+	});
+});
+
+describe("thrownErrorMessage", () => {
+	test("appends the cause that fetch hides behind 'fetch failed'", () => {
+		const error = new Error("fetch failed", {
+			cause: new Error("connect ECONNREFUSED 127.0.0.1:4002"),
+		});
+		expect(thrownErrorMessage(error, "Failed to test credential")).toBe(
+			"fetch failed: connect ECONNREFUSED 127.0.0.1:4002",
+		);
+	});
+
+	test("keeps a single message when the cause repeats it", () => {
+		const error = new Error("boom", { cause: new Error("boom") });
+		expect(thrownErrorMessage(error, "fallback")).toBe("boom");
+	});
+
+	test("falls back for a thrown value with nothing to say", () => {
+		expect(thrownErrorMessage(new Error("  "), "fallback")).toBe("fallback");
+		expect(thrownErrorMessage(undefined, "fallback")).toBe("fallback");
+	});
+});

--- a/ee/admin/src/lib/api-error.ts
+++ b/ee/admin/src/lib/api-error.ts
@@ -1,0 +1,93 @@
+/**
+ * Turns whatever the API answered with into a message worth showing an admin.
+ *
+ * Reaching the fallback means the dialog says "Failed to X" and the admin
+ * learns nothing about why, so every envelope the API can actually produce is
+ * unwrapped here:
+ *
+ * - `{ error: true, status, message }` — the global HTTPException handler.
+ * - `{ success: false, error: { issues, name: "ZodError" } }` — the
+ *   zod-openapi request validator, which never sets a top-level `message`.
+ * - a bare string or a non-JSON body — proxies, gateways and infra errors.
+ */
+
+const MAX_UNWRAP_DEPTH = 4;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function fromZodIssues(issues: unknown): string | undefined {
+	if (!Array.isArray(issues)) {
+		return undefined;
+	}
+	const described = issues.flatMap((issue) => {
+		if (!isRecord(issue) || typeof issue.message !== "string") {
+			return [];
+		}
+		const path = Array.isArray(issue.path) ? issue.path.join(".") : "";
+		return [path ? `${path}: ${issue.message}` : issue.message];
+	});
+	return described.length > 0 ? described.join("; ") : undefined;
+}
+
+function extract(value: unknown, depth = 0): string | undefined {
+	if (depth > MAX_UNWRAP_DEPTH) {
+		return undefined;
+	}
+	if (typeof value === "string") {
+		return value.trim() || undefined;
+	}
+	if (Array.isArray(value)) {
+		return fromZodIssues(value);
+	}
+	if (!isRecord(value)) {
+		return undefined;
+	}
+	if (typeof value.message === "string" && value.message.trim()) {
+		return value.message.trim();
+	}
+	return (
+		fromZodIssues(value.issues) ??
+		extract(value.error, depth + 1) ??
+		extract(value.details, depth + 1)
+	);
+}
+
+/**
+ * @param error the `error` field openapi-fetch returns for a non-2xx response
+ * @param fallback wording used when the body carries no reason at all
+ * @param response the raw response, so the status can at least be reported
+ */
+export function apiErrorMessage(
+	error: unknown,
+	fallback: string,
+	response?: Response,
+): string {
+	const message = extract(error);
+	if (message) {
+		return message;
+	}
+	return response ? `${fallback} (HTTP ${response.status})` : fallback;
+}
+
+/**
+ * Reason for a request that never produced a response — the API was
+ * unreachable, the connection dropped, or a long provider probe was aborted.
+ * Server actions replace an uncaught throw with an opaque client-side error,
+ * so these have to be caught and reported rather than left to propagate.
+ */
+export function thrownErrorMessage(cause: unknown, fallback: string): string {
+	const message =
+		cause instanceof Error ? cause.message.trim() : extract(cause);
+	if (!message) {
+		return fallback;
+	}
+	// `fetch` collapses connectivity failures into a bare "fetch failed"; the
+	// cause it attaches (ECONNREFUSED, ENOTFOUND, …) is the useful part.
+	const detail =
+		cause instanceof Error && cause.cause instanceof Error
+			? cause.cause.message.trim()
+			: undefined;
+	return detail && detail !== message ? `${message}: ${detail}` : message;
+}

--- a/ee/admin/src/lib/api-error.ts
+++ b/ee/admin/src/lib/api-error.ts
@@ -13,8 +13,26 @@
 
 const MAX_UNWRAP_DEPTH = 4;
 
+/** Long enough for a provider's rejection, short enough to stay one line-ish. */
+const MAX_MESSAGE_LENGTH = 400;
+
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;
+}
+
+/**
+ * A non-JSON body is usually a proxy's HTML error page, which is worse than
+ * the status line it would replace. Keep plain text only, and truncate it —
+ * this ends up inside a dialog, not a log.
+ */
+function usableText(value: string): string | undefined {
+	const text = value.trim();
+	if (!text || text.startsWith("<")) {
+		return undefined;
+	}
+	return text.length > MAX_MESSAGE_LENGTH
+		? `${text.slice(0, MAX_MESSAGE_LENGTH)}…`
+		: text;
 }
 
 function fromZodIssues(issues: unknown): string | undefined {
@@ -36,7 +54,7 @@ function extract(value: unknown, depth = 0): string | undefined {
 		return undefined;
 	}
 	if (typeof value === "string") {
-		return value.trim() || undefined;
+		return usableText(value);
 	}
 	if (Array.isArray(value)) {
 		return fromZodIssues(value);
@@ -44,8 +62,11 @@ function extract(value: unknown, depth = 0): string | undefined {
 	if (!isRecord(value)) {
 		return undefined;
 	}
-	if (typeof value.message === "string" && value.message.trim()) {
-		return value.message.trim();
+	if (typeof value.message === "string") {
+		const message = usableText(value.message);
+		if (message) {
+			return message;
+		}
 	}
 	return (
 		fromZodIssues(value.issues) ??
@@ -79,7 +100,7 @@ export function apiErrorMessage(
  */
 export function thrownErrorMessage(cause: unknown, fallback: string): string {
 	const message =
-		cause instanceof Error ? cause.message.trim() : extract(cause);
+		cause instanceof Error ? usableText(cause.message) : extract(cause);
 	if (!message) {
 		return fallback;
 	}


### PR DESCRIPTION
## Problem

The provider credential dialog reported

> Self-test failed: Failed to test credential

for every failure, which tells an admin nothing. That string is the generic fallback — it is reached only when the real reason was dropped somewhere on the way to the dialog.

Two paths dropped it:

1. **The error extractor only looked at a top-level `message`.** That covers the API's `HTTPException` envelope (`{ error: true, status, message }`) and nothing else. It misses the zod-openapi request-validation envelope — `zValidator` answers a bad request with `c.json({ success: false, error: <ZodError> }, 400)`, which has no top-level `message` at all — as well as nested provider errors and non-JSON bodies from a proxy.
2. **A request that threw rather than answering escaped the server action.** The API being unreachable, a dropped connection, or a long provider probe being aborted all throw out of `$api.POST` instead of returning `{ error }`. Next.js replaces an uncaught server-action throw with an opaque client-side error, so the dialog's `catch` had nothing to show but its own fallback.

## Approach

New `ee/admin/src/lib/api-error.ts` with two pure helpers, unit-tested:

- `apiErrorMessage(error, fallback, response?)` unwraps every envelope the API can produce — `message`, ZodError `issues` (rendered as `path: message`), nested `error`/`details`, bare strings — and falls back to `<fallback> (HTTP <status>)` when a body genuinely carries no reason. A non-JSON body is usually a gateway's HTML page, so it is skipped in favour of the status line, and any message is truncated to 400 chars since it lands in a dialog rather than a log.
- `thrownErrorMessage(cause, fallback)` reports a request that never produced a response, including the cause `fetch` hides behind a bare `"fetch failed"` (`ECONNREFUSED`, `ENOTFOUND`, …).

The six credential server actions now run through one `request()` helper that catches the throwing case and applies the extractor, and the dialog's own `catch` blocks report the thrown reason instead of discarding it. The self-test line also appends the upstream status code, so a provider that rejects the probe without explaining itself still says *something*.

## Scope

The self-test path is what was reported, but the extractor was shared by every mutation in that file — create, update, delete, verify-models and reorder get the same treatment. `admin-organizations.ts` and `admin-devpass.ts` still inline the old one-line version; converting them is a mechanical follow-up, deliberately left out of this diff.

Nothing on the API side changed. `validateProviderKey` already redacts the token and returns the provider's own wording; this is purely about that wording surviving the trip to the dialog.

## Verification

- `vitest run ee/admin/src/lib/api-error.spec.ts` — 13 tests covering each envelope, the truncation and HTML guards, and the `fetch failed` cause.
- `turbo run build --filter=admin` and `pnpm --filter admin lint` clean.
- Driven end-to-end against a local stack (seeded DB, API on :4002, admin on :3006) with Playwright, reproducing the reported symptom on the pre-fix code and the fixed message on this branch.

## Screenshots

**Before / after — API unreachable when the probe runs.** This is the reported symptom: the old code has nothing to say, the new code names the actual failure.

| Before | After |
| --- | --- |
| <img width="512" alt="Self-test failed: Failed to test credential (light)" src="https://raw.githubusercontent.com/theopenco/llmgateway/36fcb9d32edc6f78bfca099ca0e584e934c0fa27/before-light.png" /> | <img width="512" alt="Self-test failed: fetch failed: connect ECONNREFUSED 127.0.0.1:4002 (light)" src="https://raw.githubusercontent.com/theopenco/llmgateway/36fcb9d32edc6f78bfca099ca0e584e934c0fa27/after-light.png" /> |
| <img width="512" alt="Self-test failed: Failed to test credential (dark)" src="https://raw.githubusercontent.com/theopenco/llmgateway/36fcb9d32edc6f78bfca099ca0e584e934c0fa27/before-dark.png" /> | <img width="512" alt="Self-test failed: fetch failed: connect ECONNREFUSED 127.0.0.1:4002 (dark)" src="https://raw.githubusercontent.com/theopenco/llmgateway/36fcb9d32edc6f78bfca099ca0e584e934c0fa27/after-dark.png" /> |

**Provider rejects the probe** — this path already surfaced the provider's wording; it now also carries the upstream status.

<img width="512" alt="Self-test failed (probed gpt-5-nano): Incorrect API key provided … (HTTP 401)" src="https://raw.githubusercontent.com/theopenco/llmgateway/36fcb9d32edc6f78bfca099ca0e584e934c0fa27/after-provider-401.png" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPLEYwNHDQJ18UUXJudto9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPLEYwNHDQJ18UUXJudto9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for provider credential creation, updates, deletion, testing, verification, and reordering.
  * Preserved detailed API and network failure information, including validation issues and HTTP status details.
  * Added clearer fallback messages for unexpected or empty errors.
  * Improved self-test failure reporting with more actionable provider-specific details.

* **Tests**
  * Added comprehensive coverage for API, validation, network, nested, truncated, and fallback error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->