### PR TITLE
feat(routing): show which key served each attempt

### DIFF
--- a/apps/api/src/routes/logs.ts
+++ b/apps/api/src/routes/logs.ts
@@ -185,6 +185,16 @@ const logSchema = z.object({
 			selectionReason: z.string().optional(),
 			usedApiKeyHash: z.string().optional(),
 			usedCredentialSource: z.enum(["byok", "platform"]).optional(),
+			usedProviderKeyId: z.string().optional(),
+			usedProviderKeyLabel: z.string().optional(),
+			eligibleProviderKeys: z
+				.array(
+					z.object({
+						id: z.string(),
+						label: z.string().optional(),
+					}),
+				)
+				.optional(),
 			providerScores: z
 				.array(
 					z.object({
@@ -220,6 +230,8 @@ const logSchema = z.object({
 						succeeded: z.boolean(),
 						apiKeyHash: z.string().optional(),
 						credentialSource: z.enum(["byok", "platform"]).optional(),
+						providerKeyId: z.string().optional(),
+						providerKeyLabel: z.string().optional(),
 						logId: z.string().optional(),
 					}),
 				)

--- a/apps/api/src/routes/logs.ts
+++ b/apps/api/src/routes/logs.ts
@@ -184,6 +184,7 @@ const logSchema = z.object({
 			selectedProvider: z.string().optional(),
 			selectionReason: z.string().optional(),
 			usedApiKeyHash: z.string().optional(),
+			usedCredentialSource: z.enum(["byok", "platform"]).optional(),
 			providerScores: z
 				.array(
 					z.object({
@@ -218,6 +219,7 @@ const logSchema = z.object({
 						error_type: z.string(),
 						succeeded: z.boolean(),
 						apiKeyHash: z.string().optional(),
+						credentialSource: z.enum(["byok", "platform"]).optional(),
 						logId: z.string().optional(),
 					}),
 				)

--- a/apps/docs/content/features/routing.mdx
+++ b/apps/docs/content/features/routing.mdx
@@ -412,7 +412,7 @@ configured and the current key fails with a retryable error.
 
 ### Routing Transparency
 
-Every provider attempt — both failed and successful — is recorded in the `routing` array in the response metadata and activity logs:
+Every provider attempt — both failed and successful — is recorded in the `routing` array in the response metadata (streaming and non-streaming alike) and activity logs:
 
 ```json
 {
@@ -423,19 +423,34 @@ Every provider attempt — both failed and successful — is recorded in the `ro
 				"model": "gpt-4o",
 				"status_code": 500,
 				"error_type": "server_error",
-				"succeeded": false
+				"succeeded": false,
+				"credentialSource": "byok",
+				"apiKeyHash": "f029ee9"
 			},
 			{
 				"provider": "azure",
 				"model": "gpt-4o",
 				"status_code": 200,
 				"error_type": "none",
-				"succeeded": true
+				"succeeded": true,
+				"credentialSource": "platform",
+				"apiKeyHash": "ecb88d5"
 			}
 		]
 	}
 }
 ```
+
+#### Whose key served each attempt
+
+`credentialSource` says who owns the provider credential an attempt was sent with:
+
+| Value      | Meaning                                                                                                   |
+| ---------- | --------------------------------------------------------------------------------------------------------- |
+| `byok`     | Your own provider key. The provider bills you directly and the attempt is not deducted from your credits. |
+| `platform` | An LLM Gateway credential. The attempt runs on credits and is deducted from your balance.                 |
+
+This matters most in **hybrid** mode, where a request that fails on your own key falls back to LLM Gateway's credential: both attempts appear in the same `routing` array, and only `credentialSource` tells them apart — `apiKeyHash` is an opaque fingerprint that says two attempts used different keys, not which key was yours. The same value is stored on the log as `routingMetadata.usedCredentialSource` for the credential that ultimately served the request, and is shown as a **your key** / **LLM Gateway key** badge in the dashboard's routing view.
 
 ### Retried Log Tracking
 

--- a/apps/docs/content/features/routing.mdx
+++ b/apps/docs/content/features/routing.mdx
@@ -456,12 +456,15 @@ This matters most in **hybrid** mode, where a request that fails on your own key
 
 #### Which of your keys ran
 
-A `byok` attempt also carries the key itself: `providerKeyId`, and `providerKeyLabel` — the key as it is named on your [provider keys](https://llmgateway.io/dashboard) page (its name, or its masked token when it has none). So when several of your keys are configured for a provider and the gateway rotates between them, each attempt says which one it used instead of leaving you to decode a fingerprint. The log additionally records `routingMetadata.eligibleProviderKeys`: every one of your keys that was a candidate for the provider that served the request, in selection order.
+A `byok` attempt also carries the key itself: `providerKeyId`, and `providerKeyLabel` — the key as it is named on your [provider keys](https://llmgateway.io/dashboard) page (its name, or its masked token when it has none). So when several of your keys are configured for a provider and the gateway rotates between them, each attempt says which one it used instead of leaving you to decode a fingerprint.
+
+Chat requests additionally record `routingMetadata.eligibleProviderKeys` on the log: your keys that were candidates for the provider that served the request, in selection order. It is omitted for credits-mode projects, which route on LLM Gateway credentials, and for custom providers, whose keys are scoped by their own catalogue.
 
 <Callout type="info">
 	These fields describe **your** keys only. LLM Gateway's own credentials — the
 	ones that serve credits-mode traffic — are never named: a `platform` attempt
-	carries `credentialSource` and nothing else.
+	still reports `credentialSource` and `apiKeyHash`, but never `providerKeyId`
+	or `providerKeyLabel`.
 </Callout>
 
 ### Retried Log Tracking

--- a/apps/docs/content/features/routing.mdx
+++ b/apps/docs/content/features/routing.mdx
@@ -425,7 +425,9 @@ Every provider attempt — both failed and successful — is recorded in the `ro
 				"error_type": "server_error",
 				"succeeded": false,
 				"credentialSource": "byok",
-				"apiKeyHash": "f029ee9"
+				"apiKeyHash": "f029ee9",
+				"providerKeyId": "pk_2f9a...",
+				"providerKeyLabel": "billing-team-key"
 			},
 			{
 				"provider": "azure",
@@ -451,6 +453,16 @@ Every provider attempt — both failed and successful — is recorded in the `ro
 | `platform` | An LLM Gateway credential. The attempt runs on credits and is deducted from your balance.                 |
 
 This matters most in **hybrid** mode, where a request that fails on your own key falls back to LLM Gateway's credential: both attempts appear in the same `routing` array, and only `credentialSource` tells them apart — `apiKeyHash` is an opaque fingerprint that says two attempts used different keys, not which key was yours. The same value is stored on the log as `routingMetadata.usedCredentialSource` for the credential that ultimately served the request, and is shown as a **your key** / **LLM Gateway key** badge in the dashboard's routing view.
+
+#### Which of your keys ran
+
+A `byok` attempt also carries the key itself: `providerKeyId`, and `providerKeyLabel` — the key as it is named on your [provider keys](https://llmgateway.io/dashboard) page (its name, or its masked token when it has none). So when several of your keys are configured for a provider and the gateway rotates between them, each attempt says which one it used instead of leaving you to decode a fingerprint. The log additionally records `routingMetadata.eligibleProviderKeys`: every one of your keys that was a candidate for the provider that served the request, in selection order.
+
+<Callout type="info">
+	These fields describe **your** keys only. LLM Gateway's own credentials — the
+	ones that serve credits-mode traffic — are never named: a `platform` attempt
+	carries `credentialSource` and nothing else.
+</Callout>
 
 ### Retried Log Tracking
 

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -28,7 +28,6 @@ import {
 	findEffectiveDiscount,
 	findProviderKey,
 	findActiveProviderKeys,
-	listEligibleProviderKeys,
 	findProviderKeysByProviders,
 	type CustomModel,
 	type ManagedProviderAvailability,
@@ -272,6 +271,7 @@ import {
 	buildDevPlanCreditLimitError,
 	formatUsedModelForDisplay,
 	getAvailableCredits,
+	resolveEligibleProviderKeys,
 	resolveProviderContext,
 } from "./tools/resolve-provider-context.js";
 import { resolveReasoningTokens } from "./tools/resolve-reasoning-tokens.js";
@@ -825,32 +825,6 @@ function withUsedCredential(
 		usedProviderKeyId,
 		usedProviderKeyLabel,
 	};
-}
-
-/**
- * The organization's own keys that could have served this provider, in
- * selection order. Only BYOK-capable project modes have any: a credits-mode
- * project routes on platform credentials, which are never listed.
- */
-async function resolveEligibleProviderKeys(
-	projectMode: string,
-	organizationId: string,
-	provider: string,
-	filter?: (key: InferSelectModel<typeof tables.providerKey>) => boolean,
-): Promise<RoutingMetadata["eligibleProviderKeys"]> {
-	if (projectMode !== "api-keys" && projectMode !== "hybrid") {
-		return undefined;
-	}
-
-	const keys = await listEligibleProviderKeys(organizationId, provider, filter);
-	if (keys.length === 0) {
-		return undefined;
-	}
-
-	return keys.map((key) => ({
-		id: key.id,
-		label: providerKeyLabel(key),
-	}));
 }
 
 function usesGoogleQueryToken(provider: string): boolean {
@@ -5584,12 +5558,16 @@ chat.openapi(completions, async (c) => {
 		currentProviderKeyIdentity(),
 	);
 	if (routingMetadata) {
-		const eligibleProviderKeys = await resolveEligibleProviderKeys(
-			project.mode,
-			project.organizationId,
-			usedProvider,
+		// Same resolver (and therefore the same model-aware filter) the retry
+		// path uses, so the list never changes shape just because a request
+		// fell back.
+		const eligibleProviderKeys = await resolveEligibleProviderKeys({
+			projectMode: project.mode,
+			organizationId: project.organizationId,
+			provider: usedProvider,
+			usedInternalModel,
 			serviceTierKeyFilter,
-		);
+		});
 		if (eligibleProviderKeys) {
 			routingMetadata = { ...routingMetadata, eligibleProviderKeys };
 		}

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -313,6 +313,7 @@ import type {
 } from "./tools/provider-filter-reasons.js";
 import type { OriginalRequestParams } from "./tools/resolve-provider-context.js";
 import type { ServerTypes } from "@/vars.js";
+import type { RoutingCredentialSource } from "@llmgateway/shared/routing-telemetry";
 
 const _derivedProjectId = getVertexAnthropicProjectId();
 if (_derivedProjectId && !process.env.LLM_VERTEX_ANTHROPIC_PROJECT) {
@@ -787,21 +788,26 @@ async function addContentFilterRoutingMetadata(
 	};
 }
 
-function withUsedApiKeyHash(
+function withUsedCredential(
 	routingMetadata: RoutingMetadata | undefined,
 	usedApiKeyHash: string | undefined,
+	usedCredentialSource: RoutingCredentialSource,
 ): RoutingMetadata | undefined {
 	if (!routingMetadata || !usedApiKeyHash) {
 		return routingMetadata;
 	}
 
-	if (routingMetadata.usedApiKeyHash === usedApiKeyHash) {
+	if (
+		routingMetadata.usedApiKeyHash === usedApiKeyHash &&
+		routingMetadata.usedCredentialSource === usedCredentialSource
+	) {
 		return routingMetadata;
 	}
 
 	return {
 		...routingMetadata,
 		usedApiKeyHash,
+		usedCredentialSource,
 	};
 }
 
@@ -1356,7 +1362,17 @@ const completions = createRoute({
 										status_code: z.number(),
 										error_type: z.string(),
 										succeeded: z.boolean(),
-										apiKeyHash: z.string().optional(),
+										apiKeyHash: z.string().optional().openapi({
+											description:
+												"Stable fingerprint of the provider credential this attempt was sent with. Use it together with credentialSource to tell attempts apart when a request rotated keys.",
+										}),
+										credentialSource: z
+											.enum(["byok", "platform"])
+											.optional()
+											.openapi({
+												description:
+													"Whose provider credential served this attempt. `byok` is your organization's own provider key — the provider bills you directly and no credits are deducted. `platform` is an LLM Gateway credential, billed as credits. A hybrid-mode request whose own key fails falls back to `platform`, so both values can appear in one response.",
+											}),
 										logId: z.string().optional(),
 									}),
 								)
@@ -5047,6 +5063,15 @@ chat.openapi(completions, async (c) => {
 	// credential via envVarName instead of blaming an unused DB key. Endpoint
 	// and option resolution still use providerKey for BYOK base URLs/options.
 	let trackedKeyHealthId: string | undefined;
+	// Whose key the current attempt is sending. Derived from `providerKey`
+	// alone — exactly like the `organizationProviderKeyId` that decides
+	// `usedMode` in createLogEntry — so the routing view can never claim an
+	// attempt ran on the caller's own key while billing it as credits.
+	// Read at each attempt because a retry can swap the credential (a failing
+	// BYOK key falling back to the platform credential in hybrid mode).
+	function currentCredentialSource(): RoutingCredentialSource {
+		return providerKey ? "byok" : "platform";
+	}
 	// Flex/Priority is only honored when the request reaches the provider's real
 	// upstream endpoint on a tier-capable location. Skip provider keys whose
 	// custom base URL (proxy) may silently drop the tier, and Vertex keys pinned
@@ -5486,7 +5511,11 @@ chat.openapi(completions, async (c) => {
 	}
 
 	usedApiKeyHash = getApiKeyFingerprint(usedToken);
-	routingMetadata = withUsedApiKeyHash(routingMetadata, usedApiKeyHash);
+	routingMetadata = withUsedCredential(
+		routingMetadata,
+		usedApiKeyHash,
+		currentCredentialSource(),
+	);
 
 	// Vertex's OpenAI-compatible endpoint requires an OAuth2 access token
 	// derived from the configured service account JSON. The SA JSON is the
@@ -6935,7 +6964,11 @@ chat.openapi(completions, async (c) => {
 		frequency_penalty = ctx.frequency_penalty;
 		presence_penalty = ctx.presence_penalty;
 		usedRegion = ctx.usedRegion;
-		routingMetadata = withUsedApiKeyHash(routingMetadata, usedApiKeyHash);
+		routingMetadata = withUsedCredential(
+			routingMetadata,
+			usedApiKeyHash,
+			currentCredentialSource(),
+		);
 		if (ctx.strippedParameters.length > 0 && routingMetadata) {
 			routingMetadata.strippedParameters = [
 				...new Set([
@@ -7735,6 +7768,7 @@ chat.openapi(completions, async (c) => {
 										{
 											region: usedRegion,
 											apiKeyHash: usedApiKeyHash,
+											credentialSource: currentCredentialSource(),
 											logId: attemptLogId,
 										},
 									),
@@ -7761,6 +7795,7 @@ chat.openapi(completions, async (c) => {
 										{
 											region: usedRegion,
 											apiKeyHash: usedApiKeyHash,
+											credentialSource: currentCredentialSource(),
 											logId: attemptLogId,
 										},
 									),
@@ -7780,6 +7815,7 @@ chat.openapi(completions, async (c) => {
 										{
 											region: usedRegion,
 											apiKeyHash: usedApiKeyHash,
+											credentialSource: currentCredentialSource(),
 											logId: attemptLogId,
 										},
 									),
@@ -7993,6 +8029,7 @@ chat.openapi(completions, async (c) => {
 										{
 											region: usedRegion,
 											apiKeyHash: usedApiKeyHash,
+											credentialSource: currentCredentialSource(),
 											logId: attemptLogId,
 										},
 									),
@@ -8019,6 +8056,7 @@ chat.openapi(completions, async (c) => {
 										{
 											region: usedRegion,
 											apiKeyHash: usedApiKeyHash,
+											credentialSource: currentCredentialSource(),
 											logId: attemptLogId,
 										},
 									),
@@ -8038,6 +8076,7 @@ chat.openapi(completions, async (c) => {
 										{
 											region: usedRegion,
 											apiKeyHash: usedApiKeyHash,
+											credentialSource: currentCredentialSource(),
 											logId: attemptLogId,
 										},
 									),
@@ -8350,6 +8389,7 @@ chat.openapi(completions, async (c) => {
 									{
 										region: usedRegion,
 										apiKeyHash: usedApiKeyHash,
+										credentialSource: currentCredentialSource(),
 										logId: attemptLogId,
 									},
 								),
@@ -8376,6 +8416,7 @@ chat.openapi(completions, async (c) => {
 									{
 										region: usedRegion,
 										apiKeyHash: usedApiKeyHash,
+										credentialSource: currentCredentialSource(),
 										logId: attemptLogId,
 									},
 								),
@@ -8395,6 +8436,7 @@ chat.openapi(completions, async (c) => {
 									{
 										region: usedRegion,
 										apiKeyHash: usedApiKeyHash,
+										credentialSource: currentCredentialSource(),
 										logId: attemptLogId,
 									},
 								),
@@ -8685,6 +8727,7 @@ chat.openapi(completions, async (c) => {
 									{
 										region: usedRegion,
 										apiKeyHash: usedApiKeyHash,
+										credentialSource: currentCredentialSource(),
 										logId: attemptLogId,
 									},
 								),
@@ -8711,6 +8754,7 @@ chat.openapi(completions, async (c) => {
 									{
 										region: usedRegion,
 										apiKeyHash: usedApiKeyHash,
+										credentialSource: currentCredentialSource(),
 										logId: attemptLogId,
 									},
 								),
@@ -8730,6 +8774,7 @@ chat.openapi(completions, async (c) => {
 									{
 										region: usedRegion,
 										apiKeyHash: usedApiKeyHash,
+										credentialSource: currentCredentialSource(),
 										logId: attemptLogId,
 									},
 								),
@@ -8785,6 +8830,7 @@ chat.openapi(completions, async (c) => {
 							{
 								region: usedRegion,
 								apiKeyHash: usedApiKeyHash,
+								credentialSource: currentCredentialSource(),
 								logId: finalLogId,
 							},
 						),
@@ -12062,6 +12108,7 @@ chat.openapi(completions, async (c) => {
 						{
 							region: usedRegion,
 							apiKeyHash: usedApiKeyHash,
+							credentialSource: currentCredentialSource(),
 							logId: attemptLogId,
 						},
 					),
@@ -12088,6 +12135,7 @@ chat.openapi(completions, async (c) => {
 						{
 							region: usedRegion,
 							apiKeyHash: usedApiKeyHash,
+							credentialSource: currentCredentialSource(),
 							logId: attemptLogId,
 						},
 					),
@@ -12107,6 +12155,7 @@ chat.openapi(completions, async (c) => {
 						{
 							region: usedRegion,
 							apiKeyHash: usedApiKeyHash,
+							credentialSource: currentCredentialSource(),
 							logId: attemptLogId,
 						},
 					),
@@ -12564,6 +12613,7 @@ chat.openapi(completions, async (c) => {
 						{
 							region: usedRegion,
 							apiKeyHash: usedApiKeyHash,
+							credentialSource: currentCredentialSource(),
 							logId: attemptLogId,
 						},
 					),
@@ -12590,6 +12640,7 @@ chat.openapi(completions, async (c) => {
 						{
 							region: usedRegion,
 							apiKeyHash: usedApiKeyHash,
+							credentialSource: currentCredentialSource(),
 							logId: attemptLogId,
 						},
 					),
@@ -12609,6 +12660,7 @@ chat.openapi(completions, async (c) => {
 						{
 							region: usedRegion,
 							apiKeyHash: usedApiKeyHash,
+							credentialSource: currentCredentialSource(),
 							logId: attemptLogId,
 						},
 					),
@@ -12740,6 +12792,7 @@ chat.openapi(completions, async (c) => {
 				{
 					region: usedRegion,
 					apiKeyHash: usedApiKeyHash,
+					credentialSource: currentCredentialSource(),
 					logId: finalLogId,
 				},
 			),
@@ -13119,6 +13172,7 @@ chat.openapi(completions, async (c) => {
 						{
 							region: usedRegion,
 							apiKeyHash: usedApiKeyHash,
+							credentialSource: currentCredentialSource(),
 							logId: finalLogId,
 						},
 					);

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -28,6 +28,7 @@ import {
 	findEffectiveDiscount,
 	findProviderKey,
 	findActiveProviderKeys,
+	listEligibleProviderKeys,
 	findProviderKeysByProviders,
 	type CustomModel,
 	type ManagedProviderAvailability,
@@ -122,6 +123,7 @@ import {
 	managedCredentialOptions,
 	parseGoogleUpstreamDocumentError,
 	prepareRequestBody,
+	providerKeyLabel,
 	providerSupportsCaching,
 	readProviderKey,
 	RequestError,
@@ -792,14 +794,26 @@ function withUsedCredential(
 	routingMetadata: RoutingMetadata | undefined,
 	usedApiKeyHash: string | undefined,
 	usedCredentialSource: RoutingCredentialSource,
+	usedProviderKey: { providerKeyId?: string; providerKeyLabel?: string },
 ): RoutingMetadata | undefined {
 	if (!routingMetadata || !usedApiKeyHash) {
 		return routingMetadata;
 	}
 
+	// A platform credential contributes no identity, and the previous BYOK
+	// attempt's must not linger once a fallback switched off it.
+	const usedProviderKeyId =
+		usedCredentialSource === "byok" ? usedProviderKey.providerKeyId : undefined;
+	const usedProviderKeyLabel =
+		usedCredentialSource === "byok"
+			? usedProviderKey.providerKeyLabel
+			: undefined;
+
 	if (
 		routingMetadata.usedApiKeyHash === usedApiKeyHash &&
-		routingMetadata.usedCredentialSource === usedCredentialSource
+		routingMetadata.usedCredentialSource === usedCredentialSource &&
+		routingMetadata.usedProviderKeyId === usedProviderKeyId &&
+		routingMetadata.usedProviderKeyLabel === usedProviderKeyLabel
 	) {
 		return routingMetadata;
 	}
@@ -808,7 +822,35 @@ function withUsedCredential(
 		...routingMetadata,
 		usedApiKeyHash,
 		usedCredentialSource,
+		usedProviderKeyId,
+		usedProviderKeyLabel,
 	};
+}
+
+/**
+ * The organization's own keys that could have served this provider, in
+ * selection order. Only BYOK-capable project modes have any: a credits-mode
+ * project routes on platform credentials, which are never listed.
+ */
+async function resolveEligibleProviderKeys(
+	projectMode: string,
+	organizationId: string,
+	provider: string,
+	filter?: (key: InferSelectModel<typeof tables.providerKey>) => boolean,
+): Promise<RoutingMetadata["eligibleProviderKeys"]> {
+	if (projectMode !== "api-keys" && projectMode !== "hybrid") {
+		return undefined;
+	}
+
+	const keys = await listEligibleProviderKeys(organizationId, provider, filter);
+	if (keys.length === 0) {
+		return undefined;
+	}
+
+	return keys.map((key) => ({
+		id: key.id,
+		label: providerKeyLabel(key),
+	}));
 }
 
 function usesGoogleQueryToken(provider: string): boolean {
@@ -1373,6 +1415,14 @@ const completions = createRoute({
 												description:
 													"Whose provider credential served this attempt. `byok` is your organization's own provider key — the provider bills you directly and no credits are deducted. `platform` is an LLM Gateway credential, billed as credits. A hybrid-mode request whose own key fails falls back to `platform`, so both values can appear in one response.",
 											}),
+										providerKeyId: z.string().optional().openapi({
+											description:
+												"Id of your provider key that served this attempt. Set only when credentialSource is `byok`.",
+										}),
+										providerKeyLabel: z.string().optional().openapi({
+											description:
+												"Your provider key as it is named on the provider-keys page (its name, or its masked token when unnamed), so an attempt can be tied to a key without decoding the fingerprint. Set only when credentialSource is `byok`; LLM Gateway's own credentials are never described.",
+										}),
 										logId: z.string().optional(),
 									}),
 								)
@@ -5072,6 +5122,22 @@ chat.openapi(completions, async (c) => {
 	function currentCredentialSource(): RoutingCredentialSource {
 		return providerKey ? "byok" : "platform";
 	}
+	// How the current attempt's credential is named to the organization that
+	// owns it. Reads `providerKey` only, so a platform credential contributes
+	// nothing: its name and mask are operator-only and must never reach a
+	// tenant's routing view.
+	function currentProviderKeyIdentity(): {
+		providerKeyId?: string;
+		providerKeyLabel?: string;
+	} {
+		if (!providerKey) {
+			return {};
+		}
+		return {
+			providerKeyId: providerKey.id,
+			providerKeyLabel: providerKeyLabel(providerKey),
+		};
+	}
 	// Flex/Priority is only honored when the request reaches the provider's real
 	// upstream endpoint on a tier-capable location. Skip provider keys whose
 	// custom base URL (proxy) may silently drop the tier, and Vertex keys pinned
@@ -5515,7 +5581,19 @@ chat.openapi(completions, async (c) => {
 		routingMetadata,
 		usedApiKeyHash,
 		currentCredentialSource(),
+		currentProviderKeyIdentity(),
 	);
+	if (routingMetadata) {
+		const eligibleProviderKeys = await resolveEligibleProviderKeys(
+			project.mode,
+			project.organizationId,
+			usedProvider,
+			serviceTierKeyFilter,
+		);
+		if (eligibleProviderKeys) {
+			routingMetadata = { ...routingMetadata, eligibleProviderKeys };
+		}
+	}
 
 	// Vertex's OpenAI-compatible endpoint requires an OAuth2 access token
 	// derived from the configured service account JSON. The SA JSON is the
@@ -6968,7 +7046,13 @@ chat.openapi(completions, async (c) => {
 			routingMetadata,
 			usedApiKeyHash,
 			currentCredentialSource(),
+			currentProviderKeyIdentity(),
 		);
+		if (routingMetadata) {
+			// A fallback can switch providers, so the candidate list has to follow
+			// the provider now in use rather than the one routing started on.
+			routingMetadata.eligibleProviderKeys = ctx.eligibleProviderKeys;
+		}
 		if (ctx.strippedParameters.length > 0 && routingMetadata) {
 			routingMetadata.strippedParameters = [
 				...new Set([
@@ -7769,6 +7853,7 @@ chat.openapi(completions, async (c) => {
 											region: usedRegion,
 											apiKeyHash: usedApiKeyHash,
 											credentialSource: currentCredentialSource(),
+											...currentProviderKeyIdentity(),
 											logId: attemptLogId,
 										},
 									),
@@ -7796,6 +7881,7 @@ chat.openapi(completions, async (c) => {
 											region: usedRegion,
 											apiKeyHash: usedApiKeyHash,
 											credentialSource: currentCredentialSource(),
+											...currentProviderKeyIdentity(),
 											logId: attemptLogId,
 										},
 									),
@@ -7816,6 +7902,7 @@ chat.openapi(completions, async (c) => {
 											region: usedRegion,
 											apiKeyHash: usedApiKeyHash,
 											credentialSource: currentCredentialSource(),
+											...currentProviderKeyIdentity(),
 											logId: attemptLogId,
 										},
 									),
@@ -8030,6 +8117,7 @@ chat.openapi(completions, async (c) => {
 											region: usedRegion,
 											apiKeyHash: usedApiKeyHash,
 											credentialSource: currentCredentialSource(),
+											...currentProviderKeyIdentity(),
 											logId: attemptLogId,
 										},
 									),
@@ -8057,6 +8145,7 @@ chat.openapi(completions, async (c) => {
 											region: usedRegion,
 											apiKeyHash: usedApiKeyHash,
 											credentialSource: currentCredentialSource(),
+											...currentProviderKeyIdentity(),
 											logId: attemptLogId,
 										},
 									),
@@ -8077,6 +8166,7 @@ chat.openapi(completions, async (c) => {
 											region: usedRegion,
 											apiKeyHash: usedApiKeyHash,
 											credentialSource: currentCredentialSource(),
+											...currentProviderKeyIdentity(),
 											logId: attemptLogId,
 										},
 									),
@@ -8390,6 +8480,7 @@ chat.openapi(completions, async (c) => {
 										region: usedRegion,
 										apiKeyHash: usedApiKeyHash,
 										credentialSource: currentCredentialSource(),
+										...currentProviderKeyIdentity(),
 										logId: attemptLogId,
 									},
 								),
@@ -8417,6 +8508,7 @@ chat.openapi(completions, async (c) => {
 										region: usedRegion,
 										apiKeyHash: usedApiKeyHash,
 										credentialSource: currentCredentialSource(),
+										...currentProviderKeyIdentity(),
 										logId: attemptLogId,
 									},
 								),
@@ -8437,6 +8529,7 @@ chat.openapi(completions, async (c) => {
 										region: usedRegion,
 										apiKeyHash: usedApiKeyHash,
 										credentialSource: currentCredentialSource(),
+										...currentProviderKeyIdentity(),
 										logId: attemptLogId,
 									},
 								),
@@ -8728,6 +8821,7 @@ chat.openapi(completions, async (c) => {
 										region: usedRegion,
 										apiKeyHash: usedApiKeyHash,
 										credentialSource: currentCredentialSource(),
+										...currentProviderKeyIdentity(),
 										logId: attemptLogId,
 									},
 								),
@@ -8755,6 +8849,7 @@ chat.openapi(completions, async (c) => {
 										region: usedRegion,
 										apiKeyHash: usedApiKeyHash,
 										credentialSource: currentCredentialSource(),
+										...currentProviderKeyIdentity(),
 										logId: attemptLogId,
 									},
 								),
@@ -8775,6 +8870,7 @@ chat.openapi(completions, async (c) => {
 										region: usedRegion,
 										apiKeyHash: usedApiKeyHash,
 										credentialSource: currentCredentialSource(),
+										...currentProviderKeyIdentity(),
 										logId: attemptLogId,
 									},
 								),
@@ -8831,6 +8927,7 @@ chat.openapi(completions, async (c) => {
 								region: usedRegion,
 								apiKeyHash: usedApiKeyHash,
 								credentialSource: currentCredentialSource(),
+								...currentProviderKeyIdentity(),
 								logId: finalLogId,
 							},
 						),
@@ -12109,6 +12206,7 @@ chat.openapi(completions, async (c) => {
 							region: usedRegion,
 							apiKeyHash: usedApiKeyHash,
 							credentialSource: currentCredentialSource(),
+							...currentProviderKeyIdentity(),
 							logId: attemptLogId,
 						},
 					),
@@ -12136,6 +12234,7 @@ chat.openapi(completions, async (c) => {
 							region: usedRegion,
 							apiKeyHash: usedApiKeyHash,
 							credentialSource: currentCredentialSource(),
+							...currentProviderKeyIdentity(),
 							logId: attemptLogId,
 						},
 					),
@@ -12156,6 +12255,7 @@ chat.openapi(completions, async (c) => {
 							region: usedRegion,
 							apiKeyHash: usedApiKeyHash,
 							credentialSource: currentCredentialSource(),
+							...currentProviderKeyIdentity(),
 							logId: attemptLogId,
 						},
 					),
@@ -12614,6 +12714,7 @@ chat.openapi(completions, async (c) => {
 							region: usedRegion,
 							apiKeyHash: usedApiKeyHash,
 							credentialSource: currentCredentialSource(),
+							...currentProviderKeyIdentity(),
 							logId: attemptLogId,
 						},
 					),
@@ -12641,6 +12742,7 @@ chat.openapi(completions, async (c) => {
 							region: usedRegion,
 							apiKeyHash: usedApiKeyHash,
 							credentialSource: currentCredentialSource(),
+							...currentProviderKeyIdentity(),
 							logId: attemptLogId,
 						},
 					),
@@ -12661,6 +12763,7 @@ chat.openapi(completions, async (c) => {
 							region: usedRegion,
 							apiKeyHash: usedApiKeyHash,
 							credentialSource: currentCredentialSource(),
+							...currentProviderKeyIdentity(),
 							logId: attemptLogId,
 						},
 					),
@@ -12793,6 +12896,7 @@ chat.openapi(completions, async (c) => {
 					region: usedRegion,
 					apiKeyHash: usedApiKeyHash,
 					credentialSource: currentCredentialSource(),
+					...currentProviderKeyIdentity(),
 					logId: finalLogId,
 				},
 			),
@@ -13173,6 +13277,7 @@ chat.openapi(completions, async (c) => {
 							region: usedRegion,
 							apiKeyHash: usedApiKeyHash,
 							credentialSource: currentCredentialSource(),
+							...currentProviderKeyIdentity(),
 							logId: finalLogId,
 						},
 					);

--- a/apps/gateway/src/chat/tools/build-routing-attempt.ts
+++ b/apps/gateway/src/chat/tools/build-routing-attempt.ts
@@ -1,4 +1,5 @@
 import type { RoutingAttempt } from "./retry-with-fallback.js";
+import type { RoutingCredentialSource } from "@llmgateway/shared/routing-telemetry";
 
 export function buildRoutingAttempt(
 	provider: string,
@@ -9,6 +10,7 @@ export function buildRoutingAttempt(
 	options?: {
 		region?: string;
 		apiKeyHash?: string;
+		credentialSource?: RoutingCredentialSource;
 		logId?: string;
 	},
 ): RoutingAttempt {
@@ -20,6 +22,9 @@ export function buildRoutingAttempt(
 		error_type: errorType,
 		succeeded,
 		...(options?.apiKeyHash && { apiKeyHash: options.apiKeyHash }),
+		...(options?.credentialSource && {
+			credentialSource: options.credentialSource,
+		}),
 		...(options?.logId && { logId: options.logId }),
 	};
 }

--- a/apps/gateway/src/chat/tools/build-routing-attempt.ts
+++ b/apps/gateway/src/chat/tools/build-routing-attempt.ts
@@ -11,9 +11,17 @@ export function buildRoutingAttempt(
 		region?: string;
 		apiKeyHash?: string;
 		credentialSource?: RoutingCredentialSource;
+		providerKeyId?: string;
+		providerKeyLabel?: string;
 		logId?: string;
 	},
 ): RoutingAttempt {
+	// A key identity is only ever attached to a BYOK attempt: the caller reads
+	// it off its own provider-key row, and providerKeyLabel() returns undefined
+	// for platform credentials. Guarding here too means a future call site
+	// cannot leak one by passing the wrong row.
+	const isByok = options?.credentialSource === "byok";
+
 	return {
 		provider,
 		model,
@@ -25,6 +33,12 @@ export function buildRoutingAttempt(
 		...(options?.credentialSource && {
 			credentialSource: options.credentialSource,
 		}),
+		...(isByok && options?.providerKeyId
+			? { providerKeyId: options.providerKeyId }
+			: {}),
+		...(isByok && options?.providerKeyLabel
+			? { providerKeyLabel: options.providerKeyLabel }
+			: {}),
 		...(options?.logId && { logId: options.logId }),
 	};
 }

--- a/apps/gateway/src/chat/tools/resolve-provider-context.ts
+++ b/apps/gateway/src/chat/tools/resolve-provider-context.ts
@@ -4,6 +4,7 @@ import { getApiKeyFingerprint } from "@/lib/api-key-fingerprint.js";
 import {
 	findCustomProviderKey,
 	findProviderKey,
+	listEligibleProviderKeys,
 } from "@/lib/cached-queries.js";
 import { posthog } from "@/posthog.js";
 
@@ -14,6 +15,7 @@ import {
 	isPremiumServiceTier,
 	managedCredentialOptions,
 	prepareRequestBody,
+	providerKeyLabel,
 	readProviderKey,
 	selectProviderMapping,
 } from "@llmgateway/actions";
@@ -108,6 +110,12 @@ export interface ProviderContext {
 	strippedParameters: string[];
 	headers: Record<string, string>;
 	usedRegion: string | undefined;
+	/**
+	 * The organization's own keys that could have served this provider, in
+	 * selection order — the candidate set the credential above was chosen from.
+	 * Undefined in credits mode, which routes on platform credentials only.
+	 */
+	eligibleProviderKeys: Array<{ id: string; label?: string }> | undefined;
 }
 
 export interface OriginalRequestParams {
@@ -524,6 +532,21 @@ export async function resolveProviderContext(
 	): boolean =>
 		providerKeyAllowsModel(key.allowedModels, usedInternalModel) &&
 		(serviceTierKeyFilter ? serviceTierKeyFilter(key) : true);
+
+	// Only BYOK-capable modes have candidates. Custom providers are excluded:
+	// their keys are looked up by provider name through a different query, so
+	// the list would not describe the same candidate set.
+	const eligibleProviderKeys =
+		(project.mode === "api-keys" || project.mode === "hybrid") &&
+		usedProvider !== "custom"
+			? (
+					await listEligibleProviderKeys(
+						project.organizationId,
+						usedProvider,
+						byokKeyFilter,
+					)
+				).map((key) => ({ id: key.id, label: providerKeyLabel(key) }))
+			: undefined;
 
 	if (project.mode === "api-keys") {
 		if (usedProvider === "custom" && options.customProviderName) {
@@ -998,5 +1021,9 @@ export async function resolveProviderContext(
 		strippedParameters,
 		headers,
 		usedRegion,
+		eligibleProviderKeys:
+			eligibleProviderKeys && eligibleProviderKeys.length > 0
+				? eligibleProviderKeys
+				: undefined,
 	};
 }

--- a/apps/gateway/src/chat/tools/resolve-provider-context.ts
+++ b/apps/gateway/src/chat/tools/resolve-provider-context.ts
@@ -470,6 +470,67 @@ export function formatUsedModelForDisplay(
 }
 
 /**
+ * Which of an organization's own keys may serve a given model.
+ *
+ * Skips BYOK keys whose allowedModels restriction excludes the model being
+ * served, so a key that cannot satisfy the request upstream is never picked
+ * over a sibling key (or the credits fallback in hybrid mode) that can, and
+ * layers on the service-tier filter when the request asks for a premium tier.
+ *
+ * Shared with the routing metadata so the "your keys" list can never disagree
+ * with the set the gateway actually chose from. Custom provider keys are
+ * exempt: their catalog already scopes them.
+ */
+export function buildByokKeyFilter(
+	usedInternalModel: string,
+	serviceTierKeyFilter?: (
+		key: InferSelectModel<typeof tables.providerKey>,
+	) => boolean,
+): (key: InferSelectModel<typeof tables.providerKey>) => boolean {
+	return (key) =>
+		providerKeyAllowsModel(key.allowedModels, usedInternalModel) &&
+		(serviceTierKeyFilter ? serviceTierKeyFilter(key) : true);
+}
+
+/**
+ * The organization's own keys that could have served this provider and model,
+ * in selection order, named the way their owner sees them.
+ *
+ * Only BYOK-capable modes have candidates: a credits-mode project routes on
+ * platform credentials, which are never listed. Custom providers are excluded
+ * because their keys are looked up by provider name through a different query,
+ * so the list would not describe the same candidate set.
+ */
+export async function resolveEligibleProviderKeys(args: {
+	projectMode: string;
+	organizationId: string;
+	provider: string;
+	usedInternalModel: string;
+	serviceTierKeyFilter?: (
+		key: InferSelectModel<typeof tables.providerKey>,
+	) => boolean;
+}): Promise<Array<{ id: string; label?: string }> | undefined> {
+	if (
+		(args.projectMode !== "api-keys" && args.projectMode !== "hybrid") ||
+		args.provider === "custom"
+	) {
+		return undefined;
+	}
+
+	const keys = await listEligibleProviderKeys(
+		args.organizationId,
+		args.provider,
+		buildByokKeyFilter(args.usedInternalModel, args.serviceTierKeyFilter),
+	);
+
+	if (keys.length === 0) {
+		return undefined;
+	}
+
+	return keys.map((key) => ({ id: key.id, label: providerKeyLabel(key) }));
+}
+
+/**
  * Resolves all provider-dependent context needed to make a fetch request.
  * This includes token resolution, URL building, parameter stripping,
  * request body preparation, and header construction.
@@ -523,30 +584,18 @@ export async function resolveProviderContext(
 		? providerKeySupportsServiceTier
 		: undefined;
 
-	// Skip BYOK keys whose allowedModels restriction excludes the model being
-	// served, so a key that cannot satisfy the request upstream is never picked
-	// over a sibling key (or the credits fallback in hybrid mode) that can.
-	// Custom provider keys are exempt: their catalog already scopes them.
-	const byokKeyFilter = (
-		key: InferSelectModel<typeof tables.providerKey>,
-	): boolean =>
-		providerKeyAllowsModel(key.allowedModels, usedInternalModel) &&
-		(serviceTierKeyFilter ? serviceTierKeyFilter(key) : true);
+	const byokKeyFilter = buildByokKeyFilter(
+		usedInternalModel,
+		serviceTierKeyFilter,
+	);
 
-	// Only BYOK-capable modes have candidates. Custom providers are excluded:
-	// their keys are looked up by provider name through a different query, so
-	// the list would not describe the same candidate set.
-	const eligibleProviderKeys =
-		(project.mode === "api-keys" || project.mode === "hybrid") &&
-		usedProvider !== "custom"
-			? (
-					await listEligibleProviderKeys(
-						project.organizationId,
-						usedProvider,
-						byokKeyFilter,
-					)
-				).map((key) => ({ id: key.id, label: providerKeyLabel(key) }))
-			: undefined;
+	const eligibleProviderKeys = await resolveEligibleProviderKeys({
+		projectMode: project.mode,
+		organizationId: project.organizationId,
+		provider: usedProvider,
+		usedInternalModel,
+		serviceTierKeyFilter,
+	});
 
 	if (project.mode === "api-keys") {
 		if (usedProvider === "custom" && options.customProviderName) {
@@ -1021,9 +1070,6 @@ export async function resolveProviderContext(
 		strippedParameters,
 		headers,
 		usedRegion,
-		eligibleProviderKeys:
-			eligibleProviderKeys && eligibleProviderKeys.length > 0
-				? eligibleProviderKeys
-				: undefined,
+		eligibleProviderKeys,
 	};
 }

--- a/apps/gateway/src/chat/tools/retry-with-fallback.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.ts
@@ -46,6 +46,14 @@ export interface RoutingAttempt {
 	 * which of the two keys is the caller's own.
 	 */
 	credentialSource?: RoutingCredentialSource;
+	/**
+	 * The organization's own provider key that served this attempt, named the
+	 * way its owner sees it on the provider-keys page. Only ever set for `byok`
+	 * attempts — see providerKeyLabel(), which refuses to describe a
+	 * platform-managed credential.
+	 */
+	providerKeyId?: string;
+	providerKeyLabel?: string;
 	logId?: string;
 }
 

--- a/apps/gateway/src/chat/tools/retry-with-fallback.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.ts
@@ -2,6 +2,8 @@ import { hasInvalidProviderCredentialError } from "@/lib/provider-auth-errors.js
 
 import { DEFAULT_ROUTING_RETRY } from "@llmgateway/shared/routing-config";
 
+import type { RoutingCredentialSource } from "@llmgateway/shared/routing-telemetry";
+
 export const MAX_RETRIES = DEFAULT_ROUTING_RETRY.maxRetries;
 
 /**
@@ -36,6 +38,14 @@ export interface RoutingAttempt {
 	error_type: string;
 	succeeded: boolean;
 	apiKeyHash?: string;
+	/**
+	 * Whose credential this attempt was sent with — the organization's own
+	 * provider key (`byok`) or an LLM Gateway platform credential (`platform`).
+	 * Recorded per attempt because a hybrid-mode request that fails on a BYOK key
+	 * retries on the platform credential, and the fingerprints alone do not say
+	 * which of the two keys is the caller's own.
+	 */
+	credentialSource?: RoutingCredentialSource;
 	logId?: string;
 }
 

--- a/apps/gateway/src/embeddings/embeddings.ts
+++ b/apps/gateway/src/embeddings/embeddings.ts
@@ -54,6 +54,7 @@ import {
 	getProviderDefaultBaseUrl,
 	getProviderHeaders,
 	managedCredentialOptions,
+	providerKeyLabel,
 	readProviderKey,
 } from "@llmgateway/actions";
 import { shortid } from "@llmgateway/db";
@@ -658,11 +659,19 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 	const buildEmbeddingRoutingMetadata = (
 		usedApiKeyHash: string | undefined,
 		usedCredentialSource: RoutingCredentialSource,
+		usedProviderKey: { id?: string; label?: string },
 	): RoutingMetadata => ({
 		availableProviders: [providerId],
 		selectedProvider: providerId,
 		selectionReason,
-		...(usedApiKeyHash ? { usedApiKeyHash, usedCredentialSource } : {}),
+		...(usedApiKeyHash
+			? {
+					usedApiKeyHash,
+					usedCredentialSource,
+					usedProviderKeyId: usedProviderKey.id,
+					usedProviderKeyLabel: usedProviderKey.label,
+				}
+			: {}),
 		providerScores: [],
 		...(routingAttempts.length > 0 ? { routing: routingAttempts } : {}),
 	});
@@ -1038,6 +1047,11 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 			const credentialSource: RoutingCredentialSource = attempt.providerKey
 				? "byok"
 				: "platform";
+			// Named only for the organization's own key; providerKeyLabel()
+			// refuses to describe a platform-managed credential.
+			const providerKeyId = attempt.providerKey?.id;
+			const keyLabel = providerKeyLabel(attempt.providerKey);
+			const usedProviderKey = { id: providerKeyId, label: keyLabel };
 			const baseLogEntry = createLogEntry({
 				requestId,
 				project,
@@ -1153,6 +1167,8 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 							{
 								apiKeyHash: usedApiKeyHash,
 								credentialSource,
+								providerKeyId,
+								providerKeyLabel: keyLabel,
 								logId: willRetry ? attemptLogId : finalLogId,
 							},
 						),
@@ -1166,6 +1182,7 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 						routingMetadata: buildEmbeddingRoutingMetadata(
 							usedApiKeyHash,
 							credentialSource,
+							usedProviderKey,
 						),
 						duration,
 						timeToFirstToken: null,
@@ -1309,6 +1326,8 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 						{
 							apiKeyHash: usedApiKeyHash,
 							credentialSource,
+							providerKeyId,
+							providerKeyLabel: keyLabel,
 							logId: willRetry ? attemptLogId : finalLogId,
 						},
 					),
@@ -1321,6 +1340,7 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 						routingMetadata: buildEmbeddingRoutingMetadata(
 							usedApiKeyHash,
 							credentialSource,
+							usedProviderKey,
 						),
 						duration,
 						timeToFirstToken: null,
@@ -1578,6 +1598,8 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 					{
 						apiKeyHash: usedApiKeyHash,
 						credentialSource,
+						providerKeyId,
+						providerKeyLabel: keyLabel,
 						logId: finalLogId,
 					},
 				),
@@ -1590,6 +1612,7 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 					routingMetadata: buildEmbeddingRoutingMetadata(
 						usedApiKeyHash,
 						credentialSource,
+						usedProviderKey,
 					),
 					duration,
 					timeToFirstToken: null,

--- a/apps/gateway/src/embeddings/embeddings.ts
+++ b/apps/gateway/src/embeddings/embeddings.ts
@@ -70,6 +70,7 @@ import type { ServerTypes } from "@/vars.js";
 import type { RoutingMetadata } from "@llmgateway/actions";
 import type { InferSelectModel, tables } from "@llmgateway/db";
 import type { ModelDefinition, ProviderModelMapping } from "@llmgateway/models";
+import type { RoutingCredentialSource } from "@llmgateway/shared/routing-telemetry";
 
 const embeddingInputSchema = z
 	.union([
@@ -656,11 +657,12 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 	const routingAttempts: RoutingAttempt[] = [];
 	const buildEmbeddingRoutingMetadata = (
 		usedApiKeyHash: string | undefined,
+		usedCredentialSource: RoutingCredentialSource,
 	): RoutingMetadata => ({
 		availableProviders: [providerId],
 		selectedProvider: providerId,
 		selectionReason,
-		...(usedApiKeyHash ? { usedApiKeyHash } : {}),
+		...(usedApiKeyHash ? { usedApiKeyHash, usedCredentialSource } : {}),
 		providerScores: [],
 		...(routingAttempts.length > 0 ? { routing: routingAttempts } : {}),
 	});
@@ -1031,6 +1033,11 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 		while (true) {
 			const attemptLogId = shortid();
 			const usedApiKeyHash = getApiKeyFingerprint(attempt.usedToken);
+			// BYOK only when the organization's own key served the attempt; a
+			// platform-managed credential is LLM Gateway's key and bills as credits.
+			const credentialSource: RoutingCredentialSource = attempt.providerKey
+				? "byok"
+				: "platform";
 			const baseLogEntry = createLogEntry({
 				requestId,
 				project,
@@ -1145,6 +1152,7 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 							false,
 							{
 								apiKeyHash: usedApiKeyHash,
+								credentialSource,
 								logId: willRetry ? attemptLogId : finalLogId,
 							},
 						),
@@ -1155,7 +1163,10 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 					{
 						...baseLogEntry,
 						id: willRetry ? attemptLogId : finalLogId,
-						routingMetadata: buildEmbeddingRoutingMetadata(usedApiKeyHash),
+						routingMetadata: buildEmbeddingRoutingMetadata(
+							usedApiKeyHash,
+							credentialSource,
+						),
 						duration,
 						timeToFirstToken: null,
 						timeToFirstReasoningToken: null,
@@ -1297,6 +1308,7 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 						false,
 						{
 							apiKeyHash: usedApiKeyHash,
+							credentialSource,
 							logId: willRetry ? attemptLogId : finalLogId,
 						},
 					),
@@ -1306,7 +1318,10 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 					{
 						...baseLogEntry,
 						id: willRetry ? attemptLogId : finalLogId,
-						routingMetadata: buildEmbeddingRoutingMetadata(usedApiKeyHash),
+						routingMetadata: buildEmbeddingRoutingMetadata(
+							usedApiKeyHash,
+							credentialSource,
+						),
 						duration,
 						timeToFirstToken: null,
 						timeToFirstReasoningToken: null,
@@ -1562,6 +1577,7 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 					true,
 					{
 						apiKeyHash: usedApiKeyHash,
+						credentialSource,
 						logId: finalLogId,
 					},
 				),
@@ -1571,7 +1587,10 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 				{
 					...baseLogEntry,
 					id: finalLogId,
-					routingMetadata: buildEmbeddingRoutingMetadata(usedApiKeyHash),
+					routingMetadata: buildEmbeddingRoutingMetadata(
+						usedApiKeyHash,
+						credentialSource,
+					),
 					duration,
 					timeToFirstToken: null,
 					timeToFirstReasoningToken: null,

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -2850,6 +2850,66 @@ describe("fallback and error status code handling", () => {
 			}
 		});
 
+		test("non-streaming: your-keys list skips a key the model is not allowed on", async () => {
+			await ensureBaseFixtures();
+			await ensureProviders(["openai"]);
+			await db.insert(tables.apiKey).values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+			// The second key is restricted to a different model, so it could never
+			// have served this request. It must not show up as one of the keys the
+			// gateway had to choose from — on the very first attempt, not only
+			// after a retry re-resolved the candidate set.
+			await db.insert(tables.providerKey).values([
+				{
+					id: "openai-key-general",
+					token: "openai-general-token",
+					tokenMasked: maskToken("openai-general-token"),
+					provider: "openai",
+					organizationId: "org-id",
+					baseUrl: mockServerUrl,
+					sortOrder: 0,
+				},
+				{
+					id: "openai-key-restricted",
+					token: "openai-restricted-token",
+					tokenMasked: maskToken("openai-restricted-token"),
+					name: "embeddings-only-key",
+					provider: "openai",
+					organizationId: "org-id",
+					baseUrl: mockServerUrl,
+					allowedModels: ["text-embedding-3-small"],
+					sortOrder: 1,
+				},
+			]);
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					model: "openai/gpt-4o-mini",
+					messages: [{ role: "user", content: "Hello!" }],
+				}),
+			});
+
+			expect(res.status).toBe(200);
+
+			const logs = await waitForLogs(1);
+			expect(logs[0]?.routingMetadata?.eligibleProviderKeys).toEqual([
+				{
+					id: "openai-key-general",
+					label: maskToken("openai-general-token"),
+				},
+			]);
+		});
+
 		test("streaming: labels the BYOK attempt and the credits fallback that follows it", async () => {
 			const originalApiKey = process.env.LLM_OPENAI_API_KEY;
 			const originalBaseUrl = process.env.LLM_OPENAI_BASE_URL;

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -2642,6 +2642,168 @@ describe("fallback and error status code handling", () => {
 			}
 		});
 
+		test("non-streaming: labels the BYOK attempt and the credits fallback that follows it", async () => {
+			const originalApiKey = process.env.LLM_OPENAI_API_KEY;
+			const originalBaseUrl = process.env.LLM_OPENAI_BASE_URL;
+			process.env.LLM_OPENAI_API_KEY = "openai-env-platform-key";
+			process.env.LLM_OPENAI_BASE_URL = mockServerUrl;
+			try {
+				await ensureBaseFixtures();
+				await ensureProviders(["openai"]);
+				// Hybrid: the organization's own key is preferred, and when it fails
+				// the retry falls back to the platform credential — the two attempts
+				// this test exists to tell apart.
+				await db
+					.update(tables.project)
+					.set({ mode: "hybrid" })
+					.where(eq(tables.project.id, "project-id"));
+				await db.insert(tables.apiKey).values({
+					id: "token-id",
+					token: "real-token",
+					projectId: "project-id",
+					description: "Test API Key",
+					createdBy: "user-id",
+				});
+				await db.insert(tables.providerKey).values({
+					id: "openai-byok-key",
+					token: "openai-byok-token",
+					provider: "openai",
+					organizationId: "org-id",
+					baseUrl: mockServerUrl,
+				});
+
+				const res = await app.request("/v1/chat/completions", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: "Bearer real-token",
+					},
+					body: JSON.stringify({
+						model: "openai/gpt-4o-mini",
+						messages: [{ role: "user", content: "TRIGGER_FAIL_ONCE hello" }],
+					}),
+				});
+
+				expect(res.status).toBe(200);
+				const json = await res.json();
+				expect(json.metadata.routing).toHaveLength(2);
+				expect(json.metadata.routing[0]).toMatchObject({
+					provider: "openai",
+					succeeded: false,
+					credentialSource: "byok",
+					apiKeyHash: getApiKeyFingerprint("openai-byok-token"),
+				});
+				expect(json.metadata.routing[1]).toMatchObject({
+					provider: "openai",
+					succeeded: true,
+					credentialSource: "platform",
+					apiKeyHash: getApiKeyFingerprint("openai-env-platform-key"),
+				});
+
+				const logs = await waitForLogs(2);
+				const failedLog = logs.find((log: Log) => log.hasError);
+				const successLog = logs.find((log: Log) => !log.hasError);
+				// The credential label always agrees with how the attempt was billed.
+				expect(failedLog?.usedMode).toBe("api-keys");
+				expect(successLog?.usedMode).toBe("credits");
+				expect(successLog?.routingMetadata?.usedCredentialSource).toBe(
+					"platform",
+				);
+				expect(
+					successLog?.routingMetadata?.routing?.map(
+						(attempt) => attempt.credentialSource,
+					),
+				).toEqual(["byok", "platform"]);
+			} finally {
+				if (originalApiKey !== undefined) {
+					process.env.LLM_OPENAI_API_KEY = originalApiKey;
+				} else {
+					delete process.env.LLM_OPENAI_API_KEY;
+				}
+				if (originalBaseUrl !== undefined) {
+					process.env.LLM_OPENAI_BASE_URL = originalBaseUrl;
+				} else {
+					delete process.env.LLM_OPENAI_BASE_URL;
+				}
+			}
+		});
+
+		test("streaming: labels the BYOK attempt and the credits fallback that follows it", async () => {
+			const originalApiKey = process.env.LLM_OPENAI_API_KEY;
+			const originalBaseUrl = process.env.LLM_OPENAI_BASE_URL;
+			process.env.LLM_OPENAI_API_KEY = "openai-env-platform-key";
+			process.env.LLM_OPENAI_BASE_URL = mockServerUrl;
+			try {
+				await ensureBaseFixtures();
+				await ensureProviders(["openai"]);
+				await db
+					.update(tables.project)
+					.set({ mode: "hybrid" })
+					.where(eq(tables.project.id, "project-id"));
+				await db.insert(tables.apiKey).values({
+					id: "token-id",
+					token: "real-token",
+					projectId: "project-id",
+					description: "Test API Key",
+					createdBy: "user-id",
+				});
+				await db.insert(tables.providerKey).values({
+					id: "openai-byok-key",
+					token: "openai-byok-token",
+					provider: "openai",
+					organizationId: "org-id",
+					baseUrl: mockServerUrl,
+				});
+
+				const res = await app.request("/v1/chat/completions", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: "Bearer real-token",
+					},
+					body: JSON.stringify({
+						model: "openai/gpt-4o-mini",
+						messages: [{ role: "user", content: "TRIGGER_FAIL_ONCE hello" }],
+						stream: true,
+						stream_options: { include_usage: true },
+					}),
+				});
+
+				expect(res.status).toBe(200);
+				const streamResult = await readAll(res.body);
+				expect(streamResult.hasError).toBe(false);
+
+				// Streaming carries the routing array on the final usage chunk.
+				const routingChunk = streamResult.chunks.find(
+					(chunk) => chunk?.metadata?.routing !== undefined,
+				);
+				expect(routingChunk).toBeDefined();
+				expect(
+					routingChunk.metadata.routing.map(
+						(attempt: { credentialSource?: string }) =>
+							attempt.credentialSource,
+					),
+				).toEqual(["byok", "platform"]);
+
+				const logs = await waitForLogs(2);
+				const successLog = logs.find((log: Log) => !log.hasError);
+				expect(successLog?.routingMetadata?.usedCredentialSource).toBe(
+					"platform",
+				);
+			} finally {
+				if (originalApiKey !== undefined) {
+					process.env.LLM_OPENAI_API_KEY = originalApiKey;
+				} else {
+					delete process.env.LLM_OPENAI_API_KEY;
+				}
+				if (originalBaseUrl !== undefined) {
+					process.env.LLM_OPENAI_BASE_URL = originalBaseUrl;
+				} else {
+					delete process.env.LLM_OPENAI_BASE_URL;
+				}
+			}
+		});
+
 		test("non-streaming: same-key retries stop after the retry budget is exhausted", async () => {
 			const originalApiKey = process.env.LLM_GOOGLE_AI_STUDIO_API_KEY;
 			const originalBaseUrl = process.env.LLM_GOOGLE_AI_STUDIO_BASE_URL;

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -11,6 +11,7 @@ import {
 
 import { db, eq, tables, type Log } from "@llmgateway/db";
 import { getProviderDefinition } from "@llmgateway/models";
+import { maskToken } from "@llmgateway/shared/mask-token";
 
 import { app } from "./app.js";
 import { SAME_KEY_RETRY_DELAY_MS } from "./chat/tools/retry-with-fallback.js";
@@ -2714,6 +2715,127 @@ describe("fallback and error status code handling", () => {
 						(attempt) => attempt.credentialSource,
 					),
 				).toEqual(["byok", "platform"]);
+			} finally {
+				if (originalApiKey !== undefined) {
+					process.env.LLM_OPENAI_API_KEY = originalApiKey;
+				} else {
+					delete process.env.LLM_OPENAI_API_KEY;
+				}
+				if (originalBaseUrl !== undefined) {
+					process.env.LLM_OPENAI_BASE_URL = originalBaseUrl;
+				} else {
+					delete process.env.LLM_OPENAI_BASE_URL;
+				}
+			}
+		});
+
+		test("non-streaming: names both of the org's own keys, never the platform one", async () => {
+			const originalApiKey = process.env.LLM_OPENAI_API_KEY;
+			const originalBaseUrl = process.env.LLM_OPENAI_BASE_URL;
+			process.env.LLM_OPENAI_API_KEY = "openai-env-platform-key";
+			process.env.LLM_OPENAI_BASE_URL = mockServerUrl;
+			try {
+				await ensureBaseFixtures();
+				await ensureProviders(["openai"]);
+				await db
+					.update(tables.project)
+					.set({ mode: "hybrid" })
+					.where(eq(tables.project.id, "project-id"));
+				await db.insert(tables.apiKey).values({
+					id: "token-id",
+					token: "real-token",
+					projectId: "project-id",
+					description: "Test API Key",
+					createdBy: "user-id",
+				});
+				// Two of the organization's own keys, both pointed at a closed port
+				// so each fails and rotates to the next credential: primary key →
+				// secondary key → LLM Gateway's own credential (the env one, which
+				// does reach the mock server).
+				await db.insert(tables.providerKey).values([
+					{
+						id: "openai-byok-primary",
+						token: "openai-byok-primary-token",
+						tokenMasked: maskToken("openai-byok-primary-token"),
+						provider: "openai",
+						organizationId: "org-id",
+						baseUrl: "http://127.0.0.1:9",
+						sortOrder: 0,
+					},
+					{
+						id: "openai-byok-secondary",
+						token: "openai-byok-secondary-token",
+						tokenMasked: maskToken("openai-byok-secondary-token"),
+						// A named key, which is how its owner recognizes it.
+						name: "billing-team-key",
+						provider: "openai",
+						organizationId: "org-id",
+						baseUrl: "http://127.0.0.1:9",
+						sortOrder: 1,
+					},
+				]);
+
+				const res = await app.request("/v1/chat/completions", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: "Bearer real-token",
+					},
+					body: JSON.stringify({
+						model: "openai/gpt-4o-mini",
+						messages: [{ role: "user", content: "Hello!" }],
+					}),
+				});
+
+				expect(res.status).toBe(200);
+				const json = await res.json();
+				expect(json.metadata.routing).toHaveLength(3);
+
+				// Each of the caller's own attempts names the key it used, the way
+				// the provider-keys page names it.
+				expect(json.metadata.routing[0]).toMatchObject({
+					succeeded: false,
+					credentialSource: "byok",
+					providerKeyId: "openai-byok-primary",
+					providerKeyLabel: maskToken("openai-byok-primary-token"),
+				});
+				expect(json.metadata.routing[1]).toMatchObject({
+					succeeded: false,
+					credentialSource: "byok",
+					providerKeyId: "openai-byok-secondary",
+					providerKeyLabel: "billing-team-key",
+				});
+
+				// The platform attempt is labelled as LLM Gateway's, and carries no
+				// identity at all: naming the credential that serves credits traffic
+				// would leak platform infrastructure to every tenant that falls back
+				// onto it.
+				expect(json.metadata.routing[2]).toMatchObject({
+					succeeded: true,
+					credentialSource: "platform",
+				});
+				expect(json.metadata.routing[2].providerKeyId).toBeUndefined();
+				expect(json.metadata.routing[2].providerKeyLabel).toBeUndefined();
+
+				const logs = await waitForLogs(3);
+				const successLog = logs.find((log: Log) => !log.hasError);
+				expect(successLog?.routingMetadata?.usedCredentialSource).toBe(
+					"platform",
+				);
+				expect(successLog?.routingMetadata?.usedProviderKeyId).toBeUndefined();
+				expect(
+					successLog?.routingMetadata?.usedProviderKeyLabel,
+				).toBeUndefined();
+
+				// Both of the organization's keys were candidates, in selection
+				// order; the platform credential is not one of "your keys".
+				expect(successLog?.routingMetadata?.eligibleProviderKeys).toEqual([
+					{
+						id: "openai-byok-primary",
+						label: maskToken("openai-byok-primary-token"),
+					},
+					{ id: "openai-byok-secondary", label: "billing-team-key" },
+				]);
 			} finally {
 				if (originalApiKey !== undefined) {
 					process.env.LLM_OPENAI_API_KEY = originalApiKey;

--- a/apps/gateway/src/lib/cached-queries.ts
+++ b/apps/gateway/src/lib/cached-queries.ts
@@ -475,15 +475,17 @@ export async function findCustomModel(
 }
 
 /**
- * Find a provider key by organization and provider (cacheable)
+ * The organization's own keys for a provider that can serve this request, in
+ * selection order (index 0 is the primary). This is exactly the candidate set
+ * findProviderKey picks from, before health failover and per-attempt
+ * exclusions narrow it — the "which of my keys could have been used" answer
+ * surfaced in routing metadata.
  */
-export async function findProviderKey(
+export async function listEligibleProviderKeys(
 	organizationId: string,
 	provider: string,
-	selectionScope?: string,
-	excludedKeyIds?: ReadonlySet<string>,
 	filter?: (key: ProviderKey) => boolean,
-): Promise<ProviderKey | undefined> {
+): Promise<ProviderKey[]> {
 	const results = await swrWrap(
 		`providerKey:${organizationId}:${provider}`,
 		[providerKeyTableName],
@@ -508,9 +510,26 @@ export async function findProviderKey(
 					asc(providerKeyTable.id),
 				),
 	);
-	const filtered = filter ? results.filter(filter) : results;
+	return filter ? results.filter(filter) : results;
+}
+
+/**
+ * Find a provider key by organization and provider (cacheable)
+ */
+export async function findProviderKey(
+	organizationId: string,
+	provider: string,
+	selectionScope?: string,
+	excludedKeyIds?: ReadonlySet<string>,
+	filter?: (key: ProviderKey) => boolean,
+): Promise<ProviderKey | undefined> {
+	const eligible = await listEligibleProviderKeys(
+		organizationId,
+		provider,
+		filter,
+	);
 	return selectProviderKeyWithFailover(
-		filtered,
+		eligible,
 		selectionScope,
 		excludedKeyIds,
 	);

--- a/apps/gateway/src/ocr/ocr.ts
+++ b/apps/gateway/src/ocr/ocr.ts
@@ -44,7 +44,11 @@ import { throwIamException, validateRequestModelAccess } from "@/lib/iam.js";
 import { calculateDataStorageCost, insertLog } from "@/lib/logs.js";
 import { createCombinedSignal, isTimeoutError } from "@/lib/timeout-config.js";
 
-import { getProviderHeaders, readProviderKey } from "@llmgateway/actions";
+import {
+	getProviderHeaders,
+	providerKeyLabel,
+	readProviderKey,
+} from "@llmgateway/actions";
 import { shortid } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
 import {
@@ -544,11 +548,19 @@ ocr.openapi(createOcr, async (c): Promise<any> => {
 	const buildOcrRoutingMetadata = (
 		usedApiKeyHash: string | undefined,
 		usedCredentialSource: RoutingCredentialSource,
+		usedProviderKey: { id?: string; label?: string },
 	): RoutingMetadata => ({
 		availableProviders: [providerId],
 		selectedProvider: providerId,
 		selectionReason,
-		...(usedApiKeyHash ? { usedApiKeyHash, usedCredentialSource } : {}),
+		...(usedApiKeyHash
+			? {
+					usedApiKeyHash,
+					usedCredentialSource,
+					usedProviderKeyId: usedProviderKey.id,
+					usedProviderKeyLabel: usedProviderKey.label,
+				}
+			: {}),
 		providerScores: [],
 		...(routingAttempts.length > 0 ? { routing: routingAttempts } : {}),
 	});
@@ -740,6 +752,11 @@ ocr.openapi(createOcr, async (c): Promise<any> => {
 			const credentialSource: RoutingCredentialSource = attempt.providerKey
 				? "byok"
 				: "platform";
+			// Named only for the organization's own key; providerKeyLabel()
+			// refuses to describe a platform-managed credential.
+			const providerKeyId = attempt.providerKey?.id;
+			const keyLabel = providerKeyLabel(attempt.providerKey);
+			const usedProviderKey = { id: providerKeyId, label: keyLabel };
 			const baseLogEntry = createLogEntry({
 				requestId,
 				project,
@@ -839,6 +856,8 @@ ocr.openapi(createOcr, async (c): Promise<any> => {
 							{
 								apiKeyHash: usedApiKeyHash,
 								credentialSource,
+								providerKeyId,
+								providerKeyLabel: keyLabel,
 								logId: willRetry ? attemptLogId : finalLogId,
 							},
 						),
@@ -852,6 +871,7 @@ ocr.openapi(createOcr, async (c): Promise<any> => {
 						routingMetadata: buildOcrRoutingMetadata(
 							usedApiKeyHash,
 							credentialSource,
+							usedProviderKey,
 						),
 						duration,
 						timeToFirstToken: null,
@@ -992,6 +1012,8 @@ ocr.openapi(createOcr, async (c): Promise<any> => {
 						{
 							apiKeyHash: usedApiKeyHash,
 							credentialSource,
+							providerKeyId,
+							providerKeyLabel: keyLabel,
 							logId: willRetry ? attemptLogId : finalLogId,
 						},
 					),
@@ -1004,6 +1026,7 @@ ocr.openapi(createOcr, async (c): Promise<any> => {
 						routingMetadata: buildOcrRoutingMetadata(
 							usedApiKeyHash,
 							credentialSource,
+							usedProviderKey,
 						),
 						duration,
 						timeToFirstToken: null,
@@ -1125,6 +1148,8 @@ ocr.openapi(createOcr, async (c): Promise<any> => {
 					{
 						apiKeyHash: usedApiKeyHash,
 						credentialSource,
+						providerKeyId,
+						providerKeyLabel: keyLabel,
 						logId: finalLogId,
 					},
 				),
@@ -1137,6 +1162,7 @@ ocr.openapi(createOcr, async (c): Promise<any> => {
 					routingMetadata: buildOcrRoutingMetadata(
 						usedApiKeyHash,
 						credentialSource,
+						usedProviderKey,
 					),
 					duration,
 					timeToFirstToken: null,

--- a/apps/gateway/src/ocr/ocr.ts
+++ b/apps/gateway/src/ocr/ocr.ts
@@ -57,6 +57,7 @@ import type { ServerTypes } from "@/vars.js";
 import type { RoutingMetadata } from "@llmgateway/actions";
 import type { InferSelectModel, tables } from "@llmgateway/db";
 import type { ModelDefinition, ProviderModelMapping } from "@llmgateway/models";
+import type { RoutingCredentialSource } from "@llmgateway/shared/routing-telemetry";
 
 // Mistral accepts either a document URL/PDF or an image. The image_url variant
 // may be a bare string or an object with a `url` field, mirroring the upstream
@@ -542,11 +543,12 @@ ocr.openapi(createOcr, async (c): Promise<any> => {
 	const routingAttempts: RoutingAttempt[] = [];
 	const buildOcrRoutingMetadata = (
 		usedApiKeyHash: string | undefined,
+		usedCredentialSource: RoutingCredentialSource,
 	): RoutingMetadata => ({
 		availableProviders: [providerId],
 		selectedProvider: providerId,
 		selectionReason,
-		...(usedApiKeyHash ? { usedApiKeyHash } : {}),
+		...(usedApiKeyHash ? { usedApiKeyHash, usedCredentialSource } : {}),
 		providerScores: [],
 		...(routingAttempts.length > 0 ? { routing: routingAttempts } : {}),
 	});
@@ -733,6 +735,11 @@ ocr.openapi(createOcr, async (c): Promise<any> => {
 		while (true) {
 			const attemptLogId = shortid();
 			const usedApiKeyHash = getApiKeyFingerprint(attempt.usedToken);
+			// BYOK only when the organization's own key served the attempt; a
+			// platform-managed credential is LLM Gateway's key and bills as credits.
+			const credentialSource: RoutingCredentialSource = attempt.providerKey
+				? "byok"
+				: "platform";
 			const baseLogEntry = createLogEntry({
 				requestId,
 				project,
@@ -831,6 +838,7 @@ ocr.openapi(createOcr, async (c): Promise<any> => {
 							false,
 							{
 								apiKeyHash: usedApiKeyHash,
+								credentialSource,
 								logId: willRetry ? attemptLogId : finalLogId,
 							},
 						),
@@ -841,7 +849,10 @@ ocr.openapi(createOcr, async (c): Promise<any> => {
 					{
 						...baseLogEntry,
 						id: willRetry ? attemptLogId : finalLogId,
-						routingMetadata: buildOcrRoutingMetadata(usedApiKeyHash),
+						routingMetadata: buildOcrRoutingMetadata(
+							usedApiKeyHash,
+							credentialSource,
+						),
 						duration,
 						timeToFirstToken: null,
 						timeToFirstReasoningToken: null,
@@ -980,6 +991,7 @@ ocr.openapi(createOcr, async (c): Promise<any> => {
 						false,
 						{
 							apiKeyHash: usedApiKeyHash,
+							credentialSource,
 							logId: willRetry ? attemptLogId : finalLogId,
 						},
 					),
@@ -989,7 +1001,10 @@ ocr.openapi(createOcr, async (c): Promise<any> => {
 					{
 						...baseLogEntry,
 						id: willRetry ? attemptLogId : finalLogId,
-						routingMetadata: buildOcrRoutingMetadata(usedApiKeyHash),
+						routingMetadata: buildOcrRoutingMetadata(
+							usedApiKeyHash,
+							credentialSource,
+						),
 						duration,
 						timeToFirstToken: null,
 						timeToFirstReasoningToken: null,
@@ -1109,6 +1124,7 @@ ocr.openapi(createOcr, async (c): Promise<any> => {
 					true,
 					{
 						apiKeyHash: usedApiKeyHash,
+						credentialSource,
 						logId: finalLogId,
 					},
 				),
@@ -1118,7 +1134,10 @@ ocr.openapi(createOcr, async (c): Promise<any> => {
 				{
 					...baseLogEntry,
 					id: finalLogId,
-					routingMetadata: buildOcrRoutingMetadata(usedApiKeyHash),
+					routingMetadata: buildOcrRoutingMetadata(
+						usedApiKeyHash,
+						credentialSource,
+					),
 					duration,
 					timeToFirstToken: null,
 					timeToFirstReasoningToken: null,

--- a/apps/gateway/src/rerank/rerank.ts
+++ b/apps/gateway/src/rerank/rerank.ts
@@ -68,6 +68,7 @@ import type { ServerTypes } from "@/vars.js";
 import type { RoutingMetadata } from "@llmgateway/actions";
 import type { InferSelectModel, tables } from "@llmgateway/db";
 import type { ModelDefinition, ProviderModelMapping } from "@llmgateway/models";
+import type { RoutingCredentialSource } from "@llmgateway/shared/routing-telemetry";
 
 const rerankRequestSchema = z.object({
 	model: z.string().openapi({
@@ -543,13 +544,14 @@ rerank.openapi(createRerank, async (c): Promise<any> => {
 
 	const buildRerankRoutingMetadata = (
 		usedApiKeyHash: string | undefined,
+		usedCredentialSource: RoutingCredentialSource,
 	): RoutingMetadata => ({
 		availableProviders: [providerId],
 		selectedProvider: providerId,
 		selectionReason: explicitProvider
 			? "direct-provider-specified"
 			: "single-provider-available",
-		...(usedApiKeyHash ? { usedApiKeyHash } : {}),
+		...(usedApiKeyHash ? { usedApiKeyHash, usedCredentialSource } : {}),
 		providerScores: [],
 		...(routingAttempts.length > 0 ? { routing: routingAttempts } : {}),
 	});
@@ -774,6 +776,11 @@ rerank.openapi(createRerank, async (c): Promise<any> => {
 		while (true) {
 			const attemptLogId = shortid();
 			const usedApiKeyHash = getApiKeyFingerprint(attempt.usedToken);
+			// BYOK only when the organization's own key served the attempt; a
+			// platform-managed credential is LLM Gateway's key and bills as credits.
+			const credentialSource: RoutingCredentialSource = attempt.providerKey
+				? "byok"
+				: "platform";
 			const baseLogEntry = createLogEntry({
 				requestId,
 				project,
@@ -880,6 +887,7 @@ rerank.openapi(createRerank, async (c): Promise<any> => {
 							false,
 							{
 								apiKeyHash: usedApiKeyHash,
+								credentialSource,
 								logId: willRetry ? attemptLogId : finalLogId,
 							},
 						),
@@ -889,7 +897,10 @@ rerank.openapi(createRerank, async (c): Promise<any> => {
 				await insertLog({
 					...baseLogEntry,
 					id: willRetry ? attemptLogId : finalLogId,
-					routingMetadata: buildRerankRoutingMetadata(usedApiKeyHash),
+					routingMetadata: buildRerankRoutingMetadata(
+						usedApiKeyHash,
+						credentialSource,
+					),
 					duration,
 					timeToFirstToken: null,
 					timeToFirstReasoningToken: null,
@@ -1029,6 +1040,7 @@ rerank.openapi(createRerank, async (c): Promise<any> => {
 						false,
 						{
 							apiKeyHash: usedApiKeyHash,
+							credentialSource,
 							logId: willRetry ? attemptLogId : finalLogId,
 						},
 					),
@@ -1037,7 +1049,10 @@ rerank.openapi(createRerank, async (c): Promise<any> => {
 				await insertLog({
 					...baseLogEntry,
 					id: willRetry ? attemptLogId : finalLogId,
-					routingMetadata: buildRerankRoutingMetadata(usedApiKeyHash),
+					routingMetadata: buildRerankRoutingMetadata(
+						usedApiKeyHash,
+						credentialSource,
+					),
 					duration,
 					timeToFirstToken: null,
 					timeToFirstReasoningToken: null,
@@ -1199,7 +1214,10 @@ rerank.openapi(createRerank, async (c): Promise<any> => {
 			await insertLog({
 				...baseLogEntry,
 				id: finalLogId,
-				routingMetadata: buildRerankRoutingMetadata(usedApiKeyHash),
+				routingMetadata: buildRerankRoutingMetadata(
+					usedApiKeyHash,
+					credentialSource,
+				),
 				duration,
 				timeToFirstToken: null,
 				timeToFirstReasoningToken: null,

--- a/apps/gateway/src/rerank/rerank.ts
+++ b/apps/gateway/src/rerank/rerank.ts
@@ -54,6 +54,7 @@ import { validateModelOutput } from "@/lib/validate-model-output.js";
 import {
 	getProviderDefaultBaseUrl,
 	getProviderHeaders,
+	providerKeyLabel,
 	readProviderKey,
 } from "@llmgateway/actions";
 import { shortid } from "@llmgateway/db";
@@ -545,13 +546,21 @@ rerank.openapi(createRerank, async (c): Promise<any> => {
 	const buildRerankRoutingMetadata = (
 		usedApiKeyHash: string | undefined,
 		usedCredentialSource: RoutingCredentialSource,
+		usedProviderKey: { id?: string; label?: string },
 	): RoutingMetadata => ({
 		availableProviders: [providerId],
 		selectedProvider: providerId,
 		selectionReason: explicitProvider
 			? "direct-provider-specified"
 			: "single-provider-available",
-		...(usedApiKeyHash ? { usedApiKeyHash, usedCredentialSource } : {}),
+		...(usedApiKeyHash
+			? {
+					usedApiKeyHash,
+					usedCredentialSource,
+					usedProviderKeyId: usedProviderKey.id,
+					usedProviderKeyLabel: usedProviderKey.label,
+				}
+			: {}),
 		providerScores: [],
 		...(routingAttempts.length > 0 ? { routing: routingAttempts } : {}),
 	});
@@ -781,6 +790,11 @@ rerank.openapi(createRerank, async (c): Promise<any> => {
 			const credentialSource: RoutingCredentialSource = attempt.providerKey
 				? "byok"
 				: "platform";
+			// Named only for the organization's own key; providerKeyLabel()
+			// refuses to describe a platform-managed credential.
+			const providerKeyId = attempt.providerKey?.id;
+			const keyLabel = providerKeyLabel(attempt.providerKey);
+			const usedProviderKey = { id: providerKeyId, label: keyLabel };
 			const baseLogEntry = createLogEntry({
 				requestId,
 				project,
@@ -888,6 +902,8 @@ rerank.openapi(createRerank, async (c): Promise<any> => {
 							{
 								apiKeyHash: usedApiKeyHash,
 								credentialSource,
+								providerKeyId,
+								providerKeyLabel: keyLabel,
 								logId: willRetry ? attemptLogId : finalLogId,
 							},
 						),
@@ -900,6 +916,7 @@ rerank.openapi(createRerank, async (c): Promise<any> => {
 					routingMetadata: buildRerankRoutingMetadata(
 						usedApiKeyHash,
 						credentialSource,
+						usedProviderKey,
 					),
 					duration,
 					timeToFirstToken: null,
@@ -1041,6 +1058,8 @@ rerank.openapi(createRerank, async (c): Promise<any> => {
 						{
 							apiKeyHash: usedApiKeyHash,
 							credentialSource,
+							providerKeyId,
+							providerKeyLabel: keyLabel,
 							logId: willRetry ? attemptLogId : finalLogId,
 						},
 					),
@@ -1052,6 +1071,7 @@ rerank.openapi(createRerank, async (c): Promise<any> => {
 					routingMetadata: buildRerankRoutingMetadata(
 						usedApiKeyHash,
 						credentialSource,
+						usedProviderKey,
 					),
 					duration,
 					timeToFirstToken: null,
@@ -1211,12 +1231,30 @@ rerank.openapi(createRerank, async (c): Promise<any> => {
 			const requestCostNum = Number(rerankMapping.requestPrice ?? "0");
 			const cost = inputCost + requestCostNum;
 
+			routingAttempts.push(
+				buildRoutingAttempt(
+					providerId,
+					modelDefId,
+					upstreamResponse.status,
+					"none",
+					true,
+					{
+						apiKeyHash: usedApiKeyHash,
+						credentialSource,
+						providerKeyId,
+						providerKeyLabel: keyLabel,
+						logId: finalLogId,
+					},
+				),
+			);
+
 			await insertLog({
 				...baseLogEntry,
 				id: finalLogId,
 				routingMetadata: buildRerankRoutingMetadata(
 					usedApiKeyHash,
 					credentialSource,
+					usedProviderKey,
 				),
 				duration,
 				timeToFirstToken: null,

--- a/apps/gateway/src/speech/speech.ts
+++ b/apps/gateway/src/speech/speech.ts
@@ -43,6 +43,7 @@ import { createCombinedSignal, isTimeoutError } from "@/lib/timeout-config.js";
 import {
 	getProviderHeaders,
 	managedCredentialOptions,
+	providerKeyLabel,
 	readProviderKey,
 } from "@llmgateway/actions";
 import { shortid } from "@llmgateway/db";
@@ -679,11 +680,19 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 	const buildSpeechRoutingMetadata = (
 		usedApiKeyHash: string | undefined,
 		usedCredentialSource: RoutingCredentialSource,
+		usedProviderKey: { id?: string; label?: string },
 	): RoutingMetadata => ({
 		availableProviders: [providerId],
 		selectedProvider: providerId,
 		selectionReason,
-		...(usedApiKeyHash ? { usedApiKeyHash, usedCredentialSource } : {}),
+		...(usedApiKeyHash
+			? {
+					usedApiKeyHash,
+					usedCredentialSource,
+					usedProviderKeyId: usedProviderKey.id,
+					usedProviderKeyLabel: usedProviderKey.label,
+				}
+			: {}),
 		providerScores: [],
 		...(routingAttempts.length > 0 ? { routing: routingAttempts } : {}),
 	});
@@ -982,6 +991,11 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 			const credentialSource: RoutingCredentialSource = attempt.providerKey
 				? "byok"
 				: "platform";
+			// Named only for the organization's own key; providerKeyLabel()
+			// refuses to describe a platform-managed credential.
+			const providerKeyId = attempt.providerKey?.id;
+			const keyLabel = providerKeyLabel(attempt.providerKey);
+			const usedProviderKey = { id: providerKeyId, label: keyLabel };
 			const baseLogEntry = createLogEntry({
 				requestId,
 				project,
@@ -1086,6 +1100,8 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 							{
 								apiKeyHash: usedApiKeyHash,
 								credentialSource,
+								providerKeyId,
+								providerKeyLabel: keyLabel,
 								logId: willRetry ? attemptLogId : finalLogId,
 							},
 						),
@@ -1099,6 +1115,7 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 						routingMetadata: buildSpeechRoutingMetadata(
 							usedApiKeyHash,
 							credentialSource,
+							usedProviderKey,
 						),
 						duration,
 						timeToFirstToken: null,
@@ -1238,6 +1255,8 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 						{
 							apiKeyHash: usedApiKeyHash,
 							credentialSource,
+							providerKeyId,
+							providerKeyLabel: keyLabel,
 							logId: willRetry ? attemptLogId : finalLogId,
 						},
 					),
@@ -1250,6 +1269,7 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 						routingMetadata: buildSpeechRoutingMetadata(
 							usedApiKeyHash,
 							credentialSource,
+							usedProviderKey,
 						),
 						duration,
 						timeToFirstToken: null,
@@ -1405,6 +1425,8 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 								{
 									apiKeyHash: usedApiKeyHash,
 									credentialSource,
+									providerKeyId,
+									providerKeyLabel: keyLabel,
 									logId: finalLogId,
 								},
 							),
@@ -1416,6 +1438,7 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 								routingMetadata: buildSpeechRoutingMetadata(
 									usedApiKeyHash,
 									credentialSource,
+									usedProviderKey,
 								),
 								duration,
 								timeToFirstToken: null,
@@ -1523,6 +1546,8 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 						{
 							apiKeyHash: usedApiKeyHash,
 							credentialSource,
+							providerKeyId,
+							providerKeyLabel: keyLabel,
 							logId: finalLogId,
 						},
 					),
@@ -1535,6 +1560,7 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 						routingMetadata: buildSpeechRoutingMetadata(
 							usedApiKeyHash,
 							credentialSource,
+							usedProviderKey,
 						),
 						duration,
 						timeToFirstToken: null,
@@ -1640,6 +1666,8 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 							{
 								apiKeyHash: usedApiKeyHash,
 								credentialSource,
+								providerKeyId,
+								providerKeyLabel: keyLabel,
 								logId: finalLogId,
 							},
 						),
@@ -1650,6 +1678,7 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 						routingMetadata: buildSpeechRoutingMetadata(
 							usedApiKeyHash,
 							credentialSource,
+							usedProviderKey,
 						),
 						duration,
 						timeToFirstToken: null,
@@ -1727,6 +1756,8 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 						{
 							apiKeyHash: usedApiKeyHash,
 							credentialSource,
+							providerKeyId,
+							providerKeyLabel: keyLabel,
 							logId: finalLogId,
 						},
 					),
@@ -1738,6 +1769,7 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 					routingMetadata: buildSpeechRoutingMetadata(
 						usedApiKeyHash,
 						credentialSource,
+						usedProviderKey,
 					),
 					duration,
 					timeToFirstToken: null,
@@ -1824,6 +1856,8 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 						{
 							apiKeyHash: usedApiKeyHash,
 							credentialSource,
+							providerKeyId,
+							providerKeyLabel: keyLabel,
 							logId: finalLogId,
 						},
 					),
@@ -1836,6 +1870,7 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 						routingMetadata: buildSpeechRoutingMetadata(
 							usedApiKeyHash,
 							credentialSource,
+							usedProviderKey,
 						),
 						duration,
 						timeToFirstToken: null,
@@ -1936,6 +1971,8 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 					{
 						apiKeyHash: usedApiKeyHash,
 						credentialSource,
+						providerKeyId,
+						providerKeyLabel: keyLabel,
 						logId: finalLogId,
 					},
 				),
@@ -1948,6 +1985,7 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 					routingMetadata: buildSpeechRoutingMetadata(
 						usedApiKeyHash,
 						credentialSource,
+						usedProviderKey,
 					),
 					duration,
 					timeToFirstToken: null,

--- a/apps/gateway/src/speech/speech.ts
+++ b/apps/gateway/src/speech/speech.ts
@@ -63,6 +63,7 @@ import type {
 	ProviderModelMapping,
 	VertexTokenType,
 } from "@llmgateway/models";
+import type { RoutingCredentialSource } from "@llmgateway/shared/routing-telemetry";
 
 const speechRequestSchema = z.object({
 	model: z.string().openapi({
@@ -677,11 +678,12 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 	const routingAttempts: RoutingAttempt[] = [];
 	const buildSpeechRoutingMetadata = (
 		usedApiKeyHash: string | undefined,
+		usedCredentialSource: RoutingCredentialSource,
 	): RoutingMetadata => ({
 		availableProviders: [providerId],
 		selectedProvider: providerId,
 		selectionReason,
-		...(usedApiKeyHash ? { usedApiKeyHash } : {}),
+		...(usedApiKeyHash ? { usedApiKeyHash, usedCredentialSource } : {}),
 		providerScores: [],
 		...(routingAttempts.length > 0 ? { routing: routingAttempts } : {}),
 	});
@@ -975,6 +977,11 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 		while (true) {
 			const attemptLogId = shortid();
 			const usedApiKeyHash = getApiKeyFingerprint(attempt.usedToken);
+			// BYOK only when the organization's own key served the attempt; a
+			// platform-managed credential is LLM Gateway's key and bills as credits.
+			const credentialSource: RoutingCredentialSource = attempt.providerKey
+				? "byok"
+				: "platform";
 			const baseLogEntry = createLogEntry({
 				requestId,
 				project,
@@ -1078,6 +1085,7 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 							false,
 							{
 								apiKeyHash: usedApiKeyHash,
+								credentialSource,
 								logId: willRetry ? attemptLogId : finalLogId,
 							},
 						),
@@ -1088,7 +1096,10 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 					{
 						...baseLogEntry,
 						id: willRetry ? attemptLogId : finalLogId,
-						routingMetadata: buildSpeechRoutingMetadata(usedApiKeyHash),
+						routingMetadata: buildSpeechRoutingMetadata(
+							usedApiKeyHash,
+							credentialSource,
+						),
 						duration,
 						timeToFirstToken: null,
 						timeToFirstReasoningToken: null,
@@ -1226,6 +1237,7 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 						false,
 						{
 							apiKeyHash: usedApiKeyHash,
+							credentialSource,
 							logId: willRetry ? attemptLogId : finalLogId,
 						},
 					),
@@ -1235,7 +1247,10 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 					{
 						...baseLogEntry,
 						id: willRetry ? attemptLogId : finalLogId,
-						routingMetadata: buildSpeechRoutingMetadata(usedApiKeyHash),
+						routingMetadata: buildSpeechRoutingMetadata(
+							usedApiKeyHash,
+							credentialSource,
+						),
 						duration,
 						timeToFirstToken: null,
 						timeToFirstReasoningToken: null,
@@ -1387,14 +1402,21 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 								upstreamResponse.status,
 								"upstream_error",
 								false,
-								{ apiKeyHash: usedApiKeyHash, logId: finalLogId },
+								{
+									apiKeyHash: usedApiKeyHash,
+									credentialSource,
+									logId: finalLogId,
+								},
 							),
 						);
 						await insertLog(
 							{
 								...baseLogEntry,
 								id: finalLogId,
-								routingMetadata: buildSpeechRoutingMetadata(usedApiKeyHash),
+								routingMetadata: buildSpeechRoutingMetadata(
+									usedApiKeyHash,
+									credentialSource,
+								),
 								duration,
 								timeToFirstToken: null,
 								timeToFirstReasoningToken: null,
@@ -1500,6 +1522,7 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 						true,
 						{
 							apiKeyHash: usedApiKeyHash,
+							credentialSource,
 							logId: finalLogId,
 						},
 					),
@@ -1509,7 +1532,10 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 					{
 						...baseLogEntry,
 						id: finalLogId,
-						routingMetadata: buildSpeechRoutingMetadata(usedApiKeyHash),
+						routingMetadata: buildSpeechRoutingMetadata(
+							usedApiKeyHash,
+							credentialSource,
+						),
 						duration,
 						timeToFirstToken: null,
 						timeToFirstReasoningToken: null,
@@ -1611,13 +1637,20 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 							upstreamResponse.status,
 							"upstream_error",
 							false,
-							{ apiKeyHash: usedApiKeyHash, logId: finalLogId },
+							{
+								apiKeyHash: usedApiKeyHash,
+								credentialSource,
+								logId: finalLogId,
+							},
 						),
 					);
 					await insertLog({
 						...baseLogEntry,
 						id: finalLogId,
-						routingMetadata: buildSpeechRoutingMetadata(usedApiKeyHash),
+						routingMetadata: buildSpeechRoutingMetadata(
+							usedApiKeyHash,
+							credentialSource,
+						),
 						duration,
 						timeToFirstToken: null,
 						timeToFirstReasoningToken: null,
@@ -1693,6 +1726,7 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 						true,
 						{
 							apiKeyHash: usedApiKeyHash,
+							credentialSource,
 							logId: finalLogId,
 						},
 					),
@@ -1701,7 +1735,10 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 				await insertLog({
 					...baseLogEntry,
 					id: finalLogId,
-					routingMetadata: buildSpeechRoutingMetadata(usedApiKeyHash),
+					routingMetadata: buildSpeechRoutingMetadata(
+						usedApiKeyHash,
+						credentialSource,
+					),
 					duration,
 					timeToFirstToken: null,
 					timeToFirstReasoningToken: null,
@@ -1786,6 +1823,7 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 						false,
 						{
 							apiKeyHash: usedApiKeyHash,
+							credentialSource,
 							logId: finalLogId,
 						},
 					),
@@ -1795,7 +1833,10 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 					{
 						...baseLogEntry,
 						id: finalLogId,
-						routingMetadata: buildSpeechRoutingMetadata(usedApiKeyHash),
+						routingMetadata: buildSpeechRoutingMetadata(
+							usedApiKeyHash,
+							credentialSource,
+						),
 						duration,
 						timeToFirstToken: null,
 						timeToFirstReasoningToken: null,
@@ -1894,6 +1935,7 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 					true,
 					{
 						apiKeyHash: usedApiKeyHash,
+						credentialSource,
 						logId: finalLogId,
 					},
 				),
@@ -1903,7 +1945,10 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 				{
 					...baseLogEntry,
 					id: finalLogId,
-					routingMetadata: buildSpeechRoutingMetadata(usedApiKeyHash),
+					routingMetadata: buildSpeechRoutingMetadata(
+						usedApiKeyHash,
+						credentialSource,
+					),
 					duration,
 					timeToFirstToken: null,
 					timeToFirstReasoningToken: null,

--- a/apps/gateway/src/transcriptions/transcriptions.ts
+++ b/apps/gateway/src/transcriptions/transcriptions.ts
@@ -44,7 +44,11 @@ import { throwIamException, validateRequestModelAccess } from "@/lib/iam.js";
 import { calculateDataStorageCost, insertLog } from "@/lib/logs.js";
 import { createCombinedSignal, isTimeoutError } from "@/lib/timeout-config.js";
 
-import { getProviderHeaders, readProviderKey } from "@llmgateway/actions";
+import {
+	getProviderHeaders,
+	providerKeyLabel,
+	readProviderKey,
+} from "@llmgateway/actions";
 import { shortid } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
 import {
@@ -561,11 +565,19 @@ transcriptions.openapi(createTranscription, async (c): Promise<any> => {
 	const buildTranscriptionRoutingMetadata = (
 		usedApiKeyHash: string | undefined,
 		usedCredentialSource: RoutingCredentialSource,
+		usedProviderKey: { id?: string; label?: string },
 	): RoutingMetadata => ({
 		availableProviders: [providerId],
 		selectedProvider: providerId,
 		selectionReason,
-		...(usedApiKeyHash ? { usedApiKeyHash, usedCredentialSource } : {}),
+		...(usedApiKeyHash
+			? {
+					usedApiKeyHash,
+					usedCredentialSource,
+					usedProviderKeyId: usedProviderKey.id,
+					usedProviderKeyLabel: usedProviderKey.label,
+				}
+			: {}),
 		providerScores: [],
 		...(routingAttempts.length > 0 ? { routing: routingAttempts } : {}),
 	});
@@ -777,6 +789,11 @@ transcriptions.openapi(createTranscription, async (c): Promise<any> => {
 			const credentialSource: RoutingCredentialSource = attempt.providerKey
 				? "byok"
 				: "platform";
+			// Named only for the organization's own key; providerKeyLabel()
+			// refuses to describe a platform-managed credential.
+			const providerKeyId = attempt.providerKey?.id;
+			const keyLabel = providerKeyLabel(attempt.providerKey);
+			const usedProviderKey = { id: providerKeyId, label: keyLabel };
 			const baseLogEntry = createLogEntry({
 				requestId,
 				project,
@@ -877,6 +894,8 @@ transcriptions.openapi(createTranscription, async (c): Promise<any> => {
 							{
 								apiKeyHash: usedApiKeyHash,
 								credentialSource,
+								providerKeyId,
+								providerKeyLabel: keyLabel,
 								logId: willRetry ? attemptLogId : finalLogId,
 							},
 						),
@@ -889,6 +908,7 @@ transcriptions.openapi(createTranscription, async (c): Promise<any> => {
 					routingMetadata: buildTranscriptionRoutingMetadata(
 						usedApiKeyHash,
 						credentialSource,
+						usedProviderKey,
 					),
 					duration,
 					timeToFirstToken: null,
@@ -1027,6 +1047,8 @@ transcriptions.openapi(createTranscription, async (c): Promise<any> => {
 						{
 							apiKeyHash: usedApiKeyHash,
 							credentialSource,
+							providerKeyId,
+							providerKeyLabel: keyLabel,
 							logId: willRetry ? attemptLogId : finalLogId,
 						},
 					),
@@ -1038,6 +1060,7 @@ transcriptions.openapi(createTranscription, async (c): Promise<any> => {
 					routingMetadata: buildTranscriptionRoutingMetadata(
 						usedApiKeyHash,
 						credentialSource,
+						usedProviderKey,
 					),
 					duration,
 					timeToFirstToken: null,
@@ -1164,6 +1187,8 @@ transcriptions.openapi(createTranscription, async (c): Promise<any> => {
 					{
 						apiKeyHash: usedApiKeyHash,
 						credentialSource,
+						providerKeyId,
+						providerKeyLabel: keyLabel,
 						logId: finalLogId,
 					},
 				),
@@ -1175,6 +1200,7 @@ transcriptions.openapi(createTranscription, async (c): Promise<any> => {
 				routingMetadata: buildTranscriptionRoutingMetadata(
 					usedApiKeyHash,
 					credentialSource,
+					usedProviderKey,
 				),
 				duration,
 				timeToFirstToken: null,

--- a/apps/gateway/src/transcriptions/transcriptions.ts
+++ b/apps/gateway/src/transcriptions/transcriptions.ts
@@ -57,6 +57,7 @@ import type { ServerTypes } from "@/vars.js";
 import type { RoutingMetadata } from "@llmgateway/actions";
 import type { InferSelectModel, tables } from "@llmgateway/db";
 import type { ModelDefinition, ProviderModelMapping } from "@llmgateway/models";
+import type { RoutingCredentialSource } from "@llmgateway/shared/routing-telemetry";
 
 // The request arrives as multipart/form-data (OpenAI-compatible surface). The
 // schema documents the accepted fields; parsing happens via parseBody so file
@@ -559,11 +560,12 @@ transcriptions.openapi(createTranscription, async (c): Promise<any> => {
 	const routingAttempts: RoutingAttempt[] = [];
 	const buildTranscriptionRoutingMetadata = (
 		usedApiKeyHash: string | undefined,
+		usedCredentialSource: RoutingCredentialSource,
 	): RoutingMetadata => ({
 		availableProviders: [providerId],
 		selectedProvider: providerId,
 		selectionReason,
-		...(usedApiKeyHash ? { usedApiKeyHash } : {}),
+		...(usedApiKeyHash ? { usedApiKeyHash, usedCredentialSource } : {}),
 		providerScores: [],
 		...(routingAttempts.length > 0 ? { routing: routingAttempts } : {}),
 	});
@@ -770,6 +772,11 @@ transcriptions.openapi(createTranscription, async (c): Promise<any> => {
 		while (true) {
 			const attemptLogId = shortid();
 			const usedApiKeyHash = getApiKeyFingerprint(attempt.usedToken);
+			// BYOK only when the organization's own key served the attempt; a
+			// platform-managed credential is LLM Gateway's key and bills as credits.
+			const credentialSource: RoutingCredentialSource = attempt.providerKey
+				? "byok"
+				: "platform";
 			const baseLogEntry = createLogEntry({
 				requestId,
 				project,
@@ -869,6 +876,7 @@ transcriptions.openapi(createTranscription, async (c): Promise<any> => {
 							false,
 							{
 								apiKeyHash: usedApiKeyHash,
+								credentialSource,
 								logId: willRetry ? attemptLogId : finalLogId,
 							},
 						),
@@ -878,7 +886,10 @@ transcriptions.openapi(createTranscription, async (c): Promise<any> => {
 				await insertLog({
 					...baseLogEntry,
 					id: willRetry ? attemptLogId : finalLogId,
-					routingMetadata: buildTranscriptionRoutingMetadata(usedApiKeyHash),
+					routingMetadata: buildTranscriptionRoutingMetadata(
+						usedApiKeyHash,
+						credentialSource,
+					),
 					duration,
 					timeToFirstToken: null,
 					timeToFirstReasoningToken: null,
@@ -1015,6 +1026,7 @@ transcriptions.openapi(createTranscription, async (c): Promise<any> => {
 						false,
 						{
 							apiKeyHash: usedApiKeyHash,
+							credentialSource,
 							logId: willRetry ? attemptLogId : finalLogId,
 						},
 					),
@@ -1023,7 +1035,10 @@ transcriptions.openapi(createTranscription, async (c): Promise<any> => {
 				await insertLog({
 					...baseLogEntry,
 					id: willRetry ? attemptLogId : finalLogId,
-					routingMetadata: buildTranscriptionRoutingMetadata(usedApiKeyHash),
+					routingMetadata: buildTranscriptionRoutingMetadata(
+						usedApiKeyHash,
+						credentialSource,
+					),
 					duration,
 					timeToFirstToken: null,
 					timeToFirstReasoningToken: null,
@@ -1148,6 +1163,7 @@ transcriptions.openapi(createTranscription, async (c): Promise<any> => {
 					true,
 					{
 						apiKeyHash: usedApiKeyHash,
+						credentialSource,
 						logId: finalLogId,
 					},
 				),
@@ -1156,7 +1172,10 @@ transcriptions.openapi(createTranscription, async (c): Promise<any> => {
 			await insertLog({
 				...baseLogEntry,
 				id: finalLogId,
-				routingMetadata: buildTranscriptionRoutingMetadata(usedApiKeyHash),
+				routingMetadata: buildTranscriptionRoutingMetadata(
+					usedApiKeyHash,
+					credentialSource,
+				),
 				duration,
 				timeToFirstToken: null,
 				timeToFirstReasoningToken: null,

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -104,6 +104,7 @@ import {
 
 import type { ServerTypes } from "@/vars.js";
 import type { ResolvedRoutingConfig } from "@llmgateway/shared/routing-config";
+import type { RoutingCredentialSource } from "@llmgateway/shared/routing-telemetry";
 import type { Context } from "hono";
 
 function createProviderDiscountResolver(organizationId: string) {
@@ -4302,6 +4303,17 @@ async function processVideoImageInputs(
 	).filter((image): image is ProcessedVideoImageInput => image !== null);
 }
 
+/**
+ * Whose credential a video attempt ran on. `usedMode` on the provider context
+ * is already decided by whether the organization's own provider key served the
+ * job, so it maps one-to-one onto the routing credential vocabulary.
+ */
+function videoCredentialSource(
+	providerContext: ProviderContext,
+): RoutingCredentialSource {
+	return providerContext.usedMode === "api-keys" ? "byok" : "platform";
+}
+
 function buildVideoClientErrorRoutingMetadata(
 	routingMetadata: RoutingMetadata | undefined,
 	providerContext: ProviderContext,
@@ -4311,6 +4323,7 @@ function buildVideoClientErrorRoutingMetadata(
 	const routingAttempt: RoutingAttempt = {
 		provider: providerContext.providerId,
 		model: modelId,
+		credentialSource: videoCredentialSource(providerContext),
 		status_code: statusCode,
 		error_type: "client_error",
 		succeeded: false,
@@ -4701,6 +4714,7 @@ videos.openapi(createVideo, async (c) => {
 			routingAttempts.push({
 				provider: selectedProviderContext.providerId,
 				model: modelInfo.id,
+				credentialSource: videoCredentialSource(selectedProviderContext),
 				status_code: 402,
 				error_type: "insufficient_credits",
 				succeeded: false,
@@ -4754,6 +4768,7 @@ videos.openapi(createVideo, async (c) => {
 			routingAttempts.push({
 				provider: selectedProviderContext.providerId,
 				model: modelInfo.id,
+				credentialSource: videoCredentialSource(selectedProviderContext),
 				status_code: statusCode,
 				error_type: "client_error",
 				succeeded: false,
@@ -4828,6 +4843,7 @@ videos.openapi(createVideo, async (c) => {
 			routingAttempts.push({
 				provider: selectedProviderContext.providerId,
 				model: modelInfo.id,
+				credentialSource: videoCredentialSource(selectedProviderContext),
 				status_code: 200,
 				error_type: "none",
 				succeeded: true,
@@ -4842,6 +4858,7 @@ videos.openapi(createVideo, async (c) => {
 			routingAttempts.push({
 				provider: selectedProviderContext.providerId,
 				model: modelInfo.id,
+				credentialSource: videoCredentialSource(selectedProviderContext),
 				status_code: statusCode,
 				error_type: getErrorType(statusCode),
 				succeeded: false,

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -52,6 +52,7 @@ import {
 	getProviderHeaders,
 	managedCredentialOptions,
 	processImageUrl,
+	providerKeyLabel,
 	readProviderKey,
 	type RoutingMetadata,
 	type VideoPricingContext,
@@ -639,6 +640,11 @@ interface ProviderContext {
 	 * org's active key as they always did.
 	 */
 	providerKeyId?: string;
+	/**
+	 * That key named as its owner sees it, for the routing view. BYOK only —
+	 * providerKeyLabel() returns undefined for a platform credential.
+	 */
+	providerKeyLabel?: string;
 	vertexProjectId?: string;
 	vertexRegion?: string;
 	vertexTokenType?: VertexTokenType;
@@ -1580,6 +1586,7 @@ async function resolveProviderContext(
 			usedMode: "api-keys",
 			configIndex: null,
 			providerKeyId: providerKey.id,
+			providerKeyLabel: providerKeyLabel(providerKey),
 			vertexProjectId: sharedVertexProjectId,
 			vertexRegion: sharedVertexRegion,
 			vertexTokenType: resolveVideoVertexTokenType(
@@ -1638,6 +1645,7 @@ async function resolveProviderContext(
 			usedMode: "api-keys",
 			configIndex: null,
 			providerKeyId: providerKey.id,
+			providerKeyLabel: providerKeyLabel(providerKey),
 			vertexProjectId: sharedVertexProjectId,
 			vertexRegion: sharedVertexRegion,
 			vertexTokenType: resolveVideoVertexTokenType(
@@ -4314,6 +4322,24 @@ function videoCredentialSource(
 	return providerContext.usedMode === "api-keys" ? "byok" : "platform";
 }
 
+/**
+ * Key identity for a video attempt, and only when the organization's own key
+ * served it: `usedMode` is the same BYOK discriminator credentialSource uses,
+ * so a platform credential contributes nothing here.
+ */
+function videoProviderKeyIdentity(providerContext: ProviderContext): {
+	providerKeyId?: string;
+	providerKeyLabel?: string;
+} {
+	if (providerContext.usedMode !== "api-keys") {
+		return {};
+	}
+	return {
+		providerKeyId: providerContext.providerKeyId,
+		providerKeyLabel: providerContext.providerKeyLabel,
+	};
+}
+
 function buildVideoClientErrorRoutingMetadata(
 	routingMetadata: RoutingMetadata | undefined,
 	providerContext: ProviderContext,
@@ -4324,6 +4350,7 @@ function buildVideoClientErrorRoutingMetadata(
 		provider: providerContext.providerId,
 		model: modelId,
 		credentialSource: videoCredentialSource(providerContext),
+		...videoProviderKeyIdentity(providerContext),
 		status_code: statusCode,
 		error_type: "client_error",
 		succeeded: false,
@@ -4715,6 +4742,7 @@ videos.openapi(createVideo, async (c) => {
 				provider: selectedProviderContext.providerId,
 				model: modelInfo.id,
 				credentialSource: videoCredentialSource(selectedProviderContext),
+				...videoProviderKeyIdentity(selectedProviderContext),
 				status_code: 402,
 				error_type: "insufficient_credits",
 				succeeded: false,
@@ -4769,6 +4797,7 @@ videos.openapi(createVideo, async (c) => {
 				provider: selectedProviderContext.providerId,
 				model: modelInfo.id,
 				credentialSource: videoCredentialSource(selectedProviderContext),
+				...videoProviderKeyIdentity(selectedProviderContext),
 				status_code: statusCode,
 				error_type: "client_error",
 				succeeded: false,
@@ -4844,6 +4873,7 @@ videos.openapi(createVideo, async (c) => {
 				provider: selectedProviderContext.providerId,
 				model: modelInfo.id,
 				credentialSource: videoCredentialSource(selectedProviderContext),
+				...videoProviderKeyIdentity(selectedProviderContext),
 				status_code: 200,
 				error_type: "none",
 				succeeded: true,
@@ -4859,6 +4889,7 @@ videos.openapi(createVideo, async (c) => {
 				provider: selectedProviderContext.providerId,
 				model: modelInfo.id,
 				credentialSource: videoCredentialSource(selectedProviderContext),
+				...videoProviderKeyIdentity(selectedProviderContext),
 				status_code: statusCode,
 				error_type: getErrorType(statusCode),
 				succeeded: false,

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
@@ -41,7 +41,10 @@ import {
 	getServiceTier,
 } from "@llmgateway/models";
 import { regionFromUsedModel } from "@llmgateway/shared";
-import { API_ORIGIN_LABELS } from "@llmgateway/shared/components";
+import {
+	API_ORIGIN_LABELS,
+	CredentialSourceBadge,
+} from "@llmgateway/shared/components";
 
 import type { LogDetailData } from "@/types/activity";
 import type { Log } from "@llmgateway/db";
@@ -679,9 +682,14 @@ export function LogDetailClient({
 									{log.routingMetadata.usedApiKeyHash && (
 										<Field
 											label="Key"
-											value={formatApiKeyHash(
-												log.routingMetadata.usedApiKeyHash,
-											)}
+											value={
+												<span className="inline-flex items-center gap-1.5">
+													{formatApiKeyHash(log.routingMetadata.usedApiKeyHash)}
+													<CredentialSourceBadge
+														source={log.routingMetadata.usedCredentialSource}
+													/>
+												</span>
+											}
 											mono
 										/>
 									)}
@@ -806,6 +814,9 @@ export function LogDetailClient({
 																		key {formatApiKeyHash(attempt.apiKeyHash)}
 																	</span>
 																)}
+																<CredentialSourceBadge
+																	source={attempt.credentialSource}
+																/>
 																{attempt.logId && (
 																	<Link
 																		href={`/dashboard/${orgId}/${projectId}/activity/${attempt.logId}`}

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
@@ -687,12 +687,23 @@ export function LogDetailClient({
 													{formatApiKeyHash(log.routingMetadata.usedApiKeyHash)}
 													<CredentialSourceBadge
 														source={log.routingMetadata.usedCredentialSource}
+														keyLabel={log.routingMetadata.usedProviderKeyLabel}
 													/>
 												</span>
 											}
 											mono
 										/>
 									)}
+									{log.routingMetadata.eligibleProviderKeys &&
+										log.routingMetadata.eligibleProviderKeys.length > 0 && (
+											<Field
+												label="Your keys"
+												value={log.routingMetadata.eligibleProviderKeys
+													.map((key) => key.label ?? key.id)
+													.join(", ")}
+												mono
+											/>
+										)}
 									{log.routingMetadata.availableProviders &&
 										log.routingMetadata.availableProviders.length > 0 && (
 											<Field
@@ -816,6 +827,7 @@ export function LogDetailClient({
 																)}
 																<CredentialSourceBadge
 																	source={attempt.credentialSource}
+																	keyLabel={attempt.providerKeyLabel}
 																/>
 																{attempt.logId && (
 																	<Link

--- a/packages/actions/src/get-cheapest-from-available-providers.ts
+++ b/packages/actions/src/get-cheapest-from-available-providers.ts
@@ -22,7 +22,10 @@ import {
 	getEffectiveScoringWeights,
 } from "./compute-provider-scores.js";
 
-import type { RoutingExclusionReason } from "@llmgateway/shared/routing-telemetry";
+import type {
+	RoutingCredentialSource,
+	RoutingExclusionReason,
+} from "@llmgateway/shared/routing-telemetry";
 
 interface ProviderScore<T extends AvailableModelProvider> {
 	provider: T;
@@ -81,6 +84,11 @@ export interface RoutingMetadata {
 	selectedProvider: string;
 	selectionReason: string;
 	usedApiKeyHash?: string;
+	// Whose credential the served attempt was sent with: the organization's own
+	// provider key (`byok`) or an LLM Gateway platform credential (`platform`).
+	// Without it, `usedApiKeyHash` is an opaque fingerprint that gives no hint
+	// whether the request was billed to the provider or to credits.
+	usedCredentialSource?: RoutingCredentialSource;
 	providerScores: Array<{
 		providerId: string;
 		region?: string;
@@ -130,6 +138,10 @@ export interface RoutingMetadata {
 		error_type: string;
 		succeeded: boolean;
 		apiKeyHash?: string;
+		// Per attempt, because a single request can switch credential owners
+		// mid-flight: in hybrid mode a failing BYOK key falls back to the
+		// platform credential, and both attempts land in this array.
+		credentialSource?: RoutingCredentialSource;
 		logId?: string;
 	}>;
 	// Provider mappings that were filtered out because they don't support requested params/features

--- a/packages/actions/src/get-cheapest-from-available-providers.ts
+++ b/packages/actions/src/get-cheapest-from-available-providers.ts
@@ -89,6 +89,15 @@ export interface RoutingMetadata {
 	// Without it, `usedApiKeyHash` is an opaque fingerprint that gives no hint
 	// whether the request was billed to the provider or to credits.
 	usedCredentialSource?: RoutingCredentialSource;
+	// The organization's own key that served the request, named as its owner
+	// sees it. Only set when usedCredentialSource is "byok" — a platform
+	// credential is never described to a tenant.
+	usedProviderKeyId?: string;
+	usedProviderKeyLabel?: string;
+	// The organization's own keys that were candidates for the used provider,
+	// in selection order, so an operator can see which of their keys the
+	// gateway had to choose from. BYOK rows only; never platform credentials.
+	eligibleProviderKeys?: Array<{ id: string; label?: string }>;
 	providerScores: Array<{
 		providerId: string;
 		region?: string;
@@ -142,6 +151,8 @@ export interface RoutingMetadata {
 		// mid-flight: in hybrid mode a failing BYOK key falls back to the
 		// platform credential, and both attempts land in this array.
 		credentialSource?: RoutingCredentialSource;
+		providerKeyId?: string;
+		providerKeyLabel?: string;
 		logId?: string;
 	}>;
 	// Provider mappings that were filtered out because they don't support requested params/features

--- a/packages/actions/src/provider-key/index.ts
+++ b/packages/actions/src/provider-key/index.ts
@@ -7,9 +7,10 @@ export {
 	readProviderKey,
 	hasProviderKey,
 	providerKeyEncryptionScope,
+	providerKeyLabel,
 	MANAGED_PROVIDER_KEY_ORG_SCOPE,
 } from "./read.js";
-export type { ProviderKeyRowLike } from "./read.js";
+export type { ProviderKeyLabelRowLike, ProviderKeyRowLike } from "./read.js";
 export { redactToken } from "./redact.js";
 export { describeNetworkFailure } from "./network-error.js";
 export type { NetworkFailure } from "./network-error.js";

--- a/packages/actions/src/provider-key/read.spec.ts
+++ b/packages/actions/src/provider-key/read.spec.ts
@@ -3,7 +3,7 @@ import { randomBytes } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { encryptProviderKey } from "./crypto.js";
-import { hasProviderKey, readProviderKey } from "./read.js";
+import { hasProviderKey, providerKeyLabel, readProviderKey } from "./read.js";
 
 import type { ProviderKeyRowLike } from "./read.js";
 
@@ -138,5 +138,64 @@ describe("hasProviderKey", () => {
 	it("returns false when both fields are absent (empty stale row)", () => {
 		const empty = { id: ROW_ID, organizationId: ORG_ID } as ProviderKeyRowLike;
 		expect(hasProviderKey(empty)).toBe(false);
+	});
+});
+
+describe("providerKeyLabel", () => {
+	it("prefers the key's name", () => {
+		expect(
+			providerKeyLabel({
+				organizationId: ORG_ID,
+				managed: false,
+				name: "prod-openai",
+				tokenMasked: "sk-live-1234•••••",
+			}),
+		).toBe("prod-openai");
+	});
+
+	it("falls back to the masked token when the key is unnamed", () => {
+		expect(
+			providerKeyLabel({
+				organizationId: ORG_ID,
+				managed: false,
+				name: null,
+				tokenMasked: "sk-live-1234•••••",
+			}),
+		).toBe("sk-live-1234•••••");
+	});
+
+	it("returns undefined for a legacy row with neither", () => {
+		expect(
+			providerKeyLabel({ organizationId: ORG_ID, managed: false }),
+		).toBeUndefined();
+	});
+
+	// The whole point of this helper: a platform-managed credential is LLM
+	// Gateway's own key. Its name and mask are operator-only and must never be
+	// described to a tenant, however the row reaches this function.
+	it("never describes a platform-managed credential", () => {
+		expect(
+			providerKeyLabel({
+				organizationId: null,
+				managed: true,
+				name: "shared-openai-pool-3",
+				tokenMasked: "sk-platform-99•••••",
+			}),
+		).toBeUndefined();
+	});
+
+	it("never describes an org-less row even if it is not flagged managed", () => {
+		expect(
+			providerKeyLabel({
+				organizationId: null,
+				managed: false,
+				name: "shared-openai-pool-3",
+			}),
+		).toBeUndefined();
+	});
+
+	it("returns undefined for a missing row", () => {
+		expect(providerKeyLabel(null)).toBeUndefined();
+		expect(providerKeyLabel(undefined)).toBeUndefined();
 	});
 });

--- a/packages/actions/src/provider-key/read.ts
+++ b/packages/actions/src/provider-key/read.ts
@@ -80,3 +80,32 @@ export function hasProviderKey(
 	}
 	return !isAbsent(row.tokenCiphertext) || !isAbsent(row.token);
 }
+
+/** Row shape needed to describe a credential to the organization that owns it. */
+export interface ProviderKeyLabelRowLike {
+	organizationId: string | null;
+	managed?: boolean | null;
+	name?: string | null;
+	tokenMasked?: string | null;
+}
+
+/**
+ * How a provider key is named to the organization that owns it: its custom
+ * name when it has one, otherwise the masked token the provider-keys page
+ * lists it under. Never the plaintext token.
+ *
+ * THE SECURITY GATE FOR CREDENTIAL LABELS LIVES HERE — do not describe a
+ * provider key anywhere else. Platform-managed credentials (LLM Gateway's own
+ * keys, which have no owning organization) return undefined: their name, mask
+ * and comment are operator-only, and surfacing them in a tenant's routing view
+ * or API response would leak platform infrastructure to every customer whose
+ * request happened to fall back onto credits.
+ */
+export function providerKeyLabel(
+	row: ProviderKeyLabelRowLike | null | undefined,
+): string | undefined {
+	if (!row || row.managed || !row.organizationId) {
+		return undefined;
+	}
+	return row.name || row.tokenMasked || undefined;
+}

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1939,6 +1939,10 @@ export const log = pgTable(
 			selectedProvider?: string;
 			selectionReason?: string;
 			usedApiKeyHash?: string;
+			// Whose credential served the request: the organization's own provider
+			// key (`byok`) or an LLM Gateway platform credential (`platform`).
+			// Always agrees with the row's billing mode (`usedMode`).
+			usedCredentialSource?: "byok" | "platform";
 			providerScores?: Array<{
 				providerId: string;
 				region?: string;
@@ -1972,6 +1976,10 @@ export const log = pgTable(
 				error_type: string;
 				succeeded: boolean;
 				apiKeyHash?: string;
+				// Per attempt: a hybrid-mode request can start on the org's own key
+				// and fall back to the platform credential, so ownership differs
+				// between entries in this array.
+				credentialSource?: "byok" | "platform";
 				logId?: string;
 			}>;
 			filteredProviders?: Array<{
@@ -2265,6 +2273,10 @@ export const videoJob = pgTable(
 			selectedProvider?: string;
 			selectionReason?: string;
 			usedApiKeyHash?: string;
+			// Whose credential served the request: the organization's own provider
+			// key (`byok`) or an LLM Gateway platform credential (`platform`).
+			// Always agrees with the row's billing mode (`usedMode`).
+			usedCredentialSource?: "byok" | "platform";
 			providerScores?: Array<{
 				providerId: string;
 				region?: string;
@@ -2298,6 +2310,10 @@ export const videoJob = pgTable(
 				error_type: string;
 				succeeded: boolean;
 				apiKeyHash?: string;
+				// Per attempt: a hybrid-mode request can start on the org's own key
+				// and fall back to the platform credential, so ownership differs
+				// between entries in this array.
+				credentialSource?: "byok" | "platform";
 				logId?: string;
 			}>;
 		}>(),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1943,6 +1943,14 @@ export const log = pgTable(
 			// key (`byok`) or an LLM Gateway platform credential (`platform`).
 			// Always agrees with the row's billing mode (`usedMode`).
 			usedCredentialSource?: "byok" | "platform";
+			// The organization's own key that served the request, named as its
+			// owner sees it. Only set for "byok" — a platform-managed credential
+			// is never described to a tenant.
+			usedProviderKeyId?: string;
+			usedProviderKeyLabel?: string;
+			// The organization's own keys that were candidates for the used
+			// provider, in selection order. BYOK rows only.
+			eligibleProviderKeys?: Array<{ id: string; label?: string }>;
 			providerScores?: Array<{
 				providerId: string;
 				region?: string;
@@ -1980,6 +1988,8 @@ export const log = pgTable(
 				// and fall back to the platform credential, so ownership differs
 				// between entries in this array.
 				credentialSource?: "byok" | "platform";
+				providerKeyId?: string;
+				providerKeyLabel?: string;
 				logId?: string;
 			}>;
 			filteredProviders?: Array<{
@@ -2277,6 +2287,14 @@ export const videoJob = pgTable(
 			// key (`byok`) or an LLM Gateway platform credential (`platform`).
 			// Always agrees with the row's billing mode (`usedMode`).
 			usedCredentialSource?: "byok" | "platform";
+			// The organization's own key that served the request, named as its
+			// owner sees it. Only set for "byok" — a platform-managed credential
+			// is never described to a tenant.
+			usedProviderKeyId?: string;
+			usedProviderKeyLabel?: string;
+			// The organization's own keys that were candidates for the used
+			// provider, in selection order. BYOK rows only.
+			eligibleProviderKeys?: Array<{ id: string; label?: string }>;
 			providerScores?: Array<{
 				providerId: string;
 				region?: string;
@@ -2314,6 +2332,8 @@ export const videoJob = pgTable(
 				// and fall back to the platform credential, so ownership differs
 				// between entries in this array.
 				credentialSource?: "byok" | "platform";
+				providerKeyId?: string;
+				providerKeyLabel?: string;
 				logId?: string;
 			}>;
 		}>(),

--- a/packages/shared/src/components/credential-source-badge.tsx
+++ b/packages/shared/src/components/credential-source-badge.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Building2, KeyRound } from "lucide-react";
+
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import {
+	ROUTING_CREDENTIAL_SOURCE_DESCRIPTIONS,
+	ROUTING_CREDENTIAL_SOURCE_LABELS,
+	type RoutingCredentialSource,
+	toRoutingCredentialSource,
+} from "@/routing-telemetry.js";
+
+/**
+ * Says whose provider credential served an attempt: the organization's own key
+ * or LLM Gateway's. Without it the routing view shows two indistinguishable key
+ * fingerprints for a request that fell back from BYOK to credits.
+ */
+export function CredentialSourceBadge({
+	source,
+	className,
+}: {
+	source: string | null | undefined;
+	className?: string;
+}) {
+	const credentialSource = toRoutingCredentialSource(source);
+	if (!credentialSource) {
+		return null;
+	}
+
+	const isByok = credentialSource === "byok";
+	const Icon = isByok ? KeyRound : Building2;
+
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<span
+					className={cn(
+						"inline-flex items-center gap-1 rounded border px-1 py-px text-[10px] font-medium leading-4 whitespace-nowrap",
+						isByok
+							? "border-emerald-300 text-emerald-700 dark:border-emerald-800 dark:text-emerald-400"
+							: "border-sky-300 text-sky-700 dark:border-sky-800 dark:text-sky-400",
+						className,
+					)}
+				>
+					<Icon className="h-2.5 w-2.5" />
+					{ROUTING_CREDENTIAL_SOURCE_LABELS[credentialSource]}
+				</span>
+			</TooltipTrigger>
+			<TooltipContent className="max-w-xs">
+				<p>{ROUTING_CREDENTIAL_SOURCE_DESCRIPTIONS[credentialSource]}</p>
+			</TooltipContent>
+		</Tooltip>
+	);
+}
+
+export type { RoutingCredentialSource };

--- a/packages/shared/src/components/credential-source-badge.tsx
+++ b/packages/shared/src/components/credential-source-badge.tsx
@@ -19,12 +19,20 @@ import {
  * Says whose provider credential served an attempt: the organization's own key
  * or LLM Gateway's. Without it the routing view shows two indistinguishable key
  * fingerprints for a request that fell back from BYOK to credits.
+ *
+ * For the org's own keys the tooltip also names the exact key, so an attempt
+ * can be tied back to a row on the provider-keys page. The gateway only ever
+ * sends a label for BYOK attempts — LLM Gateway's own credentials are never
+ * described — and this component never renders one for a `platform` source
+ * even if a label were somehow present.
  */
 export function CredentialSourceBadge({
 	source,
+	keyLabel,
 	className,
 }: {
 	source: string | null | undefined;
+	keyLabel?: string | null;
 	className?: string;
 }) {
 	const credentialSource = toRoutingCredentialSource(source);
@@ -34,6 +42,7 @@ export function CredentialSourceBadge({
 
 	const isByok = credentialSource === "byok";
 	const Icon = isByok ? KeyRound : Building2;
+	const describedKey = isByok && keyLabel ? keyLabel : null;
 
 	return (
 		<Tooltip>
@@ -48,10 +57,13 @@ export function CredentialSourceBadge({
 					)}
 				>
 					<Icon className="h-2.5 w-2.5" />
-					{ROUTING_CREDENTIAL_SOURCE_LABELS[credentialSource]}
+					{describedKey ?? ROUTING_CREDENTIAL_SOURCE_LABELS[credentialSource]}
 				</span>
 			</TooltipTrigger>
 			<TooltipContent className="max-w-xs">
+				{describedKey && (
+					<p className="font-medium">Your key: {describedKey}</p>
+				)}
 				<p>{ROUTING_CREDENTIAL_SOURCE_DESCRIPTIONS[credentialSource]}</p>
 			</TooltipContent>
 		</Tooltip>

--- a/packages/shared/src/components/index.tsx
+++ b/packages/shared/src/components/index.tsx
@@ -1,4 +1,5 @@
 export * from "../deactivation";
+export * from "./credential-source-badge";
 export * from "./integration-guides-grid";
 export * from "./integration-icons";
 export * from "./log-card";

--- a/packages/shared/src/components/log-card.tsx
+++ b/packages/shared/src/components/log-card.tsx
@@ -59,6 +59,8 @@ interface RoutingMetadata {
 	selectionReason?: string;
 	usedApiKeyHash?: string;
 	usedCredentialSource?: string;
+	usedProviderKeyLabel?: string;
+	eligibleProviderKeys?: Array<{ id: string; label?: string }>;
 	availableProviders?: string[];
 	xNoFallbackHeaderSet?: boolean;
 	noFallback?: boolean;
@@ -91,6 +93,7 @@ interface RoutingMetadata {
 		error_type?: string;
 		apiKeyHash?: string;
 		credentialSource?: string;
+		providerKeyLabel?: string;
 		logId?: string;
 	}>;
 	filteredProviders?: Array<{
@@ -685,10 +688,24 @@ export function LogCard({
 													{formatApiKeyHash(routingMetadata.usedApiKeyHash)}
 													<CredentialSourceBadge
 														source={routingMetadata.usedCredentialSource}
+														keyLabel={routingMetadata.usedProviderKeyLabel}
 													/>
 												</span>
 											</div>
 										)}
+										{routingMetadata.eligibleProviderKeys &&
+											routingMetadata.eligibleProviderKeys.length > 0 && (
+												<div className="flex justify-between gap-2">
+													<span className="text-muted-foreground">
+														Your keys
+													</span>
+													<span className="font-mono text-right">
+														{routingMetadata.eligibleProviderKeys
+															.map((key) => key.label ?? key.id)
+															.join(", ")}
+													</span>
+												</div>
+											)}
 										{routingMetadata.xNoFallbackHeaderSet !== undefined && (
 											<div className="flex justify-between">
 												<span className="text-muted-foreground">
@@ -849,6 +866,7 @@ export function LogCard({
 																	)}
 																	<CredentialSourceBadge
 																		source={attempt.credentialSource}
+																		keyLabel={attempt.providerKeyLabel}
 																	/>
 																	{attempt.logId &&
 																		(getDetailUrl ? (

--- a/packages/shared/src/components/log-card.tsx
+++ b/packages/shared/src/components/log-card.tsx
@@ -29,6 +29,7 @@ import {
 import prettyBytes from "pretty-bytes";
 import { useState } from "react";
 
+import { CredentialSourceBadge } from "@/components/credential-source-badge";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -57,6 +58,7 @@ import {
 interface RoutingMetadata {
 	selectionReason?: string;
 	usedApiKeyHash?: string;
+	usedCredentialSource?: string;
 	availableProviders?: string[];
 	xNoFallbackHeaderSet?: boolean;
 	noFallback?: boolean;
@@ -88,6 +90,7 @@ interface RoutingMetadata {
 		status_code?: number;
 		error_type?: string;
 		apiKeyHash?: string;
+		credentialSource?: string;
 		logId?: string;
 	}>;
 	filteredProviders?: Array<{
@@ -678,8 +681,11 @@ export function LogCard({
 										{routingMetadata.usedApiKeyHash && (
 											<div className="flex justify-between">
 												<span className="text-muted-foreground">Key</span>
-												<span className="font-mono">
+												<span className="font-mono flex items-center gap-1.5">
 													{formatApiKeyHash(routingMetadata.usedApiKeyHash)}
+													<CredentialSourceBadge
+														source={routingMetadata.usedCredentialSource}
+													/>
 												</span>
 											</div>
 										)}
@@ -841,6 +847,9 @@ export function LogCard({
 																			key {formatApiKeyHash(attempt.apiKeyHash)}
 																		</span>
 																	)}
+																	<CredentialSourceBadge
+																		source={attempt.credentialSource}
+																	/>
 																	{attempt.logId &&
 																		(getDetailUrl ? (
 																			<LinkComponent

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -238,8 +238,11 @@ export {
 } from "./routing-config.js";
 
 export {
+	isRoutingCredentialSource,
 	isRoutingExclusionReason,
 	isRoutingSelectionReason,
+	ROUTING_CREDENTIAL_SOURCE_DESCRIPTIONS,
+	ROUTING_CREDENTIAL_SOURCE_LABELS,
 	ROUTING_EXCLUSION_REASON_LABELS,
 	ROUTING_EXCLUSION_REASON_MESSAGES,
 	ROUTING_EXCLUSION_REASONS,
@@ -249,10 +252,12 @@ export {
 	ROUTING_SELECTION_REASONS,
 	routingExclusionReasonMessage,
 	routingSelectionKind,
+	type RoutingCredentialSource,
 	type RoutingExclusionReason,
 	type RoutingSelectionKind,
 	type RoutingSelectionReason,
 	type ServiceTierMode,
+	toRoutingCredentialSource,
 	toRoutingExclusionReason,
 	toRoutingSelectionReason,
 } from "./routing-telemetry.js";

--- a/packages/shared/src/routing-telemetry.ts
+++ b/packages/shared/src/routing-telemetry.ts
@@ -240,6 +240,52 @@ export const ROUTING_SELECTION_KIND_LABELS: Record<
 };
 
 /**
+ * Whose credential a given upstream attempt was sent with.
+ *
+ * `byok` means the organization's own provider key served the attempt, so the
+ * provider bills the organization directly and no credits are deducted.
+ * `platform` means an LLM Gateway credential served it (a platform-managed
+ * provider key or an `LLM_*` environment credential), which is what credits
+ * mode — including the hybrid-mode fallback after a BYOK key fails — runs on.
+ *
+ * This mirrors the `usedMode` discriminator on the log row (`api-keys` vs
+ * `credits`): both are decided by whether an organization-owned provider key
+ * was used, so the routing view and the billing mode can never disagree.
+ */
+export type RoutingCredentialSource = "byok" | "platform";
+
+export function isRoutingCredentialSource(
+	value: string,
+): value is RoutingCredentialSource {
+	return value === "byok" || value === "platform";
+}
+
+export function toRoutingCredentialSource(
+	value: string | null | undefined,
+): RoutingCredentialSource | undefined {
+	return value && isRoutingCredentialSource(value) ? value : undefined;
+}
+
+/** Short badge labels for the routing views. */
+export const ROUTING_CREDENTIAL_SOURCE_LABELS: Record<
+	RoutingCredentialSource,
+	string
+> = {
+	byok: "your key",
+	platform: "LLM Gateway key",
+};
+
+/** Tooltip copy explaining who pays for an attempt served by this credential. */
+export const ROUTING_CREDENTIAL_SOURCE_DESCRIPTIONS: Record<
+	RoutingCredentialSource,
+	string
+> = {
+	byok: "Your own provider key (BYOK). The provider bills you directly — this attempt is not deducted from your credits.",
+	platform:
+		"LLM Gateway's own provider credential. This attempt runs on credits and is deducted from your balance.",
+};
+
+/**
  * Which service tier applied to a request. `implicit` covers the dev-plan
  * default (`organization.devPlanServiceTier`), which the client never asked for
  * but which still narrows routing to mappings that support the tier — the case


### PR DESCRIPTION
## Problem

Routing info identified a credential only by an opaque fingerprint. When a request rotated between keys, the result was a list of indistinguishable hashes:

```
openai/gpt-4o-mini   key f029ee9   403 gateway_error
openai/gpt-4o-mini   key a71b402   429 upstream_error
openai/gpt-4o-mini   key ecb88d5   200 ok
```

Nothing said which attempts ran on the customer's own BYOK keys (billed by the provider) and which fell back to LLM Gateway's credential (billed as credits) — the distinction that decides who pays. And a hash is not something anyone can match against a key on their provider-keys page.

## Approach

Every routing attempt now records **whose** credential served it and, for the caller's own keys, **which** key:

- `credentialSource` — `byok` (your own provider key; the provider bills you, no credits deducted) or `platform` (an LLM Gateway credential, billed as credits). Derived from the same discriminator that decides the log's `usedMode`, so the routing view and the billing mode can never disagree, and recorded per attempt because a hybrid request changes credential owner mid-flight.
- `providerKeyId` / `providerKeyLabel` — the key as its owner sees it on the provider-keys page: its name, or its masked token when unnamed.
- `routingMetadata.eligibleProviderKeys` — your keys that were candidates for the used provider, in selection order, so you can see what the gateway had to choose from. Chat routes only; omitted for credits-mode projects and custom providers.

**Your keys only.** `providerKeyLabel()` in `packages/actions/src/provider-key/read.ts` is the single gate and returns `undefined` for any row without an owning organization, so an LLM Gateway credential is never named — a `platform` attempt still reports `credentialSource` and `apiKeyHash`, but never `providerKeyId` or `providerKeyLabel`. `buildRoutingAttempt` refuses to attach a key identity to a non-`byok` attempt as a second guard, and the badge component renders no label for a `platform` source. All three are covered by tests.

Surfaces: chat response metadata (streaming and non-streaming, in the OpenAPI schema), activity-log routing metadata, and the dashboard routing views (shared `LogCard` + activity detail page). Recorded on every gateway surface that builds routing attempts: chat, embeddings, rerank, transcriptions, speech, OCR and videos.

## Screenshots

Dashboard → Activity → log detail, Routing card, for a request with two of the org's own keys configured: the primary 403s, the second one is rate-limited, and the request completes on LLM Gateway's credential.

**Light / dark:**

<img width="788" alt="Routing card showing two named BYOK attempts and an unnamed LLM Gateway attempt, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/dd66c4bc103366e404cc120176f9a69cae72113c/routing-keys-light.png" />

<img width="788" alt="Routing card showing two named BYOK attempts and an unnamed LLM Gateway attempt, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/dd66c4bc103366e404cc120176f9a69cae72113c/routing-keys-dark.png" />

**Hovering a key badge** names the exact key and says who pays for that attempt:

<img width="788" alt="Tooltip reading: Your key: sk-proj-open•••••, your own provider key (BYOK), the provider bills you directly" src="https://raw.githubusercontent.com/theopenco/llmgateway/dd66c4bc103366e404cc120176f9a69cae72113c/routing-hover-light.png" />

<img width="788" alt="Same tooltip in dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/dd66c4bc103366e404cc120176f9a69cae72113c/routing-hover-dark.png" />

**Before**, for comparison — hashes only, no ownership and no key identity:

<img width="788" alt="Routing card before the change, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/cb72387fec0bdf69bb35f1c88632007dd66dfe14/routing-before-light.png" />

<img width="788" alt="Routing card before the change, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/cb72387fec0bdf69bb35f1c88632007dd66dfe14/routing-before-dark.png" />

## Notes for reviewers

- No migration: `log.routingMetadata` / `video_job.routingMetadata` are JSON columns, so this is a type-level addition. Rows written by older builds simply carry none of the new fields and the UI renders nothing extra for them.
- `eligibleProviderKeys` costs no extra query: `findProviderKey` was refactored to select from `listEligibleProviderKeys`, which is the same SWR-cached read it already performed. Initial resolution and retry fallback share one helper (`buildByokKeyFilter` / `resolveEligibleProviderKeys`), so the list applies the same `allowedModels` + service-tier filter on both paths and cannot narrow just because a request fell back.
- Also fixes a gap CodeRabbit flagged on the first commit: the rerank success path never recorded a routing attempt, so successful rerank logs had no `routing` array at all. Every other surface already did.

## Verification

New tests in `apps/gateway/src/fallback.spec.ts` drive real requests through the gateway:

- Two of the org's own keys, both unreachable, then LLM Gateway's credential: asserts three attempts labelled `byok` / `byok` / `platform`, that each BYOK attempt names its key (masked token for the unnamed one, `billing-team-key` for the named one), that the `platform` attempt carries **no** `providerKeyId` or `providerKeyLabel`, and that `eligibleProviderKeys` lists both own keys and no platform credential.
- A hybrid BYOK→credits fallback asserting `["byok", "platform"]` on both the streaming and non-streaming paths, and that the labels agree with each attempt's `usedMode`.
- A key restricted by `allowedModels` is absent from `eligibleProviderKeys` on the first attempt, pinning the shared filter.
- Unit tests in `packages/actions/src/provider-key/read.spec.ts` pin the security gate directly: `providerKeyLabel()` never describes a managed or org-less row, whatever name and mask it carries.

`pnpm format`, `pnpm build`, and the gateway fallback / embeddings / ocr / speech / transcriptions / videos specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)