### PR TITLE
feat(scripts): backfill global stats attribution

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -9,6 +9,7 @@
 		"api-key-hash": "tsx src/api-key-hash.ts",
 		"api-ping": "tsx src/api-ping.ts",
 		"benchmark-model": "tsx --env-file=../../.env src/benchmark-model.ts",
+		"backfill-global-stats-attribution": "tsx src/backfill-global-stats-attribution.ts",
 		"backfill-stripe-refunds": "tsx src/backfill-stripe-refunds.ts",
 		"export-models-dev": "tsx src/export-models-dev.ts",
 		"generate-test-logs": "tsx src/generate-test-logs.ts",

--- a/packages/scripts/src/backfill-global-stats-attribution.ts
+++ b/packages/scripts/src/backfill-global-stats-attribution.ts
@@ -1,0 +1,418 @@
+/* eslint-disable no-console */
+/**
+ * One-time backfill: recover `used_mode` and `org_kind` on historical
+ * global_model_stats / global_source_stats rows.
+ *
+ * Migration 1786136603_warm_omega_flight.sql added both dimensions and
+ * backfilled `used_mode` only where a whole (day, model, provider) bucket had
+ * used a single mode; genuinely mixed buckets kept 'unknown', and `org_kind`
+ * was never backfilled at all. The admin Global Stats page therefore shows a
+ * large "Unattributed" slice, and Credits + BYOK does not add up to All.
+ *
+ * The project hourly tables still hold the answer: they are keyed per project
+ * (hence per organization, so org kind is exact) and kept the billing-mode
+ * split as denormalized credits_* / api_keys_* column pairs.
+ *
+ * Approach — redistribute, do not replace. The global tables are authoritative
+ * for TOTALS (they carry ~0.03% more traffic than the project side, because the
+ * project aggregator's backfill phase is off by default and its stale window is
+ * only STATS_STALE_DAYS). The project side is authoritative for ATTRIBUTION. So
+ * each row needing repair is split across the (mode, kind) tuples observed on
+ * the project side, scaled so the parts sum back to exactly what the row held.
+ * Nothing is gained or lost.
+ *
+ * Rows are only ever split along the dimension that is actually unknown: a row
+ * that already knows its mode is redistributed across kinds *within* that mode.
+ *
+ * Exactness: the distribution is built per (project, hour, model) bucket, so a
+ * bucket that used a single mode contributes all of its tokens and errors to
+ * that mode. Only genuinely mixed buckets are prorated by request share —
+ * measured at 0.049% of buckets and 0.121% of tokens.
+ *
+ * Usage:
+ *   pnpm --filter @llmgateway/scripts backfill-global-stats-attribution
+ *   pnpm --filter @llmgateway/scripts backfill-global-stats-attribution --commit
+ *   pnpm --filter @llmgateway/scripts backfill-global-stats-attribution --from=2025-02-01 --to=2026-08-11
+ *   pnpm --filter @llmgateway/scripts backfill-global-stats-attribution --table=model
+ *
+ * Environment:
+ *   DATABASE_URL - defaults to local postgres if unset
+ */
+
+import {
+	db,
+	globalModelStats,
+	globalSourceStats,
+	inArray,
+	sql,
+	type GlobalStatsOrgKind,
+	type GlobalStatsUsedMode,
+} from "@llmgateway/db";
+
+import {
+	ALL_METRICS,
+	type Candidate,
+	emptyMetrics,
+	type GlobalRow,
+	type MetricKey,
+	type Metrics,
+	PAIR_METRICS,
+	SHARE_METRICS,
+	splitRow,
+	type SplitPart,
+	TOKEN_METRICS,
+} from "./lib/global-stats-split.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Drizzle's `casing: "snake_case"` applies at SQL emission time; raw column
+// references have to be converted by hand.
+function toSnake(s: string): string {
+	return s.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+}
+
+function readMetrics(row: Record<string, unknown>): Metrics {
+	const out = emptyMetrics();
+	for (const metric of ALL_METRICS) {
+		out[metric] = Number(row[toSnake(metric)] ?? 0);
+	}
+	return out;
+}
+
+function parseFlag(name: string): string | undefined {
+	const flag = `--${name}=`;
+	const arg = process.argv.find((a) => a.startsWith(flag));
+	return arg ? arg.slice(flag.length) : undefined;
+}
+
+function hasFlag(name: string): boolean {
+	return process.argv.includes(`--${name}`);
+}
+
+interface Target {
+	name: "model" | "source";
+	globalTable: typeof globalModelStats | typeof globalSourceStats;
+	globalTableName: "global_model_stats" | "global_source_stats";
+	projectTableName: "project_hourly_model_stats" | "project_hourly_source_stats";
+	keyColumns: string[];
+}
+
+const TARGETS: Record<"model" | "source", Target> = {
+	model: {
+		name: "model",
+		globalTable: globalModelStats,
+		globalTableName: "global_model_stats",
+		projectTableName: "project_hourly_model_stats",
+		keyColumns: ["used_model", "used_provider"],
+	},
+	source: {
+		name: "source",
+		globalTable: globalSourceStats,
+		globalTableName: "global_source_stats",
+		projectTableName: "project_hourly_source_stats",
+		keyColumns: ["source"],
+	},
+};
+
+function keyOf(values: string[]): string {
+	// NUL cannot appear in a Postgres text value, so it is a safe joiner —
+	// x-source header values may well contain spaces or slashes.
+	return values.join("\u0000");
+}
+
+async function loadGlobalRows(
+	target: Target,
+	dayStr: string,
+): Promise<GlobalRow[]> {
+	const keySelect = sql.join(
+		target.keyColumns.map((c) => sql`${sql.identifier(c)}`),
+		sql`, `,
+	);
+	const metricSelect = sql.join(
+		ALL_METRICS.map((m) => sql`${sql.identifier(toSnake(m))}`),
+		sql`, `,
+	);
+	const result = await db.execute(sql`
+		select id, ${keySelect}, used_mode, org_kind, ${metricSelect}
+		from ${sql.identifier(target.globalTableName)}
+		where day_timestamp = ${dayStr}::timestamp
+		  and (used_mode = 'unknown' or org_kind = 'unknown')
+	`);
+	return (result.rows as Record<string, unknown>[]).map((r) => ({
+		id: String(r.id),
+		keyValues: target.keyColumns.map((c) => String(r[c] ?? "")),
+		usedMode: r.used_mode as GlobalStatsUsedMode,
+		orgKind: r.org_kind as GlobalStatsOrgKind,
+		metrics: readMetrics(r),
+	}));
+}
+
+/**
+ * The project-side (mode, kind) distribution for one UTC day.
+ *
+ * Each project-hour bucket is split into a credits part and an api-keys part via
+ * the column pairs. Metrics without a pair are scaled by that part's share of
+ * the bucket's requests — which is 1 or 0 for a bucket that used a single mode,
+ * so only genuinely mixed buckets are ever approximated.
+ */
+async function loadDistribution(
+	target: Target,
+	dayStr: string,
+	nextStr: string,
+): Promise<Map<string, Candidate[]>> {
+	const keySelect = sql.join(
+		target.keyColumns.map((c) => sql`s.${sql.identifier(c)}`),
+		sql`, `,
+	);
+	const pairSelect = sql.join(
+		PAIR_METRICS.map(
+			(m) =>
+				sql`sum(m.${sql.identifier(toSnake(m))}) as ${sql.identifier(toSnake(m))}`,
+		),
+		sql`, `,
+	);
+	const shareSelect = sql.join(
+		SHARE_METRICS.map(
+			(m) =>
+				sql`sum(s.${sql.identifier(toSnake(m))}::numeric * m.share) as ${sql.identifier(toSnake(m))}`,
+		),
+		sql`, `,
+	);
+	// Group by ordinal: the key columns, then used_mode, then org_kind.
+	const groupBy = sql.join(
+		Array.from({ length: target.keyColumns.length + 2 }, (_, i) =>
+			sql.raw(String(i + 1)),
+		),
+		sql`, `,
+	);
+
+	const result = await db.execute(sql`
+		select ${keySelect},
+		       m.used_mode,
+		       coalesce(o.kind, 'unknown') as org_kind,
+		       ${pairSelect}, ${shareSelect}
+		from ${sql.identifier(target.projectTableName)} s
+		left join project p on p.id = s.project_id
+		left join organization o on o.id = p.organization_id
+		cross join lateral (values
+			('credits',
+			 s.credits_request_count::numeric,
+			 s.credits_cost::float8::numeric,
+			 s.credits_data_storage_cost::float8::numeric,
+			 s.credits_request_count::numeric / nullif(s.request_count, 0)),
+			('api-keys',
+			 s.api_keys_request_count::numeric,
+			 s.api_keys_cost::float8::numeric,
+			 s.api_keys_data_storage_cost::float8::numeric,
+			 s.api_keys_request_count::numeric / nullif(s.request_count, 0))
+		) as m(used_mode, request_count, cost, data_storage_cost, share)
+		where s.hour_timestamp >= ${dayStr}::timestamp
+		  and s.hour_timestamp < ${nextStr}::timestamp
+		  and m.request_count > 0
+		group by ${groupBy}
+	`);
+
+	const byKey = new Map<string, Candidate[]>();
+	for (const r of result.rows as Record<string, unknown>[]) {
+		const key = keyOf(target.keyColumns.map((c) => String(r[c] ?? "")));
+		const candidate: Candidate = {
+			usedMode: r.used_mode as Exclude<GlobalStatsUsedMode, "unknown">,
+			orgKind: r.org_kind as GlobalStatsOrgKind,
+			metrics: readMetrics(r),
+		};
+		const list = byKey.get(key);
+		if (list) {
+			list.push(candidate);
+		} else {
+			byKey.set(key, [candidate]);
+		}
+	}
+	return byKey;
+}
+
+function toInsertValues(target: Target, part: SplitPart, day: Date) {
+	const key =
+		target.name === "model"
+			? { usedModel: part.keyValues[0], usedProvider: part.keyValues[1] }
+			: { source: part.keyValues[0] };
+	const metrics = Object.fromEntries(
+		ALL_METRICS.map((m) => [
+			m,
+			// Token columns are `decimal`, which drizzle expects as a string.
+			(TOKEN_METRICS as readonly string[]).includes(m)
+				? String(part.metrics[m])
+				: part.metrics[m],
+		]),
+	);
+	return {
+		dayTimestamp: day,
+		usedMode: part.usedMode,
+		orgKind: part.orgKind,
+		...key,
+		...metrics,
+	};
+}
+
+/** `col = table.col + excluded.col`, matching the aggregator's ADD upsert. */
+function addUpsertSet(target: Target) {
+	const set: Record<string, ReturnType<typeof sql>> = {};
+	for (const metric of ALL_METRICS) {
+		const name = toSnake(metric);
+		set[metric] = sql`${sql.identifier(target.globalTableName)}.${sql.identifier(name)} + excluded.${sql.identifier(name)}`;
+	}
+	set.updatedAt = sql`now()`;
+	return set;
+}
+
+interface DayResult {
+	repaired: number;
+	skipped: number;
+	requestsMoved: number;
+}
+
+async function processDay(
+	target: Target,
+	day: Date,
+	commit: boolean,
+): Promise<DayResult> {
+	const dayStr = day.toISOString().slice(0, 19).replace("T", " ");
+	const nextStr = new Date(day.getTime() + DAY_MS)
+		.toISOString()
+		.slice(0, 19)
+		.replace("T", " ");
+
+	const globalRows = await loadGlobalRows(target, dayStr);
+	if (globalRows.length === 0) {
+		return { repaired: 0, skipped: 0, requestsMoved: 0 };
+	}
+
+	const byKey = await loadDistribution(target, dayStr, nextStr);
+
+	const deleteIds: string[] = [];
+	const parts: SplitPart[] = [];
+	let repaired = 0;
+	let skipped = 0;
+	let requestsMoved = 0;
+
+	for (const row of globalRows) {
+		const all = byKey.get(keyOf(row.keyValues)) ?? [];
+		// A row that already knows its mode may only be split across kinds
+		// *within* that mode, or its mode would silently change.
+		const candidates =
+			row.usedMode === "unknown"
+				? all
+				: all.filter((c) => c.usedMode === row.usedMode);
+
+		if (candidates.length === 0) {
+			// No project-side evidence — those project rows are gone. Leave the row
+			// exactly as it is rather than guessing.
+			skipped++;
+			continue;
+		}
+
+		deleteIds.push(row.id);
+		for (const part of splitRow(row, candidates)) {
+			if (ALL_METRICS.every((m) => part.metrics[m] === 0)) {
+				continue;
+			}
+			parts.push(part);
+		}
+		repaired++;
+		requestsMoved += row.metrics.requestCount;
+	}
+
+	if (!commit || deleteIds.length === 0) {
+		return { repaired, skipped, requestsMoved };
+	}
+
+	await db.transaction(async (tx) => {
+		// Delete first: the split rows are upserted with ADD semantics, so leaving
+		// the originals in place would double the day.
+		for (let i = 0; i < deleteIds.length; i += 1000) {
+			await tx
+				.delete(target.globalTable)
+				.where(inArray(target.globalTable.id, deleteIds.slice(i, i + 1000)));
+		}
+		for (let i = 0; i < parts.length; i += 500) {
+			const values = parts
+				.slice(i, i + 500)
+				.map((part) => toInsertValues(target, part, day));
+			await tx
+				.insert(target.globalTable)
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any -- the two target tables have different key columns, so the row shape is only known at runtime
+				.values(values as any)
+				.onConflictDoUpdate({
+					target: [
+						target.globalTable.dayTimestamp,
+						...(target.name === "model"
+							? [globalModelStats.usedModel, globalModelStats.usedProvider]
+							: [globalSourceStats.source]),
+						target.globalTable.usedMode,
+						target.globalTable.orgKind,
+					],
+					set: addUpsertSet(target),
+				});
+		}
+	});
+
+	return { repaired, skipped, requestsMoved };
+}
+
+async function main(): Promise<void> {
+	const commit = hasFlag("commit");
+	const which = (parseFlag("table") ?? "both") as "model" | "source" | "both";
+	const targets =
+		which === "both" ? [TARGETS.model, TARGETS.source] : [TARGETS[which]];
+
+	console.log(
+		`${commit ? "APPLYING" : "DRY RUN"} — tables: ${targets
+			.map((t) => t.globalTableName)
+			.join(", ")}`,
+	);
+
+	for (const target of targets) {
+		// Per target: the two global tables do not necessarily span the same days,
+		// so deriving one range from global_model_stats would silently skip rows.
+		const bounds = await db.execute(sql`
+			select to_char(min(day_timestamp), 'YYYY-MM-DD') as lo,
+			       to_char(max(day_timestamp), 'YYYY-MM-DD') as hi
+			from ${sql.identifier(target.globalTableName)}
+		`);
+		const row = bounds.rows[0] as
+			| { lo: string | null; hi: string | null }
+			| undefined;
+		const fromStr = parseFlag("from") ?? row?.lo;
+		const toStr = parseFlag("to") ?? row?.hi;
+		if (!fromStr || !toStr) {
+			console.log(`${target.globalTableName}: no rows — nothing to do.`);
+			continue;
+		}
+		const from = new Date(`${fromStr}T00:00:00Z`);
+		const to = new Date(`${toStr}T00:00:00Z`);
+		console.log(`${target.globalTableName}: scanning ${fromStr} .. ${toStr}`);
+
+		let repaired = 0;
+		let skipped = 0;
+		let requestsMoved = 0;
+		for (let d = new Date(from); d <= to; d = new Date(d.getTime() + DAY_MS)) {
+			const res = await processDay(target, d, commit);
+			repaired += res.repaired;
+			skipped += res.skipped;
+			requestsMoved += res.requestsMoved;
+		}
+		console.log(
+			`${target.globalTableName}: ${repaired} rows repaired, ${skipped} left unattributed (no project-side rows), ${requestsMoved.toLocaleString()} requests reattributed`,
+		);
+	}
+
+	if (!commit) {
+		console.log("\nDry run — nothing was written. Re-run with --commit.");
+	}
+}
+
+main()
+	.then(() => process.exit(0))
+	.catch((error) => {
+		console.error(error);
+		process.exit(1);
+	});

