### PR TITLE
feat(admin): passkey sign-in, hide signed-out nav

### DIFF
--- a/apps/api/src/auth/config.ts
+++ b/apps/api/src/auth/config.ts
@@ -28,6 +28,7 @@ const apiUrl = getApiBaseUrl();
 const cookieDomain = process.env.COOKIE_DOMAIN ?? "localhost";
 const uiUrl = process.env.UI_URL ?? "http://localhost:3002";
 const codeUrl = process.env.CODE_URL ?? "http://localhost:3004";
+const adminUrl = process.env.ADMIN_URL ?? "http://localhost:3006";
 const originUrls =
 	process.env.ORIGIN_URLS ??
 	"http://localhost:3002,http://localhost:3003,http://localhost:3004,http://localhost:4002,http://localhost:3006";
@@ -655,9 +656,11 @@ export const apiAuth: ReturnType<typeof instrumentBetterAuth> =
 				passkey({
 					rpID: process.env.PASSKEY_RP_ID ?? "localhost",
 					rpName: process.env.PASSKEY_RP_NAME ?? "LLMGateway",
-					// Accept passkey ceremonies from both the main dashboard and the
-					// DevPass (code) app, which share the same registrable rpID.
-					origin: [uiUrl, codeUrl],
+					// Accept passkey ceremonies from the main dashboard, the DevPass
+					// (code) app and the admin dashboard, which all share the same
+					// registrable rpID. Passkeys are registered on the main dashboard;
+					// listing the admin origin lets admins reuse them to sign in there.
+					origin: [uiUrl, codeUrl, adminUrl],
 				}),
 				sso({
 					// This app uses a custom organization model (userOrganization),

--- a/ee/admin/package.json
+++ b/ee/admin/package.json
@@ -16,6 +16,7 @@
 		"start": "next start"
 	},
 	"dependencies": {
+		"@better-auth/passkey": "1.6.25",
 		"@hookform/resolvers": "5.2.2",
 		"@llmgateway/ai-sdk-provider": "3.7.0",
 		"@llmgateway/models": "workspace:*",
@@ -37,6 +38,7 @@
 		"@radix-ui/react-tabs": "^1.1.13",
 		"@radix-ui/react-tooltip": "^1.2.8",
 		"@radix-ui/react-use-controllable-state": "1.2.2",
+		"@simplewebauthn/browser": "13.3.0",
 		"@stripe/react-stripe-js": "5.2.0",
 		"@stripe/stripe-js": "8.1.0",
 		"@tanstack/react-query": "^5.90.5",

--- a/ee/admin/src/app/api/generate-reply/route.ts
+++ b/ee/admin/src/app/api/generate-reply/route.ts
@@ -3,7 +3,8 @@ import { cookies } from "next/headers";
 import { z } from "zod";
 
 import { getConfig } from "@/lib/config-server";
-import { getUser } from "@/lib/getUser";
+import { getAdminUser } from "@/lib/getUser";
+import { getSessionCookieHeader } from "@/lib/session-cookie";
 
 import { createLLMGateway } from "@llmgateway/ai-sdk-provider";
 
@@ -36,20 +37,8 @@ async function getApiKey(): Promise<{
 		return { token: existing };
 	}
 
-	const user = await getUser();
-	if (!user) {
-		return null;
-	}
-
 	const config = getConfig();
-	const key = "better-auth.session_token";
-	const sessionCookie = cookieStore.get(`${key}`);
-	const secureSessionCookie = cookieStore.get(`__Secure-${key}`);
-	const cookieHeader = secureSessionCookie
-		? `__Secure-${key}=${secureSessionCookie.value}`
-		: sessionCookie
-			? `${key}=${sessionCookie.value}`
-			: "";
+	const cookieHeader = await getSessionCookieHeader();
 
 	// Get user's first org
 	const orgsRes = await fetch(`${config.apiBackendUrl}/orgs`, {
@@ -109,6 +98,10 @@ async function getApiKey(): Promise<{
 }
 
 export async function POST(req: Request) {
+	if (!(await getAdminUser())) {
+		return Response.json({ error: "Forbidden" }, { status: 403 });
+	}
+
 	let data: GenerateReplyRequest;
 	try {
 		data = await req.json();

--- a/ee/admin/src/app/layout.tsx
+++ b/ee/admin/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter, Geist_Mono, Plus_Jakarta_Sans } from "next/font/google";
 import { AdminShell } from "@/components/admin-shell";
 import { getConfig } from "@/lib/config-server";
 import { Providers } from "@/lib/providers";
+import { hasSessionCookie } from "@/lib/require-session";
 
 import "./globals.css";
 
@@ -46,8 +47,13 @@ export const metadata: Metadata = {
 	},
 };
 
-export default function RootLayout({ children }: { children: ReactNode }) {
+export default async function RootLayout({
+	children,
+}: {
+	children: ReactNode;
+}) {
 	const config = getConfig();
+	const signedIn = await hasSessionCookie();
 
 	return (
 		<html
@@ -57,7 +63,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 		>
 			<body className="antialiased">
 				<Providers config={config}>
-					<AdminShell>{children}</AdminShell>
+					<AdminShell signedIn={signedIn}>{children}</AdminShell>
 				</Providers>
 			</body>
 		</html>

--- a/ee/admin/src/app/layout.tsx
+++ b/ee/admin/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { Inter, Geist_Mono, Plus_Jakarta_Sans } from "next/font/google";
 import { AdminShell } from "@/components/admin-shell";
 import { getConfig } from "@/lib/config-server";
 import { Providers } from "@/lib/providers";
-import { hasSessionCookie } from "@/lib/require-session";
+import { hasSessionCookie } from "@/lib/session-cookie";
 
 import "./globals.css";
 

--- a/ee/admin/src/app/login/page.tsx
+++ b/ee/admin/src/app/login/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { WebAuthnAbortService } from "@simplewebauthn/browser";
 import { useQueryClient } from "@tanstack/react-query";
-import { Loader2 } from "lucide-react";
+import { KeySquare, Loader2 } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import * as z from "zod";
@@ -60,8 +61,60 @@ export default function Login() {
 		},
 	});
 
+	const passkeyAutofillStarted = useRef(false);
+	useEffect(() => {
+		// Start the conditional (autofill) passkey ceremony exactly once. Re-running
+		// it restarts the WebAuthn request, which flickers the browser/password
+		// manager prompt and aborts an in-progress manual passkey button click.
+		if (passkeyAutofillStarted.current) {
+			return;
+		}
+		if (typeof window === "undefined" || !window.PublicKeyCredential) {
+			return;
+		}
+		passkeyAutofillStarted.current = true;
+		void signIn.passkey({ autoFill: true }).then((res) => {
+			if (res?.data) {
+				queryClient.clear();
+				router.push(returnUrl);
+			} else if (res?.error) {
+				if (res.error.message?.toLowerCase().includes("cancelled")) {
+					return;
+				}
+				toast.error(res.error.message ?? "Failed to sign in with passkey");
+			}
+		});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	async function handlePasskeySignIn() {
+		setIsLoading(true);
+		try {
+			// Cancel the pending conditional (autofill) ceremony started on mount so
+			// it doesn't collide with this modal request and abort it as "cancelled".
+			WebAuthnAbortService.cancelCeremony();
+			const res = await signIn.passkey();
+			if (res?.error) {
+				toast.error(res.error.message ?? "Failed to sign in with passkey");
+				return;
+			}
+			queryClient.clear();
+			toast.success("Login successful");
+			router.push(returnUrl);
+		} catch (error: unknown) {
+			toast.error(
+				(error as Error)?.message || "Failed to sign in with passkey",
+			);
+		} finally {
+			setIsLoading(false);
+		}
+	}
+
 	async function onSubmit(values: z.infer<typeof formSchema>) {
 		setIsLoading(true);
+		// Abort the pending conditional (autofill) passkey ceremony so it can't pop a
+		// native passkey/biometric prompt after a successful email sign-in + redirect.
+		WebAuthnAbortService.cancelCeremony();
 		const { error } = await signIn.email(
 			{
 				email: values.email,
@@ -165,6 +218,19 @@ export default function Login() {
 						<span className="bg-background px-2 text-muted-foreground">Or</span>
 					</div>
 				</div>
+				<Button
+					onClick={handlePasskeySignIn}
+					variant="outline"
+					className="w-full"
+					disabled={isLoading}
+				>
+					{isLoading ? (
+						<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+					) : (
+						<KeySquare className="mr-2 h-4 w-4" />
+					)}
+					Sign in with passkey
+				</Button>
 			</div>
 		</div>
 	);

--- a/ee/admin/src/components/admin-shell.tsx
+++ b/ee/admin/src/components/admin-shell.tsx
@@ -41,6 +41,7 @@ import {
 	SidebarTrigger,
 	useSidebar,
 } from "@/components/ui/sidebar";
+import { useUser } from "@/hooks/useUser";
 import { useAuth } from "@/lib/auth-client";
 
 import { Logo } from "./ui/logo";
@@ -49,6 +50,12 @@ import type { ReactNode } from "react";
 
 interface AdminShellProps {
 	children: ReactNode;
+	/**
+	 * Server-rendered session-cookie presence. Used only as the fallback while
+	 * `/user/me` is still in flight, so the navigation does not flash in or out
+	 * on every full page load.
+	 */
+	signedIn: boolean;
 }
 
 function MobileHeader() {
@@ -83,11 +90,28 @@ function MobileHeader() {
 	);
 }
 
-export function AdminShell({ children }: AdminShellProps) {
+export function AdminShell({ children, signedIn }: AdminShellProps) {
 	const pathname = usePathname();
 	const router = useRouter();
 	const { signOut } = useAuth();
 	const queryClient = useQueryClient();
+	const { user, isLoading, error } = useUser();
+
+	// Visitors without an admin session never see the navigation: the section
+	// list would suggest there is something reachable behind it, and a sign out
+	// button makes no sense when nobody is signed in.
+	const showNav = user ? user.isAdmin : isLoading && !error && signedIn;
+
+	if (!showNav) {
+		return (
+			<div className="relative min-h-svh w-full">
+				<div className="absolute right-4 top-4 z-50">
+					<ThemeToggle size="compact" />
+				</div>
+				{children}
+			</div>
+		);
+	}
 
 	const isDashboard = pathname === "/" || pathname === "";
 	const isOrganizations = pathname.startsWith("/organizations");

--- a/ee/admin/src/lib/auth-client.ts
+++ b/ee/admin/src/lib/auth-client.ts
@@ -1,3 +1,4 @@
+import { passkeyClient } from "@better-auth/passkey/client";
 import { createAuthClient } from "better-auth/react";
 import { useMemo } from "react";
 
@@ -10,6 +11,7 @@ export function useAuthClient() {
 	return useMemo(() => {
 		return createAuthClient({
 			baseURL: config.apiUrl + "/auth",
+			plugins: [passkeyClient()],
 		});
 	}, [config.apiUrl]);
 }

--- a/ee/admin/src/lib/getUser.ts
+++ b/ee/admin/src/lib/getUser.ts
@@ -1,34 +1,40 @@
-import { cookies } from "next/headers";
-
 import { getConfig } from "@/lib/config-server";
+import { getSessionCookieHeader } from "@/lib/session-cookie";
 
-import type { User } from "better-auth/types";
+export interface SessionUser {
+	id: string;
+	email: string;
+	name: string | null;
+	isAdmin: boolean;
+}
 
-export async function getUser() {
+export async function getUser(): Promise<SessionUser | null> {
 	const config = getConfig();
-	const cookieStore = await cookies();
 
-	const key = "better-auth.session_token";
-	// Get session cookie for authentication
-	const sessionCookie = cookieStore.get(`${key}`);
-	const secureSessionCookie = cookieStore.get(`__Secure-${key}`);
-
-	const data = await fetch(`${config.apiBackendUrl}/user/me`, {
+	const res = await fetch(`${config.apiBackendUrl}/user/me`, {
 		method: "GET",
 		headers: {
-			Cookie: secureSessionCookie
-				? `__Secure-${key}=${secureSessionCookie.value}`
-				: sessionCookie
-					? `${key}=${sessionCookie.value}`
-					: "",
+			Cookie: await getSessionCookieHeader(),
 		},
 	});
 
-	if (!data.ok) {
+	if (!res.ok) {
 		return null;
 	}
 
-	const user: User = await data.json();
+	const data = (await res.json()) as { user?: SessionUser };
 
-	return user;
+	return data.user ?? null;
+}
+
+/**
+ * Same as {@link getUser}, but only resolves for users on the API's admin
+ * allowlist. Route handlers under `/api/*` must use this: the session cookie is
+ * shared with the main dashboard, and the proxy skips its admin check for that
+ * path prefix, so any signed-in user reaches them otherwise.
+ */
+export async function getAdminUser(): Promise<SessionUser | null> {
+	const user = await getUser();
+
+	return user?.isAdmin ? user : null;
 }

--- a/ee/admin/src/lib/require-session.ts
+++ b/ee/admin/src/lib/require-session.ts
@@ -1,13 +1,17 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
-export async function requireSession() {
+export async function hasSessionCookie() {
 	const cookieStore = await cookies();
-	const hasSession =
-		cookieStore.has("better-auth.session_token") ||
-		cookieStore.has("__Secure-better-auth.session_token");
 
-	if (!hasSession) {
+	return (
+		cookieStore.has("better-auth.session_token") ||
+		cookieStore.has("__Secure-better-auth.session_token")
+	);
+}
+
+export async function requireSession() {
+	if (!(await hasSessionCookie())) {
 		redirect("/login");
 	}
 }

--- a/ee/admin/src/lib/require-session.ts
+++ b/ee/admin/src/lib/require-session.ts
@@ -1,14 +1,6 @@
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
-export async function hasSessionCookie() {
-	const cookieStore = await cookies();
-
-	return (
-		cookieStore.has("better-auth.session_token") ||
-		cookieStore.has("__Secure-better-auth.session_token")
-	);
-}
+import { hasSessionCookie } from "@/lib/session-cookie";
 
 export async function requireSession() {
 	if (!(await hasSessionCookie())) {

--- a/ee/admin/src/lib/server-api.ts
+++ b/ee/admin/src/lib/server-api.ts
@@ -1,27 +1,18 @@
-import { cookies } from "next/headers";
 import createFetchClient from "openapi-fetch";
 
 import { getConfig } from "./config-server";
+import { getSessionCookieHeader } from "./session-cookie";
 
 import type { paths } from "./api/v1";
 
 export async function createServerApiClient() {
 	const config = getConfig();
-	const cookieStore = await cookies();
-
-	const key = "better-auth.session_token";
-	const sessionCookie = cookieStore.get(`${key}`);
-	const secureSessionCookie = cookieStore.get(`__Secure-${key}`);
 
 	return createFetchClient<paths>({
 		baseUrl: config.apiBackendUrl,
 		credentials: "include",
 		headers: {
-			Cookie: secureSessionCookie
-				? `__Secure-${key}=${secureSessionCookie.value}`
-				: sessionCookie
-					? `${key}=${sessionCookie.value}`
-					: "",
+			Cookie: await getSessionCookieHeader(),
 		},
 	});
 }

--- a/ee/admin/src/lib/session-cookie.ts
+++ b/ee/admin/src/lib/session-cookie.ts
@@ -1,0 +1,32 @@
+import { cookies } from "next/headers";
+
+const SESSION_COOKIE = "better-auth.session_token";
+
+/**
+ * Builds the `Cookie` header used to forward the caller's better-auth session
+ * to the API. Returns an empty string when the visitor has no session cookie.
+ */
+export async function getSessionCookieHeader() {
+	const cookieStore = await cookies();
+	const sessionCookie = cookieStore.get(SESSION_COOKIE);
+	const secureSessionCookie = cookieStore.get(`__Secure-${SESSION_COOKIE}`);
+
+	if (secureSessionCookie) {
+		return `__Secure-${SESSION_COOKIE}=${secureSessionCookie.value}`;
+	}
+
+	if (sessionCookie) {
+		return `${SESSION_COOKIE}=${sessionCookie.value}`;
+	}
+
+	return "";
+}
+
+export async function hasSessionCookie() {
+	const cookieStore = await cookies();
+
+	return (
+		cookieStore.has(SESSION_COOKIE) ||
+		cookieStore.has(`__Secure-${SESSION_COOKIE}`)
+	);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,13 +299,13 @@ importers:
     dependencies:
       '@better-auth/passkey':
         specifier: 1.6.25
-        version: 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.76))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.25(@opentelemetry/api@1.9.0)(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.16.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(vite@7.3.6(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3))))(better-call@1.3.7(zod@3.25.76))(nanostores@1.4.2)
+        version: 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.76))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.25(@opentelemetry/api@1.9.0)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.16.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(vite@7.3.6(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3))))(better-call@1.3.7(zod@3.25.76))(nanostores@1.4.2)
       '@content-collections/core':
         specifier: 0.15.0
         version: 0.15.0(typescript@5.9.3)
       '@content-collections/next':
         specifier: 0.2.11
-        version: 0.2.11(@content-collections/core@0.15.0(typescript@5.9.3))(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+        version: 0.2.11(@content-collections/core@0.15.0(typescript@5.9.3))(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       '@hookform/resolvers':
         specifier: 5.2.2
         version: 5.2.2(react-hook-form@7.65.0(react@19.2.8))(zod@3.25.76)
@@ -377,7 +377,7 @@ importers:
         version: 1.0.0
       better-auth:
         specifier: 1.6.25
-        version: 1.6.25(@opentelemetry/api@1.9.0)(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.16.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(vite@7.3.6(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3)))
+        version: 1.6.25(@opentelemetry/api@1.9.0)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.16.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(vite@7.3.6(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3)))
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -468,7 +468,7 @@ importers:
         version: 9.38.0(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.0.0
-        version: 16.0.0(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.0.0(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       openapi-typescript:
         specifier: 7.10.1
         version: 7.10.1(typescript@5.9.3)
@@ -695,7 +695,7 @@ importers:
         version: 3.0.29(react@19.2.8)(zod@4.3.6)
       '@better-auth/passkey':
         specifier: 1.6.25
-        version: 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.25(@opentelemetry/api@1.9.0)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.16.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(vite@7.3.6(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3))))(better-call@1.3.7(zod@4.3.6))(nanostores@1.4.2)
+        version: 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.25(@opentelemetry/api@1.9.0)(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.16.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(vite@7.3.6(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3))))(better-call@1.3.7(zod@4.3.6))(nanostores@1.4.2)
       '@hookform/resolvers':
         specifier: 5.2.2
         version: 5.2.2(react-hook-form@7.65.0(react@19.2.8))(zod@4.3.6)
@@ -815,7 +815,7 @@ importers:
         version: 1.0.0
       better-auth:
         specifier: 1.6.25
-        version: 1.6.25(@opentelemetry/api@1.9.0)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.16.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(vite@7.3.6(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3)))
+        version: 1.6.25(@opentelemetry/api@1.9.0)(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.16.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(vite@7.3.6(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3)))
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -942,7 +942,7 @@ importers:
         version: 9.38.0(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.0.0
-        version: 16.0.0(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.0.0(@typescript-eslint/parser@8.56.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.2))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       openapi-typescript:
         specifier: 7.10.1
         version: 7.10.1(typescript@5.9.3)
@@ -1250,6 +1250,9 @@ importers:
 
   ee/admin:
     dependencies:
+      '@better-auth/passkey':
+        specifier: 1.6.25
+        version: 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.76))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.25(@opentelemetry/api@1.9.0)(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.16.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(vite@7.3.6(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3))))(better-call@1.3.7(zod@3.25.76))(nanostores@1.4.2)
       '@hookform/resolvers':
         specifier: 5.2.2
         version: 5.2.2(react-hook-form@7.65.0(react@19.2.8))(zod@3.25.76)
@@ -1313,6 +1316,9 @@ importers:
       '@radix-ui/react-use-controllable-state':
         specifier: 1.2.2
         version: 1.2.2(@types/react@19.2.18)(react@19.2.8)
+      '@simplewebauthn/browser':
+        specifier: 13.3.0
+        version: 13.3.0
       '@stripe/react-stripe-js':
         specifier: 5.2.0
         version: 5.2.0(@stripe/stripe-js@8.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -7715,6 +7721,7 @@ packages:
 
   drizzle-orm@1.0.0-beta.1-fd5d1e8:
     resolution: {integrity: sha512-p/6rhE/MU3qD61sYOiUW9u6EM3S+GspByTzpgDHwzv9s7JEMSmfcDrFa4eyRSWCczx6/IC2AnB4SJt6uM0xydQ==}
+    deprecated: The 1.0.0-beta line is superseded by the 1.0 release candidate. Install drizzle-orm@rc instead.
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -13446,6 +13453,18 @@ snapshots:
       nanostores: 1.4.2
       zod: 4.3.6
 
+  '@better-auth/passkey@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.76))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.25(@opentelemetry/api@1.9.0)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.16.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(vite@7.3.6(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3))))(better-call@1.3.7(zod@3.25.76))(nanostores@1.4.2)':
+    dependencies:
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.76))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@simplewebauthn/browser': 13.3.0
+      '@simplewebauthn/server': 13.3.2
+      better-auth: 1.6.25(@opentelemetry/api@1.9.0)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.16.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(vite@7.3.6(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3)))
+      better-call: 1.3.7(zod@3.25.76)
+      nanostores: 1.4.2
+      zod: 4.3.6
+
   '@better-auth/passkey@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.76))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.25(@opentelemetry/api@1.9.0)(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.16.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(vite@7.3.6(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3))))(better-call@1.3.7(zod@3.25.76))(nanostores@1.4.2)':
     dependencies:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.76))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2)
@@ -13458,14 +13477,14 @@ snapshots:
       nanostores: 1.4.2
       zod: 4.3.6
 
-  '@better-auth/passkey@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.25(@opentelemetry/api@1.9.0)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.16.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(vite@7.3.6(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3))))(better-call@1.3.7(zod@4.3.6))(nanostores@1.4.2)':
+  '@better-auth/passkey@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.25(@opentelemetry/api@1.9.0)(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.16.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(vite@7.3.6(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3))))(better-call@1.3.7(zod@4.3.6))(nanostores@1.4.2)':
     dependencies:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@simplewebauthn/browser': 13.3.0
       '@simplewebauthn/server': 13.3.2
-      better-auth: 1.6.25(@opentelemetry/api@1.9.0)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.16.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(vite@7.3.6(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3)))
+      better-auth: 1.6.25(@opentelemetry/api@1.9.0)(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.16.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(vite@7.3.6(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3)))
       better-call: 1.3.7(zod@4.3.6)
       nanostores: 1.4.2
       zod: 4.3.6
@@ -13680,11 +13699,11 @@ snapshots:
     dependencies:
       '@content-collections/core': 0.15.0(typescript@5.9.3)
 
-  '@content-collections/next@0.2.11(@content-collections/core@0.15.0(typescript@5.9.3))(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@content-collections/next@0.2.11(@content-collections/core@0.15.0(typescript@5.9.3))(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
       '@content-collections/core': 0.15.0(typescript@5.9.3)
       '@content-collections/integrations': 0.5.0(@content-collections/core@0.15.0(typescript@5.9.3))
-      next: 16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
   '@content-collections/next@0.2.11(@content-collections/core@0.15.0(typescript@5.9.3))(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.2.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
@@ -18640,13 +18659,13 @@ snapshots:
 
   better-auth@1.6.25(@opentelemetry/api@1.9.0)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.16.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(vite@7.3.6(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3))):
     dependencies:
-      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2)
-      '@better-auth/drizzle-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/kysely-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.28.17)
-      '@better-auth/memory-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.76))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2)
+      '@better-auth/drizzle-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.76))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/kysely-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.76))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.28.17)
+      '@better-auth/memory-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.76))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.76))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.76))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.76))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.3.0
@@ -18669,13 +18688,13 @@ snapshots:
 
   better-auth@1.6.25(@opentelemetry/api@1.9.0)(next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.16.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.1.2)(vite@7.3.6(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3))):
     dependencies:
-      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.76))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2)
-      '@better-auth/drizzle-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.76))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/kysely-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.76))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.28.17)
-      '@better-auth/memory-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.76))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.76))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.76))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.76))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2)
+      '@better-auth/drizzle-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/kysely-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.28.17)
+      '@better-auth/memory-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.8)(kysely@0.28.17)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.3.0
@@ -22820,6 +22839,7 @@ snapshots:
       - '@babel/core'
       - '@types/node'
       - babel-plugin-macros
