### PR TITLE
fix(admin): span full window in spend charts

### DIFF
--- a/apps/api/src/lib/stats-window.spec.ts
+++ b/apps/api/src/lib/stats-window.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+
+import { getWindowBucketTimestamps } from "./stats-window.js";
+
+describe("getWindowBucketTimestamps", () => {
+	const now = new Date("2026-08-11T13:37:00.000Z");
+
+	test("covers a daily window from its first to its current bucket", () => {
+		const buckets = getWindowBucketTimestamps("7d", now);
+
+		// Both partial edge buckets belong to the window: the query filter starts
+		// mid-day seven days ago and the current day is still accumulating.
+		expect(buckets[0]).toBe("2026-08-04T00:00:00.000Z");
+		expect(buckets[buckets.length - 1]).toBe("2026-08-11T00:00:00.000Z");
+		expect(buckets).toHaveLength(8);
+	});
+
+	test("steps hourly for short windows", () => {
+		const buckets = getWindowBucketTimestamps("1d", now);
+
+		expect(buckets[0]).toBe("2026-08-10T13:00:00.000Z");
+		expect(buckets[buckets.length - 1]).toBe("2026-08-11T13:00:00.000Z");
+		expect(buckets).toHaveLength(25);
+	});
+
+	test("emits no gaps and no duplicates over a long window", () => {
+		const buckets = getWindowBucketTimestamps("90d", now);
+
+		expect(buckets).toHaveLength(91);
+		expect(new Set(buckets).size).toBe(buckets.length);
+		for (let index = 1; index < buckets.length; index++) {
+			expect(
+				new Date(buckets[index]).getTime() -
+					new Date(buckets[index - 1]).getTime(),
+			).toBe(24 * 60 * 60 * 1000);
+		}
+	});
+});

