### PR TITLE
feat(admin): filter org keys by status

### DIFF
--- a/apps/api/src/routes/admin-org-keys.spec.ts
+++ b/apps/api/src/routes/admin-org-keys.spec.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db, tables } from "@llmgateway/db";
+
+const originalAdminEmails = process.env.ADMIN_EMAILS;
+
+const ORG_ID = "org-keys-test";
+const PROJECT_ID = "org-keys-project";
+
+async function get(path: string, token: string): Promise<Response> {
+	return await app.request(`/admin/organizations/${ORG_ID}${path}`, {
+		headers: { Cookie: token },
+	});
+}
+
+async function seedOrg() {
+	await db.insert(tables.organization).values({
+		id: ORG_ID,
+		name: "Org Keys Test",
+		billingEmail: "org-keys@test.example",
+		plan: "pro",
+	});
+	await db.insert(tables.project).values({
+		id: PROJECT_ID,
+		name: "Org Keys Project",
+		organizationId: ORG_ID,
+	});
+}
+
+describe("admin organization key listings", () => {
+	let cookie: string;
+
+	beforeEach(async () => {
+		process.env.ADMIN_EMAILS = "admin@example.com";
+		cookie = await createTestUser();
+		await seedOrg();
+	});
+
+	afterEach(async () => {
+		if (originalAdminEmails === undefined) {
+			delete process.env.ADMIN_EMAILS;
+		} else {
+			process.env.ADMIN_EMAILS = originalAdminEmails;
+		}
+		await deleteAll();
+	});
+
+	describe("api keys", () => {
+		beforeEach(async () => {
+			await db.insert(tables.apiKey).values([
+				{
+					id: "ak-active",
+					projectId: PROJECT_ID,
+					token: "ak-token-active",
+					description: "active key",
+					createdBy: "test-user-id",
+					status: "active",
+				},
+				{
+					id: "ak-inactive",
+					projectId: PROJECT_ID,
+					token: "ak-token-inactive",
+					description: "disabled key",
+					createdBy: "test-user-id",
+					status: "inactive",
+				},
+				{
+					id: "ak-deleted",
+					projectId: PROJECT_ID,
+					token: "ak-token-deleted",
+					description: "deleted key",
+					createdBy: "test-user-id",
+					status: "deleted",
+				},
+			]);
+		});
+
+		it("defaults to active keys while reporting every status in the counts", async () => {
+			const res = await get("/api-keys", cookie);
+			expect(res.status).toBe(200);
+			const json = await res.json();
+
+			expect(json.apiKeys.map((k: { id: string }) => k.id)).toEqual([
+				"ak-active",
+			]);
+			expect(json.total).toBe(1);
+			expect(json.counts).toEqual({
+				all: 3,
+				active: 1,
+				inactive: 1,
+				deleted: 1,
+			});
+		});
+
+		it("filters by each status and returns everything for all", async () => {
+			for (const status of ["inactive", "deleted"]) {
+				const res = await get(`/api-keys?status=${status}`, cookie);
+				const json = await res.json();
+				expect(json.apiKeys.map((k: { id: string }) => k.id)).toEqual([
+					`ak-${status}`,
+				]);
+				expect(json.total).toBe(1);
+				// Counts stay organization-wide so the tab header is stable.
+				expect(json.counts.all).toBe(3);
+			}
+
+			const all = await get("/api-keys?status=all", cookie);
+			const allJson = await all.json();
+			expect(allJson.apiKeys).toHaveLength(3);
+			expect(allJson.total).toBe(3);
+		});
+
+		it("counts a legacy NULL status as active", async () => {
+			await db.insert(tables.apiKey).values({
+				id: "ak-null",
+				projectId: PROJECT_ID,
+				token: "ak-token-null",
+				description: "legacy key",
+				createdBy: "test-user-id",
+				status: null,
+			});
+
+			const res = await get("/api-keys", cookie);
+			const json = await res.json();
+			expect(json.apiKeys.map((k: { id: string }) => k.id).sort()).toEqual([
+				"ak-active",
+				"ak-null",
+			]);
+			expect(json.counts.active).toBe(2);
+			expect(json.counts.all).toBe(4);
+		});
+	});
+
+	describe("provider keys", () => {
+		beforeEach(async () => {
+			await db.insert(tables.providerKey).values([
+				{
+					id: "pk-active",
+					organizationId: ORG_ID,
+					provider: "openai",
+					token: "sk-active",
+					status: "active",
+				},
+				{
+					id: "pk-inactive",
+					organizationId: ORG_ID,
+					provider: "anthropic",
+					token: "sk-inactive",
+					status: "inactive",
+				},
+				{
+					id: "pk-deleted",
+					organizationId: ORG_ID,
+					provider: "google-ai-studio",
+					token: "sk-deleted",
+					status: "deleted",
+				},
+			]);
+		});
+
+		it("defaults to active keys while reporting every status in the counts", async () => {
+			const res = await get("/provider-keys", cookie);
+			expect(res.status).toBe(200);
+			const json = await res.json();
+
+			expect(json.providerKeys.map((k: { id: string }) => k.id)).toEqual([
+				"pk-active",
+			]);
+			expect(json.total).toBe(1);
+			expect(json.counts).toEqual({
+				all: 3,
+				active: 1,
+				inactive: 1,
+				deleted: 1,
+			});
+		});
+
+		it("filters by each status and returns everything for all", async () => {
+			for (const status of ["inactive", "deleted"]) {
+				const res = await get(`/provider-keys?status=${status}`, cookie);
+				const json = await res.json();
+				expect(json.providerKeys.map((k: { id: string }) => k.id)).toEqual([
+					`pk-${status}`,
+				]);
+				expect(json.counts.all).toBe(3);
+			}
+
+			const all = await get("/provider-keys?status=all", cookie);
+			const allJson = await all.json();
+			expect(allJson.providerKeys).toHaveLength(3);
+			expect(allJson.total).toBe(3);
+		});
+	});
+});

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -500,11 +500,67 @@ const apiKeySchema = z.object({
 	iamRules: z.array(iamRuleAdminSchema),
 });
 