--- a/packages/scripts/src/lib/global-stats-split.spec.ts
+++ b/packages/scripts/src/lib/global-stats-split.spec.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "vitest";
+
+import {
+	ALL_METRICS,
+	type Candidate,
+	emptyMetrics,
+	type GlobalRow,
+	splitReal,
+	splitRow,
+	splitWhole,
+} from "./global-stats-split.js";
+
+function candidate(
+	usedMode: Candidate["usedMode"],
+	orgKind: Candidate["orgKind"],
+	overrides: Partial<Record<string, number>>,
+): Candidate {
+	return {
+		usedMode,
+		orgKind,
+		metrics: { ...emptyMetrics(), ...overrides },
+	};
+}
+
+function globalRow(
+	usedMode: GlobalRow["usedMode"],
+	orgKind: GlobalRow["orgKind"],
+	overrides: Partial<Record<string, number>>,
+): GlobalRow {
+	return {
+		id: "row-1",
+		keyValues: ["openai/gpt-5.6", "openai"],
+		usedMode,
+		orgKind,
+		metrics: { ...emptyMetrics(), ...overrides },
+	};
+}
+
+describe("splitWhole", () => {
+	test("parts always sum to the total, however awkward the ratio", () => {
+		for (const total of [1, 7, 100, 1015, 999_999]) {
+			for (const weights of [
+				[1, 1, 1],
+				[1, 2, 7],
+				[999, 1],
+				[1, 0, 0],
+				[5, 5, 5, 5, 5, 5, 5],
+			]) {
+				const parts = splitWhole(total, weights);
+				expect(parts.reduce((a, b) => a + b, 0)).toBe(total);
+				expect(parts.every((p) => Number.isInteger(p) && p >= 0)).toBe(true);
+			}
+		}
+	});
+
+	test("keeps the total when there is nothing to weight on", () => {
+		// Dropping it would quietly shrink the page's totals — the exact bug this
+		// backfill exists to fix.
+		expect(splitWhole(42, [0, 0, 0])).toEqual([42, 0, 0]);
+	});
+
+	test("gives a single candidate everything", () => {
+		expect(splitWhole(1015, [1010])).toEqual([1015]);
+	});
+});
+
+describe("splitReal", () => {
+	test("distributes proportionally and preserves the total", () => {
+		const parts = splitReal(903, [900, 2]);
+		expect(parts[0] + parts[1]).toBeCloseTo(903, 9);
+		expect(parts[0] / parts[1]).toBeCloseTo(450, 9);
+	});
+});
+
+describe("splitRow", () => {
+	// The core invariant: the global tables stay authoritative for totals, the
+	// project side only decides the proportions. The candidates here deliberately
+	// sum to LESS than the row (1010 vs 1015 requests, 902 vs 903 cost), which is
+	// the real-world drift between the two aggregations.
+	const candidates = [
+		candidate("credits", "default", {
+			requestCount: 1000,
+			cost: 900,
+			totalTokens: 5_000_000,
+			errorCount: 3,
+		}),
+		candidate("api-keys", "devpass", {
+			requestCount: 10,
+			cost: 2,
+			totalTokens: 50_000,
+			errorCount: 0,
+		}),
+	];
+
+	test("preserves every metric total exactly", () => {
+		const row = globalRow("unknown", "unknown", {
+			requestCount: 1015,
+			cost: 903,
+			totalTokens: 5_075_000,
+			errorCount: 3,
+		});
+		const parts = splitRow(row, candidates);
+
+		for (const metric of ALL_METRICS) {
+			const sum = parts.reduce((acc, p) => acc + p.metrics[metric], 0);
+			expect(sum).toBeCloseTo(row.metrics[metric], 6);
+		}
+		expect(parts.map((p) => `${p.usedMode}/${p.orgKind}`)).toEqual([
+			"credits/default",
+			"api-keys/devpass",
+		]);
+	});
+
+	test("only resolves the dimension that was unknown", () => {
+		// Mode is already known, so every part must keep it and differ only in kind.
+		const row = globalRow("credits", "unknown", { requestCount: 400, cost: 40 });
+		const parts = splitRow(row, [
+			candidate("credits", "default", { requestCount: 300, cost: 30 }),
+			candidate("credits", "devpass", { requestCount: 100, cost: 10 }),
+		]);
+
+		expect(parts.every((p) => p.usedMode === "credits")).toBe(true);
+		expect(parts.map((p) => p.orgKind)).toEqual(["default", "devpass"]);
+		expect(parts.map((p) => p.metrics.requestCount)).toEqual([300, 100]);
+	});
+
+	test("falls back to the request distribution for metrics the project side never recorded", () => {
+		const row = globalRow("unknown", "unknown", {
+			requestCount: 100,
+			cachedTokens: 900,
+		});
+		const parts = splitRow(row, candidates);
+
+		// Neither candidate recorded cachedTokens, so it follows the requests.
+		expect(
+			parts.reduce((acc, p) => acc + p.metrics.cachedTokens, 0),
+		).toBe(900);
+		expect(parts[0].metrics.cachedTokens).toBeGreaterThan(
+			parts[1].metrics.cachedTokens,
+		);
+	});
+
+	test("carries the key through untouched", () => {
+		const row = globalRow("unknown", "unknown", { requestCount: 10 });
+		for (const part of splitRow(row, candidates)) {
+			expect(part.keyValues).toEqual(["openai/gpt-5.6", "openai"]);
+		}
+	});
+});

