### PR TITLE
fix(admin): sum global stats costs in numeric

### DIFF
--- a/apps/api/src/routes/admin-global-stats.spec.ts
+++ b/apps/api/src/routes/admin-global-stats.spec.ts
@@ -6,6 +6,9 @@ import { createTestUser, deleteAll } from "@/testing.js";
 import { db, eq, tables } from "@llmgateway/db";
 
 const MODEL = "openai/global-stats-model";
+// Separate model id so the bulk precision fixture cannot collide with the
+// per-bucket rows above on (day, model, provider, mode, kind).
+const BULK_MODEL = "openai/global-stats-bulk-model";
 const SOURCE = "global-stats-source";
 
 const DAY = new Date();
@@ -54,6 +57,12 @@ const BUCKETS: Bucket[] = [
 	},
 ];
 
+// The per-bucket fixture above also lands in the window every query covers.
+const BASE_FIXTURE_COST = BUCKETS.reduce(
+	(sum, bucket) => sum + Math.fround(bucket.cost),
+	0,
+);
+
 interface GlobalStatsResponse {
 	totals: {
 		requestCount: number;
@@ -100,6 +109,9 @@ const clearFixtures = async () => {
 	await db
 		.delete(tables.globalModelStats)
 		.where(eq(tables.globalModelStats.usedModel, MODEL));
+	await db
+		.delete(tables.globalModelStats)
+		.where(eq(tables.globalModelStats.usedModel, BULK_MODEL));
 	await db
 		.delete(tables.globalSourceStats)
 		.where(eq(tables.globalSourceStats.source, SOURCE));
@@ -226,6 +238,64 @@ describe("admin — global stats mode/kind dimensions", () => {
 		expect(
 			byok.composition.byKind.find((item) => item.requestCount > 0)?.key,
 		).toBe("default");
+	});
+
+	// Costs are stored in float4 columns. Summing them *as* float4 (Postgres'
+	// default for SUM(real)) runs out of significant digits well before the
+	// all-time totals this page shows, and the error depends on how the rows were
+	// grouped — so the headline stopped matching the slices underneath it. A
+	// handful of rows never showed it; the drift only appears at production
+	// magnitude, hence the bulk fixture.
+	test("large all-time sums stay exact and grouping-independent", async () => {
+		const DAYS = 700;
+		const PER_ROW_COST = 4321.1234;
+		const days = Array.from(
+			{ length: DAYS },
+			(_, i) => new Date(DAY.getTime() - i * 24 * 60 * 60 * 1000), // eslint-disable-line no-mixed-operators
+		);
+
+		await db.insert(tables.globalModelStats).values(
+			days.flatMap((day) =>
+				BUCKETS.map((bucket) => ({
+					dayTimestamp: day,
+					usedModel: BULK_MODEL,
+					usedProvider: "openai",
+					usedMode: bucket.usedMode,
+					orgKind: bucket.orgKind,
+					requestCount: bucket.requestCount,
+					cost: PER_ROW_COST,
+				})),
+			),
+		);
+
+		const from = days[days.length - 1].toISOString().split("T")[0];
+		const body = await fetchStats(cookie, { from, to: DATE });
+
+		// The reported symptom: the headline and the slices under it are the same
+		// rows grouped two ways, so they have to agree to the cent.
+		const byMode = body.composition.byMode.reduce(
+			(sum, item) => sum + item.cost,
+			0,
+		);
+		const byKind = body.composition.byKind.reduce(
+			(sum, item) => sum + item.cost,
+			0,
+		);
+		const timeseriesTotal = body.timeseries.reduce(
+			(sum, point) => sum + point.cost,
+			0,
+		);
+		expect(byMode).toBeCloseTo(body.totals.cost, 2);
+		expect(byKind).toBeCloseTo(body.totals.cost, 2);
+		expect(timeseriesTotal).toBeCloseTo(body.totals.cost, 2);
+
+		// float4 rounds PER_ROW_COST on the way in, so compare against the value
+		// the column actually holds rather than the literal above.
+		const stored = Math.fround(PER_ROW_COST);
+		expect(body.totals.cost).toBeCloseTo(
+			stored * DAYS * BUCKETS.length + BASE_FIXTURE_COST, // eslint-disable-line no-mixed-operators
+			2,
+		);
 	});
 
 	test("groups the breakdown by billing mode and organization kind", async () => {

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1905,6 +1905,23 @@ const globalStatsResponseSchema = z.object({
 	breakdown: z.array(globalStatsBreakdownItemSchema),
 });
 
+// Cost columns on the stats tables are `real` (float4), and Postgres accumulates
+// SUM(real) in float4 as well — only ~7 significant digits. Past a few hundred
+// thousand dollars the running sum's ulp is larger than a cent, so the result
+// depends on how the rows happened to be grouped: the blended total and the
+// per-mode / per-kind slices of the *same* rows drift apart by double-digit
+// dollars and the cards visibly stop adding up. NUMERIC accumulation is exact,
+// so every grouping of a set of rows yields the identical sum.
+//
+// The double-precision hop is required, not decorative: `real::numeric` goes
+// through float4's 6-digit display form (1234.5678 -> 1234.57), which throws
+// away more than the float4 sum did. `real::float8` is the exact stored value.
+function sumMoney(column: AnyColumn, alias: string) {
+	return sql<number>`COALESCE(SUM(CAST(CAST(${column} AS DOUBLE PRECISION) AS NUMERIC)), 0)::float8`.as(
+		alias,
+	);
+}
+
 const getGlobalStats = createRoute({
 	method: "get",
 	path: "/global-stats",
@@ -2011,16 +2028,19 @@ admin.openapi(getGlobalStats, async (c) => {
 	}
 
 	const metricSums = {
+		// Counts are exact (SUM(int) accumulates in bigint) but this endpoint sums
+		// all of history, so the result is carried as float8 rather than narrowed
+		// back to int4 — a cross-tenant all-time request count outgrows 2^31.
 		requestCount:
-			sql<number>`COALESCE(SUM(${sourceTable.requestCount}), 0)::int`.as(
+			sql<number>`COALESCE(SUM(${sourceTable.requestCount}), 0)::float8`.as(
 				"requestCount",
 			),
 		errorCount:
-			sql<number>`COALESCE(SUM(${sourceTable.errorCount}), 0)::int`.as(
+			sql<number>`COALESCE(SUM(${sourceTable.errorCount}), 0)::float8`.as(
 				"errorCount",
 			),
 		cacheCount:
-			sql<number>`COALESCE(SUM(${sourceTable.cacheCount}), 0)::int`.as(
+			sql<number>`COALESCE(SUM(${sourceTable.cacheCount}), 0)::float8`.as(
 				"cacheCount",
 			),
 		inputTokens:
@@ -2039,19 +2059,10 @@ admin.openapi(getGlobalStats, async (c) => {
 			sql<number>`COALESCE(SUM(CAST(${sourceTable.totalTokens} AS NUMERIC)), 0)::float8`.as(
 				"totalTokens",
 			),
-		cost: sql<number>`COALESCE(SUM(${sourceTable.cost}), 0)::float8`.as("cost"),
-		inputCost:
-			sql<number>`COALESCE(SUM(${sourceTable.inputCost}), 0)::float8`.as(
-				"inputCost",
-			),
-		cachedInputCost:
-			sql<number>`COALESCE(SUM(${sourceTable.cachedInputCost}), 0)::float8`.as(
-				"cachedInputCost",
-			),
-		outputCost:
-			sql<number>`COALESCE(SUM(${sourceTable.outputCost}), 0)::float8`.as(
-				"outputCost",
-			),
+		cost: sumMoney(sourceTable.cost, "cost"),
+		inputCost: sumMoney(sourceTable.inputCost, "inputCost"),
+		cachedInputCost: sumMoney(sourceTable.cachedInputCost, "cachedInputCost"),
+		outputCost: sumMoney(sourceTable.outputCost, "outputCost"),
 	};
 
 	const dateExpr =

--- a/apps/worker/src/services/project-stats-aggregator.ts
+++ b/apps/worker/src/services/project-stats-aggregator.ts
@@ -1,4 +1,5 @@
 import {
+	type AnyColumn,
 	db,
 	log,
 	projectHourlyStats,
@@ -47,6 +48,16 @@ function getCurrentHourStart(): string {
 				0,
 			),
 		),
+	);
+}
+
+/**
+ * SUM of a money column in double precision. Never `SUM(<real column>)` — that
+ * accumulates in float4 and loses cents long before the hour is over.
+ */
+function sumLogMoney(column: AnyColumn, alias: string) {
+	return sql<number>`coalesce(sum(cast(${column} as double precision)), 0)`.as(
+		alias,
 	);
 }
 
@@ -137,51 +148,37 @@ export function getBaseAggregationFields() {
 			sql<string>`coalesce(sum(cast(${log.cacheWriteTokens} as numeric)), 0)`.as(
 				"cacheWriteTokens",
 			),
-		// Costs
-		cost: sql<number>`coalesce(sum(${log.cost}), 0)`.as("cost"),
-		inputCost: sql<number>`coalesce(sum(${log.inputCost}), 0)`.as("inputCost"),
-		outputCost: sql<number>`coalesce(sum(${log.outputCost}), 0)`.as(
-			"outputCost",
-		),
-		requestCost: sql<number>`coalesce(sum(${log.requestCost}), 0)`.as(
-			"requestCost",
-		),
-		dataStorageCost:
-			sql<number>`coalesce(sum(cast(${log.dataStorageCost} as real)), 0)`.as(
-				"dataStorageCost",
-			),
+		// Costs. `log.cost` and friends are float4, and Postgres accumulates
+		// SUM(real) in float4 too — a busy hour is tens of thousands of rows, so the
+		// running sum runs out of its ~7 significant digits and the bucket is stored
+		// already-wrong. Casting to double precision first keeps the accumulation
+		// accurate; the target column is still float4, so only the final value is
+		// rounded rather than every partial sum along the way.
+		cost: sumLogMoney(log.cost, "cost"),
+		inputCost: sumLogMoney(log.inputCost, "inputCost"),
+		outputCost: sumLogMoney(log.outputCost, "outputCost"),
+		requestCost: sumLogMoney(log.requestCost, "requestCost"),
+		dataStorageCost: sumLogMoney(log.dataStorageCost, "dataStorageCost"),
 		discountSavings: sql<number>`coalesce(
 			sum(
 				case
 					when ${log.discount} > 0 and ${log.discount} < 1
-					then ${log.cost} * ${log.discount} / (1 - ${log.discount})
+					then cast(${log.cost} as double precision) * ${log.discount} / (1 - ${log.discount})
 					else 0
 				end
 			),
 			0
 		)`.as("discountSavings"),
-		imageInputCost: sql<number>`coalesce(sum(${log.imageInputCost}), 0)`.as(
-			"imageInputCost",
+		imageInputCost: sumLogMoney(log.imageInputCost, "imageInputCost"),
+		imageOutputCost: sumLogMoney(log.imageOutputCost, "imageOutputCost"),
+		audioInputCost: sumLogMoney(log.audioInputCost, "audioInputCost"),
+		audioOutputCost: sumLogMoney(log.audioOutputCost, "audioOutputCost"),
+		videoOutputCost: sumLogMoney(log.videoOutputCost, "videoOutputCost"),
+		cachedInputCost: sumLogMoney(log.cachedInputCost, "cachedInputCost"),
+		cacheWriteInputCost: sumLogMoney(
+			log.cacheWriteInputCost,
+			"cacheWriteInputCost",
 		),
-		imageOutputCost: sql<number>`coalesce(sum(${log.imageOutputCost}), 0)`.as(
-			"imageOutputCost",
-		),
-		audioInputCost: sql<number>`coalesce(sum(${log.audioInputCost}), 0)`.as(
-			"audioInputCost",
-		),
-		audioOutputCost: sql<number>`coalesce(sum(${log.audioOutputCost}), 0)`.as(
-			"audioOutputCost",
-		),
-		videoOutputCost: sql<number>`coalesce(sum(${log.videoOutputCost}), 0)`.as(
-			"videoOutputCost",
-		),
-		cachedInputCost: sql<number>`coalesce(sum(${log.cachedInputCost}), 0)`.as(
-			"cachedInputCost",
-		),
-		cacheWriteInputCost:
-			sql<number>`coalesce(sum(${log.cacheWriteInputCost}), 0)`.as(
-				"cacheWriteInputCost",
-			),
 	};
 }
 
@@ -202,19 +199,19 @@ export function getCommonAggregationFields() {
 				"apiKeysRequestCount",
 			),
 		creditsCost:
-			sql<number>`coalesce(sum(case when ${log.usedMode} = 'credits' then ${log.cost} else 0 end), 0)`.as(
+			sql<number>`coalesce(sum(case when ${log.usedMode} = 'credits' then cast(${log.cost} as double precision) else 0 end), 0)`.as(
 				"creditsCost",
 			),
 		apiKeysCost:
-			sql<number>`coalesce(sum(case when ${log.usedMode} = 'api-keys' then ${log.cost} else 0 end), 0)`.as(
+			sql<number>`coalesce(sum(case when ${log.usedMode} = 'api-keys' then cast(${log.cost} as double precision) else 0 end), 0)`.as(
 				"apiKeysCost",
 			),
 		creditsDataStorageCost:
-			sql<number>`coalesce(sum(case when ${log.usedMode} = 'credits' then cast(${log.dataStorageCost} as real) else 0 end), 0)`.as(
+			sql<number>`coalesce(sum(case when ${log.usedMode} = 'credits' then cast(${log.dataStorageCost} as double precision) else 0 end), 0)`.as(
 				"creditsDataStorageCost",
 			),
 		apiKeysDataStorageCost:
-			sql<number>`coalesce(sum(case when ${log.usedMode} = 'api-keys' then cast(${log.dataStorageCost} as real) else 0 end), 0)`.as(
+			sql<number>`coalesce(sum(case when ${log.usedMode} = 'api-keys' then cast(${log.dataStorageCost} as double precision) else 0 end), 0)`.as(
 				"apiKeysDataStorageCost",
 			),
 	};
@@ -497,7 +494,7 @@ function getProviderKeySpendAggregationFields() {
 			sql<string>`coalesce(sum(cast(${log.totalTokens} as numeric)), 0)`.as(
 				"totalTokens",
 			),
-		cost: sql<number>`coalesce(sum(${log.cost}), 0)`.as("cost"),
+		cost: sumLogMoney(log.cost, "cost"),
 	};
 }
 


### PR DESCRIPTION
## Problem

On the admin **Global Stats** page the cost card does not add up: the headline total and the per-mode / per-kind slices printed underneath it are the same rows grouped two ways, yet they disagree by double-digit dollars at all-time scale. Narrow the view to a small enough slice and it reconciles.

Request counts reconcile everywhere; only money drifts, and only at scale. That is the tell.

Every cost column on the stats tables is `real` (float4), and **Postgres accumulates `SUM(real)` in float4 too** — `sum(real) → real`, about 7 significant digits. Once a running sum is large enough its ulp exceeds a cent, so the result depends on the order and grouping of the rows. The headline (one `SUM` over everything) and the composition slices (`SUM` per mode / per kind) therefore diverge. Small slices reconcile because they stay well inside float4's range.

Reproduced standalone:

```sql
with r as (select (i % 4) as bucket, 1234.5678::real as c from generate_series(1,800) i)
select (select sum(c)::text from r),                                       -- 987650.7
       (select sum(s)::text from (select sum(c) s from r group by bucket) g), -- 987652.7
       (select sum(c::float8::numeric)::text from r);                      -- 987654.19921875
```

Three different answers for the same 800 rows.

## Fix

**Read path** (`GET /admin/global-stats`) — accumulate cost sums in `NUMERIC`, which is exact, so any grouping of a row set yields a bit-identical total.

The cast chain matters and is not decorative: `real::numeric` routes through float4's **6-digit** display form (`1234.5678::real::numeric` → `1234.57`), losing more than the float4 sum did. `real::double precision` is the exact stored value, so the cast is `real → float8 → numeric`, then back to `float8` for JSON.

Also stopped narrowing the all-time request/error/cache counts back to `int4` — this endpoint is cross-tenant and all-time, so the count will outgrow 2^31 eventually and fail hard.

**Write path** (`apps/worker` hourly aggregation) — same bug a layer down: an hour is tens of thousands of log rows, summed in float4 before being stored, so the buckets were already wrong before anything read them. Now cast to `double precision` first; the target column is still float4, so only the final value is rounded rather than every partial sum along the way. This covers `global_*_stats`, `project_hourly_*`, `api_key_hourly_*` and `provider_key_hourly_stats`.

While there: `data_storage_cost` was being summed as `cast(... as real)` even though `log.data_storage_cost` is `numeric` — it was downcast for no reason.

## Not in this PR

- **No column-type migration.** The stats tables keep `real` columns. Per-row rounding is ~5e-8 of the row's own value; the error that was visible came overwhelmingly from the *accumulation*, which is what this fixes.
- **The other `SUM(<real column>)` sites** across `analytics.ts`, the model/mapping history rollups and `stats-calculator.ts` have the same latent bug, but they are per-project or per-model and orders of magnitude smaller, so the drift is currently invisible. Left for a follow-up rather than bundled into a bug fix.
- **The "Unattributed" bucket is a separate defect** — `org_kind` was never backfilled when the column was added, and `used_mode` only partially. That is addressed in #3549.

## Verification

New spec `large all-time sums stay exact and grouping-independent` builds a synthetic production-magnitude fixture (700 days × 4 mode/kind buckets) and asserts the headline matches the mode composition, the kind composition, and the timeseries.

Against the unfixed code it reproduces the reported symptom at scale:

```
AssertionError: expected 12098983.5 to be close to 12099147.748046875,
received difference is 164.248046875, but expected 0.005
```

- `apps/api` — 930 tests pass (70 files)
- `apps/worker` — 114 tests pass (9 files)
- `pnpm format`, `pnpm build` clean

No screenshots: this is a numeric correctness fix behind an existing card, nothing about the layout changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of cost and usage totals in global statistics.
  * Prevented rounding drift when aggregating large volumes of decimal-based costs.
  * Preserved fractional request, error, and cache counts instead of narrowing them to whole numbers.
  * Updated cost breakdowns across modes, providers, discounts, and storage metrics for more reliable totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->