### PR TITLE
fix(gateway): cache multi-candidate tool call ids

### DIFF
--- a/apps/gateway/src/chat/tools/transform-response-to-openai.spec.ts
+++ b/apps/gateway/src/chat/tools/transform-response-to-openai.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import {
 	applyExtendedUsageFields,
@@ -6,6 +6,23 @@ import {
 	stripRequestScopedMetadataFromOpenAiResponse,
 	withCurrentRequestMetadataOnOpenAiResponse,
 } from "./transform-response-to-openai.js";
+
+const { setexMock } = vi.hoisted(() => ({
+	setexMock: vi.fn().mockResolvedValue("OK"),
+}));
+
+vi.mock("@llmgateway/cache", () => ({
+	redisClient: {
+		setex: setexMock,
+	},
+}));
+
+vi.mock("@llmgateway/logger", () => ({
+	logger: {
+		warn: vi.fn(),
+		error: vi.fn(),
+	},
+}));
 
 describe("transformResponseToOpenai", () => {
 	test("includes request_id in response metadata", () => {
@@ -259,22 +276,126 @@ describe("transformResponseToOpenai", () => {
 		expect(response.choices).toHaveLength(2);
 		expect(response.choices[0].message.tool_calls).toHaveLength(1);
 		expect(response.choices[0].message.tool_calls[0]).toMatchObject({
-			id: "get_weather_0_0",
 			function: {
 				name: "get_weather",
 				arguments: JSON.stringify({ city: "Paris" }),
 			},
 		});
+		expect(response.choices[0].message.tool_calls[0].id).toMatch(
+			/^get_weather_/,
+		);
 		expect(response.choices[0].finish_reason).toBe("tool_calls");
 		expect(response.choices[1].message.tool_calls).toHaveLength(1);
 		expect(response.choices[1].message.tool_calls[0]).toMatchObject({
-			id: "get_weather_1_0",
 			function: {
 				name: "get_weather",
 				arguments: JSON.stringify({ city: "Rome" }),
 			},
 		});
+		expect(response.choices[1].message.tool_calls[0].id).toMatch(
+			/^get_weather_/,
+		);
+		expect(response.choices[1].message.tool_calls[0].id).not.toBe(
+			response.choices[0].message.tool_calls[0].id,
+		);
 		expect(response.choices[1].finish_reason).toBe("tool_calls");
+	});
+
+	test("keeps multi-candidate Google tool_call ids in the thought_signature cache", () => {
+		setexMock.mockClear();
+		const json = {
+			candidates: [
+				{
+					content: {
+						parts: [
+							{
+								functionCall: { name: "get_weather", args: { city: "Paris" } },
+								thoughtSignature: "sig-candidate-0",
+							},
+						],
+						role: "model",
+					},
+					finishReason: "STOP",
+					index: 0,
+				},
+				{
+					content: {
+						parts: [
+							{
+								functionCall: { name: "get_weather", args: { city: "Rome" } },
+								thoughtSignature: "sig-candidate-1",
+							},
+						],
+						role: "model",
+					},
+					finishReason: "STOP",
+					index: 1,
+				},
+			],
+		};
+		// What parseProviderResponse emits for candidate 0: a unique
+		// `${name}_${shortid(24)}` id plus the inline signature, with the
+		// signature cached in Redis under `thought_signature:<id>`.
+		const parsedToolCalls = [
+			{
+				id: "get_weather_cachedid0",
+				type: "function",
+				function: {
+					name: "get_weather",
+					arguments: JSON.stringify({ city: "Paris" }),
+				},
+				extra_content: {
+					google: { thought_signature: "sig-candidate-0" },
+				},
+			},
+		];
+
+		const response = transformResponseToOpenai(
+			"google-ai-studio",
+			"gemini-2.5-flash",
+			json,
+			null,
+			null,
+			"STOP",
+			10,
+			20,
+			30,
+			null,
+			null,
+			parsedToolCalls,
+			[],
+			"gemini-2.5-flash",
+			null,
+			"gemini-2.5-flash",
+			null,
+			false,
+			null,
+			null,
+			"req_google_n_tools_signature",
+		);
+
+		expect(response.choices).toHaveLength(2);
+		// Choice 0 reuses the tool calls from parseProviderResponse, so the id
+		// the client sends back is the one the signature was cached under.
+		expect(response.choices[0].message.tool_calls).toEqual(parsedToolCalls);
+		// Candidates parse did not process get the same treatment: a unique
+		// id, the inline signature, and a Redis entry under the emitted id.
+		const choice1ToolCall = response.choices[1].message.tool_calls[0];
+		expect(choice1ToolCall.id).toMatch(/^get_weather_/);
+		expect(choice1ToolCall.id).not.toBe(parsedToolCalls[0].id);
+		expect(choice1ToolCall.extra_content).toEqual({
+			google: { thought_signature: "sig-candidate-1" },
+		});
+		expect(setexMock).toHaveBeenCalledWith(
+			`thought_signature:${choice1ToolCall.id}`,
+			86400,
+			"sig-candidate-1",
+		);
+		expect(setexMock).not.toHaveBeenCalledWith(
+			`thought_signature:${parsedToolCalls[0].id}`,
+			expect.anything(),
+			expect.anything(),
+		);
 	});
 
 	test("does not overwrite choice 0 content on multi-choice OpenAI responses", () => {

--- a/apps/gateway/src/chat/tools/transform-response-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-response-to-openai.ts
@@ -1,3 +1,7 @@
+import { redisClient } from "@llmgateway/cache";
+import { shortid } from "@llmgateway/db";
+import { logger } from "@llmgateway/logger";
+
 import { dedupeGoogleCandidateParts } from "./google-candidates.js";
 import { mapFinishReasonToOpenai } from "./map-finish-reason-to-openai.js";
 import { formatUsedModelForDisplay } from "./resolve-provider-context.js";
@@ -450,16 +454,55 @@ export function transformResponseToOpenai(
 							const candidateIndex = candidate.index ?? position;
 							const candidateToolCalls = candidateParts
 								.filter((part: any) => part.functionCall)
-								.map((part: any, fcIndex: number) => ({
-									// Same id scheme as parse-provider-response so choice 0's
-									// ids line up with the cached thought signatures.
-									id: `${part.functionCall.name}_${candidateIndex}_${fcIndex}`,
-									type: "function",
-									function: {
-										name: part.functionCall.name,
-										arguments: JSON.stringify(part.functionCall.args ?? {}),
-									},
-								}));
+								.map((part: any, fcIndex: number) => {
+									// parseProviderResponse only processes candidate 0, and it
+									// caches the thought signature under the id it emits
+									// (`${name}_${shortid(24)}`, as `thought_signature:<id>` in
+									// Redis). Reuse those exact tool calls so the id the client
+									// echoes back on the next turn is the one the signature is
+									// cached under. Regenerating a name+index id here (the scheme
+									// parse abandoned in #1448) made the Redis lookup miss and
+									// Gemini reject the replay with "Corrupted thought signature".
+									// Candidates parse did not process (1+) get the same
+									// treatment inline: unique id, inline signature, and the
+									// Redis entry under the emitted id.
+									if (
+										position === 0 &&
+										Array.isArray(toolResults) &&
+										toolResults[fcIndex]
+									) {
+										return toolResults[fcIndex];
+									}
+									const toolCall: any = {
+										id: `${part.functionCall.name}_${shortid(24)}`,
+										type: "function",
+										function: {
+											name: part.functionCall.name,
+											arguments: JSON.stringify(part.functionCall.args ?? {}),
+										},
+									};
+									if (part.thoughtSignature) {
+										toolCall.extra_content = {
+											google: {
+												thought_signature: part.thoughtSignature,
+											},
+										};
+										// Same cache as parse-provider-response: the id is the
+										// `thought_signature:<id>` key read back on the next turn.
+										redisClient
+											.setex(
+												`thought_signature:${toolCall.id}`,
+												86400,
+												part.thoughtSignature,
+											)
+											.catch((err) => {
+												logger.error("Failed to cache thought_signature", {
+													err,
+												});
+											});
+									}
+									return toolCall;
+								});
 							return {
 								index: candidateIndex,
 								message: {


### PR DESCRIPTION
## Summary

`parseProviderResponse` (Google branch) caches Gemini thought signatures in
Redis under the id it emits — `${name}_${shortid(24)}`, as
`thought_signature:<id>` — so the signature can be re-injected when the client
replays the call next turn. The `n > 1` branch of `transformResponseToOpenai`
(`apps/gateway/src/chat/tools/transform-response-to-openai.ts:454-456`)
regenerated tool calls from the raw parts with `${name}_${candidateIndex}_${fcIndex}`
ids and dropped `extra_content`, so the id the client echoes back never matches
the cached key. The next-turn lookup in `chat.ts`
(`redisClient.get("thought_signature:" + toolCall.id)`) misses, the signature
is not re-injected, and Gemini rejects the replay with *"Corrupted thought
signature"* — the exact failure the shortid fix (#1448) eliminated on the
streaming path. The `n > 1` branch is the one path left behind: the
single-candidate path reuses parse's `toolResults` and is consistent.

This is the same "forgotten sibling branch" pattern as #3492 (our previous
fix) and #3504 (the maintainer's own follow-up).

## Fix

Two changes in the multi-candidate branch:

- **Candidate 0** reuses the tool calls from `toolResults` (what
  `parseProviderResponse` already emitted and cached), so the id the client
  receives is exactly the one the signature is cached under.
- **Candidates 1+** (which parse does not process) get the same treatment
  parse applies to candidate 0: a unique `${name}_${shortid(24)}` id, the
  inline `extra_content.google.thought_signature`, and the
  `setex("thought_signature:<id>", 86400, sig)` Redis entry under the emitted
  id.

Fallback keeps the branch safe: if `toolResults` is absent for candidate 0
(e.g. no tool calls parsed), the shortid path applies.

## Tests

`transform-response-to-openai.spec.ts`:

- The existing multi-candidate test no longer pins the broken
  `${name}_${candidateIndex}_${fcIndex}` ids; it asserts the id scheme and
  that candidates are distinct.
- New test: `keeps multi-candidate Google tool_call ids in the thought_signature
  cache` — mocks `@llmgateway/cache` (`setex`) and asserts:
  - choice 0 reuses the parsed tool calls verbatim (id + inline signature);
  - choice 1 gets a unique id, `extra_content` with its own signature, and a
    `setex("thought_signature:<id>", 86400, sig)` call under the emitted id;
  - no `setex` is written under choice 0's id from the transform (parse
    already did that).

## Verification

Every command below was run and its output captured. The record is
reproducible — commands included so you can re-run them.

**red — probe against main (c1cd97ba), real functions via esbuild, before the
fix** (harness preserved at the hub):

```
parse toolResults[0].id      : get_weather_xxxxxxxxxxxxxxxxxxxxxxxx
                             + extra_content.google.thought_signature
Redis writes made by parse   : [{"key":"thought_signature:get_weather_xxxxxxxxxxxxxxxxxxxxxxxx", …}]
transform choice 0 tool_calls: id get_weather_0_0, extra_content undefined
RESULT: MISMATCH — next-turn GET thought_signature:get_weather_0_0 misses;
signature lost, Gemini 3 rejects replay
=== control (n=1) ===
CONTROL RESULT: MATCH — single-candidate path is consistent
```

**green — same probe after the fix**:

```
choice 0 tool_calls: id get_weather_xxxxxxxxxxxxxxxxxxxxxxxx
                     extra_content.google.thought_signature sig-candidate-0
choice 1 tool_calls: id get_weather_xxxxxxxxxxxxxxxxxxxxxxxx
                     extra_content.google.thought_signature sig-candidate-1
Redis writes: thought_signature:get_weather_xxx = sig-candidate-0
              thought_signature:get_weather_xxx = sig-candidate-1
RESULT: MATCH (no bug)
CONTROL RESULT: MATCH — single-candidate path is consistent
```

(The deterministic shortid stub makes both candidate ids equal in the probe;
the real `shortid` yields unique ids per candidate, asserted in the spec.)

**green — vitest, full spec**:

```
$ pnpm exec vitest run apps/gateway/src/chat/tools/transform-response-to-openai.spec.ts --no-file-parallelism
 ✓ apps/gateway/src/chat/tools/transform-response-to-openai.spec.ts (14 tests) 24ms
 Test Files  1 passed (1)
      Tests  14 passed (14)
[exit code 0]
```

**Area suite** — `vitest run apps/gateway/src/chat/tools`: **593/603 tests,
37/38 files pass**. The only failing file is
`openai-content-filter.spec.ts` (10 tests), a service-harness spec whose
fetch/Redis mocks time out in this environment; it imports only
`openai-content-filter.ts`, which this change does not touch (same class of
harness failures documented in previous PRs here).

<details><summary>Environment</summary>

```
so: Windows 11 (AMD64)
node --version: v24.14.1
pnpm --version: 9.15.9 (via npx; repo packageManager is pnpm@10.30.3)
vitest: 4.1.8
base: c1cd97ba5c5483b9493a2e5632855155702387e3 (origin/main @ 08-09)
fix commit: 7e76bf9b (2 files, +177/−13)
```

</details>

**Gates:** eslint ✅ on both files (after `import/order` fix) · prettier ✅ ·
`git diff --check` clean · gateway typecheck ✅ (builds in `build:core`,
turbo 12/12) · `pnpm-lock.yaml` untouched.

**Collisions:** no open PR touches the multi-candidate Google tool_call ids /
thought_signature path (checked live 2026-08-11). #3486 (reasoning tokens)
and #3233 (Claude on Azure) also touch `transform-response-to-openai.ts` but
in unrelated areas (usage tokens / new provider branch); no semantic overlap.

Not verified: a live multi-turn round-trip against Gemini (no provider keys on
this machine). The id↔Redis-key chain is covered end-to-end by the spec's
`setex` assertions and the probe's recorded Redis writes.

---

Disclosure: an AI coding assistant helped locate the drift and draft the test
scaffolding. The reproduction, the red→green cycle and this write-up were
verified by running the code; I own the change and will follow up on review
comments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Google responses containing multiple candidates and tool calls.
  * Preserved candidate-specific thought signatures for reliable follow-up processing.
  * Prevented tool-call identifiers and cached data from being overwritten across candidates.
  * Added graceful logging when caching metadata cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
