### PR TITLE
feat(models): split soft vs strict JSON output

### DIFF
--- a/apps/docs/content/learn/meta.json
+++ b/apps/docs/content/learn/meta.json
@@ -8,6 +8,7 @@
 		"api-keys",
 		"provider-keys",
 		"models",
+		"structured-outputs",
 		"preferences",
 		"guardrails",
 		"security-events",

--- a/apps/docs/content/learn/structured-outputs.mdx
+++ b/apps/docs/content/learn/structured-outputs.mdx
@@ -1,0 +1,86 @@
+---
+title: Structured outputs
+description: Soft JSON output vs strict JSON output schema — what LLM Gateway declares and how it enforces each
+icon: Braces
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+LLM Gateway exposes **two distinct JSON capabilities**, and they are kept
+separate on every surface: the models API, the [models
+directory](https://llmgateway.io/models), the model detail pages, and the
+gateway's request validation.
+
+## Soft JSON output (`json_output`)
+
+A model with soft JSON output can be **nudged** into emitting JSON — typically
+via `response_format: { "type": "json_object" }` or prompt guidance. There is
+no server-side schema guarantee: the model may still produce off-schema or
+malformed JSON, so the consumer's parser must be able to handle it.
+
+## Strict JSON output schema (`structured_outputs`)
+
+A model with strict JSON output schema is served by an **upstream provider
+that natively enforces schema-guided decoding** (for example OpenAI structured
+outputs or vLLM guided decoding). You provide a JSON schema via
+`response_format: { "type": "json_schema", "json_schema": { ... } }` and the
+provider guarantees the output conforms to it.
+
+<Callout type="info">
+	The gateway only **declares** this capability — it never emulates schema
+	enforcement (no prompt-and-validate adapter). A model whose provider does not
+	natively support `json_schema` rejects such requests with `400 does not
+	support JSON schema output mode`. That rejection is **by design**, not a
+	missing feature.
+</Callout>
+
+## Field mapping
+
+| Models API field     | Catalogue flag     | Meaning                                       |
+| -------------------- | ------------------ | --------------------------------------------- |
+| `json_output`        | `jsonOutput`       | Soft: nudged JSON, no schema guarantee        |
+| `structured_outputs` | `jsonOutputSchema` | Strict: upstream provider enforces the schema |
+
+The snake_case names are what the OpenAI-compatible [`/v1/models`](/learn/models) endpoint exposes;
+the camelCase names are used in the model catalogue and the directory UI.
+
+The two tiers are **independent per provider mapping**: a provider may support
+strict `json_schema` without soft `json_object` (for example Runware or
+Perplexity declare `structured_outputs` without `json_output`), or soft
+`json_object` without strict schema. The gateway routes each mode by its own
+flag — `json_schema` requests only require `structured_outputs`, they are never
+emulated or silently downgraded.
+
+## How to verify a model
+
+Probe a model with a strict `json_schema` request:
+
+```bash
+curl -s https://api.llmgateway.io/v1/chat/completions \
+  -H "Authorization: Bearer $LLMGATEWAY_API_KEY" \
+  -d '{
+    "model": "gpt-4o-mini",
+    "messages": [{ "role": "user", "content": "Reply JSON: {\"ok\":true}" }],
+    "max_tokens": 16,
+    "response_format": {
+      "type": "json_schema",
+      "json_schema": {
+        "name": "probe",
+        "strict": true,
+        "schema": {
+          "type": "object",
+          "properties": { "ok": { "type": "boolean" } },
+          "required": ["ok"],
+          "additionalProperties": false
+        }
+      }
+    }
+  }'
+```
+
+- `200` → the upstream provider enforces the schema; the model should declare `structured_outputs: true`.
+- `400 does not support JSON schema output mode` → soft-only; the model should expose `json_output` without `structured_outputs`.
+
+The probe above can be run for any model listed in `GET /v1/models`; a
+declared flag that does not match the observed status is a catalog bug and
+should be reported against the repository.

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -3130,6 +3130,11 @@ chat.openapi(completions, async (c) => {
 					message: `Model '${requestedModel}' is not configured to support tool calls. Remove the tools/tool_choice parameter or enable tools for this custom model.`,
 				});
 			}
