### PR TITLE
fix(gateway): preserve Google finish reason

### DIFF
--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.spec.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.spec.ts
@@ -535,6 +535,132 @@ describe("transformStreamingToOpenai", () => {
 		expect(result?.choices?.[0]?.finish_reason).toBe("stop");
 	});
 
+	it("preserves Google finishReason on a final chunk that also has text", () => {
+		const result = transformStreamingToOpenai(
+			"google-ai-studio",
+			"gemini-2.5-pro",
+			{
+				candidates: [
+					{
+						content: {
+							role: "model",
+							parts: [{ text: "Done." }],
+						},
+						finishReason: "STOP",
+						index: 0,
+					},
+				],
+				modelVersion: "gemini-2.5-pro",
+				responseId: "resp_final",
+			},
+			[],
+		);
+
+		expect(result).toMatchObject({
+			id: "resp_final",
+			choices: [
+				{
+					index: 0,
+					delta: { role: "assistant", content: "Done." },
+					finish_reason: "stop",
+				},
+			],
+		});
+	});
+
+	it("maps Google MAX_TOKENS on a final chunk that also has text", () => {
+		const result = transformStreamingToOpenai(
+			"google-vertex",
+			"gemini-2.5-pro",
+			{
+				candidates: [
+					{
+						content: {
+							role: "model",
+							parts: [{ text: "Partial answer" }],
+						},
+						finishReason: "MAX_TOKENS",
+						index: 0,
+					},
+				],
+			},
+			[],
+		);
+
+		expect(result?.choices?.[0]).toMatchObject({
+			delta: { role: "assistant", content: "Partial answer" },
+			finish_reason: "length",
+		});
+	});
+
+	it("keeps Google finish_reason null when a content chunk has no finishReason", () => {
+		const result = transformStreamingToOpenai(
+			"google-ai-studio",
+			"gemini-2.5-flash",
+			{
+				candidates: [
+					{
+						content: {
+							role: "model",
+							parts: [{ text: "Still streaming" }],
+						},
+						index: 0,
+					},
+				],
+			},
+			[],
+		);
+
+		expect(result?.choices?.[0]).toMatchObject({
+			delta: { role: "assistant", content: "Still streaming" },
+			finish_reason: null,
+		});
+	});
+
+	it("maps Google STOP to tool_calls on a final function-call chunk", () => {
+		const result = transformStreamingToOpenai(
+			"google-ai-studio",
+			"gemini-2.5-pro",
+			{
+				candidates: [
+					{
+						content: {
+							role: "model",
+							parts: [
+								{
+									functionCall: {
+										name: "get_weather",
+										args: { city: "Paris" },
+									},
+								},
+							],
+						},
+						finishReason: "STOP",
+						index: 0,
+					},
+				],
+			},
+			[],
+		);
+
+		expect(result?.choices?.[0]).toMatchObject({
+			delta: {
+				role: "assistant",
+				tool_calls: [
+					{
+						index: 0,
+						type: "function",
+						function: {
+							name: "get_weather",
+							arguments: JSON.stringify({ city: "Paris" }),
+						},
+					},
+				],
+			},
+			finish_reason: "tool_calls",
+		});
+	});
+
 	it("maps Google usage-only trailing chunk without logging", () => {
 		warn.mockClear();
 		error.mockClear();

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -653,7 +653,15 @@ export function transformStreamingToOpenai(
 							? candidate.index
 							: candidateIdx,
 					delta,
-					finish_reason: null,
+					finish_reason:
+						candidate.finishReason === undefined
+							? null
+							: mapFinishReasonToOpenai(
+									candidate.finishReason,
+									usedProvider,
+									toolCalls.length > 0,
+									data.promptFeedback?.blockReason,
+								),
 				};
 			});
 


### PR DESCRIPTION
Google streaming can return content and `finishReason` in the same candidate chunk. The content branch previously emitted `finish_reason: null` unconditionally, so OpenAI-compatible clients could miss the terminal reason.

This change:

- maps a present Google `finishReason` through the existing canonical helper
- preserves `null` when `finishReason` is absent, avoiding premature stream termination
- preserves `tool_calls` when a final chunk contains a function call
- adds coverage for AI Studio and Vertex (`STOP`, `MAX_TOKENS`, absence, and function calls)

TDD evidence during implementation: the first regression test failed with `finish_reason: null` instead of `stop` (1 failed / 24 passed), then passed after the minimal source change. Fresh post-rebase verification:

- focused spec: 28/28 passed
- `pnpm turbo run build --filter=gateway`: 10/10 tasks passed, including gateway TypeScript build and generation
- ESLint on both touched files: passed
- Prettier check on both touched files: passed
- `git diff --check` / `git show --check`: passed

The diff is limited to the transformer and its spec; no package manifest or lockfile changed.

The full unit suite was not run because the repository requires isolated PostgreSQL/Redis services and Docker is unavailable on this host. The package-wide lint command is also not reported as green: on this Windows checkout its Prettier phase flags 298 untouched files due inherited CRLF checkout behavior. The two changed files pass the repository's ESLint and Prettier checks.

Review note: there is not a dedicated multi-candidate fixture, although the implementation computes `finishReason`, tool calls, and fallback index inside each `candidates.map` iteration. Open PR #3233 touches the same transformer/spec for Azure-Anthropic only; its hunks do not overlap this Google logic, though sharing files may create future rebase friction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming response compatibility by accurately reporting completion reasons, including normal completion, token limits, tool calls, and prompt blocks.
  * Ensured ongoing streamed text remains marked as incomplete until a final status is available.

* **Tests**
  * Added coverage for final text responses, token-limit endings, ongoing text streams, and function-call responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->