+    optional: true
 
   next@16.3.0(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.2.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:


### PR DESCRIPTION
Prepares the admin dashboard for dropping the nginx basic-auth sidecar that currently sits in front of it (infra side: theopenco/llmgateway-infra#1454). Basic auth is today's second factor, so this replaces it with a real one and closes the gaps that layer was hiding.

## 1. Hide the nav for signed-out visitors

The admin shell rendered the full section list — and a `Sign out` button — on the login page and for any non-admin session. Nothing is reachable behind those links (the Next proxy and the API's `adminMiddleware` both gate every admin route server-side), but it reads like data is leaking there.

`AdminShell` now gates the sidebar on the resolved `isAdmin` flag from `/user/me`. While that request is in flight it falls back to a server-rendered hint — session-cookie presence, passed down from the root layout — so the nav does not flash in or out on full page loads. Signed-out visitors keep the theme toggle, which previously only lived in the sidebar footer.

## 2. Passkey sign-in on the admin login page

Admin access rested on a single email + password, with no second factor anywhere in the repo. The admin login page now offers `Sign in with passkey` plus the conditional (autofill) ceremony, mirroring the main dashboard. Passkeys are registered on the main dashboard and reused here — they share the registrable `rpID`.

This requires the admin origin on the passkey plugin's allowlist (`origin: [uiUrl, codeUrl, adminUrl]`), and therefore an `ADMIN_URL` on the API deployment, which is part of the infra change. Without it the ceremony is rejected — see the control test below.

## 3. Guard `POST /api/generate-reply`

It required *any* valid session, not an admin one. The better-auth cookie is shared across subdomains and the proxy skips its admin check for `/api/*`, so any signed-in user could drive it — two LLM calls billed to their own org. It now requires an admin session, checked *before* the cached-API-key cookie short-circuit that previously skipped the user lookup entirely.

While in there: `getUser()` unwrapped `/user/me` incorrectly (the endpoint returns `{ user }`), so it returned a truthy wrapper with no `id` or `email` — harmless only because it was used as a bare truthiness check. Fixed and typed, and the session-cookie header construction that was copy-pasted across three files moved into one helper.

## Deliberately not included

No better-auth rate-limit changes. Sign-in still falls back to the built-in in-memory 3-per-10s rule, which is per-replica and resets on deploy. Worth revisiting separately.

## Verification

Ran the stack locally against seeded data.

**Passkey**, using a CDP virtual authenticator: registered a passkey on the main dashboard, then signed in with it on the admin dashboard — `verify-authentication` 200, session issued, landed on the dashboard. Control: restarting the API without `ADMIN_URL` (so the admin origin is not on the allowlist) makes the identical ceremony fail with `AUTHENTICATION_FAILED`. That confirms both that the allowlist entry is load-bearing and that the infra env var is required.

**generate-reply**: 403 with no session, 403 with a stale `llmgateway_admin_key` cookie and no session, 403 for a valid non-admin session (a seeded project-scoped user), 200 and a generated draft for the seeded admin.

**Nav**: signed-out `/login` has no nav, signing in as a seeded admin restores it, signing out drops it again without a reload.

### Login page, before → after

| | Before | After |
| --- | --- | --- |
| Light | <img width="720" alt="Login page with full admin sidebar, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/3a657f9f3ac015bf84e7bf07e4bbb4fdec6cadbf/before-login-light.png" /> | <img width="720" alt="Login page with no sidebar and a passkey button, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/72cd54b25a551da04c07ce9dec75bf907c753007/after-login-passkey-light.png" /> |
| Dark | <img width="720" alt="Login page with full admin sidebar, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/3a657f9f3ac015bf84e7bf07e4bbb4fdec6cadbf/before-login-dark.png" /> | <img width="720" alt="Login page with no sidebar and a passkey button, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/72cd54b25a551da04c07ce9dec75bf907c753007/after-login-passkey-dark.png" /> |

### Signed in as an admin — nav unchanged

| Light | Dark |
| --- | --- |
| <img width="720" alt="Admin dashboard with sidebar, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/3a657f9f3ac015bf84e7bf07e4bbb4fdec6cadbf/after-dashboard-light.png" /> | <img width="720" alt="Admin dashboard with sidebar, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/3a657f9f3ac015bf84e7bf07e4bbb4fdec6cadbf/after-dashboard-dark.png" /> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added passkey sign-in with automatic and manual authentication options.
  * Improved admin navigation visibility based on sign-in status.
  * Unauthenticated visitors now see a streamlined admin layout without sidebar navigation.
* **Bug Fixes**
  * Improved session detection across supported sign-in cookies.
  * Unauthenticated access is more consistently redirected to the login page.
  * Protected reply-generation requests now require admin authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->