### PR TITLE
fix(providers): vertex-anthropic project setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -264,6 +264,8 @@ LLM_VERTEX_OPENAI_REGION=global
 # Paste the full GCP service account JSON as a single-line string.
 # Project ID is extracted automatically. See docs/integrations/vertex-anthropic for setup.
 LLM_VERTEX_ANTHROPIC_SERVICE_ACCOUNT_JSON={"type":"service_account","project_id":"your-project","private_key":"-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----\n","client_email":"vertex-ai-caller@your-project.iam.gserviceaccount.com","token_uri":"https://oauth2.googleapis.com/token"}
+# Only needed to call a different project than the service account's own.
+LLM_VERTEX_ANTHROPIC_PROJECT=
 LLM_VERTEX_ANTHROPIC_REGION=global
 
 # Inference.net

--- a/apps/api/src/routes/admin-provider-credentials.spec.ts
+++ b/apps/api/src/routes/admin-provider-credentials.spec.ts
@@ -444,6 +444,18 @@ describe("admin provider credentials", () => {
 			required: true,
 		});
 		expect(vertex?.configKeys.map((k) => k.key)).not.toContain("apiKey");
+
+		// The gateway cannot recover the project from a managed credential's
+		// service-account JSON, so the form has to offer the field.
+		const vertexAnthropic = json.providers.find(
+			(p) => p.id === "vertex-anthropic",
+		);
+		expect(vertexAnthropic?.configKeys).toContainEqual({
+			key: "project",
+			envVar: "LLM_VERTEX_ANTHROPIC_PROJECT",
+			required: true,
+		});
+
 		expect(json.providers.some((p) => p.id === "custom")).toBe(false);
 	});
 