--- a/apps/api/src/lib/stats-window.ts
+++ b/apps/api/src/lib/stats-window.ts
@@ -16,7 +16,10 @@ export const tokenWindowSchema = z.enum([
 
 export type TokenWindow = z.infer<typeof tokenWindowSchema>;
 
-export function getTokenWindowStartDate(window: string): Date {
+export function getTokenWindowStartDate(
+	window: string,
+	now: Date = new Date(),
+): Date {
 	const windowMs: Record<string, number> = {
 		"1h": 60 * 60 * 1000,
 		"4h": 4 * 60 * 60 * 1000,
@@ -28,7 +31,7 @@ export function getTokenWindowStartDate(window: string): Date {
 		"365d": 365 * 24 * 60 * 60 * 1000,
 	};
 	const ms = windowMs[window] ?? 7 * 24 * 60 * 60 * 1000;
-	return new Date(Date.now() - ms);
+	return new Date(now.getTime() - ms);
 }
 
 /**
@@ -46,4 +49,40 @@ export function getBucketUnitForWindow(window: string): "hour" | "day" {
 		return "hour";
 	}
 	return "day";
+}
+
+/**
+ * Every bucket boundary the window covers, oldest first, as UTC ISO strings.
+ *
+ * Rollup queries only return buckets that actually hold rows, so a chart drawn
+ * straight from them silently shrinks to the busy days. Callers hand this grid
+ * to the client so quiet buckets can be zero-filled and the axis always spans
+ * the whole window. The hourly stats tables store UTC in a zone-less
+ * `timestamp`, so `date_trunc` cuts on UTC boundaries — hence UTC arithmetic
+ * here, matching the ISO strings the endpoints emit.
+ */
+export function getWindowBucketTimestamps(
+	window: string,
+	now: Date = new Date(),
+): string[] {
+	const bucketUnit = getBucketUnitForWindow(window);
+	const stepMs = bucketUnit === "hour" ? 60 * 60 * 1000 : 24 * 60 * 60 * 1000;
+	const truncate = (date: Date) =>
+		Date.UTC(
+			date.getUTCFullYear(),
+			date.getUTCMonth(),
+			date.getUTCDate(),
+			bucketUnit === "hour" ? date.getUTCHours() : 0,
+		);
+
+	const end = truncate(now);
+	const buckets: string[] = [];
+	for (
+		let ms = truncate(getTokenWindowStartDate(window, now));
+		ms <= end;
+		ms += stepMs
+	) {
+		buckets.push(new Date(ms).toISOString());
+	}
+	return buckets;
 }

--- a/apps/api/src/routes/admin-provider-credentials.spec.ts
+++ b/apps/api/src/routes/admin-provider-credentials.spec.ts
@@ -1191,12 +1191,36 @@ describe("managed credential reorder cache invalidation", () => {
 			expect(res.status).toBe(200);
 			const body = (await res.json()) as {
 				totalCost: number;
+				buckets: string[];
 				data: unknown[];
 				organizations: unknown[];
 			};
 			expect(body.totalCost).toBe(0);
 			expect(body.data).toEqual([]);
 			expect(body.organizations).toEqual([]);
+			// The chart still spans the whole window: the grid is returned even when
+			// nothing was spent, so the axis does not collapse to nothing.
+			expect(body.buckets).toHaveLength(25);
+		});
+
+		test("returns a bucket grid covering the whole window", async () => {
+			await seedTraffic([{ providerKeyId, cost: 0.01 }]);
+
+			const res = await getSpend();
+			const body = (await res.json()) as {
+				buckets: string[];
+				data: { timestamp: string }[];
+			};
+
+			// One hourly bucket per hour of the 24h window, and the only bucket that
+			// carried traffic is part of that grid — so zero-filling the rest lines
+			// the series up with the axis.
+			expect(body.buckets).toHaveLength(25);
+			expect(new Set(body.buckets).size).toBe(body.buckets.length);
+			expect(body.data.length).toBeGreaterThan(0);
+			for (const point of body.data) {
+				expect(body.buckets).toContain(point.timestamp);
+			}
 		});
 	});
 
@@ -1216,8 +1240,14 @@ describe("managed credential reorder cache invalidation", () => {
 
 		interface OverviewBody {
 			bucket: string;
+			buckets: string[];
 			keys: OverviewKey[];
-			data: { providerKeyId: string; cost: number; totalTokens: string }[];
+			data: {
+				providerKeyId: string;
+				timestamp: string;
+				cost: number;
+				totalTokens: string;
+			}[];
 		}
 
 		async function seedTraffic(
@@ -1327,6 +1357,28 @@ describe("managed credential reorder cache invalidation", () => {
 			expect(seriesIds).toEqual(
 				new Set(["overview-cred-a", "overview-cred-b"]),
 			);
+		});
+
+		test("returns a bucket grid covering the whole window", async () => {
+			await db.insert(tables.providerKey).values({
+				id: "overview-grid",
+				token: "sk-overview-grid",
+				provider: "openai",
+				managed: true,
+				organizationId: null,
+			});
+			await seedTraffic([{ providerKeyId: "overview-grid", cost: 0.01 }]);
+
+			const body = await getOverview();
+
+			// The rollup only holds the current hour, but the grid still spans the
+			// full 24h window so quiet buckets can be zero-filled client-side.
+			expect(body.buckets).toHaveLength(25);
+			expect(new Set(body.buckets).size).toBe(body.buckets.length);
+			expect(body.data.length).toBeGreaterThan(0);
+			for (const point of body.data) {
+				expect(body.buckets).toContain(point.timestamp);
+			}
 		});
 
 		test("excludes BYOK keys and their spend", async () => {

--- a/apps/api/src/routes/admin-provider-credentials.ts
+++ b/apps/api/src/routes/admin-provider-credentials.ts
@@ -12,6 +12,7 @@ import {
 import {
 	getBucketUnitForWindow,
 	getTokenWindowStartDate,
+	getWindowBucketTimestamps,
 	tokenWindowSchema,
 } from "@/lib/stats-window.js";
 import { adminMiddleware } from "@/middleware/admin.js";
@@ -58,7 +59,7 @@ import { maskToken } from "@llmgateway/shared/mask-token";
 import { assertSafeProviderUrl } from "@llmgateway/shared/url-safety-node";
 
 import type { ServerTypes } from "@/vars.js";
-import type { ProviderKeyVariant } from "@llmgateway/db";
+import type { ProviderKeyVariant, SQL } from "@llmgateway/db";
 import type { ProviderDefinition, ProviderId } from "@llmgateway/models";
 
 export const adminProviderCredentials = new OpenAPIHono<ServerTypes>();
@@ -526,6 +527,14 @@ adminProviderCredentials.openapi(listCredentials, async (c) => {
 	return c.json({ credentials: rows.map(toCredential) });
 });
 
+/**
+ * ISO-8601 UTC label for a truncated bucket, formatted the same way
+ * `Date#toISOString` would, so it can be compared to a generated bucket grid.
+ */
+function bucketLabel(bucketExpr: SQL<Date>) {
+	return sql<string>`to_char(${bucketExpr}, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`;
+}
+
 const spendPointSchema = z.object({
 	timestamp: z.string(),
 	cost: z.number(),
@@ -560,6 +569,11 @@ const providerKeySpendSchema = z.object({
 	totalCost: z.number(),
 	totalRequests: z.number(),
 	totalErrors: z.number(),
+	/**
+	 * Every bucket boundary in the window, including the quiet ones `data` skips,
+	 * so a chart can zero-fill and span the whole selected duration.
+	 */
+	buckets: z.array(z.string()),
 	data: z.array(spendPointSchema),
 	/**
 	 * Spend split by consuming organization, highest first. Always a single
@@ -613,6 +627,11 @@ adminProviderCredentials.openapi(getProviderKeySpend, async (c) => {
 	}
 
 	const bucketExpr = sql<Date>`date_trunc(${sql.raw(`'${bucketUnit}'`)}, ${tables.providerKeyHourlyStats.hourTimestamp})`;
+	// `hourTimestamp` is a zone-less `timestamp` holding UTC, so label the bucket
+	// in SQL rather than letting the driver reinterpret it in the process
+	// timezone — that is what makes these strings line up with the zero-filled
+	// `buckets` grid below.
+	const bucketLabelExpr = bucketLabel(bucketExpr);
 
 	const baseFilter = and(
 		eq(tables.providerKeyHourlyStats.providerKeyId, providerKeyId),
@@ -622,7 +641,7 @@ adminProviderCredentials.openapi(getProviderKeySpend, async (c) => {
 	const [points, organizations] = await Promise.all([
 		db
 			.select({
-				timestamp: bucketExpr.as("bucket"),
+				timestamp: bucketLabelExpr.as("bucket"),
 				cost: sql<number>`COALESCE(SUM(${tables.providerKeyHourlyStats.cost}), 0)`.as(
 					"cost",
 				),
@@ -678,7 +697,7 @@ adminProviderCredentials.openapi(getProviderKeySpend, async (c) => {
 	]);
 
 	const data = points.map((point) => ({
-		timestamp: new Date(point.timestamp).toISOString(),
+		timestamp: point.timestamp,
 		cost: Number(point.cost),
 		requestCount: Number(point.requestCount),
 		errorCount: Number(point.errorCount),
@@ -702,6 +721,7 @@ adminProviderCredentials.openapi(getProviderKeySpend, async (c) => {
 		totalCost: data.reduce((sum, point) => sum + point.cost, 0),
 		totalRequests: data.reduce((sum, point) => sum + point.requestCount, 0),
 		totalErrors: data.reduce((sum, point) => sum + point.errorCount, 0),
+		buckets: getWindowBucketTimestamps(window),
 		data,
 		organizations: organizations.map((row) => ({
 			organizationId: row.organizationId,
@@ -746,6 +766,12 @@ const spendOverviewSchema = z.object({
 	 * their history should not vanish before the money stops being interesting.
 	 */
 	keys: z.array(spendOverviewKeySchema),
+	/**
+	 * Every bucket boundary in the window, quiet ones included. `data` only
+	 * carries buckets that saw traffic, so the chart zero-fills against this grid
+	 * instead of collapsing to the busy days.
+	 */
+	buckets: z.array(z.string()),
 	/** One row per (bucket, credential); pivot client-side for stacking. */
 	data: z.array(spendOverviewPointSchema),
 });
@@ -783,6 +809,7 @@ adminProviderCredentials.openapi(getSpendOverview, async (c) => {
 	const bucketUnit = getBucketUnitForWindow(window);
 
 	const bucketExpr = sql<Date>`date_trunc(${sql.raw(`'${bucketUnit}'`)}, ${tables.providerKeyHourlyStats.hourTimestamp})`;
+	const bucketLabelExpr = bucketLabel(bucketExpr);
 
 	const [keys, points] = await Promise.all([
 		// Any status: a soft-deleted key is kept when the window still holds its
@@ -798,7 +825,7 @@ adminProviderCredentials.openapi(getSpendOverview, async (c) => {
 		}),
 		db
 			.select({
-				timestamp: bucketExpr.as("bucket"),
+				timestamp: bucketLabelExpr.as("bucket"),
 				providerKeyId: tables.providerKeyHourlyStats.providerKeyId,
 				cost: sql<number>`COALESCE(SUM(${tables.providerKeyHourlyStats.cost}), 0)`.as(
 					"cost",
@@ -828,7 +855,7 @@ adminProviderCredentials.openapi(getSpendOverview, async (c) => {
 	]);
 
 	const data = points.map((point) => ({
-		timestamp: new Date(point.timestamp).toISOString(),
+		timestamp: point.timestamp,
 		providerKeyId: point.providerKeyId,
 		cost: Number(point.cost),
 		requestCount: Number(point.requestCount),
@@ -854,6 +881,7 @@ adminProviderCredentials.openapi(getSpendOverview, async (c) => {
 	return c.json({
 		window,
 		bucket: bucketUnit,
+		buckets: getWindowBucketTimestamps(window),
 		keys: keys
 			.filter((key) => key.status !== "deleted" || totalsByKey.has(key.id))
 			.map((key) => {

--- a/ee/admin/src/components/provider-credentials-spend-overview.tsx
+++ b/ee/admin/src/components/provider-credentials-spend-overview.tsx
@@ -146,6 +146,8 @@ interface ProviderSeries {
 	/** Series keys in stacking order (largest spender first). */
 	seriesKeys: string[];
 	data: Record<string, number | string>[];
+	/** Whether any bucket in the window carried traffic for this provider. */
+	hasTraffic: boolean;
 	windowCost: number;
 	windowRequests: number;
 	windowTokens: number;
@@ -153,13 +155,15 @@ interface ProviderSeries {
 
 /**
  * Pivots the flat (bucket, credential) rows into one stacked series set per
- * provider. Every series is zero-filled across the provider's buckets — a
- * stacked area with holes would silently reassign the missing band to the
- * series below it.
+ * provider. Every series is zero-filled across the window's full bucket grid —
+ * a stacked area with holes would silently reassign the missing band to the
+ * series below it, and a chart built only from buckets that saw traffic would
+ * quietly shrink its axis to the busy days instead of the selected window.
  */
 function buildProviderSeries(
 	keys: OverviewKey[],
 	points: OverviewPoint[],
+	buckets: string[],
 	metric: Metric,
 ): ProviderSeries[] {
 	const pointsByKey = new Map<string, OverviewPoint[]>();
@@ -211,10 +215,14 @@ function buildProviderSeries(
 
 		const foldedIds = new Set(folded.map((key) => key.id));
 		const rows = new Map<string, Record<string, number | string>>();
-		const timestamps = new Set<string>();
+		// The server's grid spans the whole window; the provider's own buckets are
+		// unioned in so nothing is dropped if a rollup row falls just outside it.
+		const timestamps = new Set<string>(buckets);
+		let hasTraffic = false;
 		for (const key of providerKeys) {
 			for (const point of pointsByKey.get(key.id) ?? []) {
 				timestamps.add(point.timestamp);
+				hasTraffic = true;
 			}
 		}
 		for (const timestamp of Array.from(timestamps).sort()) {
@@ -237,6 +245,7 @@ function buildProviderSeries(
 			config,
 			seriesKeys,
 			data: Array.from(rows.values()),
+			hasTraffic,
 			windowCost: providerKeys.reduce((sum, key) => sum + key.totalCost, 0),
 			windowRequests: providerKeys.reduce(
 				(sum, key) => sum + key.totalRequests,
@@ -276,7 +285,7 @@ function ProviderSpendChart({
 					{compactFormatter.format(series.windowTokens)} tokens
 				</span>
 			</div>
-			{series.data.length === 0 ? (
+			{!series.hasTraffic ? (
 				<div className="flex h-56 items-center justify-center text-sm text-muted-foreground">
 					No attributed spend in this window.
 				</div>
@@ -395,7 +404,7 @@ export function ProviderCredentialsSpendOverview({
 		const keys = (data.keys as OverviewKey[]).filter(
 			(key) => providerFilter === null || key.provider === providerFilter,
 		);
-		return buildProviderSeries(keys, data.data, metric);
+		return buildProviderSeries(keys, data.data, data.buckets, metric);
 	}, [data, providerFilter, metric]);
 
 	const bucketIsHour = data?.bucket === "hour";

--- a/ee/admin/src/components/provider-key-spend-dialog.tsx
+++ b/ee/admin/src/components/provider-key-spend-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { format } from "date-fns";
 import { BarChart3 } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
 
 import { Badge } from "@/components/ui/badge";
@@ -86,6 +86,18 @@ export function ProviderKeySpendDialog({
 		(sum, point) => sum + Number(point.totalTokens),
 		0,
 	);
+	// The rollup only returns buckets that saw traffic, which would shrink the
+	// axis to the busy days; zero-fill against the window's full bucket grid so
+	// the chart always covers the selected duration.
+	const chartData = useMemo(() => {
+		const byTimestamp = new Map(
+			points.map((point) => [point.timestamp, point]),
+		);
+		return (data?.buckets ?? []).map(
+			(timestamp) =>
+				byTimestamp.get(timestamp) ?? { timestamp, cost: 0, requestCount: 0 },
+		);
+	}, [data?.buckets, points]);
 
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>
@@ -155,7 +167,7 @@ export function ProviderKeySpendDialog({
 							</p>
 						) : (
 							<ChartContainer config={chartConfig} className="h-64 w-full">
-								<AreaChart data={points}>
+								<AreaChart data={chartData}>
 									<CartesianGrid vertical={false} />
 									<XAxis
 										dataKey="timestamp"


### PR DESCRIPTION
## Problem

The credential spend charts on `/provider-credentials?view=spend` were drawn straight from `provider_key_hourly_stats`, which only returns buckets that actually saw traffic. A 7d window containing two busy days rendered as a two-point axis (Aug 5 → Aug 9) with a straight line interpolated across the quiet days — so the chart both hid the selected duration and implied continuous spend on days where nothing was spent.

## Approach

- Both spend endpoints (`GET /admin/provider-credentials/spend` and `GET /admin/provider-keys/{id}/spend`) now return a `buckets` array: every bucket boundary the window covers, quiet ones included. The overview returns the grid rather than a padded (bucket × credential) cross product, which would multiply the payload by the fleet size for no extra information.
- Both admin charts zero-fill against that grid, so the axis always spans the full 24h/7d/30d/90d window. A provider with no traffic at all still shows the existing "No attributed spend in this window" message instead of a flat-zero chart.
- Bucket timestamps are now labelled as UTC ISO in SQL. `hour_timestamp` is a zone-less `timestamp` holding UTC, so the pg driver was reinterpreting the truncated value in the API process timezone; labelling in SQL keeps the returned points aligned with the generated grid regardless of where the API runs. No change in production, where the process is UTC.

## Verification

- New unit specs for the bucket-grid helper plus route specs asserting the grid covers the window and contains every timestamp `data` reports.
- `pnpm format`, `pnpm build`, and the API specs for the touched routes (`admin-provider-credentials`, `admin-routing-analytics`, `admin-global-stats`, `activity`) all pass.
- Verified locally against a seeded fleet with spend on only 2 of the last 7 days.

## Screenshots

Admin → Provider Credentials → Spend, 7d window, seeded so only Aug 5 and Aug 9 have spend.

### Before

<img width="1440" alt="Spend by credential, light theme, axis collapsed to Aug 5 – Aug 9" src="https://raw.githubusercontent.com/theopenco/llmgateway/6bc0fd5e11dc96303c58cd70f5265e4d400b0ebc/before-light.png" />
<img width="1440" alt="Spend by credential, dark theme, axis collapsed to Aug 5 – Aug 9" src="https://raw.githubusercontent.com/theopenco/llmgateway/6bc0fd5e11dc96303c58cd70f5265e4d400b0ebc/before-dark.png" />

### After

<img width="1440" alt="Spend by credential, light theme, axis spans Aug 4 – Aug 11 with zeroed quiet days" src="https://raw.githubusercontent.com/theopenco/llmgateway/6bc0fd5e11dc96303c58cd70f5265e4d400b0ebc/after-light.png" />
<img width="1440" alt="Spend by credential, dark theme, axis spans Aug 4 – Aug 11 with zeroed quiet days" src="https://raw.githubusercontent.com/theopenco/llmgateway/6bc0fd5e11dc96303c58cd70f5265e4d400b0ebc/after-dark.png" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Spend charts now show complete hourly or daily timelines, including periods with zero activity.
  * Improved empty-state messaging to distinguish no traffic from missing data.
  * Standardized timestamps in UTC for more consistent reporting across time zones.
* **Tests**
  * Added coverage for time-window boundaries, hourly and daily intervals, and gap-free spend data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->