--- a/packages/scripts/src/lib/global-stats-split.ts
+++ b/packages/scripts/src/lib/global-stats-split.ts
@@ -1,0 +1,184 @@
+/**
+ * Pure splitting logic for the global stats attribution backfill.
+ *
+ * Kept separate from the script so it can be tested without the script's
+ * top-level `main()` running on import.
+ */
+
+import type { GlobalStatsOrgKind, GlobalStatsUsedMode } from "@llmgateway/db";
+
+/** Metrics whose per-mode value comes from a denormalized pair — exact, never prorated. */
+export const PAIR_METRICS = ["requestCount", "cost", "dataStorageCost"] as const;
+
+/** Integer counters. Split with largest-remainder so the parts sum exactly. */
+export const INT_METRICS = [
+	"errorCount",
+	"cacheCount",
+	"streamedCount",
+	"nonStreamedCount",
+	"completedCount",
+	"lengthLimitCount",
+	"contentFilterCount",
+	"toolCallsCount",
+	"canceledCount",
+	"unknownFinishCount",
+	"clientErrorCount",
+	"gatewayErrorCount",
+	"upstreamErrorCount",
+] as const;
+
+/** `decimal` token columns — whole numbers in practice, so split like integers. */
+export const TOKEN_METRICS = [
+	"inputTokens",
+	"outputTokens",
+	"totalTokens",
+	"reasoningTokens",
+	"cachedTokens",
+	"cacheWriteTokens",
+] as const;
+
+/** float4 money columns, split proportionally. */
+export const REAL_METRICS = [
+	"inputCost",
+	"outputCost",
+	"requestCost",
+	"discountSavings",
+	"imageInputCost",
+	"imageOutputCost",
+	"audioInputCost",
+	"audioOutputCost",
+	"videoOutputCost",
+	"cachedInputCost",
+	"cacheWriteInputCost",
+] as const;
+
+export type MetricKey =
+	| (typeof PAIR_METRICS)[number]
+	| (typeof INT_METRICS)[number]
+	| (typeof TOKEN_METRICS)[number]
+	| (typeof REAL_METRICS)[number];
+
+/** Metrics that must stay whole numbers after the split. */
+export const WHOLE_METRICS = new Set<MetricKey>([
+	"requestCount",
+	...INT_METRICS,
+	...TOKEN_METRICS,
+]);
+
+export const ALL_METRICS: MetricKey[] = [
+	...PAIR_METRICS,
+	...INT_METRICS,
+	...TOKEN_METRICS,
+	...REAL_METRICS,
+];
+
+/** Metrics the project hourly tables scale by request share rather than a pair. */
+export const SHARE_METRICS: MetricKey[] = [
+	...INT_METRICS,
+	...TOKEN_METRICS,
+	...REAL_METRICS,
+];
+
+export type Metrics = Record<MetricKey, number>;
+
+export function emptyMetrics(): Metrics {
+	return Object.fromEntries(ALL_METRICS.map((m) => [m, 0])) as Metrics;
+}
+
+export interface Candidate {
+	usedMode: Exclude<GlobalStatsUsedMode, "unknown">;
+	orgKind: GlobalStatsOrgKind;
+	metrics: Metrics;
+}
+
+export interface GlobalRow {
+	id: string;
+	keyValues: string[];
+	usedMode: GlobalStatsUsedMode;
+	orgKind: GlobalStatsOrgKind;
+	metrics: Metrics;
+}
+
+export interface SplitPart {
+	keyValues: string[];
+	usedMode: GlobalStatsUsedMode;
+	orgKind: GlobalStatsOrgKind;
+	metrics: Metrics;
+}
+
+/**
+ * Distribute `total` across `weights` as whole numbers summing to exactly
+ * `total`. Plain rounding would drift by a request or two per row, which across
+ * hundreds of thousands of rows stops the page adding up all over again.
+ */
+export function splitWhole(total: number, weights: number[]): number[] {
+	if (weights.length === 0) {
+		return [];
+	}
+	if (total === 0) {
+		return weights.map(() => 0);
+	}
+	const sum = weights.reduce((a, b) => a + b, 0);
+	if (sum <= 0) {
+		// No signal to distribute on — keep it all rather than silently dropping it.
+		return weights.map((_, i) => (i === 0 ? total : 0));
+	}
+	const raw = weights.map((w) => (total * w) / sum);
+	const parts = raw.map((v) => Math.floor(v));
+	let remainder = total - parts.reduce((a, b) => a + b, 0);
+	const byFraction = raw
+		.map((v, i) => ({ i, frac: v - Math.floor(v) }))
+		.sort((a, b) => b.frac - a.frac);
+	for (let k = 0; remainder > 0 && k < byFraction.length; k++) {
+		parts[byFraction[k].i]++;
+		remainder--;
+	}
+	return parts;
+}
+
+export function splitReal(total: number, weights: number[]): number[] {
+	if (weights.length === 0) {
+		return [];
+	}
+	if (total === 0) {
+		return weights.map(() => 0);
+	}
+	const sum = weights.reduce((a, b) => a + b, 0);
+	if (sum <= 0) {
+		return weights.map((_, i) => (i === 0 ? total : 0));
+	}
+	return weights.map((w) => (total * w) / sum);
+}
+
+/**
+ * Split one global row across the candidate tuples, scaling each metric so the
+ * parts sum back to exactly what the row held. The global tables stay
+ * authoritative for totals; the candidates only decide the proportions.
+ */
+export function splitRow(row: GlobalRow, candidates: Candidate[]): SplitPart[] {
+	const requestWeights = candidates.map((c) => c.metrics.requestCount);
+	const parts = candidates.map(() => emptyMetrics());
+
+	for (const metric of ALL_METRICS) {
+		let weights = candidates.map((c) => c.metrics[metric]);
+		// A metric the project side never recorded still has to go somewhere;
+		// fall back to the request distribution.
+		if (weights.every((w) => w === 0)) {
+			weights = requestWeights;
+		}
+		const values = WHOLE_METRICS.has(metric)
+			? splitWhole(Math.round(row.metrics[metric]), weights)
+			: splitReal(row.metrics[metric], weights);
+		values.forEach((v, i) => {
+			parts[i][metric] = v;
+		});
+	}
+
+	return candidates.map((c, i) => ({
+		keyValues: row.keyValues,
+		// Only ever resolve the dimension that was actually unknown.
+		usedMode: row.usedMode === "unknown" ? c.usedMode : row.usedMode,
+		orgKind: row.orgKind === "unknown" ? c.orgKind : row.orgKind,
+		metrics: parts[i],
+	}));
+}