+const keyStatusFilterSchema = z.enum(["all", "active", "inactive", "deleted"]);
+
+type KeyStatusFilter = z.infer<typeof keyStatusFilterSchema>;
+
+/**
+ * Per-status totals for a key list. Always computed over every key of the
+ * organization, never over the filtered rows, so the dashboard can show
+ * "active / total" next to a list that only renders one status.
+ */
+const keyStatusCountsSchema = z.object({
+	all: z.number(),
+	active: z.number(),
+	inactive: z.number(),
+	deleted: z.number(),
+});
+
+type KeyStatusCounts = z.infer<typeof keyStatusCountsSchema>;
+
+function emptyKeyStatusCounts(): KeyStatusCounts {
+	return { all: 0, active: 0, inactive: 0, deleted: 0 };
+}
+
+function toKeyStatusCounts(
+	rows: { status: string; count: number }[],
+): KeyStatusCounts {
+	const counts = emptyKeyStatusCounts();
+	for (const row of rows) {
+		const count = Number(row.count);
+		counts.all += count;
+		if (
+			row.status === "active" ||
+			row.status === "inactive" ||
+			row.status === "deleted"
+		) {
+			counts[row.status] += count;
+		}
+	}
+	return counts;
+}
+
+/**
+ * Both key tables declare `status` nullable with an `active` default, so legacy
+ * NULL rows have to be folded into `active` — otherwise they vanish from every
+ * filtered view and from the counts.
+ */
+function keyStatusCondition(column: AnyColumn, status: KeyStatusFilter) {
+	if (status === "all") {
+		return undefined;
+	}
+	if (status === "active") {
+		return or(eq(column, "active"), isNull(column));
+	}
+	return eq(column, status);
+}
+
 const apiKeysListSchema = z.object({
 	apiKeys: z.array(apiKeySchema),
 	total: z.number(),
 	limit: z.number(),
 	offset: z.number(),
+	counts: keyStatusCountsSchema,
 });
 
 const providerKeyAdminSchema = z.object({
@@ -528,6 +584,7 @@ const providerKeyAdminSchema = z.object({
 const providerKeysListSchema = z.object({
 	providerKeys: z.array(providerKeyAdminSchema),
 	total: z.number(),
+	counts: keyStatusCountsSchema,
 });
 
 const memberSchema = z.object({
@@ -694,6 +751,7 @@ const getOrganizationApiKeys = createRoute({
 		query: z.object({
 			limit: z.coerce.number().min(1).max(100).default(25).optional(),
 			offset: z.coerce.number().min(0).default(0).optional(),
+			status: keyStatusFilterSchema.default("active").optional(),
 		}),
 	},
 	responses: {
@@ -717,6 +775,9 @@ const getOrganizationProviderKeys = createRoute({
 	request: {
 		params: z.object({
 			orgId: z.string(),
+		}),
+		query: z.object({
+			status: keyStatusFilterSchema.default("active").optional(),
 		}),
 	},
 	responses: {
@@ -2937,6 +2998,7 @@ admin.openapi(getOrganizationApiKeys, async (c) => {
 	const query = c.req.valid("query");
 	const limit = query.limit ?? 25;
 	const offset = query.offset ?? 0;
+	const status = query.status ?? "active";
 
 	const org = await db.query.organization.findFirst({
 		where: {
@@ -2963,17 +3025,22 @@ admin.openapi(getOrganizationApiKeys, async (c) => {
 			total: 0,
 			limit,
 			offset,
+			counts: emptyKeyStatusCounts(),
 		});
 	}
 
-	const [countResult] = await db
+	const apiKeyStatusExpr = sql<string>`COALESCE(${tables.apiKey.status}, 'active')`;
+	const countRows = await db
 		.select({
-			count: sql<number>`COUNT(*)`.as("count"),
+			status: apiKeyStatusExpr,
+			count: sql<number>`COUNT(*)`,
 		})
 		.from(tables.apiKey)
-		.where(inArray(tables.apiKey.projectId, ids));
+		.where(inArray(tables.apiKey.projectId, ids))
+		.groupBy(apiKeyStatusExpr);
 
-	const total = Number(countResult?.count ?? 0);
+	const counts = toKeyStatusCounts(countRows);
+	const total = status === "all" ? counts.all : counts[status];
 
 	const apiKeys = await db
 		.select({
@@ -2989,7 +3056,12 @@ admin.openapi(getOrganizationApiKeys, async (c) => {
 		})
 		.from(tables.apiKey)
 		.innerJoin(tables.project, eq(tables.apiKey.projectId, tables.project.id))
-		.where(inArray(tables.apiKey.projectId, ids))
+		.where(
+			and(
+				inArray(tables.apiKey.projectId, ids),
+				keyStatusCondition(tables.apiKey.status, status),
+			),
+		)
 		.orderBy(desc(tables.apiKey.createdAt))
 		.limit(limit)
 		.offset(offset);
@@ -3029,11 +3101,13 @@ admin.openapi(getOrganizationApiKeys, async (c) => {
 		total,
 		limit,
 		offset,
+		counts,
 	});
 });
 
 admin.openapi(getOrganizationProviderKeys, async (c) => {
 	const { orgId } = c.req.valid("param");
+	const status = c.req.valid("query").status ?? "active";
 
 	const org = await db.query.organization.findFirst({
 		where: {
@@ -3046,6 +3120,18 @@ admin.openapi(getOrganizationProviderKeys, async (c) => {
 			message: "Organization not found",
 		});
 	}
+
+	const providerKeyStatusExpr = sql<string>`COALESCE(${tables.providerKey.status}, 'active')`;
+	const providerKeyCountRows = await db
+		.select({
+			status: providerKeyStatusExpr,
+			count: sql<number>`COUNT(*)`,
+		})
+		.from(tables.providerKey)
+		.where(eq(tables.providerKey.organizationId, orgId))
+		.groupBy(providerKeyStatusExpr);
+
+	const counts = toKeyStatusCounts(providerKeyCountRows);
 
 	const providerKeys = await db
 		.select({
@@ -3065,7 +3151,12 @@ admin.openapi(getOrganizationProviderKeys, async (c) => {
 			updatedAt: tables.providerKey.updatedAt,
 		})
 		.from(tables.providerKey)
-		.where(eq(tables.providerKey.organizationId, orgId))
+		.where(
+			and(
+				eq(tables.providerKey.organizationId, orgId),
+				keyStatusCondition(tables.providerKey.status, status),
+			),
+		)
 		.orderBy(desc(tables.providerKey.createdAt));
 
 	return c.json({
@@ -3086,6 +3177,7 @@ admin.openapi(getOrganizationProviderKeys, async (c) => {
 			updatedAt: k.updatedAt.toISOString(),
 		})),
 		total: providerKeys.length,
+		counts,
 	});
 });
 

--- a/ee/admin/src/app/organizations/[orgId]/api-keys-table.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/api-keys-table.tsx
@@ -15,6 +15,9 @@ import {
 	TableHeader,
 	TableRow,
 } from "@/components/ui/table";
+import { KEY_STATUS_DEFAULT, type KeyStatusFilter } from "@/lib/key-status";
+
+import { KeyStatusFilter as KeyStatusFilterControl } from "./key-status-filter";
 
 import type { paths } from "@/lib/api/v1";
 
@@ -74,6 +77,23 @@ function formatRuleValue(rule: IamRule): string {
 	return "—";
 }
 
+function buildHref(
+	orgId: string,
+	txPage: number,
+	akPage: number,
+	akStatus: KeyStatusFilter,
+) {
+	const params = new URLSearchParams({
+		tab: "api-keys",
+		txPage: String(txPage),
+		akPage: String(akPage),
+	});
+	if (akStatus !== KEY_STATUS_DEFAULT) {
+		params.set("akStatus", akStatus);
+	}
+	return `/organizations/${orgId}?${params.toString()}`;
+}
+
 interface ApiKeysTableProps {
 	apiKeys: ApiKey[];
 	orgId: string;
@@ -83,6 +103,8 @@ interface ApiKeysTableProps {
 	akLimit: number;
 	akTotal: number;
 	akTotalPages: number;
+	akStatus: KeyStatusFilter;
+	counts: ApiKeysResponse["counts"];
 }
 
 export function ApiKeysTable({
@@ -94,6 +116,8 @@ export function ApiKeysTable({
 	akLimit,
 	akTotal,
 	akTotalPages,
+	akStatus,
+	counts,
 }: ApiKeysTableProps) {
 	const [expanded, setExpanded] = useState<Record<string, boolean>>({});
 
@@ -103,6 +127,14 @@ export function ApiKeysTable({
 
 	return (
 		<div className="space-y-4">
+			<KeyStatusFilterControl
+				param="akStatus"
+				tab="api-keys"
+				pageParam="akPage"
+				value={akStatus}
+				counts={counts}
+			/>
+
 			<div className="overflow-x-auto rounded-lg border border-border/60 bg-card">
 				<Table>
 					<TableHeader>
@@ -125,7 +157,9 @@ export function ApiKeysTable({
 									colSpan={9}
 									className="h-24 text-center text-muted-foreground"
 								>
-									No API keys found
+									{akStatus === "all"
+										? "No API keys found"
+										: `No ${akStatus === "inactive" ? "disabled" : akStatus} API keys found`}
 								</TableCell>
 							</TableRow>
 						) : (
@@ -277,7 +311,7 @@ export function ApiKeysTable({
 					<div className="flex items-center gap-2">
 						<Button variant="outline" size="sm" asChild disabled={akPage <= 1}>
 							<Link
-								href={`/organizations/${orgId}?tab=api-keys&txPage=${txPage}&akPage=${akPage - 1}`}
+								href={buildHref(orgId, txPage, akPage - 1, akStatus)}
 								className={akPage <= 1 ? "pointer-events-none opacity-50" : ""}
 							>
 								Previous
@@ -293,7 +327,7 @@ export function ApiKeysTable({
 							disabled={akPage >= akTotalPages}
 						>
 							<Link
-								href={`/organizations/${orgId}?tab=api-keys&txPage=${txPage}&akPage=${akPage + 1}`}
+								href={buildHref(orgId, txPage, akPage + 1, akStatus)}
 								className={
 									akPage >= akTotalPages ? "pointer-events-none opacity-50" : ""
 								}

--- a/ee/admin/src/app/organizations/[orgId]/key-status-filter.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/key-status-filter.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { SegmentedUrlSelector } from "@/components/segmented-url-selector";
+import {
+	KEY_STATUS_DEFAULT,
+	KEY_STATUS_OPTIONS,
+	type KeyStatusFilter as KeyStatus,
+} from "@/lib/key-status";
+
+/**
+ * Active / Disabled / Deleted / All toggle for a key list, persisted in a URL
+ * search param. Selecting a status pins the tab it belongs to and resets that
+ * list's page, since page N of the previous status is meaningless (and usually
+ * empty) under the new one.
+ */
+export function KeyStatusFilter({
+	param,
+	tab,
+	pageParam,
+	value,
+	counts,
+}: {
+	param: string;
+	tab: string;
+	pageParam?: string;
+	value: KeyStatus;
+	counts: Record<KeyStatus, number>;
+}) {
+	return (
+		<div className="flex flex-wrap items-center gap-3">
+			<SegmentedUrlSelector
+				param={param}
+				value={value}
+				defaultValue={KEY_STATUS_DEFAULT}
+				options={KEY_STATUS_OPTIONS.map((option) => ({
+					...option,
+					label: `${option.label} (${counts[option.value]})`,
+				}))}
+				extraParams={{ tab, ...(pageParam ? { [pageParam]: null } : {}) }}
+				compact
+			/>
+		</div>
+	);
+}

--- a/ee/admin/src/app/organizations/[orgId]/page.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/page.tsx
@@ -38,6 +38,7 @@ import {
 	manageOrganization,
 	updateReferralBonus,
 } from "@/lib/admin-organizations";
+import { KEY_STATUS_DEFAULT, parseKeyStatus } from "@/lib/key-status";
 import { getOrgDeletionBlockedReason } from "@/lib/org-deletion";
 import { requireSession } from "@/lib/require-session";
 import { createServerApiClient } from "@/lib/server-api";
@@ -146,6 +147,31 @@ function formatTransactionType(type: string) {
 	return type.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
+/**
+ * Transactions pagination link. It carries the other tabs' state so paging one
+ * list does not silently reset the API-key page or its status filter.
+ */
+function buildTransactionsHref(
+	orgId: string,
+	txPage: number,
+	akPage: number,
+	akStatus: string,
+	pkStatus: string,
+) {
+	const params = new URLSearchParams({
+		tab: "transactions",
+		txPage: String(txPage),
+		akPage: String(akPage),
+	});
+	if (akStatus !== KEY_STATUS_DEFAULT) {
+		params.set("akStatus", akStatus);
+	}
+	if (pkStatus !== KEY_STATUS_DEFAULT) {
+		params.set("pkStatus", pkStatus);
+	}
+	return `/organizations/${orgId}?${params.toString()}`;
+}
+
 export default async function OrganizationPage({
 	params,
 	searchParams,
@@ -154,6 +180,8 @@ export default async function OrganizationPage({
 	searchParams?: Promise<{
 		txPage?: string;
 		akPage?: string;
+		akStatus?: string;
+		pkStatus?: string;
 		alPage?: string;
 		alAction?: string;
 		alResource?: string;
@@ -166,6 +194,8 @@ export default async function OrganizationPage({
 	const searchParamsData = await searchParams;
 	const txPage = parsePage(searchParamsData?.txPage);
 	const akPage = parsePage(searchParamsData?.akPage);
+	const akStatus = parseKeyStatus(searchParamsData?.akStatus);
+	const pkStatus = parseKeyStatus(searchParamsData?.pkStatus);
 	const alPage = parsePage(searchParamsData?.alPage);
 	const alAction = searchParamsData?.alAction ?? "";
 	const alResource = searchParamsData?.alResource ?? "";
@@ -201,11 +231,11 @@ export default async function OrganizationPage({
 		$api.GET("/admin/organizations/{orgId}/api-keys", {
 			params: {
 				path: { orgId },
-				query: { limit: akLimit, offset: akOffset },
+				query: { limit: akLimit, offset: akOffset, status: akStatus },
 			},
 		}),
 		$api.GET("/admin/organizations/{orgId}/provider-keys", {
-			params: { path: { orgId } },
+			params: { path: { orgId }, query: { status: pkStatus } },
 		}),
 		$api.GET("/admin/organizations/{orgId}/members", {
 			params: { path: { orgId } },
@@ -254,12 +284,14 @@ export default async function OrganizationPage({
 	const txTotal = transactionsData.total;
 	const txTotalPages = Math.ceil(txTotal / txLimit);
 
+	const emptyKeyCounts = { all: 0, active: 0, inactive: 0, deleted: 0 };
 	const projects = projectsData?.projects ?? [];
 	const apiKeys = apiKeysData?.apiKeys ?? [];
 	const akTotal = apiKeysData?.total ?? 0;
+	const akCounts = apiKeysData?.counts ?? emptyKeyCounts;
 	const akTotalPages = Math.ceil(akTotal / akLimit);
 	const providerKeys = providerKeysData?.providerKeys ?? [];
-	const providerKeysTotal = providerKeysData?.total ?? 0;
+	const pkCounts = providerKeysData?.counts ?? emptyKeyCounts;
 	const members = membersData?.members ?? [];
 	const membersTotal = membersData?.total ?? 0;
 
@@ -445,13 +477,16 @@ export default async function OrganizationPage({
 						<Receipt className="mr-1.5 h-4 w-4" />
 						Transactions ({txTotal})
 					</TabsTrigger>
-					<TabsTrigger value="api-keys">
+					<TabsTrigger value="api-keys" title="Active / total API keys">
 						<Key className="mr-1.5 h-4 w-4" />
-						API Keys ({akTotal})
+						API Keys ({akCounts.active}/{akCounts.all})
 					</TabsTrigger>
-					<TabsTrigger value="provider-keys">
+					<TabsTrigger
+						value="provider-keys"
+						title="Active / total provider keys"
+					>
 						<KeyRound className="mr-1.5 h-4 w-4" />
-						Provider Keys ({providerKeysTotal})
+						Provider Keys ({pkCounts.active}/{pkCounts.all})
 					</TabsTrigger>
 					<TabsTrigger value="members">
 						<Users className="mr-1.5 h-4 w-4" />
@@ -569,7 +604,13 @@ export default async function OrganizationPage({
 										disabled={txPage <= 1}
 									>
 										<Link
-											href={`/organizations/${orgId}?tab=transactions&txPage=${txPage - 1}&akPage=${akPage}`}
+											href={buildTransactionsHref(
+												orgId,
+												txPage - 1,
+												akPage,
+												akStatus,
+												pkStatus,
+											)}
 											className={
 												txPage <= 1 ? "pointer-events-none opacity-50" : ""
 											}
@@ -588,7 +629,13 @@ export default async function OrganizationPage({
 										disabled={txPage >= txTotalPages}
 									>
 										<Link
-											href={`/organizations/${orgId}?tab=transactions&txPage=${txPage + 1}&akPage=${akPage}`}
+											href={buildTransactionsHref(
+												orgId,
+												txPage + 1,
+												akPage,
+												akStatus,
+												pkStatus,
+											)}
 											className={
 												txPage >= txTotalPages
 													? "pointer-events-none opacity-50"
@@ -615,11 +662,17 @@ export default async function OrganizationPage({
 						akLimit={akLimit}
 						akTotal={akTotal}
 						akTotalPages={akTotalPages}
+						akStatus={akStatus}
+						counts={akCounts}
 					/>
 				</TabsContent>
 
 				<TabsContent value="provider-keys">
-					<ProviderKeysTable providerKeys={providerKeys} />
+					<ProviderKeysTable
+						providerKeys={providerKeys}
+						pkStatus={pkStatus}
+						counts={pkCounts}
+					/>
 				</TabsContent>
 
 				<TabsContent value="members">

--- a/ee/admin/src/app/organizations/[orgId]/provider-keys-table.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/provider-keys-table.tsx
@@ -11,10 +11,14 @@ import {
 	TableRow,
 } from "@/components/ui/table";
 
-import type { paths } from "@/lib/api/v1";
+import { KeyStatusFilter as KeyStatusFilterControl } from "./key-status-filter";
 
-type ProviderKey =
-	paths["/admin/organizations/{orgId}/provider-keys"]["get"]["responses"]["200"]["content"]["application/json"]["providerKeys"][number];
+import type { paths } from "@/lib/api/v1";
+import type { KeyStatusFilter } from "@/lib/key-status";
+
+type ProviderKeysResponse =
+	paths["/admin/organizations/{orgId}/provider-keys"]["get"]["responses"]["200"]["content"]["application/json"];
+type ProviderKey = ProviderKeysResponse["providerKeys"][number];
 
 function formatDate(dateString: string) {
 	return new Date(dateString).toLocaleDateString("en-US", {
@@ -26,65 +30,82 @@ function formatDate(dateString: string) {
 
 export function ProviderKeysTable({
 	providerKeys,
+	pkStatus,
+	counts,
 }: {
 	providerKeys: ProviderKey[];
+	pkStatus: KeyStatusFilter;
+	counts: ProviderKeysResponse["counts"];
 }) {
 	return (
-		<div className="overflow-x-auto rounded-lg border border-border/60 bg-card">
-			<Table>
-				<TableHeader>
-					<TableRow>
-						<TableHead>Provider</TableHead>
-						<TableHead>Name</TableHead>
-						<TableHead>Token</TableHead>
-						<TableHead>Base URL</TableHead>
-						<TableHead>Spend</TableHead>
-						<TableHead>Status</TableHead>
-						<TableHead>Created</TableHead>
-						<TableHead className="text-right">Usage</TableHead>
-					</TableRow>
-				</TableHeader>
-				<TableBody>
-					{providerKeys.length === 0 ? (
+		<div className="space-y-4">
+			<KeyStatusFilterControl
+				param="pkStatus"
+				tab="provider-keys"
+				value={pkStatus}
+				counts={counts}
+			/>
+
+			<div className="overflow-x-auto rounded-lg border border-border/60 bg-card">
+				<Table>
+					<TableHeader>
 						<TableRow>
-							<TableCell
-								colSpan={8}
-								className="h-24 text-center text-muted-foreground"
-							>
-								No provider keys found
-							</TableCell>
+							<TableHead>Provider</TableHead>
+							<TableHead>Name</TableHead>
+							<TableHead>Token</TableHead>
+							<TableHead>Base URL</TableHead>
+							<TableHead>Spend</TableHead>
+							<TableHead>Status</TableHead>
+							<TableHead>Created</TableHead>
+							<TableHead className="text-right">Usage</TableHead>
 						</TableRow>
-					) : (
-						providerKeys.map((key) => (
-							<TableRow key={key.id}>
-								<TableCell>
-									<Badge variant="outline">{key.provider}</Badge>
-								</TableCell>
-								<TableCell className="text-sm">{key.name ?? "—"}</TableCell>
-								<TableCell className="font-mono text-xs">{key.token}</TableCell>
-								<TableCell className="max-w-[240px] truncate text-xs text-muted-foreground">
-									{key.baseUrl ?? "—"}
-								</TableCell>
-								<TableCell className="text-sm">
-									<ProviderKeySpendCell keyRow={key} />
-								</TableCell>
-								<TableCell>
-									<ProviderKeyStatusBadge keyRow={key} />
-								</TableCell>
-								<TableCell className="text-muted-foreground">
-									{formatDate(key.createdAt)}
-								</TableCell>
-								<TableCell className="text-right">
-									<ProviderKeySpendDialog
-										providerKeyId={key.id}
-										label={key.name ?? key.provider}
-									/>
+					</TableHeader>
+					<TableBody>
+						{providerKeys.length === 0 ? (
+							<TableRow>
+								<TableCell
+									colSpan={8}
+									className="h-24 text-center text-muted-foreground"
+								>
+									{pkStatus === "all"
+										? "No provider keys found"
+										: `No ${pkStatus === "inactive" ? "disabled" : pkStatus} provider keys found`}
 								</TableCell>
 							</TableRow>
-						))
-					)}
-				</TableBody>
-			</Table>
+						) : (
+							providerKeys.map((key) => (
+								<TableRow key={key.id}>
+									<TableCell>
+										<Badge variant="outline">{key.provider}</Badge>
+									</TableCell>
+									<TableCell className="text-sm">{key.name ?? "—"}</TableCell>
+									<TableCell className="font-mono text-xs">
+										{key.token}
+									</TableCell>
+									<TableCell className="max-w-[240px] truncate text-xs text-muted-foreground">
+										{key.baseUrl ?? "—"}
+									</TableCell>
+									<TableCell className="text-sm">
+										<ProviderKeySpendCell keyRow={key} />
+									</TableCell>
+									<TableCell>
+										<ProviderKeyStatusBadge keyRow={key} />
+									</TableCell>
+									<TableCell className="text-muted-foreground">
+										{formatDate(key.createdAt)}
+									</TableCell>
+									<TableCell className="text-right">
+										<ProviderKeySpendDialog
+											providerKeyId={key.id}
+											label={key.name ?? key.provider}
+										/>
+									</TableCell>
+								</TableRow>
+							))
+						)}
+					</TableBody>
+				</Table>
+			</div>
 		</div>
 	);
 }

--- a/ee/admin/src/components/segmented-url-selector.tsx
+++ b/ee/admin/src/components/segmented-url-selector.tsx
@@ -12,6 +12,10 @@ import { cn } from "@/lib/utils";
  * short and the "everything" view has one canonical URL.
  *
  * `compact` renders the dense bordered variant used by the dashboard headers.
+ *
+ * `extraParams` are applied alongside the selection — a `null` value drops the
+ * param. Use it to pin params the selection implies (the tab a filter lives in)
+ * and to reset ones it invalidates (a page number of a now-shorter list).
  */
 export function SegmentedUrlSelector<T extends string>({
 	param,
@@ -20,6 +24,7 @@ export function SegmentedUrlSelector<T extends string>({
 	options,
 	className,
 	compact = false,
+	extraParams,
 }: {
 	param: string;
 	value: T;
@@ -27,6 +32,7 @@ export function SegmentedUrlSelector<T extends string>({
 	options: { value: T; label: string }[];
 	className?: string;
 	compact?: boolean;
+	extraParams?: Record<string, string | null>;
 }) {
 	const searchParams = useSearchParams();
 	const router = useRouter();
@@ -40,6 +46,13 @@ export function SegmentedUrlSelector<T extends string>({
 			} else {
 				params.set(param, next);
 			}
+			for (const [key, paramValue] of Object.entries(extraParams ?? {})) {
+				if (paramValue === null) {
+					params.delete(key);
+				} else {
+					params.set(key, paramValue);
+				}
+			}
 			const query = params.toString();
 			// replace + scroll:false to match the other filters on these pages:
 			// push would make Back walk every toggle instead of leaving the page,
@@ -49,7 +62,7 @@ export function SegmentedUrlSelector<T extends string>({
 				scroll: false,
 			});
 		},
-		[searchParams, router, pathname, param, defaultValue],
+		[searchParams, router, pathname, param, defaultValue, extraParams],
 	);
 
 	return (

--- a/ee/admin/src/lib/key-status.ts
+++ b/ee/admin/src/lib/key-status.ts
@@ -1,0 +1,27 @@
+/**
+ * Status filter for the API-key and provider-key lists on the organization
+ * detail page. Mirrors the `status` enum both key tables share.
+ *
+ * Keys are soft-deleted rather than removed, so an organization accumulates
+ * `deleted` rows forever. The list therefore defaults to `active` — the only
+ * status that says anything about what the organization can do right now —
+ * and the other views exist for forensics.
+ */
+export type KeyStatusFilter = "active" | "inactive" | "deleted" | "all";
+
+export const KEY_STATUS_DEFAULT: KeyStatusFilter = "active";
+
+export const KEY_STATUS_OPTIONS: { value: KeyStatusFilter; label: string }[] = [
+	{ value: "active", label: "Active" },
+	{ value: "inactive", label: "Disabled" },
+	{ value: "deleted", label: "Deleted" },
+	{ value: "all", label: "All" },
+];
+
+export function parseKeyStatus(
+	value: string | null | undefined,
+): KeyStatusFilter {
+	return KEY_STATUS_OPTIONS.some((o) => o.value === value)
+		? (value as KeyStatusFilter)
+		: KEY_STATUS_DEFAULT;
+}


### PR DESCRIPTION
## Problem

The organization detail page in the admin dashboard listed **every** API key and provider key an organization has ever had, with no way to narrow it down. Both key tables soft-delete (`status: deleted`) rather than removing rows, so an established organization's list is dominated by keys that say nothing about what it can do today — and the tab counts grew monotonically with churn, which made them close to useless at a glance.

## Approach

**API** (`GET /admin/organizations/{orgId}/api-keys`, `GET /admin/organizations/{orgId}/provider-keys`)

- Both endpoints take a `status` query param: `active` (default) / `inactive` / `deleted` / `all`.
- Both responses gained a `counts` object (`{ all, active, inactive, deleted }`) computed over **all** of the organization's keys, never over the filtered rows — so the tab header stays stable no matter which status the list is showing.
- `status` is nullable with an `active` default on both tables, so legacy `NULL` rows are folded into `active` in both the filter and the counts instead of vanishing from every view.

The default changes the endpoints' previous behavior (they returned everything); the admin dashboard is the only consumer.

**Admin UI**

- Each key tab gets an Active / Disabled / Deleted / All segmented filter, with the per-status count on each option, persisted in a URL search param (`akStatus` / `pkStatus`). Selecting a status pins the tab and resets the API-key page, since page N of the previous status is usually empty under the new one.
- Tab headers now read `active / total` — e.g. `API Keys (5/10)`, `Provider Keys (2/7)` — instead of a single total.
- `SegmentedUrlSelector` gained an `extraParams` prop for the pin/reset above; existing callers are unaffected.
- Pagination links on the transactions and API-keys tabs carry the filters so paging one list no longer resets the other's state.

Not screenshotted per request.

## Verification

- New spec `apps/api/src/routes/admin-org-keys.spec.ts` covers the default, each status filter, `all`, that counts stay organization-wide under a filter, and the `NULL`-status-counts-as-active case.
- Full admin API suite: 163 passed (run sequentially against an isolated per-worktree stack).
- `pnpm format` and a full `pnpm build` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added status filters for organization API keys and provider keys: Active, Inactive, Deleted, and All.
  - Added status counts to key listings.
  - Preserved selected filters during pagination and navigation.
  - Added clearer empty states for each key status view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->