### PR TITLE
fix(gateway): route bare ids over regions

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -4398,7 +4398,22 @@ chat.openapi(completions, async (c) => {
 			});
 		}
 
-		if (iamFilteredModelProviders.length === 1) {
+		// Only a genuinely single candidate may skip provider selection. A bare
+		// model id (no provider prefix) leaves `modelInfo.providers` un-expanded:
+		// one entry per provider, its `region` undefined and the concrete regions
+		// still inside its `regions` array. Gating on that count alone therefore
+		// pins `usedRegion = undefined` for a provider with several regions and
+		// sends the request to the provider's default region, so `qwen3.7-plus`
+		// and `alibaba/qwen3.7-plus` — the same request, two spellings — resolve
+		// different regions at different prices. Gate on the expanded count as
+		// well so those candidates go through the routing branch below, which
+		// prices the regions against each other. Providers that pin their default
+		// region (AWS Bedrock) are collapsed straight back to it there by
+		// `applyPinnedDefaultRegions`, so their routing is unchanged.
+		if (
+			iamFilteredModelProviders.length === 1 &&
+			expandedIamFilteredModelProviders.length === 1
+		) {
 			usedProvider = iamFilteredModelProviders[0].providerId;
 			usedInternalModel = modelInfo.id;
 			usedExternalId = iamFilteredModelProviders[0].externalId;

--- a/apps/gateway/src/chat/managed-credentials.spec.ts
+++ b/apps/gateway/src/chat/managed-credentials.spec.ts
@@ -477,7 +477,9 @@ describe("managed provider credentials", () => {
 	 * provider's default region, so the credential pinned to that region is the
 	 * one that serves it. Falling through to "no managed credential" 500s every
 	 * region-less request the moment the last region-agnostic credential goes
-	 * away.
+	 * away. Uses `qwen-omni-turbo`, whose mapping has no regional variants at
+	 * all, so the request genuinely resolves no region — a model with regional
+	 * variants routes over those instead (see the cheapest-region test below).
 	 */
 	test("serves a region-less request from the default-region credential", async () => {
 		await seedApiKey();
@@ -497,12 +499,47 @@ describe("managed provider credentials", () => {
 		const captured = captureUpstream(chatCompletion);
 
 		// Bare model id: no provider prefix and no `:region` suffix.
-		const res = await completions("qwen3.7-plus");
+		const res = await completions("qwen-omni-turbo");
 		expect(res.status).toBe(200);
 
 		expect(captured).toHaveLength(1);
 		expect(captured[0].url).toContain("dashscope-intl.aliyuncs.com");
 		expect(captured[0].authorization).toBe("Bearer sk-managed-singapore");
+	});
+
+	/**
+	 * A bare model id must route over the provider's regional variants exactly
+	 * like the `provider/model` spelling does: the credentialed regions are
+	 * priced against each other and the cheapest one wins. The single-provider
+	 * shortcut used to read the un-expanded mapping's `region: undefined` and
+	 * send every such request to the default region, so `qwen3.7-plus` and
+	 * `alibaba/qwen3.7-plus` — the same request, two spellings — picked
+	 * different regions at different prices.
+	 */
+	test("routes a bare multi-region id to the cheapest eligible region", async () => {
+		await seedApiKey();
+		await seedManagedCredential({
+			id: "managed-alibaba-singapore",
+			provider: "alibaba",
+			token: "sk-managed-singapore",
+			region: "singapore",
+		});
+		await seedManagedCredential({
+			id: "managed-alibaba-frankfurt",
+			provider: "alibaba",
+			token: "sk-managed-frankfurt",
+			region: "eu-frankfurt",
+		});
+
+		const captured = captureUpstream(chatCompletion);
+
+		// Frankfurt undercuts the mapping's (singapore) prices for this model.
+		const res = await completions("qwen3.7-plus");
+		expect(res.status).toBe(200);
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0].url).toContain("eu-central-1.maas.aliyuncs.com");
+		expect(captured[0].authorization).toBe("Bearer sk-managed-frankfurt");
 	});
 
 	test("serves each pinned region from its own credential", async () => {


### PR DESCRIPTION
Fixes #3530. Supersedes #3533.

## Problem

The same request spelled two ways picks two different regions:

| Request | Region chosen |
| --- | --- |
| `{"model": "alibaba/qwen3.7-plus"}` | cheapest eligible region (`eu-frankfurt`) |
| `{"model": "qwen3.7-plus"}` | always the default region (`singapore`) |

Without a provider prefix `useExpandedRoutingProviders` is false, so `modelInfo.providers` keeps the catalogue's un-expanded mappings — one Alibaba entry whose `region` is undefined, with the concrete regions still inside its `regions` array. When only that provider survives IAM/compliance/availability filtering, the single-provider shortcut in `chat.ts` takes it directly and reads `usedRegion` off that mapping, so `usedRegion` stays undefined and the request falls through to the provider's `defaultRegion`. `expandedIamFilteredModelProviders` — the region-expanded, credential-filtered list the multi-provider branch right below prices the regions over — is never consulted.

This is a missed optimization, not a billing bug: the un-expanded mapping carries the default region's prices and the request really is served by that endpoint, so cost accounting matches what was served.

## Fix

Gate the shortcut on the expanded candidate count as well, so a single provider with several credentialed regions falls into the normal routing branch and its regions get priced against each other. A genuinely single candidate (no `regions` array, or only one region credentialed) keeps the shortcut unchanged.

## Impact

Only mappings with more than one region can reach the new branch:

| Provider | Multi-region models | Effect |
| --- | --- | --- |
| `alibaba` | 21 (19 with per-region prices) | the intended change — bare ids now price regions |
| `aws-bedrock` | 16 | none: `pinDefaultRegion: true`, so `applyPinnedDefaultRegions` collapses straight back to `global` (covered by `pin-default-regions.spec.ts`) |
| `aws-mantle` | 3 | region can now be re-selected among credentialed US regions; all three price identically, so this is a tie broken on routing metrics |
| `vertex-openai` | 0 | none today |

`azure` is region-scoped through its credentials and filtered at the same pre-routing step, so it is unaffected. Service-tier narrowing already updates both candidate lists in lockstep, and session stickiness is preserved: the shortcut's explicit `sessionStore.set` is replaced by the routing branch's own sticky pinning.

One behavioural note: the shortcut skipped the provider-availability check entirely, so an api-keys-mode project with no key for a multi-region single-provider model used to fail later at credential resolution and now gets the routing branch's "No provider key set for any of the providers that support model X" up front. Same outcome, clearer message.

## Testing

- New `routes a bare multi-region id to the cheapest eligible region` in `managed-credentials.spec.ts`, verified **red before** the `chat.ts` change (routes to `dashscope-intl.aliyuncs.com`) and green after (`eu-central-1.maas.aliyuncs.com`, Frankfurt credential).
- The #3528 regression test `serves a region-less request from the default-region credential` now pins `qwen-omni-turbo`, whose mapping has no regional variants, so it still exercises the region-less path it was written for instead of accidentally asserting the behaviour this PR changes.
- `apps/gateway/src/chat/**`, `session-sticky.spec.ts`, `fallback.spec.ts`, `preferred-provider*.spec.ts` pass against an isolated Postgres/Redis stack.
- Verified live against a running gateway with the seeded DevPass Pro org (credits mode, managed Alibaba credentials for `singapore` + `eu-frankfurt`): before, `qwen3.7-plus` → `:singapore`, cost `1.52e-05`; after, `:eu-frankfurt`, cost `1.185e-05` for the identical request.

## What this deliberately does not do

#3533 additionally claimed bare ids were fully broken for coding/DevPass plans and that a `alibaba_region` provider-key pin was ignored on this path. Neither reproduces: on `main`, bare `qwen3.7-plus` / `qwen3.7-flash` / `qwen3.6-flash` / `qwen3-vl-flash` all return 200 on a DevPass org, and a bare id with a `cn-beijing` key pin already routes to `:cn-beijing` (the pin is applied at request execution, below the shortcut). The one configuration that genuinely cannot route — managed Alibaba credentials with none for the default region — fails before the shortcut is reached and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