### PR DESCRIPTION
## Problem

On the admin Global Stats page, Credits + BYOK does not sum to All. A third `unknown` bucket swallows the difference. Separately, the overwhelming majority of all-time cost shows no organization kind at all — the cost card is dominated by an "Unattributed" slice.

Both come from `1786136603_warm_omega_flight.sql`, which added `used_mode` and `org_kind` to the global stats tables. It backfilled `used_mode` only where a whole `(day, model, provider)` bucket had used a single mode, and never backfilled `org_kind`:

```sql
UPDATE global_model_stats SET used_mode='credits'  WHERE credits_request_count > 0 AND api_keys_request_count = 0;
UPDATE global_model_stats SET used_mode='api-keys' WHERE api_keys_request_count > 0 AND credits_request_count = 0;
```

Any bucket that saw *both* kinds of traffic that day stayed `unknown` and took all of its requests, tokens, errors and cost with it. That is a strong amplifier: a handful of BYOK requests scattered across model-days poisons entire days of credits traffic, which is why the reported BYOK figure is understated by roughly **3.2×** in requests and **3.4×** in cost.

Live traffic can never land in `unknown` — `log.usedMode` is `NOT NULL` with enum exactly `["api-keys", "credits"]` and the aggregator copies it verbatim — so the bucket is frozen historical data that only ever shrinks in relative terms.

