### PR TITLE
feat(worker): rebuild global stats from logs

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -20,6 +20,7 @@
 		"dev": "concurrently \"tsc-watch --onSuccess 'resolve-tspaths'\" \"nodemon --exec node --enable-source-maps --env-file=../../.env dist/index.js\"",
 		"format": "eslint --fix . && prettier --write .",
 		"lint": "eslint . && prettier --check .",
+		"rebuild-global-stats": "tsx --env-file=../../.env ./src/scripts/rebuild-global-stats.ts",
 		"start": "node --enable-source-maps dist/index.js"
 	},
 	"dependencies": {

--- a/apps/worker/src/scripts/rebuild-global-stats.ts
+++ b/apps/worker/src/scripts/rebuild-global-stats.ts
@@ -1,0 +1,180 @@
+/* eslint-disable no-console */
+/**
+ * Rebuild global_model_stats / global_source_stats from `log`.
+ *
+ * Why this is possible at all: data retention never deletes log rows. The
+ * cleanup job (cleanupExpiredLogData) only nulls the verbose payload columns —
+ * messages, content, raw/upstream request and response, tools, customHeaders,
+ * userAgent, responsesApiData — and sets data_retention_cleaned_up. Every column
+ * the aggregator reads (used_model, used_provider, used_mode, source,
+ * organization_id, created_at, the token columns, the cost columns, has_error,
+ * cached, streamed, unified_finish_reason) survives untouched, so a rebuild is
+ * lossless.
+ *
+ * That makes this the correct fix for rows the mode/kind migration
+ * (1786136603_warm_omega_flight.sql) left as 'unknown': re-deriving from the
+ * source data gives an exact used_mode and org_kind for every row, with no
+ * proration and no scaling.
+ *
+ * Each day is handled by the aggregator's own recomputeDayFully(), which deletes
+ * that day's rows and re-aggregates its 24 hours. So the script is idempotent
+ * and resumable: re-running any day is safe, and a crashed run is continued by
+ * re-running with --from/--to for whatever is left.
+ *
+ * Ordering: newest day first by default, so the recent days people actually look
+ * at are correct within minutes instead of at the very end of the run.
+ *
+ * Today and yesterday are skipped. The incremental walker owns today, and the
+ * safety net wipes-and-recomputes yesterday; racing either of them risks
+ * interleaving a delete with an insert and double-counting a day.
+ *
+ * Usage:
+ *   pnpm --filter worker rebuild-global-stats                       # dry run: report the plan
+ *   pnpm --filter worker rebuild-global-stats --commit              # rebuild everything
+ *   pnpm --filter worker rebuild-global-stats --commit --limit=7    # rebuild the 7 newest days first
+ *   pnpm --filter worker rebuild-global-stats --commit --from=2025-05-20 --to=2026-08-01
+ *   pnpm --filter worker rebuild-global-stats --commit --oldest-first
+ *
+ * Environment:
+ *   DATABASE_URL - defaults to local postgres if unset
+ */
+
+import { recomputeDayFully } from "@/services/global-stats-aggregator.js";
+
+import { db, sql } from "@llmgateway/db";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function parseFlag(name: string): string | undefined {
+	const flag = `--${name}=`;
+	const arg = process.argv.find((a) => a.startsWith(flag));
+	return arg ? arg.slice(flag.length) : undefined;
+}
+
+function hasFlag(name: string): boolean {
+	return process.argv.includes(`--${name}`);
+}
+
+function floorToUTCDay(d: Date): Date {
+	return new Date(
+		Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(), 0, 0, 0, 0),
+	);
+}
+
+function toDateString(d: Date): string {
+	return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Earliest day worth rebuilding: whichever of the first log and the first
+ * existing stats row is older, so a rebuild can also fill in days the walker
+ * never reached.
+ *
+ * `order by created_at limit 1` rather than `min(created_at)` — the log table is
+ * huge, and this form is guaranteed to ride the index on (created_at, ...)
+ * instead of risking a sequential scan.
+ */
+async function resolveStart(): Promise<Date | null> {
+	const result = await db.execute(sql`
+		select least(
+			(select created_at from log order by created_at limit 1),
+			(select min(day_timestamp) from global_model_stats),
+			(select min(day_timestamp) from global_source_stats)
+		) as start
+	`);
+	const start = (result.rows[0] as { start: Date | string | null } | undefined)
+		?.start;
+	return start ? floorToUTCDay(new Date(start)) : null;
+}
+
+async function main(): Promise<void> {
+	const commit = hasFlag("commit");
+	const oldestFirst = hasFlag("oldest-first");
+	const limit = parseFlag("limit") ? Number(parseFlag("limit")) : undefined;
+
+	const fromFlag = parseFlag("from");
+	const toFlag = parseFlag("to");
+
+	const today = floorToUTCDay(new Date());
+	// Today belongs to the walker, yesterday to the safety net.
+	const defaultEnd = new Date(today.getTime() - 2 * DAY_MS); // eslint-disable-line no-mixed-operators
+
+	const start = fromFlag
+		? floorToUTCDay(new Date(`${fromFlag}T00:00:00Z`))
+		: await resolveStart();
+	if (!start) {
+		console.log("No logs and no global stats rows — nothing to rebuild.");
+		return;
+	}
+
+	let end = toFlag
+		? floorToUTCDay(new Date(`${toFlag}T00:00:00Z`))
+		: defaultEnd;
+	if (end.getTime() > defaultEnd.getTime()) {
+		console.log(
+			`Clamping --to to ${toDateString(defaultEnd)}: today and yesterday are owned by the walker and the safety net.`,
+		);
+		end = defaultEnd;
+	}
+
+	if (end.getTime() < start.getTime()) {
+		console.log("Nothing to rebuild — the range is empty.");
+		return;
+	}
+
+	const days: Date[] = [];
+	for (let d = new Date(start); d <= end; d = new Date(d.getTime() + DAY_MS)) {
+		days.push(new Date(d));
+	}
+	if (!oldestFirst) {
+		days.reverse();
+	}
+	const planned = limit ? days.slice(0, limit) : days;
+
+	console.log(
+		`${commit ? "REBUILDING" : "DRY RUN"} — ${toDateString(start)} .. ${toDateString(end)} (${planned.length} of ${days.length} days, ${oldestFirst ? "oldest" : "newest"} first)`,
+	);
+
+	if (!commit) {
+		const before = await db.execute(sql`
+			select
+				(select count(*) from global_model_stats
+				 where used_mode = 'unknown' or org_kind = 'unknown')  as model_rows_unattributed,
+				(select count(*) from global_source_stats
+				 where used_mode = 'unknown' or org_kind = 'unknown')  as source_rows_unattributed
+		`);
+		console.log(before.rows[0]);
+		console.log("\nDry run — nothing was written. Re-run with --commit.");
+		return;
+	}
+
+	const startedAt = Date.now();
+	let done = 0;
+	for (const day of planned) {
+		const completed = await recomputeDayFully(day);
+		if (!completed) {
+			console.log(`Stop requested — halted after ${done} day(s).`);
+			break;
+		}
+		done++;
+		if (done % 10 === 0 || done === planned.length) {
+			const elapsed = (Date.now() - startedAt) / 1000;
+			const rate = done / elapsed;
+			const remaining = planned.length - done;
+			console.log(
+				`${done}/${planned.length} days (${toDateString(day)}) — ${elapsed.toFixed(0)}s elapsed, ~${rate > 0 ? Math.round(remaining / rate) : 0}s remaining`,
+			);
+		}
+	}
+
+	console.log(
+		`Rebuilt ${done} day(s) in ${((Date.now() - startedAt) / 1000).toFixed(0)}s.`,
+	);
+}
+
+main()
+	.then(() => process.exit(0))
+	.catch((error) => {
+		console.error(error);
+		process.exit(1);
+	});

--- a/apps/worker/src/services/global-stats-aggregator.ts
+++ b/apps/worker/src/services/global-stats-aggregator.ts
@@ -286,7 +286,7 @@ async function setLastSafetyNetDay(day: Date): Promise<void> {
 // Returns true on full completion. Returns false if stop was requested
 // mid-walk; the caller must NOT mark the day as recomputed in that case so the
 // next worker start retries from the partially-recomputed state.
-async function recomputeDayFully(day: Date): Promise<boolean> {
+export async function recomputeDayFully(day: Date): Promise<boolean> {
 	const dayStr = formatUTCTimestamp(day);
 
 	await db.transaction(async (tx) => {


### PR DESCRIPTION
## Why this is possible

The mode/kind migration (`1786136603_warm_omega_flight.sql`) left a large slice of `global_model_stats` / `global_source_stats` with `used_mode` and `org_kind` set to `unknown`, so the admin Global Stats page can't make Credits + BYOK add up to All and shows almost no organization-kind attribution.

The migration's note says recovering that means re-reading raw logs, which retention has pruned. **That turns out to be wrong.** `cleanupExpiredLogData` (`apps/worker/src/worker.ts:740`) is an UPDATE, not a DELETE — after 30 days it nulls the verbose payload columns and sets `data_retention_cleaned_up`:

```
messages, content, reasoningContent, tools, toolChoice, toolResults,
customHeaders, rawRequest, rawResponse, upstreamRequest, upstreamResponse,
userAgent, gatewayContentFilterResponse, responsesApiData
```

No production code path deletes `log` rows at all — not the retention job, not account deletion. And **not one column the aggregator reads is in that list**: `used_model`, `used_provider`, `used_mode`, `source`, `organization_id`, `created_at`, every token column, every cost column, `has_error`, `cached`, `streamed`, `unified_finish_reason`.

Confirmed against production: the earliest `log` row falls *inside* the first `global_model_stats` day bucket, so there is no stats history predating the logs. A rebuild is lossless.

That makes re-deriving from source strictly better than a redistribution backfill — it yields an **exact** `used_mode` and `org_kind` for every row, with no proration and no scaling.

## Design

Each day goes through the aggregator's own `recomputeDayFully()`, which already deletes that day's rows and re-aggregates its 24 hours. Reusing it means no new aggregation logic to keep in sync — the only production change is making that function `export`ed.

- **Newest day first.** The recent days people actually look at are correct within minutes rather than at the end of a multi-hour run.
- **No truncate, no watermark change.** The table is never fully empty; each day flips atomically from wrong to right. Truncating and letting the incremental walker rebuild would leave the dashboard blank for the whole run *and* rebuild oldest-first, so the most-viewed days would come back last — plus resetting `global_aggregation_state` without also raising `GLOBAL_STATS_INITIAL_LOOKBACK_DAYS` (default **30**) would silently rebuild only one month.
- **Today and yesterday are skipped.** The incremental walker owns today, the safety net wipes-and-recomputes yesterday; racing either risks interleaving a delete with an insert and double-counting a day. `--to` is clamped accordingly.
- **Idempotent and resumable.** Re-running any day is safe; a crashed run continues with `--from`/`--to`.

## Usage

Dry run by default — reports the plan and how many rows are currently unattributed.

```bash
pnpm --filter worker rebuild-global-stats                       # dry run
pnpm --filter worker rebuild-global-stats --commit --limit=7    # 7 newest days, then eyeball the page
pnpm --filter worker rebuild-global-stats --commit              # the rest
pnpm --filter worker rebuild-global-stats --commit --from=2025-05-20 --to=2026-08-01
pnpm --filter worker rebuild-global-stats --commit --oldest-first
```

## Verification

Driven end to end against a local stack seeded with **real log rows** in the exact shape the migration collapsed — 100 logs on one model and one UTC day, 60 credits/PAYG and 40 BYOK/DevPass, plus a bogus pre-existing `unknown/unknown` aggregate row.

After the rebuild:

```
 used_mode | org_kind | request_count | total_tokens | cost
-----------+----------+---------------+--------------+-------
 api-keys  | devpass  |            40 |         4800 | 20.00
 credits   | default  |            60 |         7200 | 30.00

 TOTAL: 100 requests / 50.00 / 12000 tokens   ← matches `log` exactly
```

Exact, not approximated. Also verified:

- **Idempotent** — a second `--commit` run produces identical rows.
- **`global_source_stats`** rebuilt with the same attribution, including a source value containing spaces and a slash.
- **`--to` clamping** — a future `--to` is clamped to today-2 with an explanatory message.
- **`--limit`** — restricts to the N newest days.

`apps/worker` suite: `global-stats-aggregator.spec.ts` passes 5/5. Four `sync-models.spec.ts` tests time out at 30s in my environment; they passed earlier in the same session at 5–11s each and are unaffected by this change (which adds an `export` and a new file), so I've treated them as environment flake rather than a regression.

`pnpm format` and `pnpm build` clean.

## Operational notes

- Back up the two tables first — they're small, and the rebuild is delete-then-insert per day.
- Each day is 24 hours × 2 `GROUP BY` scans over `log`. The model query rides `log_created_at_used_model_used_provider_idx`; the source query groups on `source`, which isn't in that index. Run it off-peak.
- The rebuild recomputes **totals**, not just attribution. The global tables currently carry marginally more traffic than the project hourly aggregates, so expect the headline to shift slightly — the rebuilt figure is whatever `log` actually says.

## Relationship to the other PRs

- **#3549** (redistribution backfill) — superseded by this. Recommend closing: it approximates what this derives exactly.
- **#3547** (float4 summation) — still needed. Independent bug; without it the page wouldn't add up even on freshly rebuilt rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a worker command to rebuild global model and source statistics from retained logs.
  * Supports date ranges, commit and dry-run modes, result ordering, processing limits, progress reporting, and resumable execution.
  * Automatically excludes recent days that may still be receiving data and safely handles empty or invalid ranges.

* **Improvements**
  * Enabled full recomputation of selected days for reliable statistics recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->