--- a/apps/docs/content/integrations/vertex-anthropic.mdx
+++ b/apps/docs/content/integrations/vertex-anthropic.mdx
@@ -135,8 +135,9 @@ LLM_VERTEX_ANTHROPIC_REGION=global
 ```
 
 <Callout type="info">
-	The project ID is extracted automatically from the service account JSON — no
-	separate `LLM_VERTEX_ANTHROPIC_PROJECT` variable is needed.
+	The project ID is extracted automatically from the service account JSON, so
+	`LLM_VERTEX_ANTHROPIC_PROJECT` only needs setting to call a different project
+	than the service account's own.
 </Callout>
 
 ## How Token Refresh Works

--- a/packages/actions/src/get-provider-endpoint.managed.spec.ts
+++ b/packages/actions/src/get-provider-endpoint.managed.spec.ts
@@ -14,6 +14,7 @@ const ENV_VARS = [
 	"LLM_AZURE_DEPLOYMENT_TYPE",
 	"LLM_VERTEX_ANTHROPIC_REGION",
 	"LLM_VERTEX_ANTHROPIC_BASE_URL",
+	"LLM_VERTEX_ANTHROPIC_PROJECT",
 ] as const;
 
 const originals = new Map(ENV_VARS.map((name) => [name, process.env[name]]));
@@ -243,6 +244,33 @@ describe("managed credential config in getProviderEndpoint", () => {
 			false,
 			false,
 			managed({ region: "us-east5" }),
+			0,
+			false,
+			undefined,
+			true,
+		);
+
+		expect(url).toBe(
+			"https://us-east5-aiplatform.googleapis.com/v1/projects/managed-project/locations/us-east5/publishers/anthropic/models/claude-sonnet-4-6:rawPredict",
+		);
+	});
+
+	it("takes the Vertex Anthropic project from the credential, not the env", () => {
+		process.env.LLM_VERTEX_ANTHROPIC_PROJECT = "env-project";
+		delete process.env.LLM_VERTEX_ANTHROPIC_REGION;
+		delete process.env.LLM_VERTEX_ANTHROPIC_BASE_URL;
+
+		const url = getProviderEndpoint(
+			"vertex-anthropic",
+			undefined,
+			"claude-sonnet-4-6",
+			// The credential's service-account JSON is already an access token by
+			// the time the request is built, so nothing is derivable from it.
+			undefined,
+			false,
+			false,
+			false,
+			managed({ project: "managed-project", region: "us-east5" }),
 			0,
 			false,
 			undefined,

--- a/packages/actions/src/get-provider-endpoint.ts
+++ b/packages/actions/src/get-provider-endpoint.ts
@@ -676,10 +676,13 @@ export function getProviderEndpoint(
 			return `${url}/v1/projects/${projectId}/locations/${vertexRegion}/endpoints/openapi/chat/completions`;
 		}
 		case "vertex-anthropic": {
+			// A managed credential states its project outright: by the time a
+			// request is built its service-account JSON has already been exchanged
+			// for an access token, so nothing downstream can derive one from it.
+			let vaProjectId = credentialConfig?.project;
 			// BYOK provider keys hold the customer's service-account JSON; derive
 			// the project from it so requests hit their project, not the server's.
-			let vaProjectId: string | undefined;
-			if (token) {
+			if (!vaProjectId && token) {
 				try {
 					const sa = JSON.parse(token) as { project_id?: string };
 					vaProjectId = sa.project_id;
@@ -689,11 +692,13 @@ export function getProviderEndpoint(
 				}
 			}
 			if (!vaProjectId) {
-				vaProjectId =
-					process.env[
-						getVariantEnvVarNameFor("LLM_VERTEX_ANTHROPIC_PROJECT", variant) ??
-							"LLM_VERTEX_ANTHROPIC_PROJECT"
-					];
+				vaProjectId = getProviderEnvValue(
+					"vertex-anthropic",
+					"project",
+					configIndex,
+					undefined,
+					variant,
+				);
 			}
 			if (!vaProjectId) {
 				const saJson =
@@ -729,7 +734,7 @@ export function getProviderEndpoint(
 
 			if (!vaProjectId) {
 				throw new Error(
-					"vertex-anthropic provider requires LLM_VERTEX_ANTHROPIC_PROJECT or a valid LLM_VERTEX_ANTHROPIC_SERVICE_ACCOUNT_JSON with project_id",
+					"vertex-anthropic provider requires a project setting on the credential, LLM_VERTEX_ANTHROPIC_PROJECT, or a valid LLM_VERTEX_ANTHROPIC_SERVICE_ACCOUNT_JSON with project_id",
 				);
 			}
 

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -566,6 +566,12 @@ export const providers: ProviderDefinition[] = [
 		env: {
 			required: {
 				apiKey: "LLM_VERTEX_ANTHROPIC_SERVICE_ACCOUNT_JSON",
+				// The GCP project the models are called under; it becomes part of the
+				// request path. An env-var deployment can leave it unset — the gateway
+				// derives it from the service-account JSON on startup — but a managed
+				// credential's JSON is only ever decrypted to mint an access token, so
+				// the credential has to carry the project itself.
+				project: "LLM_VERTEX_ANTHROPIC_PROJECT",
 			},
 			optional: {
 				baseUrl: "LLM_VERTEX_ANTHROPIC_BASE_URL",


### PR DESCRIPTION
## Problem

The Vertex AI (Anthropic) provider had no way to say which GCP project its requests go to.

Its catalogue entry (`packages/models/src/providers.ts`) declared only `apiKey`, `baseUrl` and `region` — no `project`. The admin **Provider Credentials** dialog builds its per-provider settings form from exactly that list, so the field never rendered and a managed credential could not carry a project.

Endpoint building could not recover it either. `getProviderEndpoint` only parsed `project_id` out of a service-account JSON passed as `token`, but the gateway passes **no token** for `vertex-anthropic` (`usesGoogleQueryToken()` excludes it, and by then the SA JSON has already been exchanged for an OAuth access token). Every request therefore fell through to `LLM_VERTEX_ANTHROPIC_PROJECT` — a variable a managed-credentials deployment has no reason to set — and failed with `vertex-anthropic provider requires LLM_VERTEX_ANTHROPIC_PROJECT or a valid LLM_VERTEX_ANTHROPIC_SERVICE_ACCOUNT_JSON with project_id`.

## Approach

- Declare `project: LLM_VERTEX_ANTHROPIC_PROJECT` as a **required** setting on the provider. That is what makes the field appear in the dialog, gets it validated on save, and stores it in `provider_key.config`. It matches `vertex-openai`, which is the same SA-JSON shape and already requires a project.
- Resolve the project from the credential's own config **first**, then the token's SA JSON (still the BYOK path), then the environment. The env lookup now goes through `getProviderEnvValue` like every other setting instead of reading `process.env` by hand.
- Env-var deployments are unaffected: the gateway still derives the project from `LLM_VERTEX_ANTHROPIC_SERVICE_ACCOUNT_JSON` on startup, so `LLM_VERTEX_ANTHROPIC_PROJECT` stays optional there — it is only needed to target a project other than the service account's own. Docs and `.env.example` updated to say so rather than "no separate variable is needed".

## Not included

BYOK `vertex-anthropic` provider keys have a separate, pre-existing gap: `chat.ts` swaps a BYOK key's token for the deployment's own `getGcpAccessToken()` result before the request goes out, so a customer key does not really serve its own project today. Fixing that changes live routing and token attribution, so it is left out of this PR.

## Screenshots

Admin → Provider Credentials → Add credential, with Vertex AI (Anthropic) selected.

| Before | After |
| --- | --- |
| <img width="512" alt="Vertex Anthropic settings before: only baseUrl and region" src="https://raw.githubusercontent.com/theopenco/llmgateway/8fe195892ec1ed651b48a053515963b94fca15e3/before-light.png" /> | <img width="512" alt="Vertex Anthropic settings after: project, baseUrl and region" src="https://raw.githubusercontent.com/theopenco/llmgateway/8fe195892ec1ed651b48a053515963b94fca15e3/after-light.png" /> |
| <img width="512" alt="Vertex Anthropic settings before, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/8fe195892ec1ed651b48a053515963b94fca15e3/before-dark.png" /> | <img width="512" alt="Vertex Anthropic settings after, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/8fe195892ec1ed651b48a053515963b94fca15e3/after-dark.png" /> |

## Verification

- `pnpm format`, `pnpm build` — clean.
- `pnpm test:unit` against an isolated per-worktree stack: 4506 passed, 1 failed. The failure is `apps/gateway/src/onboarding-sponsorship.spec.ts > the logged call is billed nothing and belongs to the caller` (expects 1 log, gets 2) — it reproduces identically on a clean tree with these changes stashed, so it is pre-existing and unrelated.
- New coverage: endpoint resolution takes the project from a managed credential over the env (`get-provider-endpoint.managed.spec.ts`), and the admin catalog exposes the new config key (`admin-provider-credentials.spec.ts`).
- Verified in the running admin dashboard (screenshots above), before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional configuration for using a separate Google Cloud project with Vertex AI Anthropic.
  - Managed credentials now take priority when determining the Vertex AI project.
  - Service-account configuration can automatically derive the project when available.

- **Documentation**
  - Updated Vertex AI Anthropic self-hosting guidance with project selection details.

- **Bug Fixes**
  - Improved project resolution and error messaging for missing Vertex AI Anthropic project settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->