The migration's note says recovering this means re-reading raw logs that retention has pruned. That is true of `log`, but not of the project hourly tables: nothing prunes them, they are keyed per project (hence per organization, so org kind is exact), and they kept the billing-mode split as `credits_*` / `api_keys_*` column pairs.

## What the backfill recovers

Measured against production, the corrections are large: BYOK understated ~3.2× in requests and ~3.4× in cost; PAYG cost understated ~36×; DevPass cost ~7.4×. After the backfill, genuinely-unknown org kind falls to a negligible rounding-level share. The `unknown` bucket decomposes exactly into its credits and BYOK parts plus the known project-side shortfall described below — nothing is left unexplained.

## Approach: redistribute, don't replace

The two sides disagree slightly on totals — the global tables carry about **0.03% more** traffic than the project side, because the project aggregator's backfill phase is off by default (`STATS_BACKFILL_ENABLED === "true"`) and its stale window is only `STATS_STALE_DAYS=7`, so a project-hour bucket missed at the time is never created once the logs are pruned.

So: **global is authoritative for totals, project is authoritative for attribution.** Each row needing repair is split across the `(mode, kind)` tuples observed on the project side, then scaled so the parts sum back to exactly what the row already held. Rebuilding from the project side instead would have silently dropped that 0.03%.