+			// Custom models are soft-JSON-only by data model: org-model records
+			// carry jsonOutput but no jsonOutputSchema, so both json_object and
+			// json_schema are gated on jsonOutput (a custom model can still reach
+			// an upstream that enforces schema via a catalog mapping; extending
+			// custom models with jsonOutputSchema is a follow-up).
 			if (
 				customModelEntry.jsonOutput === false &&
 				(response_format?.type === "json_object" ||
@@ -4001,17 +4006,16 @@ chat.openapi(completions, async (c) => {
 						return false;
 					}
 					if (
-						response_format?.type === "json_object" ||
-						response_format?.type === "json_schema"
+						response_format?.type === "json_object" &&
+						provider.jsonOutput !== true
 					) {
-						if (provider.jsonOutput !== true) {
-							return false;
-						}
+						return false;
 					}
-					if (response_format?.type === "json_schema") {
-						if (provider.jsonOutputSchema !== true) {
-							return false;
-						}
+					if (
+						response_format?.type === "json_schema" &&
+						provider.jsonOutputSchema !== true
+					) {
+						return false;
 					}
 					if (hasImages && provider.vision !== true) {
 						return false;
@@ -8948,6 +8952,9 @@ chat.openapi(completions, async (c) => {
 				const streamingResponseHealingEnabled = plugins?.some(
 					(p) => p.id === "response-healing",
 				);
+				// Note: the two-tier capability check (json_object -> jsonOutput,
+				// json_schema -> jsonOutputSchema) already happened at validation
+				// and routing; this is a healing decision, not a capability gate.
 				const streamingIsJsonResponseFormat =
 					response_format?.type === "json_object" ||
 					response_format?.type === "json_schema";
@@ -13349,6 +13356,9 @@ chat.openapi(completions, async (c) => {
 	const responseHealingEnabled = plugins?.some(
 		(p) => p.id === "response-healing",
 	);
+	// Note: this groups both JSON modes for healing; the two-tier
+	// capability gate (json_object -> jsonOutput, json_schema ->
+	// jsonOutputSchema) is enforced upstream at validation/routing.
 	const isJsonResponseFormat =
 		response_format?.type === "json_object" ||
 		response_format?.type === "json_schema";

--- a/apps/gateway/src/chat/tools/provider-filter-reasons.spec.ts
+++ b/apps/gateway/src/chat/tools/provider-filter-reasons.spec.ts
@@ -120,6 +120,25 @@ describe("getProviderFilterReasons", () => {
 		).toEqual([exclusionReason("json_schema")]);
 	});
 
+	it("treats the two JSON tiers independently for json_schema routing", () => {
+		// A provider that supports strict json_schema without json_object
+		// (e.g. Runware, Perplexity, Anthropic) must not be excluded from
+		// json_schema routing just because it lacks soft jsonOutput.
+		expect(
+			getProviderFilterReasons(
+				mapping({ jsonOutputSchema: true, jsonOutput: false }),
+				{ responseFormatType: "json_schema" },
+			),
+		).toEqual([]);
+		// ...but json_object still requires soft jsonOutput.
+		expect(
+			getProviderFilterReasons(
+				mapping({ jsonOutputSchema: true, jsonOutput: false }),
+				{ responseFormatType: "json_object" },
+			),
+		).toEqual([exclusionReason("json_output")]);
+	});
+
 	it("flags unsupported modalities", () => {
 		expect(getProviderFilterReasons(mapping(), { hasImages: true })).toEqual([
 			exclusionReason("vision"),

--- a/apps/gateway/src/chat/tools/provider-filter-reasons.ts
+++ b/apps/gateway/src/chat/tools/provider-filter-reasons.ts
@@ -106,8 +106,7 @@ export function getProviderFilterReasons(
 		}
 	}
 	if (
-		(options.responseFormatType === "json_object" ||
-			options.responseFormatType === "json_schema") &&
+		options.responseFormatType === "json_object" &&
 		provider.jsonOutput !== true
 	) {
 		reasons.push(exclusionReason("json_output"));

--- a/apps/gateway/src/chat/tools/validate-model-capabilities.spec.ts
+++ b/apps/gateway/src/chat/tools/validate-model-capabilities.spec.ts
@@ -5,7 +5,7 @@ import { models } from "@llmgateway/models";
 
 import { validateModelCapabilities } from "./validate-model-capabilities.js";
 
-import type { ModelDefinition } from "@llmgateway/models";
+import type { ModelDefinition, ProviderModelMapping } from "@llmgateway/models";
 
 function getModel(id: string): ModelDefinition {
 	const m = models.find((model) => model.id === id);
@@ -64,6 +64,39 @@ const textImageModel = (() => {
 // gemma-4-31b-it has runware (supportsAssistantPrefill: false) alongside
 // providers that accept a trailing assistant message.
 const mixedPrefillModel = getModel("gemma-4-31b-it");
+
+// JSON capability fixtures — looked up by capability combination so the tests
+// don't pin to a specific model id that may churn. Only chat-servable models
+// (text/image output) qualify; the "auto"/"custom" sentinel entries are
+// excluded.
+function getModelByJsonCapability(
+	kind: "none" | "soft" | "strict",
+): ModelDefinition {
+	const isChat = (m: ModelDefinition) =>
+		(m.output ?? ["text"]).some((o) => o === "text" || o === "image");
+	const m = (models as readonly ModelDefinition[]).find((model) => {
+		if (!isChat(model) || model.id === "auto" || model.id === "custom") {
+			return false;
+		}
+		const soft = model.providers.some(
+			(p) => (p as ProviderModelMapping).jsonOutput === true,
+		);
+		const strict = model.providers.some(
+			(p) => (p as ProviderModelMapping).jsonOutputSchema === true,
+		);
+		return kind === "none"
+			? !soft && !strict
+			: kind === "soft"
+				? soft && !strict
+				: strict;
+	});
+	if (!m) {
+		throw new Error(
+			`Test fixture missing: no model with JSON capability "${kind}"`,
+		);
+	}
+	return m;
+}
 
 describe("validateModelCapabilities - assistant prefill", () => {
 	it("rejects when the explicit provider rejects a trailing assistant message", () => {
@@ -321,6 +354,69 @@ describe("validateModelCapabilities - output capability", () => {
 				undefined,
 				{},
 			),
+		).not.toThrow();
+	});
+});
+
+describe("validateModelCapabilities - JSON output", () => {
+	it("rejects json_object for a model without jsonOutput", () => {
+		const m = getModelByJsonCapability("none");
+		expect(() =>
+			validateModelCapabilities(m, m.id, undefined, {
+				response_format: { type: "json_object" },
+			}),
+		).toThrow(/does not support JSON output mode/);
+	});
+
+	it("accepts json_object for a soft-only model (jsonOutput true, schema false)", () => {
+		const m = getModelByJsonCapability("soft");
+		expect(() =>
+			validateModelCapabilities(m, m.id, undefined, {
+				response_format: { type: "json_object" },
+			}),
+		).not.toThrow();
+	});
+
+	it("rejects json_schema for a soft-only model — the gateway never emulates strict schema", () => {
+		const m = getModelByJsonCapability("soft");
+		expect(() =>
+			validateModelCapabilities(m, m.id, undefined, {
+				response_format: { type: "json_schema" },
+			}),
+		).toThrow(/does not support JSON schema output mode/);
+	});
+
+	it("accepts json_schema for a model with jsonOutputSchema true", () => {
+		const m = getModelByJsonCapability("strict");
+		expect(() =>
+			validateModelCapabilities(m, m.id, undefined, {
+				response_format: { type: "json_schema" },
+			}),
+		).not.toThrow();
+	});
+
+	it("rejects json_schema when the pinned provider is soft-only even if a sibling mapping is strict", () => {
+		// gpt-4o: openai is strict, azure is soft-only. The contract is
+		// per mapping, so pinning the soft-only provider must reject json_schema.
+		const m = getModel("gpt-4o");
+		expect(() =>
+			validateModelCapabilities(m, "gpt-4o", "azure", {
+				response_format: { type: "json_schema" },
+			}),
+		).toThrow(/does not support JSON schema output mode/);
+		expect(() =>
+			validateModelCapabilities(m, "gpt-4o", "openai", {
+				response_format: { type: "json_schema" },
+			}),
+		).not.toThrow();
+	});
+
+	it("accepts json_schema when pinning azure gpt-4o-mini (azure supports structured outputs)", () => {
+		const m = getModel("gpt-4o-mini");
+		expect(() =>
+			validateModelCapabilities(m, "gpt-4o-mini", "azure", {
+				response_format: { type: "json_schema" },
+			}),
 		).not.toThrow();
 	});
 });

--- a/apps/gateway/src/models/models.spec.ts
+++ b/apps/gateway/src/models/models.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import { app } from "@/app.js";
 
@@ -479,6 +479,64 @@ describe("Models API", () => {
 		expect(deepseek.pricing.prompt).toBe("0.26e-6");
 		expect(deepseek.pricing.completion).toBe("0.38e-6");
 		expect(deepseek.pricing.input_cache_read).toBe("0.13e-6");
+	});
+
+	test("GET /v1/models reports JSON capabilities only from servable provider mappings", async () => {
+		// Freeze the clock: the handler captures `new Date()` during the
+		// request, so the test must evaluate servability at the same instant
+		// (otherwise a mapping whose deactivatedAt lies between the request
+		// and the assertion could flake).
+		const frozenNow = new Date("2026-08-11T00:00:00Z");
+		vi.useFakeTimers();
+		vi.setSystemTime(frozenNow);
+		try {
+			const res = await app.request("/v1/models");
+			expect(res.status).toBe(200);
+
+			const json = await res.json();
+			const isServable = (p: ProviderModelMapping) =>
+				!(p.deactivatedAt && frozenNow > p.deactivatedAt);
+			const definitionById = new Map(modelsList.map((m) => [m.id, m]));
+
+			// json_output / structured_outputs must reflect mappings that can
+			// actually serve requests: a deactivated mapping can no longer be
+			// routed to, so it must not advertise a JSON capability (mirrors the
+			// deactivation filter used for pricing and max_output). Deprecated
+			// mappings remain servable (isServable only filters deactivatedAt);
+			// no deprecated-only mapping with a JSON flag exists in the catalog
+			// today, so that branch is covered by this loop's semantics.
+			for (const model of json.data) {
+				const definition = definitionById.get(model.id);
+				expect(definition).toBeDefined();
+				const servable = (
+					definition!.providers as ProviderModelMapping[]
+				).filter(isServable);
+				expect(model.json_output, `json_output for ${model.id}`).toBe(
+					servable.some((p) => p.jsonOutput === true),
+				);
+				expect(
+					model.structured_outputs,
+					`structured_outputs for ${model.id}`,
+				).toBe(servable.some((p) => p.jsonOutputSchema === true));
+			}
+
+			// Focused branches: qwen3-235b-a22b-thinking-2507 has its only soft
+			// mapping (nebius) deactivated, so json_output must be false even
+			// though a jsonOutput mapping exists. minimax-m2.7 has a deactivated
+			// soft mapping (together-ai) alongside servable soft mappings, so
+			// json_output stays true and structured_outputs stays false.
+			const byId = (id: string) =>
+				json.data.find((m: { id: string }) => m.id === id);
+			const qwen = byId("qwen3-235b-a22b-thinking-2507");
+			expect(qwen).toBeDefined();
+			expect(qwen!.json_output).toBe(false);
+			const m27 = byId("minimax-m2.7");
+			expect(m27).toBeDefined();
+			expect(m27!.json_output).toBe(true);
+			expect(m27!.structured_outputs).toBe(false);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	test("GET /v1/models exposes cache pricing detail per provider mapping", async () => {

--- a/apps/gateway/src/models/models.ts
+++ b/apps/gateway/src/models/models.ts
@@ -417,15 +417,17 @@ modelsApi.openapi(listModels, async (c) => {
 				per_request_limits: getPerRequestLimits(model),
 				// Get supported parameters from model definitions with fallback to defaults
 				supported_parameters: getSupportedParametersFromModel(model),
-				// Add model-level capabilities
-				json_output:
-					model.providers.some(
-						(p) => (p as ProviderModelMapping).jsonOutput === true,
-					) || false,
-				structured_outputs:
-					model.providers.some(
-						(p) => (p as ProviderModelMapping).jsonOutputSchema === true,
-					) || false,
+				// A deactivated mapping can no longer serve requests, so the
+				// JSON capabilities advertised at the model level must come
+				// from mappings that can actually be routed to — the same
+				// deactivation filter used for pricing and max_output.
+				// Deprecated mappings remain routable and keep contributing.
+				json_output: (model.providers as ProviderModelMapping[])
+					.filter((p) => !(p.deactivatedAt && currentDate > p.deactivatedAt))
+					.some((p) => p.jsonOutput === true),
+				structured_outputs: (model.providers as ProviderModelMapping[])
+					.filter((p) => !(p.deactivatedAt && currentDate > p.deactivatedAt))
+					.some((p) => p.jsonOutputSchema === true),
 				free: model.free ?? false,
 				// A model is only deprecated/deactivated once EVERY provider mapping
 				// is — the same `.every()` semantics used for filtering above. Report

--- a/apps/ui/src/app/models/[name]/[provider]/page.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/page.tsx
@@ -7,6 +7,7 @@ import {
 	MessageSquare,
 	ImagePlus,
 	Braces,
+	FileJson2,
 } from "lucide-react";
 import Link from "next/link";
 import { notFound, permanentRedirect } from "next/navigation";
@@ -339,6 +340,14 @@ export default async function ModelProviderPage({ params }: PageProps) {
 										icon: Braces,
 										label: "JSON Output",
 										color: "text-cyan-500",
+									});
+								}
+								if (providerMapping.jsonOutputSchema) {
+									items.push({
+										key: "jsonOutputSchema",
+										icon: FileJson2,
+										label: "Structured JSON",
+										color: "text-teal-500",
 									});
 								}
 								const hasImageGen = Array.isArray(modelDef.output)

--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -4,6 +4,7 @@ import {
 	ArrowLeft,
 	Zap,
 	Eye,
+	FileJson2,
 	Wrench,
 	MessageSquare,
 	ImagePlus,
@@ -505,6 +506,9 @@ export default async function ModelPage({ params }: PageProps) {
 								const hasJsonOutput = visibleProviders.some(
 									(p) => p.jsonOutput,
 								);
+								const hasJsonOutputSchema = visibleProviders.some(
+									(p) => p.jsonOutputSchema,
+								);
 								const hasImageGen = Array.isArray(modelDef.output)
 									? modelDef.output.includes("image")
 									: false;
@@ -553,6 +557,14 @@ export default async function ModelPage({ params }: PageProps) {
 										icon: Braces,
 										label: "JSON Output",
 										color: "text-cyan-500",
+									});
+								}
+								if (hasJsonOutputSchema) {
+									items.push({
+										key: "jsonOutputSchema",
+										icon: FileJson2,
+										label: "Structured JSON",
+										color: "text-teal-500",
 									});
 								}
 								if (hasImageGen) {

--- a/apps/ui/src/components/models/model-comparison.tsx
+++ b/apps/ui/src/components/models/model-comparison.tsx
@@ -194,7 +194,7 @@ const groupedRows: Array<{
 			{ key: "parallelToolCalls", label: "Parallel Tool Calls" },
 			{ key: "reasoning", label: "Reasoning" },
 			{ key: "jsonOutput", label: "JSON Output" },
-			{ key: "jsonOutputSchema", label: "JSON Schema" },
+			{ key: "jsonOutputSchema", label: "Structured JSON" },
 			{ key: "webSearch", label: "Web Search" },
 			{ key: "outputTypes", label: "Output Types" },
 		],

--- a/apps/ui/src/components/models/model-detail-card.tsx
+++ b/apps/ui/src/components/models/model-detail-card.tsx
@@ -123,7 +123,7 @@ export function ModelDetailCard({ model }: ModelDetailCardProps) {
 		if (provider.jsonOutputSchema) {
 			capabilities.push({
 				icon: FileJson2,
-				label: "JSON Schema",
+				label: "Structured JSON",
 				color: "text-teal-500",
 			});
 		}

--- a/apps/ui/src/components/models/model-provider-card.tsx
+++ b/apps/ui/src/components/models/model-provider-card.tsx
@@ -789,7 +789,7 @@ export function ModelProviderCard({
 										</div>
 									</TooltipTrigger>
 									<TooltipContent>
-										<p>Supports structured JSON output</p>
+										<p>Supports JSON output (soft, no schema guarantee)</p>
 									</TooltipContent>
 								</Tooltip>
 							)}

--- a/apps/ui/src/components/models/provider-card.tsx
+++ b/apps/ui/src/components/models/provider-card.tsx
@@ -297,7 +297,7 @@ export function ProviderCard({
 										</div>
 									</TooltipTrigger>
 									<TooltipContent>
-										<p>Supports structured JSON output</p>
+										<p>Supports JSON output (soft, no schema guarantee)</p>
 									</TooltipContent>
 								</Tooltip>
 							)}

--- a/apps/ui/src/lib/model-faq.spec.ts
+++ b/apps/ui/src/lib/model-faq.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { buildModelFaqs } from "./model-faq";
+
+import type { ModelDefinition } from "@llmgateway/models";
+
+// Minimal model fixture — only the fields the FAQ builder reads.
+function model(id: string): ModelDefinition {
+	return {
+		id,
+		name: id,
+		family: "test",
+		providers: [],
+	};
+}
+
+describe("buildModelFaqs — JSON capability truthfulness", () => {
+	it("does not claim structured outputs when only soft jsonOutput is supported (qwen case)", () => {
+		const faqs = buildModelFaqs(model("qwen3.7-flash"), [
+			{
+				providerId: "alibaba",
+				tools: true,
+				jsonOutput: true,
+				jsonOutputSchema: false,
+			},
+		]);
+		const faq = faqs.find((f) => f.question.includes("structured outputs"))!;
+		expect(faq).toBeDefined();
+		expect(faq.answer).not.toContain("structured JSON outputs");
+		expect(faq.answer.toLowerCase()).toContain("soft");
+	});
+
+	it("claims strict JSON output schema only when jsonOutputSchema is true (gpt-4o-mini case)", () => {
+		const faqs = buildModelFaqs(model("gpt-4o-mini"), [
+			{
+				providerId: "openai",
+				tools: true,
+				jsonOutput: true,
+				jsonOutputSchema: true,
+			},
+		]);
+		const faq = faqs.find((f) => f.question.includes("structured outputs"))!;
+		expect(faq).toBeDefined();
+		expect(faq.answer).toContain("JSON output schema");
+		expect(faq.answer).toContain("upstream-enforced");
+	});
+
+	it("mentions soft JSON output when the model supports neither tools nor strict schema", () => {
+		const faqs = buildModelFaqs(model("soft-only-model"), [
+			{ providerId: "alibaba", jsonOutput: true, jsonOutputSchema: false },
+		]);
+		const faq = faqs.find((f) => f.question.includes("structured outputs"))!;
+		expect(faq.answer).toContain("soft JSON output");
+		expect(faq.answer).not.toContain("structured JSON outputs");
+	});
+
+	it("does not claim soft JSON output for tool-only models (CodeRabbit)", () => {
+		const faqs = buildModelFaqs(model("tool-only-model"), [
+			{
+				providerId: "acme",
+				tools: true,
+				jsonOutput: false,
+				jsonOutputSchema: false,
+			},
+		]);
+		const faq = faqs.find((f) => f.question.includes("structured outputs"))!;
+		expect(faq.answer).toContain("tool (function) calling");
+		expect(faq.answer).not.toContain("soft JSON output");
+		expect(faq.answer).not.toContain("strict JSON output schema");
+	});
+
+	it("denies tools and structured outputs when nothing is supported", () => {
+		const faqs = buildModelFaqs(model("no-capability-model"), [
+			{
+				providerId: "acme",
+				tools: false,
+				jsonOutput: false,
+				jsonOutputSchema: false,
+			},
+		]);
+		const faq = faqs.find((f) => f.question.includes("structured outputs"))!;
+		expect(faq.answer).toContain("does not currently support");
+	});
+});

--- a/apps/ui/src/lib/model-faq.ts
+++ b/apps/ui/src/lib/model-faq.ts
@@ -95,19 +95,27 @@ export function buildModelFaqs(
 	}
 
 	const hasTools = providers.some((p) => p.tools);
-	const hasStructured = providers.some(
-		(p) => p.jsonOutput || p.jsonOutputSchema,
-	);
+	// STRICT ONLY: schema-enforced structured outputs. Soft jsonOutput
+	// (response_format json_object / nudged) carries no schema guarantee and
+	// must NOT be presented as structured outputs. The strict flag is
+	// upstream-provider-dependent — the gateway never emulates schema
+	// enforcement, so a mapping without jsonOutputSchema rejects json_schema.
+	const hasStrictJson = providers.some((p) => p.jsonOutputSchema);
+	const hasSoftJson = providers.some((p) => p.jsonOutput);
 	faqs.push({
 		question: `Does ${displayName} support tool calling and structured outputs?`,
 		answer:
-			hasTools && hasStructured
-				? `Yes. ${displayName} supports both tool (function) calling and structured JSON outputs through LLM Gateway.`
+			hasTools && hasStrictJson
+				? `Yes. ${displayName} supports both tool (function) calling and strict JSON output schema (upstream-enforced) through LLM Gateway.`
 				: hasTools
-					? `${displayName} supports tool (function) calling, but not structured JSON output mode.`
-					: hasStructured
-						? `${displayName} supports structured JSON outputs, but not tool calling.`
-						: `No. ${displayName} does not currently support tool calling or structured JSON outputs through LLM Gateway.`,
+					? hasSoftJson
+						? `${displayName} supports tool (function) calling and soft JSON output, but NOT strict JSON output schema (its upstream provider does not enforce it).`
+						: `${displayName} supports tool (function) calling, but not JSON output modes.`
+					: hasStrictJson
+						? `${displayName} supports strict JSON output schema, but not tool calling.`
+						: hasSoftJson
+							? `${displayName} supports soft JSON output, but not tool calling or strict JSON output schema.`
+							: `No. ${displayName} does not currently support tool calling or structured JSON outputs through LLM Gateway.`,
 	});
 
 	if (modelDef.releasedAt) {

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -478,7 +478,10 @@ export interface ProviderModelMapping {
 	 */
 	parallelToolCalls?: boolean;
 	/**
-	 * Whether this specific model supports JSON output mode for this provider
+	 * SOFT JSON output (models API: `json_output`): the model can be nudged
+	 * into emitting JSON (response_format json_object / prompt guidance).
+	 * There is no server-side schema guarantee — off-schema or malformed JSON
+	 * is possible and must be caught by the consumer's parser.
 	 */
 	jsonOutput?: boolean;
 	/**
@@ -489,7 +492,13 @@ export interface ProviderModelMapping {
 	 */
 	healStreamingJsonOutput?: boolean;
 	/**
-	 * Whether this provider supports JSON schema output mode (json_schema response format)
+	 * STRICT JSON output schema (models API: `structured_outputs`): the
+	 * UPSTREAM PROVIDER enforces schema-guided decoding (e.g. OpenAI
+	 * structured outputs, vLLM guided decoding). Declare true ONLY when the
+	 * true upstream provider natively supports it. The gateway MUST NOT
+	 * emulate schema enforcement (no prompt+validate adapter); when false,
+	 * requests with response_format: json_schema are rejected with a 400
+	 * ("does not support JSON schema output mode").
 	 */
 	jsonOutputSchema?: boolean;
 	/**

--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -2487,7 +2487,6 @@ export const googleModels = [
 				vision: true,
 				tools: true,
 				jsonOutput: true,
-				jsonOutputSchema: true,
 				supportsN: true,
 			},
 		],

--- a/packages/models/src/models/minimax.ts
+++ b/packages/models/src/models/minimax.ts
@@ -152,7 +152,6 @@ export const minimaxModels = [
 				vision: false,
 				tools: false,
 				jsonOutput: true,
-				jsonOutputSchema: true,
 			},
 			{
 				providerId: "scx-ai",
@@ -258,7 +257,6 @@ export const minimaxModels = [
 				vision: false,
 				tools: false,
 				jsonOutput: true,
-				jsonOutputSchema: true,
 			},
 			{
 				// Embercloud's upstream routing for this model is broken: streaming

--- a/packages/models/src/models/openai.ts
+++ b/packages/models/src/models/openai.ts
@@ -92,6 +92,10 @@ export const openaiModels = [
 				vision: true,
 				tools: true,
 				jsonOutput: true,
+				// Azure OpenAI supports structured outputs for gpt-4o-mini.
+				// Mapping is deprecated 2026-01-09 / deactivated 2026-03-31 —
+				// flag kept for data truthfulness (never served post-deactivation).
+				jsonOutputSchema: true,
 				deprecatedAt: new Date("2026-01-09"),
 				deactivatedAt: new Date("2026-03-31"),
 			},

--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -281,7 +281,6 @@ export const zaiModels = [
 				vision: false,
 				tools: true,
 				jsonOutput: true,
-				jsonOutputSchema: true,
 			},
 			{
 				providerId: "deepinfra",
@@ -390,7 +389,6 @@ export const zaiModels = [
 				vision: false,
 				tools: true,
 				jsonOutput: true,
-				jsonOutputSchema: true,
 			},
 			{
 				providerId: "novita",


### PR DESCRIPTION
## Summary

LLM Gateway now exposes two **clearly separated JSON capabilities**, per provider/model pair, mirroring what each upstream serving backend actually enforces. The gateway never emulates strict schema — a model without `jsonOutputSchema` rejects `response_format: json_schema` with a 400 by design.

### Soft JSON output vs strict JSON output schema — side by side

| Aspect | Soft JSON output | Strict JSON output schema |
|---|---|---|
| Internal flag | `jsonOutput` | `jsonOutputSchema` |
| Models API field | `json_output` | `structured_outputs` |
| `response_format` | `json_object` | `json_schema` |
| Enforcement | nudged / prompted — **no server-side schema guarantee** | **upstream provider enforces** schema-guided decoding (OpenAI structured outputs, vLLM guided decoding, …) |
| Failure mode | off-schema / malformed JSON possible; consumer's parser must handle it | gateway returns `400 does not support JSON schema output mode` when the pair lacks the flag |
| Emulation | allowed | **the gateway MUST NEVER emulate** — declare only what the upstream backend natively supports |
| Example | `qwen3.7-flash` (soft only) | `gpt-4o-mini`, `claude-haiku-4-5`, `gemini-2.5-flash`, `deepseek-v4-flash` |

### What changed

1. **Model flags corrected to upstream reality** (empirical probe evidence):
   - Removed over-declared `jsonOutputSchema` from: `gemma-4-31b-it`, `minimax-m2.5`, `minimax-m2.7`, `glm-5.1`, `glm-5` — each verified returning `400 does not support JSON schema output mode` via live probes (`LLMGATEWAY_API_KEY` against api.llmgateway.io).
   - Added missing `jsonOutputSchema` to the azure `gpt-4o-mini` mapping (OpenAI parity; openai `gpt-4o-mini` verified 200).
   - Top-10 models used by the author's Hermes Agent were probe-verified **already correct**: `qwen3.7-flash`, `deepseek-v4-flash`, `deepseek-v4-pro`, `qwen3-vl-235b-a22b-instruct`, `qwen3.7-plus`, `qwen3.6-plus`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-3.1-pro-preview`, `minimax-m3` (+ `gpt-4o-mini`). No changes needed; flags now have probe evidence behind them.
2. **Two-tier routing fix** — provider selection now treats the tiers independently: `json_object` requires `jsonOutput`, `json_schema` requires `jsonOutputSchema`. Previously a `json_schema` request also required soft `jsonOutput`, so strict-only providers (e.g. `jsonOutputSchema: true` without `jsonOutput`) were wrongly excluded from routing. Matches the already-correct request-time validation (`validate-model-capabilities.ts`). Regression tests added.
3. **Model detail page** — shows a **Structured JSON** badge in addition to JSON Output, so each model advertises soft and/or strict exactly as declared. FAQ now claims structured outputs only when `jsonOutputSchema` is true (was counting soft JSON as structured).
4. **Deactivated mappings** no longer contribute `json_output` / `structured_outputs` flags to `/v1/models` — same deactivation filter already used for pricing/max_output.
5. **Policy contract + docs** — `ProviderModelMapping` type comments define soft vs strict and the upstream-only, never-emulated rule; new docs page `learn/structured-outputs` documents both tiers, the API field mapping (`json_output` ↔ `jsonOutput`, `structured_outputs` ↔ `jsonOutputSchema`), and the 400-by-design behavior.

### Probe evidence (2026-08-11, live api.llmgateway.io)

| Model | Declared `structured_outputs` | Actual strict probe | Verdict |
|---|---|---|---|
| gemma-4-31b-it | true | 400 (capability rejection) | over-declared → fixed |
| minimax-m2.5 | true | 400 (capability rejection) | over-declared → fixed |
| minimax-m2.7 | true | 400 (capability rejection) | over-declared → fixed |
| glm-5.1 | true | 400 (capability rejection) | over-declared → fixed |
| glm-5 | true | 400 (capability rejection) | over-declared → fixed |
| gpt-4o-mini (openai) | true | 200 | correct (reference) |
| claude-haiku-4-5 | true | 200 (via bedrock) | correct |
| qwen3.7-flash | false | 400 (capability rejection) | correct |
| deepseek-v4-flash | true | 200 | correct |
| gemini-2.5-flash | true | 200 | correct |
| minimax-m3 | true | 200 | correct |

Probes not possible for models without a routable credential in the probe account (e.g. most Anthropic models, coding-plan-restricted models) — their existing declarations were left untouched; no speculative changes. A local audit script was used for probing; it is intentionally not part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation explaining the difference between soft JSON output and strict schema-enforced structured outputs.
  * Model pages now show a “Structured JSON” capability badge when supported.
  * Model listings report JSON and structured-output capabilities more accurately.

* **Bug Fixes**
  * Improved provider routing so JSON objects and strict JSON schemas require their respective capabilities.
  * Corrected capability declarations for several models and providers.
  * Excluded deactivated provider mappings from advertised capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


### Note on the catalog flag edits (from independent review)

The five removed `jsonOutputSchema` flags and the azure `gpt-4o-mini` addition all land on **deactivated** provider mappings (e.g. ranoai gemma-4-31b-it deactivated 2026-08-09; together-ai minimax/glm mappings deactivated 2026-03..2026-07; azure gpt-4o-mini deactivated 2026-03-31). Combined with the new deactivated-mapping filter in `/v1/models`, these edits are consistency cleanups: the live-observable behavior change comes from the two-tier routing split (chat.ts / provider-filter-reasons.ts) and the `/v1/models` deactivation filter, not from the flag removals themselves. They are still correct — the pre-PR API advertised `structured_outputs: true` for these models while rejecting `json_schema` with a 400 — but they are data hygiene rather than behavior fixes.