### PR TITLE
fix(alibaba): make it work again after EU Frankfurt update

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -4398,7 +4398,21 @@ chat.openapi(completions, async (c) => {
 			});
 		}
 
-		if (iamFilteredModelProviders.length === 1) {
+		// The shortcut only applies when the provider has a single expanded
+		// candidate. A bare model id (no provider prefix) keeps
+		// `modelInfo.providers` un-expanded — one Alibaba entry whose region is
+		// undefined, with the concrete regions still inside its `regions` array —
+		// so `iamFilteredModelProviders` has one entry while
+		// `expandedIamFilteredModelProviders` lists every regional variant. Taking
+		// the shortcut then reads `region: undefined` and the request falls
+		// through to the provider's default region, skipping the cheapest-region
+		// routing the multi-provider branch below would have performed. Gate the
+		// shortcut on the expanded count so a single provider with several regions
+		// routes over its regional candidates like `provider/model` spellings do.
+		if (
+			iamFilteredModelProviders.length === 1 &&
+			expandedIamFilteredModelProviders.length === 1
+		) {
 			usedProvider = iamFilteredModelProviders[0].providerId;
 			usedInternalModel = modelInfo.id;
 			usedExternalId = iamFilteredModelProviders[0].externalId;

--- a/apps/gateway/src/chat/managed-credentials.spec.ts
+++ b/apps/gateway/src/chat/managed-credentials.spec.ts
@@ -37,6 +37,7 @@ describe("managed provider credentials", () => {
 		provider: string;
 		token: string;
 		config?: Record<string, string>;
+		options?: Record<string, string> | null;
 		variant?: "default" | "enterprise" | "plans";
 		region?: string;
 		allowedModels?: string[];
@@ -48,6 +49,7 @@ describe("managed provider credentials", () => {
 			managed: true,
 			organizationId: null,
 			config: values.config,
+			options: values.options ?? null,
 			variant: values.variant ?? "default",
 			region: values.region,
 			allowedModels: values.allowedModels,
@@ -477,7 +479,8 @@ describe("managed provider credentials", () => {
 	 * provider's default region, so the credential pinned to that region is the
 	 * one that serves it. Falling through to "no managed credential" 500s every
 	 * region-less request the moment the last region-agnostic credential goes
-	 * away.
+	 * away. `qwen-omni-turbo` has no regional variants at all, so a bare id for
+	 * it genuinely resolves no region and lands on the default region.
 	 */
 	test("serves a region-less request from the default-region credential", async () => {
 		await seedApiKey();
@@ -497,12 +500,115 @@ describe("managed provider credentials", () => {
 		const captured = captureUpstream(chatCompletion);
 
 		// Bare model id: no provider prefix and no `:region` suffix.
-		const res = await completions("qwen3.7-plus");
+		const res = await completions("qwen-omni-turbo");
 		expect(res.status).toBe(200);
 
 		expect(captured).toHaveLength(1);
 		expect(captured[0].url).toContain("dashscope-intl.aliyuncs.com");
 		expect(captured[0].authorization).toBe("Bearer sk-managed-singapore");
+	});
+
+	/**
+	 * A bare id for a model with regional variants must route over those
+	 * regions exactly like the `provider/model` spelling: the expanded
+	 * candidates are priced against each other and the cheapest eligible
+	 * region wins. Before the fix, the single-provider shortcut read the
+	 * un-expanded mapping's `region: undefined` and always landed on the
+	 * default region (singapore), silently skipping cheapest-region routing.
+	 */
+	test("routes a bare multi-region id to the cheapest eligible region", async () => {
+		await seedApiKey();
+		await seedManagedCredential({
+			id: "managed-alibaba-singapore",
+			provider: "alibaba",
+			token: "sk-managed-singapore",
+			region: "singapore",
+		});
+		await seedManagedCredential({
+			id: "managed-alibaba-frankfurt",
+			provider: "alibaba",
+			token: "sk-managed-frankfurt",
+			region: "eu-frankfurt",
+		});
+
+		const captured = captureUpstream(chatCompletion);
+
+		// Bare model id, no provider prefix and no `:region` suffix — must
+		// still price the regional variants (eu-frankfurt is cheaper than
+		// singapore for qwen3.7-plus) instead of defaulting to singapore.
+		const res = await completions("qwen3.7-plus");
+		expect(res.status).toBe(200);
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0].url).toContain("eu-central-1.maas.aliyuncs.com");
+		expect(captured[0].authorization).toBe("Bearer sk-managed-frankfurt");
+	});
+
+	test("routes a bare multi-region id to the default region when only it is credentialed", async () => {
+		await seedApiKey();
+		await seedManagedCredential({
+			id: "managed-alibaba-singapore",
+			provider: "alibaba",
+			token: "sk-man...pore",
+			region: "singapore",
+		});
+
+		const captured = captureUpstream(chatCompletion);
+
+		// Only the default region's credential exists: the routing branch must
+		// still resolve the bare id to it (the shortcut path would have done
+		// the same, but via the un-expanded mapping).
+		const res = await completions("qwen3.7-plus");
+		expect(res.status).toBe(200);
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0].url).toContain("dashscope-intl.aliyuncs.com");
+		expect(captured[0].authorization).toBe("Bearer sk-man...pore");
+	});
+
+	test("routes a bare multi-region id to a provider-key-pinned region", async () => {
+		await seedApiKey();
+		await harness.setProjectMode("api-keys");
+		await cdb.insert(tables.providerKey).values({
+			id: "byok-alibaba-beijing",
+			provider: "alibaba",
+			token: "sk-byo...jing",
+			organizationId: "org-id",
+			options: { alibaba_region: "cn-beijing" },
+		});
+
+		const captured = captureUpstream(chatCompletion);
+
+		// A provider-key region pin (alibaba_region) must be honored for bare
+		// ids: the routing branch applies buildProviderLockedRegions, which the
+		// single-provider shortcut previously bypassed entirely.
+		const res = await completions("qwen3.7-plus");
+		expect(res.status).toBe(200);
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0].url).toContain("dashscope.aliyuncs.com");
+		expect(captured[0].authorization).toBe("Bearer sk-byo...jing");
+	});
+
+	test("routes a bare multi-provider id through the provider that has a credential", async () => {
+		await seedApiKey();
+		await seedManagedCredential({
+			id: "managed-novita",
+			provider: "novita",
+			token: "sk-man...novita",
+		});
+
+		const captured = captureUpstream(chatCompletion);
+
+		// qwen3-vl-235b-a22b-instruct is catalogued with alibaba, novita and
+		// deepinfra. With only novita credentialed, the bare id must route to
+		// novita - the provider-level shortcut must not fire on alibaba.
+		const res = await completions("qwen3-vl-235b-a22b-instruct");
+		expect(res.status).toBe(200);
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0].url).toContain("api.novita.ai");
+		expect(captured[0].authorization).toBe("Bearer sk-man...novita");
 	});
 
 	test("serves each pinned region from its own credential", async () => {


### PR DESCRIPTION
## 🔴 URGENT

Since the Alibaba EU-Frankfurt region update (#3525), **all standard-routing (bare model id) requests to Alibaba models are broken for coding/DevPass plan users**. `qwen3.7-flash`, `qwen3.7-plus`, `qwen3-vl-flash`, `qwen3.6-flash` and the other latest Alibaba models are Alibaba-only — there is no fallback provider, and on coding plans neither `alibaba/` prefix (403) nor `:region` suffix (400) is allowed. These users have **no workaround**; they cannot route to Alibaba models at all until this ships. Please prioritize review + release.

## Problem

After the Alibaba EU-Frankfurt region update (#3525) and the region-less managed-credentials fix (#3528), **bare** Alibaba model ids (`qwen3.7-flash`, `qwen3.7-plus`, and other latest Alibaba models — no `alibaba/` prefix, no `:region` suffix) still skip region routing entirely.

A bare id makes `useExpandedRoutingProviders` false, so the catalogue keeps the **un-expanded** provider mapping (one Alibaba entry, `region: undefined`). The single-provider shortcut in `chat.ts` (`iamFilteredModelProviders.length === 1`) then pins `usedRegion = undefined`, and the request falls through to the provider's default region. The region-expanded, credential-filtered list that the multi-provider branch prices over is never consulted.

On coding/DevPass plans there is no workaround: provider prefixes are 403 ("Direct provider routing is not available on coding plans") and `:region` suffixes are 400. So standard routing (bare ids) is the only path those users have — and it cannot resolve Alibaba's per-region routing.

## Fix

Gate the single-provider shortcut on the **expanded** candidate count instead of the provider-level count:

- `if (iamFilteredModelProviders.length === 1)` → `if (expandedIamFilteredModelProviders.length === 1)` (shortcut site)
- Same mirror change at the routing-metadata label site

A single provider with several regions (Alibaba with singapore/eu-frankfurt/us-virginia/cn-beijing) now flows through the normal routing branch, where `collapseProvidersToBestRegionPerProvider` prices regions against each other and resolves a concrete, credentialed region. Genuinely single-candidate models (no `regions` array) keep the shortcut, unchanged.

Also corrects: bare ids + a provider-key region pin (e.g. `alibaba_region: cn-beijing`) now honor the pin, since the routing branch applies `buildProviderLockedRegions`; the shortcut previously ignored it.

## Impact

Checked for the shared regional providers: google-vertex, aws-mantle, aws-bedrock (shared credentials across regions), azure (region-scoped, filtered at the same pre-routing step). service_tier narrowing updates both candidate lists in lockstep. Session stickiness is preserved on both paths.

## Tests

- New unit tests in `apps/gateway/src/chat/managed-credentials.spec.ts` (21/21 pass):
  - bare `qwen3.7-plus` with singapore + eu-frankfurt credentials routes to eu-frankfurt (cheapest), asserting upstream host + credential
  - bare `qwen3.7-plus` with only the default-region (singapore) credential still resolves to it via the routing branch
  - bare `qwen3.7-plus` with a BYOK key pinned via `options: { alibaba_region: "cn-beijing" }` routes to cn-beijing — the pin the shortcut previously bypassed is honored
  - bare `qwen3-vl-235b-a22b-instruct` (alibaba + novita + deepinfra catalog) with only a novita credential routes to novita
- #3528 regression coverage preserved: the default-region credential test now uses `qwen-omni-turbo` (no regional variants).
- `pnpm build` — passes (17/17 tasks).
- `pnpm test:unit` — 0 failures across `apps/gateway`; the only repo-wide failures are `apps/api` Stripe/wallet/webhook specs that require a Postgres test DB + external services not provisioned in this environment (pre-existing, unrelated to this change).
- E2E not run (no DashScope key in this environment).

Tested against upstream/main @ e8b84aa15.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider routing for models with multiple regional mappings.
  * Ensured bare model IDs consistently use the default region or the most appropriate eligible region.
  * Added support for provider-specific region selection and credential-aware provider routing.

* **Tests**
  * Expanded coverage for regional routing, default-region behavior, and managed credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->