Two details that matter:

- **Only the unknown dimension is resolved.** A row that already knows its mode is redistributed across kinds *within* that mode, so its mode can't silently change.
- **Largest-remainder on integer columns.** Plain rounding drifts by a request or two per row, which across hundreds of thousands of rows would stop the page adding up all over again.

## Accuracy

`requestCount`, `cost` and `dataStorageCost` come straight from the column pairs — exact. The other metrics have no pair, so the distribution is built **per `(project, hour, model)` bucket** and only then summed: a bucket that used a single mode contributes *all* of its tokens and errors to that mode. Only genuinely mixed buckets are prorated by request share, and measured against production those are **0.049% of buckets, 0.040% of requests, 0.021% of cost and 0.121% of tokens**. That is the entire approximation — small enough that no proration policy decision was needed.

## Usage

Dry run by default — it reports what it would change and writes nothing.

```bash
pnpm --filter @llmgateway/scripts backfill-global-stats-attribution
pnpm --filter @llmgateway/scripts backfill-global-stats-attribution --commit
pnpm --filter @llmgateway/scripts backfill-global-stats-attribution --from=2025-02-01 --to=2026-08-11 --table=model
```

## Verification

Driven end to end against a local stack with synthetic fixtures where the project side deliberately does **not** sum to the global row (1010 vs 1015 requests, 902 vs 903 cost), so the scaling is actually exercised:

