### PR TITLE
fix(gateway): adapt failed requests billing

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -8665,6 +8665,115 @@ describe("api", () => {
 			expect(Number(logs[0].outputCost)).toBe(0);
 		});
 
+		// The invariant that would have made the phantom charges self-evident:
+		// whatever count the charge was computed from is the count the row shows.
+		test("a successful stream logs the completion count it was billed for", async () => {
+			await db.insert(tables.apiKey).values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+			await db.insert(tables.providerKey).values({
+				id: "provider-key-id",
+				token: "sk-test-key",
+				provider: "anthropic",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			});
+
+			// Completes cleanly, but the provider never reports output_tokens and
+			// emits tool calls only — so the cost comes from an estimate.
+			const toolArgs = JSON.stringify({ query: "y".repeat(4000) });
+			const sse = [
+				`event: message_start\ndata: ${JSON.stringify({
+					type: "message_start",
+					message: {
+						id: "msg_no_usage",
+						type: "message",
+						role: "assistant",
+						model: "claude-opus-4-8",
+						content: [],
+						usage: { input_tokens: 100 },
+					},
+				})}\n\n`,
+				`event: content_block_start\ndata: ${JSON.stringify({
+					type: "content_block_start",
+					index: 0,
+					content_block: { type: "tool_use", id: "toolu_1", name: "search" },
+				})}\n\n`,
+				`event: content_block_delta\ndata: ${JSON.stringify({
+					type: "content_block_delta",
+					index: 0,
+					delta: { type: "input_json_delta", partial_json: toolArgs },
+				})}\n\n`,
+				`event: content_block_stop\ndata: ${JSON.stringify({
+					type: "content_block_stop",
+					index: 0,
+				})}\n\n`,
+				`event: message_delta\ndata: ${JSON.stringify({
+					type: "message_delta",
+					delta: { stop_reason: "tool_use", stop_sequence: null },
+				})}\n\n`,
+				`event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`,
+			].join("");
+
+			const fetchSpy = spyUpstreamResponse(
+				`${mockServerUrl}/v1/messages`,
+				sse,
+				"text/event-stream",
+			);
+
+			try {
+				const res = await app.request("/v1/chat/completions", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: "Bearer real-token",
+						"x-no-fallback": "true",
+					},
+					body: JSON.stringify({
+						model: "anthropic/claude-opus-4-8",
+						messages: [{ role: "user", content: "Call a tool" }],
+						tools: [
+							{
+								type: "function",
+								function: {
+									name: "search",
+									description: "Search",
+									parameters: {
+										type: "object",
+										properties: { query: { type: "string" } },
+									},
+								},
+							},
+						],
+						stream: true,
+					}),
+				});
+
+				expect(res.status).toBe(200);
+				await readAll(res.body);
+			} finally {
+				fetchSpy.mockRestore();
+			}
+
+			const logs = await waitForLogs(1);
+			expect(logs.length).toBe(1);
+			expect(logs[0].hasError).toBe(false);
+
+			// Cost and tokens must tell the same story: outputCost is exactly the
+			// logged completion count at the mapping's output price, never a
+			// number that appears nowhere in the row.
+			const loggedCompletion = Number(logs[0].completionTokens ?? 0);
+			expect(loggedCompletion).toBeGreaterThan(0);
+			expect(Number(logs[0].outputCost)).toBeCloseTo(
+				loggedCompletion * 25e-6,
+				8,
+			);
+		});
+
 		test("empty non-streaming response is not billed", async () => {
 			await db.insert(tables.apiKey).values({
 				id: "token-id",

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -11230,6 +11230,10 @@ chat.openapi(completions, async (c) => {
 										explicitCacheUsed,
 										servedServiceTier,
 										customPricing: customPricingMapping,
+										// A stream that died never delivered a usage frame, so
+										// there is nothing to estimate from but the partial text
+										// and tool-call JSON that happened to arrive. Don't guess.
+										allowOutputEstimate: streamingError === null,
 									},
 									finishReason === "content_filter",
 								));
@@ -11257,6 +11261,50 @@ chat.openapi(completions, async (c) => {
 							calculatedTotalTokens =
 								(calculatedTotalTokens ?? 0) + promptDelta;
 						}
+					}
+
+					// Same for the completion count. calculateCosts derives its own
+					// estimate when the provider reported none, and that estimate is what
+					// the charge is computed from — so it has to be what the log records.
+					// Without this the row can read "0 completion tokens" next to a large
+					// output cost, which is how phantom charges stayed invisible until a
+					// customer noticed them.
+					if (
+						costs.completionTokens !== null &&
+						costs.completionTokens !== undefined
+					) {
+						const completionDelta =
+							costs.completionTokens - (calculatedCompletionTokens ?? 0);
+						if (completionDelta > 0) {
+							calculatedCompletionTokens = costs.completionTokens;
+							calculatedTotalTokens =
+								(calculatedTotalTokens ?? 0) + completionDelta;
+						}
+					}
+
+					// A successful stream that never reported a completion count means the
+					// provider ignored our `stream_options: { include_usage: true }`.
+					// Surface it rather than papering over it with an estimate: the fix
+					// belongs in the request we send that provider, and until then its
+					// output is billed at 0 rather than at a guess.
+					if (
+						!streamingError &&
+						!canceled &&
+						!completionTokens &&
+						(fullContent.length > 0 ||
+							(streamingToolCalls && streamingToolCalls.length > 0))
+					) {
+						logger.warn(
+							"[streaming] Provider reported no completion tokens on a successful stream",
+							{
+								provider: usedProvider,
+								model: usedInternalModel,
+								finishReason,
+								contentLength: fullContent.length,
+								toolCallCount: streamingToolCalls?.length ?? 0,
+								billedCompletionTokens: costs.completionTokens ?? 0,
+							},
+						);
 					}
 
 					// Extract plugin IDs for logging

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -11287,10 +11287,14 @@ chat.openapi(completions, async (c) => {
 					// Surface it rather than papering over it with an estimate: the fix
 					// belongs in the request we send that provider, and until then its
 					// output is billed at 0 rather than at a guess.
+					// Deliberately narrower than the "billed on estimated token counts"
+					// warning in calculateCosts, so one event never logs twice: this
+					// fires only when the output ended up billed at zero.
 					if (
 						!streamingError &&
 						!canceled &&
 						!completionTokens &&
+						!costs.completionTokens &&
 						(fullContent.length > 0 ||
 							(streamingToolCalls && streamingToolCalls.length > 0))
 					) {
@@ -11302,7 +11306,6 @@ chat.openapi(completions, async (c) => {
 								finishReason,
 								contentLength: fullContent.length,
 								toolCallCount: streamingToolCalls?.length ?? 0,
-								billedCompletionTokens: costs.completionTokens ?? 0,
 							},
 						);
 					}

--- a/apps/gateway/src/lib/costs.spec.ts
+++ b/apps/gateway/src/lib/costs.spec.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { logger } from "@llmgateway/logger";
+
 import {
 	calculateCosts,
 	isBilledFailureFinishReason,
@@ -2045,6 +2047,85 @@ describe("output-token estimation guardrails", () => {
 
 		const withoutReEncoding = Math.ceil(("search" + args).length / 4);
 		expect(result.completionTokens).toBeLessThanOrEqual(withoutReEncoding);
+	});
+});
+
+describe("estimated-cost warning", () => {
+	// So an estimated charge is auditable after the fact: grep the message, and
+	// the trace id the logger attaches leads back to the log row it charged.
+	beforeEach(() => {
+		vi.mocked(mockGetEffectiveDiscount).mockImplementation(async () => ({
+			discount: "0",
+			source: "none",
+		}));
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("warns when a billed request used estimated token counts", async () => {
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+		await calculateCosts("gpt-4", "openai", null, null, null, null, {
+			prompt: "Hello, how are you?",
+			completion: "I'm doing well, thank you for asking!",
+		});
+
+		const call = warn.mock.calls.find(
+			([message]) => message === "Billed a request on estimated token counts",
+		);
+		expect(call).toBeDefined();
+		expect(call?.[1]).toMatchObject({
+			model: "gpt-4",
+			provider: "openai",
+			promptTokensEstimated: true,
+			completionTokensEstimated: true,
+		});
+	});
+
+	it("does not warn when both token counts came from the provider", async () => {
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+		await calculateCosts("gpt-4", "openai", null, 100, 50, null);
+
+		expect(
+			warn.mock.calls.some(
+				([message]) => message === "Billed a request on estimated token counts",
+			),
+		).toBe(false);
+	});
+
+	it("does not warn when the estimate produced no charge", async () => {
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+		// Prompt tokens reported, output estimation disallowed: nothing is
+		// invented, so there is nothing to audit.
+		await calculateCosts(
+			"gpt-4",
+			"openai",
+			null,
+			100,
+			0,
+			null,
+			{ prompt: "hi", completion: "" },
+			null,
+			0,
+			undefined,
+			0,
+			null,
+			null,
+			undefined,
+			null,
+			null,
+			{ allowOutputEstimate: false },
+		);
+
+		expect(
+			warn.mock.calls.some(
+				([message]) => message === "Billed a request on estimated token counts",
+			),
+		).toBe(false);
 	});
 });
 

--- a/apps/gateway/src/lib/costs.spec.ts
+++ b/apps/gateway/src/lib/costs.spec.ts
@@ -1948,6 +1948,106 @@ describe("isRefusalFinishReason", () => {
 	});
 });
 
+describe("output-token estimation guardrails", () => {
+	// Regression for the phantom-charge incident: a truncated agentic stream was
+	// billed 1,165,619 output tokens (9.1x the mapping's maxOutput) estimated
+	// from accumulated tool-call JSON, on a log row recording 0 output tokens.
+	const bigToolCall = [
+		{
+			id: "call_1",
+			type: "function" as const,
+			function: {
+				name: "search",
+				arguments: JSON.stringify({ q: "x".repeat(2_000_000) }),
+			},
+		},
+	];
+
+	it("does not estimate output tokens when estimation is disallowed", async () => {
+		const result = await calculateCosts(
+			"gpt-5.6-sol",
+			"openai",
+			null,
+			1000,
+			null,
+			null,
+			{ prompt: "hi", completion: "", toolResults: bigToolCall },
+			null,
+			0,
+			undefined,
+			0,
+			null,
+			null,
+			undefined,
+			null,
+			null,
+			{ allowOutputEstimate: false },
+		);
+
+		expect(result.completionTokens).toBe(0);
+		expect(result.outputCost).toBe(0);
+		expect(result.inputCost).toBeGreaterThan(0);
+	});
+
+	it("clamps an estimated output count to the mapping's maxOutput", async () => {
+		const result = await calculateCosts(
+			"gpt-5.6-sol",
+			"openai",
+			null,
+			1000,
+			null,
+			null,
+			{ prompt: "hi", completion: "", toolResults: bigToolCall },
+		);
+
+		// gpt-5.6-sol advertises maxOutput 128000; the raw estimate is far larger.
+		expect(result.completionTokens).toBe(128000);
+		expect(result.outputCost).toBeCloseTo(128000 * 30e-6, 6);
+	});
+
+	it("never clamps a provider-reported output count", async () => {
+		const reported = 200000;
+		const result = await calculateCosts(
+			"gpt-5.6-sol",
+			"openai",
+			null,
+			1000,
+			reported,
+		);
+
+		expect(result.completionTokens).toBe(reported);
+		expect(result.outputCost).toBeCloseTo(reported * 30e-6, 6);
+	});
+
+	it("does not re-encode tool-call arguments when estimating", async () => {
+		// `arguments` is already a JSON string; JSON.stringify-ing it again
+		// escapes every quote and inflates the chars/4 estimate.
+		const args = JSON.stringify({ query: "a".repeat(400) });
+		const result = await calculateCosts(
+			"gpt-5.6-sol",
+			"openai",
+			null,
+			1000,
+			null,
+			null,
+			{
+				prompt: "hi",
+				completion: "",
+				toolResults: [
+					{
+						id: "call_1",
+						type: "function" as const,
+						function: { name: "search", arguments: args },
+					},
+				],
+			},
+		);
+
+		const withoutReEncoding = Math.ceil(("search" + args).length / 4);
+		expect(result.completionTokens).toBeLessThanOrEqual(withoutReEncoding);
+	});
+});
+
 describe("zeroInferenceCosts", () => {
 	it("zeroes every inference cost field in place but leaves data storage", () => {
 		const costs = {

--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -4,6 +4,7 @@ import { estimateTokensFromContent } from "@/chat/tools/estimate-tokens-from-con
 import { encodeChatMessages } from "@/chat/tools/tokenizer.js";
 
 import { getEffectiveDiscount } from "@llmgateway/db";
+import { logger } from "@llmgateway/logger";
 import {
 	type ModelDefinition,
 	type ProviderModelMapping,
@@ -283,6 +284,18 @@ export async function calculateCosts(
 		 * entry (which remain unbilled).
 		 */
 		customPricing?: ProviderModelMapping;
+		/**
+		 * Whether an output-token count may be *estimated* from the response text
+		 * when the provider reported no completion count of its own.
+		 *
+		 * Pass `false` whenever the response did not complete. A truncated stream
+		 * never delivers a usage frame, so the only material left to estimate from
+		 * is whatever partial text and tool-call JSON happened to accumulate —
+		 * which is a guess about output we never saw the end of, not a measurement.
+		 * Billing that guess is how a request logged with 0 completion tokens ended
+		 * up charged for 1.17M of them.
+		 */
+		allowOutputEstimate?: boolean;
 	},
 	contentFilterTriggered = false,
 ) {
@@ -293,6 +306,7 @@ export async function calculateCosts(
 	const explicitCacheUsed = options?.explicitCacheUsed ?? false;
 	const servedServiceTier = options?.servedServiceTier ?? null;
 	const customPricing = options?.customPricing;
+	const allowOutputEstimate = options?.allowOutputEstimate ?? true;
 
 	// Look up the model definition by the canonical root id only.
 	// externalId-based lookups are intentionally not supported here — the
@@ -340,6 +354,10 @@ export async function calculateCosts(
 	let calculatedCompletionTokens = completionTokens;
 	// Track if we're using estimated tokens
 	let isEstimated = false;
+	// Narrower than isEstimated, which also covers a prompt-only estimate. Only
+	// an estimated *output* count gets clamped below: a provider-reported count
+	// is the provider's own measurement and is billed as reported.
+	let completionTokensEstimated = false;
 
 	if ((!promptTokens || !completionTokens) && fullOutput) {
 		// We're going to estimate at least some of the tokens
@@ -358,7 +376,7 @@ export async function calculateCosts(
 		}
 
 		// Calculate completion tokens
-		if (!completionTokens && fullOutput) {
+		if (!completionTokens && fullOutput && allowOutputEstimate) {
 			let completionText = "";
 
 			// Include main completion content
@@ -372,14 +390,22 @@ export async function calculateCosts(
 					if (toolResult?.function?.name) {
 						completionText += toolResult.function.name;
 					}
-					if (toolResult?.function?.arguments) {
-						completionText += JSON.stringify(toolResult.function.arguments);
+					const args = toolResult?.function?.arguments;
+					if (args) {
+						// `arguments` is already a JSON *string*. Running it through
+						// JSON.stringify re-escapes every quote and newline, inflating the
+						// character count — and therefore the chars/4 estimate — by a
+						// large factor on exactly the tool-heavy payloads where the
+						// estimate matters most.
+						completionText +=
+							typeof args === "string" ? args : JSON.stringify(args);
 					}
 				}
 			}
 
 			if (completionText) {
 				calculatedCompletionTokens = estimateTokensFromContent(completionText);
+				completionTokensEstimated = true;
 			}
 		}
 	}
@@ -440,6 +466,28 @@ export async function calculateCosts(
 			discount: undefined,
 			pricingTier: undefined,
 		};
+	}
+
+	// An estimated output count is a guess, so bound it by what the deployment
+	// can physically emit. Without this a runaway estimate bills tokens the
+	// model could not have produced — the reported incident charged 1,165,619
+	// output tokens against a mapping whose maxOutput is 128,000. Provider-
+	// reported counts are never clamped: those are the provider's measurement,
+	// and quietly rewriting them would hide a real upstream disagreement.
+	if (
+		completionTokensEstimated &&
+		providerInfo.maxOutput &&
+		calculatedCompletionTokens !== null &&
+		calculatedCompletionTokens > providerInfo.maxOutput
+	) {
+		logger.warn("Clamped an estimated completion count to maxOutput", {
+			model,
+			provider,
+			region,
+			estimatedCompletionTokens: calculatedCompletionTokens,
+			maxOutput: providerInfo.maxOutput,
+		});
+		calculatedCompletionTokens = providerInfo.maxOutput;
 	}
 
 	// Without prompt tokens we can't calculate token costs — except for

--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -358,20 +358,21 @@ export async function calculateCosts(
 	// an estimated *output* count gets clamped below: a provider-reported count
 	// is the provider's own measurement and is billed as reported.
 	let completionTokensEstimated = false;
+	let promptTokensEstimated = false;
 
 	if ((!promptTokens || !completionTokens) && fullOutput) {
-		// We're going to estimate at least some of the tokens
-		isEstimated = true;
 		// Calculate prompt tokens using a cheap length-based estimate.
 		// Accuracy is intentionally traded for throughput so we never run
 		// gpt-tokenizer on the gateway hot path.
 		if (!promptTokens && fullOutput) {
 			if (fullOutput.messages) {
 				calculatedPromptTokens = encodeChatMessages(fullOutput.messages);
+				promptTokensEstimated = true;
 			} else if (fullOutput.prompt) {
 				calculatedPromptTokens = estimateTokensFromContent(
 					JSON.stringify(fullOutput.prompt),
 				);
+				promptTokensEstimated = true;
 			}
 		}
 
@@ -409,6 +410,12 @@ export async function calculateCosts(
 			}
 		}
 	}
+
+	// Derived from what was actually estimated, not from merely entering the
+	// block above: a request whose prompt tokens the provider reported and whose
+	// output estimation was declined has invented nothing, so it must not be
+	// labelled (or warned about) as estimated.
+	isEstimated = promptTokensEstimated || completionTokensEstimated;
 
 	// Find the provider-specific pricing, keyed by providerId + region.
 	// Region matters when a single root model id has multiple per-region
@@ -874,6 +881,28 @@ export async function calculateCosts(
 		.plus(requestCost)
 		.plus(webSearchCost)
 		.plus(contentFilterCost);
+
+	// Every request billed on a token count we made up rather than one the
+	// provider reported. Logged at warn on purpose: this is the class of charge
+	// that produced the phantom-billing incident, it should be rare (we ask every
+	// streaming provider for usage via `stream_options: { include_usage: true }`),
+	// and if it turns out not to be rare that is itself the finding. The logger
+	// attaches the trace id in production, which is also stored on the log row,
+	// so a hit here pivots straight to the request it charged.
+	if (isEstimated && totalCost.greaterThan(0)) {
+		logger.warn("Billed a request on estimated token counts", {
+			model,
+			provider,
+			region,
+			promptTokensEstimated,
+			completionTokensEstimated,
+			promptTokens: calculatedPromptTokens,
+			completionTokens: calculatedCompletionTokens,
+			inputCost: inputCost.toNumber(),
+			outputCost: outputCost.toNumber(),
+			totalCost: totalCost.toNumber(),
+		});
+	}
 
 	return {
 		inputCost: inputCost.toNumber(),


### PR DESCRIPTION
Follow-up to #3505. That PR stopped charging for failed requests; this one fixes the estimator that produced the charges in the first place, and makes any future estimated charge auditable.

## Problem

A customer was charged **$17.48 for 1,165,619 output tokens on a log row recording 0 of them**. Two smaller charges ($2.76, $2.98) have the same shape.

The stream died before OpenAI sent a usage frame, so `calculateCosts` fell back to estimating a completion count from the tool-call JSON that had accumulated over an hour of agentic work. Four things went wrong at once:

1. It estimated from a response that never completed — a guess about output we never saw the end of.
2. The estimate drove the charge but was **never written back to `log.completionTokens`**. Prompt tokens have a reconciliation step in `chat.ts`; completion tokens had none. So cost and tokens told different stories, and the discrepancy was invisible until a customer noticed.
3. Nothing bounded the estimate. 1,165,619 tokens is **9.1x** `gpt-5.6-sol`'s `maxOutput` of 128,000 — physically impossible output, billed anyway.
4. `JSON.stringify(toolResult.function.arguments)` runs on a value typed `arguments: string`, re-escaping every quote and newline and inflating the chars/4 estimate on exactly the tool-heavy payloads where it matters most.

The arithmetic confirms it was never upstream-reported usage: input is `83,042 × $5/M × 0.5 (flex) = $0.20760500`, matching the log exactly, while output is `$17.484285 ÷ ($30/M × 0.5) = 1,165,619` — a number appearing nowhere else in the row.

## Approach

Estimation is a fallback for an anomaly, not a revenue path: `prepare-request-body.ts` sets `stream_options: { include_usage: true }` across 11 provider branches, so a missing completion count means something broke. Each change below is independently sufficient to have caught this.

- **Don't estimate output for a response that didn't complete.** New `allowOutputEstimate` option on `calculateCosts`, passed `false` from the streaming failure path.
- **Write the billed completion count back to the log.** A row showing 0 output tokens beside a non-zero output cost is now structurally impossible.
- **Clamp an estimated count to the mapping's `maxOutput`** (declared on 575 mappings). Provider-reported counts are never clamped — those are the provider's own measurement, and rewriting them would hide a real upstream disagreement.
- **Stop re-encoding tool-call arguments.**

## Auditability

`calculateCosts` now warns — `Billed a request on estimated token counts` — whenever a billed request used a count we made up rather than one the provider reported. It lives in the one place every call site goes through, so no path can miss it, and the logger attaches the trace id in production (also stored on the log row), so a hit pivots straight to the request it charged.

Warn rather than info on purpose: this is the class of charge behind the incident, and it should be rare. If it turns out not to be rare, that is the finding.

Writing that warning surfaced a related mislabel: `estimatedCost` was set on merely *entering* the estimation branch, so a request whose prompt tokens the provider reported and whose output estimation was declined was recorded as estimated. It is now derived from what was actually estimated, which keeps both the log column and the warning honest.

A second, narrower warning fires when a *successful* stream reports no completion count and its output ends up billed at zero — that means the provider ignored our `include_usage`, and the right fix is in the request we send it. The two conditions are mutually exclusive, so one event never logs twice.

## Verification

Both new integration tests were confirmed to fail against the pre-fix code:

- `a successful stream logs the completion count it was billed for` → `expected 0 to be greater than 0` (the row logged 0 output tokens on a billed request).
- `stream truncated after tool calls only is not billed` (added in #3505) → charged `$0.02565` on 0 recorded completion tokens.

Unit tests in `costs.spec.ts` cover the disallowed estimate, the `maxOutput` clamp, the never-clamp-reported-counts guarantee, the double-encode, and all three warning cases (fires when estimated, silent when measured, silent when the estimate produced no charge).

`api.spec.ts` (157), `fallback.spec.ts` (54), `responses.spec.ts` (73), `costs.spec.ts` (85), and the four pricing suites (338) pass, run serially. `pnpm format` and `pnpm build` clean.

## Not included

Surfacing `estimatedCost` in the UI — it's on the log row and in the generated API types (`v1.d.ts:4472`) but rendered nowhere, so a user cannot tell an estimated charge from a measured one. Separate UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cost and token tracking for streaming responses, including Anthropic tool-call responses.
  * Prevented failed streams from receiving guessed completion-token counts.
  * Improved handling when providers omit completion usage information.
  * Added safeguards to keep estimated output tokens within model limits while preserving provider-reported values.
  * Improved handling of tool-call content and added warnings when billing relies on estimated usage.
* **Tests**
  * Added coverage for streaming costs, estimation limits, disabled estimation, warnings, and tool-call arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->