### PR TITLE
fix(ui): server-render the member limits card

### DIFF
--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/me/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/me/page.tsx
@@ -1,5 +1,31 @@
 import { DeveloperDashboardClient } from "@/components/dashboard/developer-dashboard-client";
+import { fetchServerData } from "@/lib/server-api";
 
-export default function DeveloperDashboardPage() {
-	return <DeveloperDashboardClient />;
+import type { MyMemberBudgetData } from "@/hooks/useTeam";
+
+export default async function DeveloperDashboardPage({
+	params,
+}: {
+	params: Promise<{ orgId: string; projectId: string }>;
+}) {
+	const { orgId } = await params;
+
+	// Server-side fetch so the limits card renders filled in on first paint.
+	const initialMemberBudget = await fetchServerData<MyMemberBudgetData>(
+		"GET",
+		"/team/{organizationId}/members/me",
+		{
+			params: {
+				path: {
+					organizationId: orgId,
+				},
+			},
+		},
+	);
+
+	return (
+		<DeveloperDashboardClient
+			initialMemberBudget={initialMemberBudget ?? undefined}
+		/>
+	);
 }

--- a/apps/ui/src/components/dashboard/developer-dashboard-client.tsx
+++ b/apps/ui/src/components/dashboard/developer-dashboard-client.tsx
@@ -35,6 +35,8 @@ import { useApi } from "@/lib/fetch-client";
 import { getBrowserTimeZone } from "@/lib/timezone";
 import { applyUsageMode, pickCost, pickRequests } from "@/lib/usage-mode";
 
+import type { MyMemberBudgetData } from "@/hooks/useTeam";
+
 function SummaryStat({
 	label,
 	value,
@@ -63,7 +65,11 @@ function SummaryStat({
 	);
 }
 
-export function DeveloperDashboardClient() {
+export function DeveloperDashboardClient({
+	initialMemberBudget,
+}: {
+	initialMemberBudget?: MyMemberBudgetData;
+}) {
 	const params = useParams();
 	const organizationId = params.orgId as string;
 	const projectId = params.projectId as string;
@@ -151,7 +157,10 @@ export function DeveloperDashboardClient() {
 					</div>
 				</div>
 
-				<MemberLimitsCard organizationId={organizationId} />
+				<MemberLimitsCard
+					organizationId={organizationId}
+					initialData={initialMemberBudget}
+				/>
 
 				<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
 					{stats.map((stat) => (

--- a/apps/ui/src/components/team/member-limits-card.tsx
+++ b/apps/ui/src/components/team/member-limits-card.tsx
@@ -10,6 +10,8 @@ import {
 	CardTitle,
 } from "@/lib/components/card";
 
+import type { MyMemberBudgetData } from "@/hooks/useTeam";
+
 function periodLabel(value: number, unit: string): string {
 	return value === 1 ? unit : `${value} ${unit}s`;
 }
@@ -19,13 +21,18 @@ function periodLabel(value: number, unit: string): string {
  * API keys, total spend cap, rolling period cap) and current usage against
  * them. Renders nothing when no limits are set, so it stays out of the way for
  * unrestricted members.
+ *
+ * `initialData` is fetched server-side so the card renders filled in on the
+ * first paint instead of popping in after hydration.
  */
 export function MemberLimitsCard({
 	organizationId,
+	initialData,
 }: {
 	organizationId: string;
+	initialData?: MyMemberBudgetData;
 }) {
-	const { data } = useMyMemberBudget(organizationId);
+	const { data } = useMyMemberBudget(organizationId, initialData);
 
 	const budget = data?.budget ?? null;
 	const spend = data?.spend ?? null;

--- a/apps/ui/src/hooks/useTeam.ts
+++ b/apps/ui/src/hooks/useTeam.ts
@@ -7,6 +7,9 @@ import type { paths } from "@/lib/api/v1";
 export type TeamMembersData =
 	paths["/team/{organizationId}/members"]["get"]["responses"][200]["content"]["application/json"];
 
+export type MyMemberBudgetData =
+	paths["/team/{organizationId}/members/me"]["get"]["responses"][200]["content"]["application/json"];
+
 export function useTeamMembers(
 	organizationId: string | undefined,
 	initialData?: TeamMembersData,
@@ -33,7 +36,10 @@ export function useTeamMembers(
 
 // The authenticated user's OWN budget/spend for an org (self-service, no admin
 // gate) — so members can see the limits an admin has set on them.
-export function useMyMemberBudget(organizationId: string) {
+export function useMyMemberBudget(
+	organizationId: string,
+	initialData?: MyMemberBudgetData,
+) {
 	const api = useApi();
 
 	return api.useQuery(
@@ -47,6 +53,7 @@ export function useMyMemberBudget(organizationId: string) {
 			},
 		},
 		{
+			...(initialData ? { initialData } : {}),
 			enabled: !!organizationId,
 		},
 	);


### PR DESCRIPTION
## Problem

On `/dashboard/[orgId]/[projectId]/me`, the **Your usage limits** card (the limits an organization admin set on the member) was rendered entirely client-side: the page was a bare client component, and `useMyMemberBudget` fired `GET /team/{organizationId}/members/me` only after hydration. The card was therefore missing from the server HTML and popped in a beat later, shifting everything below it down.

## Approach

Turn `me/page.tsx` into an async server component that fetches the member budget with `fetchServerData`, and thread it down to `MemberLimitsCard` as react-query `initialData` — the same `initialData` pattern the project dashboard and API-keys pages already use (`useTeamMembers` takes it the same way). The client query still runs on mount, so the card stays live; it just starts filled in.

Nothing else on the page is server-rendered here: the `/analytics/me` query is keyed on the browser's IANA time zone, which isn't available server-side, so pre-fetching it would produce a hydration mismatch rather than a faster paint.

## Verification

Ran the stack locally (isolated slot) and fetched the page HTML with a seeded `developer@example.com` session — that member has `maxApiKeys: 3`, `usageLimit: 50`, `periodUsageLimit: 10/day`:

| | card in server HTML |
| --- | --- |
| before | 0 matches for `Your usage limits` |
| after | card present, with `$50.00`, `$10.00`, `per day`, `of key limit` |

Screenshots below are taken at first paint (the client-side `members/me` request held open), so they show what SSR alone puts on screen.

### Before

<img width="1280" alt="Developer dashboard, light theme, no limits card at first paint" src="https://raw.githubusercontent.com/theopenco/llmgateway/d618fdf6ec78c273ad153f99284004c0f8914a33/me-before-light.png" />

<img width="1280" alt="Developer dashboard, dark theme, no limits card at first paint" src="https://raw.githubusercontent.com/theopenco/llmgateway/d618fdf6ec78c273ad153f99284004c0f8914a33/me-before-dark.png" />

### After

<img width="1280" alt="Developer dashboard, light theme, limits card pre-filled at first paint" src="https://raw.githubusercontent.com/theopenco/llmgateway/d618fdf6ec78c273ad153f99284004c0f8914a33/me-after-light.png" />

<img width="1280" alt="Developer dashboard, dark theme, limits card pre-filled at first paint" src="https://raw.githubusercontent.com/theopenco/llmgateway/d618fdf6ec78c273ad153f99284004c0f8914a33/me-after-dark.png" />

`pnpm format` and `pnpm build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Member budget and usage information now appears on the initial dashboard load.
  * Dashboard views load budget data for the selected organization and project before rendering.
  * Usage limits remain available through client-side updates after the initial display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->