- **Totals preserved exactly** — an `unknown/unknown` row (1015 req, 903 cost, 5,075,000 tokens) became `credits/default` (1005) + `api-keys/devpass` (10), still summing to 1015 / 903 / 5,075,000.
- **Partial unknown** — a `credits/unknown` row split into `credits/default` (300) + `credits/devpass` (100); mode untouched.
- **No project-side evidence** — a `deleted/model` row was left exactly as it was and counted as skipped, not guessed at.
- **Idempotent** — a second `--commit` run repairs 0 rows.
- **Source path** — verified with an x-source value containing spaces and a slash (`my app / v2`), which is why the composite map key joins on NUL.

Unit spec (8 tests) covers the split invariants: parts always sum to the total across awkward ratios, the total is never dropped when there is nothing to weight on, only the unknown dimension is resolved, and metrics the project side never recorded fall back to the request distribution.

`pnpm format` and `pnpm build` clean. The pre-existing `tsc` errors in `packages/scripts` (`api-ping.ts`, `export-models-dev.ts`, `poc-end-user-bonus.ts`) are untouched by this change.

## Follow-ups, not in this PR

- The project aggregator gap that produced the ~0.03% shortfall (backfill disabled by default) is left alone — worth fixing separately so it stops accruing.
- While reconciling, `global_model_stats` and `global_source_stats` came back with identical request counts but a small non-zero difference in cost. The sums used were exact, so that is the *stored* float4 values diverging — the two tables spread the same money over different row counts and each row accumulates 24 hourly float4 additions. That strengthens the case for migrating those cost columns to `double precision`, which #3547 explicitly deferred.

Related: #3547 fixes the float4 summation on the read path, which is a different reason the same page did not add up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)