### PR TITLE
feat(models): expand alibaba regions, drop dead ones

### DIFF
--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -79,6 +79,10 @@ export const alibabaModels = [
 				vision: true,
 				tools: true,
 				jsonOutput: true,
+				// Both declared regions are dead: Singapore answers 403 access_denied
+				// and Beijing 404 model_not_found, while plain `qwen-max` still serves
+				// in both.
+				deactivatedAt: new Date("2026-08-11"),
 			},
 		],
 	},
@@ -119,6 +123,7 @@ export const alibabaModels = [
 				],
 				regions: [
 					{ id: "singapore" },
+					{ id: "eu-frankfurt" },
 					{
 						id: "us-virginia",
 						inputPrice: "0.115e-6",
@@ -320,6 +325,52 @@ export const alibabaModels = [
 						],
 					},
 					{
+						id: "eu-frankfurt",
+						pricingTiers: [
+							{
+								name: "Up to 256K",
+								upToTokens: 256000,
+								inputPrice: "0.05e-6",
+								outputPrice: "0.4e-6",
+								cachedInputPrice: "0.01e-6",
+								cacheReadInputPrice: "0.005e-6",
+								cacheWriteInputPrice: "0.0625e-6",
+							},
+							{
+								name: "Over 256K",
+								upToTokens: Infinity,
+								inputPrice: "0.25e-6",
+								outputPrice: "2.0e-6",
+								cachedInputPrice: "0.05e-6",
+								cacheReadInputPrice: "0.025e-6",
+								cacheWriteInputPrice: "0.3125e-6",
+							},
+						],
+					},
+					{
+						id: "us-virginia",
+						pricingTiers: [
+							{
+								name: "Up to 256K",
+								upToTokens: 256000,
+								inputPrice: "0.05e-6",
+								outputPrice: "0.4e-6",
+								cachedInputPrice: "0.01e-6",
+								cacheReadInputPrice: "0.005e-6",
+								cacheWriteInputPrice: "0.0625e-6",
+							},
+							{
+								name: "Over 256K",
+								upToTokens: Infinity,
+								inputPrice: "0.25e-6",
+								outputPrice: "2.0e-6",
+								cachedInputPrice: "0.05e-6",
+								cacheReadInputPrice: "0.025e-6",
+								cacheWriteInputPrice: "0.3125e-6",
+							},
+						],
+					},
+					{
 						id: "cn-beijing",
 						inputPrice: "0.022e-6",
 						outputPrice: "0.216e-6",
@@ -379,6 +430,7 @@ export const alibabaModels = [
 				externalId: "qwen-omni-turbo",
 				inputPrice: "0.2e-6",
 				outputPrice: "0.8e-6",
+				regions: [{ id: "singapore" }, { id: "cn-beijing" }],
 				requestPrice: "0",
 				contextSize: 32768,
 				maxOutput: 8192,
@@ -1975,8 +2027,12 @@ export const alibabaModels = [
 				externalId: "qwen3.5-397b-a17b",
 				inputPrice: "0.6e-6",
 				outputPrice: "3.6e-6",
+				// No eu-frankfurt: the model answers there, but takes ~120s even for a
+				// single token and returns garbage content, while other models on the
+				// same host reply in ~2s. Tool calls and JSON output never return.
 				regions: [
 					{ id: "singapore" },
+					{ id: "us-virginia" },
 					{
 						id: "cn-beijing",
 						inputPrice: "0.172e-6",
@@ -2306,7 +2362,7 @@ export const alibabaModels = [
 				externalId: "qwen-coder-plus",
 				inputPrice: "0.502e-6",
 				outputPrice: "1.004e-6",
-				regions: [{ id: "cn-beijing" }],
+				regions: [{ id: "singapore" }, { id: "cn-beijing" }],
 				requestPrice: "0",
 				contextSize: 131072,
 				maxOutput: 8192,
@@ -2335,6 +2391,47 @@ export const alibabaModels = [
 				regions: [
 					{
 						id: "singapore",
+						pricingTiers: [
+							{
+								name: "Up to 32K",
+								upToTokens: 32000,
+								inputPrice: "0.3e-6",
+								outputPrice: "1.5e-6",
+								cachedInputPrice: "0.06e-6",
+								cacheReadInputPrice: "0.03e-6",
+								cacheWriteInputPrice: "0.375e-6",
+							},
+							{
+								name: "32K-128K",
+								upToTokens: 128000,
+								inputPrice: "0.5e-6",
+								outputPrice: "2.5e-6",
+								cachedInputPrice: "0.1e-6",
+								cacheReadInputPrice: "0.05e-6",
+								cacheWriteInputPrice: "0.625e-6",
+							},
+							{
+								name: "128K-256K",
+								upToTokens: 256000,
+								inputPrice: "0.8e-6",
+								outputPrice: "4.0e-6",
+								cachedInputPrice: "0.16e-6",
+								cacheReadInputPrice: "0.08e-6",
+								cacheWriteInputPrice: "1.0e-6",
+							},
+							{
+								name: "Over 256K",
+								upToTokens: Infinity,
+								inputPrice: "1.6e-6",
+								outputPrice: "9.6e-6",
+								cachedInputPrice: "0.32e-6",
+								cacheReadInputPrice: "0.16e-6",
+								cacheWriteInputPrice: "2.0e-6",
+							},
+						],
+					},
+					{
+						id: "eu-frankfurt",
 						pricingTiers: [
 							{
 								name: "Up to 32K",
@@ -2495,6 +2592,38 @@ export const alibabaModels = [
 				regions: [
 					{
 						id: "singapore",
+						pricingTiers: [
+							{
+								name: "Up to 32K",
+								upToTokens: 32000,
+								inputPrice: "0.2e-6",
+								outputPrice: "1.6e-6",
+								cachedInputPrice: "0.04e-6",
+								cacheReadInputPrice: "0.02e-6",
+								cacheWriteInputPrice: "0.25e-6",
+							},
+							{
+								name: "32K-128K",
+								upToTokens: 128000,
+								inputPrice: "0.3e-6",
+								outputPrice: "2.4e-6",
+								cachedInputPrice: "0.06e-6",
+								cacheReadInputPrice: "0.03e-6",
+								cacheWriteInputPrice: "0.375e-6",
+							},
+							{
+								name: "128K-256K",
+								upToTokens: 256000,
+								inputPrice: "0.6e-6",
+								outputPrice: "4.8e-6",
+								cachedInputPrice: "0.12e-6",
+								cacheReadInputPrice: "0.06e-6",
+								cacheWriteInputPrice: "0.75e-6",
+							},
+						],
+					},
+					{
+						id: "eu-frankfurt",
 						pricingTiers: [
 							{
 								name: "Up to 32K",
@@ -2839,6 +2968,10 @@ export const alibabaModels = [
 				vision: true,
 				tools: false,
 				jsonOutput: true,
+				// Model Studio answers 403 access_denied on both hosts that serve it
+				// (Singapore and Beijing) and 404s everywhere else, so no request can
+				// succeed on this mapping.
+				deactivatedAt: new Date("2026-08-11"),
 			},
 		],
 	},
@@ -3096,6 +3229,8 @@ export const alibabaModels = [
 						outputPrice: "1.651e-6",
 						cachedInputPrice: "0.0276e-6",
 					},
+					{ id: "us-virginia" },
+					{ id: "cn-beijing" },
 				],
 				requestPrice: "0",
 				contextSize: 262144,
@@ -3146,7 +3281,12 @@ export const alibabaModels = [
 				externalId: "qwen3.6-35b-a3b",
 				inputPrice: "0.248e-6",
 				outputPrice: "1.485e-6",
-				regions: [{ id: "singapore" }],
+				regions: [
+					{ id: "singapore" },
+					{ id: "eu-frankfurt" },
+					{ id: "us-virginia" },
+					{ id: "cn-beijing" },
+				],
 				requestPrice: "0",
 				contextSize: 262144,
 				maxOutput: 65536,
@@ -3247,6 +3387,7 @@ export const alibabaModels = [
 				],
 				regions: [
 					{ id: "singapore" },
+					{ id: "eu-frankfurt" },
 					{
 						id: "us-virginia",
 						inputPrice: "0.165e-6",

--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -351,6 +351,7 @@ export const deepseekModels = [
 				outputPrice: "4.8e-6",
 				regions: [
 					{ id: "singapore" },
+					{ id: "eu-frankfurt" },
 					{ id: "us-virginia" },
 					{
 						id: "cn-beijing",
@@ -584,6 +585,7 @@ export const deepseekModels = [
 				outputPrice: "0.4e-6",
 				regions: [
 					{ id: "singapore" },
+					{ id: "eu-frankfurt" },
 					{ id: "us-virginia" },
 					{
 						id: "cn-beijing",

--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -300,7 +300,11 @@ export const moonshotModels = [
 				externalId: "kimi-k2.5",
 				inputPrice: "0.574e-6",
 				outputPrice: "3.011e-6",
-				regions: [{ id: "cn-beijing" }],
+				regions: [
+					{ id: "eu-frankfurt" },
+					{ id: "us-virginia" },
+					{ id: "cn-beijing" },
+				],
 				requestPrice: "0",
 				contextSize: 262144,
 				maxOutput: 98304,

--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -128,7 +128,12 @@ export const zaiModels = [
 				inputPrice: "1.4e-6",
 				cachedInputPrice: "0.28e-6",
 				outputPrice: "4.4e-6",
-				regions: [{ id: "singapore" }],
+				regions: [
+					{ id: "singapore" },
+					{ id: "eu-frankfurt" },
+					{ id: "us-virginia" },
+					{ id: "cn-beijing" },
+				],
 				requestPrice: "0",
 				contextSize: 1000000,
 				maxOutput: 131072,


### PR DESCRIPTION
Follow-up to #3532, which covered only the Qwen 3.7/3.8 line. This sweeps the rest of the Alibaba catalogue.

## What was found

Every Alibaba-hosted model was probed against all four Model Studio endpoints with that region's real key. 22 model/region pairs serve traffic but were not declared, and two mappings turned out to be dead everywhere they claim to work.

**Regions added**

| model | added |
| --- | --- |
| `deepseek-v4-pro`, `deepseek-v4-flash` | `eu-frankfurt` |
| `kimi-k2.5` | `eu-frankfurt`, `us-virginia` |
| `qwen-plus`, `qwen3-coder-flash`, `qwen3-vl-plus`, `qwen3.6-flash` | `eu-frankfurt` |
| `qwen-flash` | `eu-frankfurt`, `us-virginia` |
| `qwen3.5-397b-a17b` | `us-virginia` |
| `qwen3.6-plus` | `us-virginia`, `cn-beijing` |
| `qwen3.6-35b-a3b`, `glm-5.2` | `eu-frankfurt`, `us-virginia`, `cn-beijing` |
| `qwen-coder-plus` | `singapore` |
| `qwen-omni-turbo` | `singapore`, `cn-beijing` (had no `regions` array at all) |

**Mappings deactivated** — both are unreachable in every region they declare, so any request routed to them fails:

- `qwen-max-latest` — 403 `access_denied` in Singapore, 404 `model_not_found` in Beijing. Plain `qwen-max` still serves in both, so this is the dated alias being retired, not an outage.
- `qwen2.5-vl-32b-instruct` — 403 `access_denied` on both hosts that would serve it, 404 elsewhere.

**One region deliberately not added.** `qwen3.5-397b-a17b` answers in Frankfurt, but takes ~120s for a single token and returns garbage content (`"assistant"`), while tool calls and JSON output never return at all. `qwen3.6-flash` on the same host replies in 2.1s, and the same model in Singapore/US Virginia replies in 2–3s, so it is that deployment, not the endpoint or the model. Verified against both the workspace host and the shared `trial.` host. A comment on the mapping records why, so nobody adds it back from a naive availability probe — my own first probe recorded it as "OK" precisely because it had no timeout.

## Pricing

New region entries carry the mapping's global list price, as in #3532 and as every other unverified Alibaba region entry already does. Where the Singapore entry defines pricing *tiers* (`qwen-flash`, `qwen3-coder-flash`, `qwen3-vl-plus`), the new international entries replicate that tier structure verbatim rather than inheriting the flat base price — otherwise long-context requests would bill at the short-context rate.

## Verification

`pnpm format`, `pnpm build`, and the models + `alibaba-pricing` specs (307 tests) pass. A catalogue/live cross-check reports zero mismatches in both directions: every declared region serves, and every serving region is declared.

Real e2e, one pass per region with `LLM_ALIBABA_API_KEY` pointed at that region's key (the seeded BYOK key only ever reads that slot):

| region | new-variant cases |
| --- | --- |
| `singapore` | 17 passed / 0 failed |
| `eu-frankfurt` | 132 passed / 0 failed |
| `us-virginia` | 97 passed / 0 failed |
| `cn-beijing` | 62 passed / 0 failed |

The Frankfurt run also produced 9 failures for `qwen3.5-397b-a17b:eu-frankfurt` — that is the deployment described above, and the entry has since been removed. Remaining red in every run is unrelated: six provider-key registration cases for providers with no local key (AtlasCloud, AWS Mantle, Azure, Azure AI Foundry, ElevenLabs, Sakana AI), plus in the non-Singapore runs the two Alibaba key-registration cases, which validate `LLM_ALIBABA_API_KEY` against the Singapore host while that variable holds another region's key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded regional availability and pricing for multiple Qwen models, including deployments in Frankfurt, Virginia, Singapore, and Beijing.
  * Added Frankfurt availability for DeepSeek V4 Pro and V4 Flash.
  * Expanded Kimi K2.5 availability to Frankfurt and Virginia.
  * Expanded GLM-5.2 availability to Frankfurt, Virginia, and Beijing.
* **Model Availability**
  * Qwen Max Latest and Qwen2.5-VL-32B-Instruct are scheduled for deactivation on August 11, 2026.
  * Updated availability notices for selected model endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->