### PR TITLE
fix(ui): fold footer community into resources

### DIFF
--- a/apps/ui/src/components/landing/footer.tsx
+++ b/apps/ui/src/components/landing/footer.tsx
@@ -342,22 +342,14 @@ export default function Footer() {
 								</li>
 								<li>
 									<a
-										href="mailto:contact@llmgateway.io"
+										href={config.discordUrl}
 										target="_blank"
-										rel="noreferrer noopener"
+										rel="noopener noreferrer"
 										className="text-sm hover:underline underline-offset-4 hover:text-foreground"
 									>
-										Contact Us
+										Discord
 									</a>
 								</li>
-							</ul>
-						</div>
-
-						<div>
-							<h3 className="font-display text-sm font-semibold mb-4 text-foreground">
-								Community
-							</h3>
-							<ul className="space-y-2">
 								<li>
 									<a
 										href={config.twitterUrl}
@@ -370,12 +362,12 @@ export default function Footer() {
 								</li>
 								<li>
 									<a
-										href={config.discordUrl}
+										href="mailto:contact@llmgateway.io"
 										target="_blank"
-										rel="noopener noreferrer"
+										rel="noreferrer noopener"
 										className="text-sm hover:underline underline-offset-4 hover:text-foreground"
 									>
-										Discord
+										Contact Us
 									</a>
 								</li>
 							</ul>


### PR DESCRIPTION
## Problem

The landing footer renders its link columns in a `lg:grid-cols-6` grid, but there were seven columns. The Providers column therefore wrapped onto a second row on its own, leaving a large gap in the layout. The Community column was also the odd one out: it only held two links (Twitter, Discord), while the neighbouring columns hold seven to eighteen.

## Change

Dropped the standalone Community column and moved Twitter and Discord into Resources, right next to the existing GitHub link. That brings the grid back to exactly six columns, so everything sits on one row and Providers no longer wraps. Both social links are also still reachable from the icon row on the left of the footer.

No links were removed.

## Screenshots

**Before — light** (seven columns, Providers wraps to its own row)

<img width="1440" alt="Footer before, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/ffb2642045f128e1ddee2bda39855b8680d2c314/before-light.png" />

**After — light** (six columns on one row, Discord and Twitter under Resources)

<img width="1440" alt="Footer after, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/ffb2642045f128e1ddee2bda39855b8680d2c314/after-light.png" />

**Before — dark**

<img width="1440" alt="Footer before, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/ffb2642045f128e1ddee2bda39855b8680d2c314/before-dark.png" />

**After — dark**

<img width="1440" alt="Footer after, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/ffb2642045f128e1ddee2bda39855b8680d2c314/after-dark.png" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Added Discord to the footer’s Resources links.
  * Moved Contact Us to the Community links.
  * Removed Discord from the Community links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->