### PR TITLE
fix(ui): make top-up amount look editable

### DIFF
--- a/apps/ui/src/components/credits/top-up-credits-dialog.tsx
+++ b/apps/ui/src/components/credits/top-up-credits-dialog.tsx
@@ -8,7 +8,14 @@ import {
 } from "@stripe/react-stripe-js";
 import { keepPreviousData, useQueryClient } from "@tanstack/react-query";
 import confetti from "canvas-confetti";
-import { ChevronDown, Coins, CreditCard, Lock, Plus } from "lucide-react";
+import {
+	ChevronDown,
+	Coins,
+	CreditCard,
+	Lock,
+	Pencil,
+	Plus,
+} from "lucide-react";
 import Link from "next/link";
 import { usePostHog } from "posthog-js/react";
 import { useEffect, useState } from "react";
@@ -296,12 +303,20 @@ function AmountStep({
 			<div className="space-y-5 py-2">
 				{/* Hero amount input */}
 				<div className="flex flex-col items-center gap-1.5 pt-1">
-					<Label htmlFor="amount" className="sr-only">
-						Amount in USD
+					<Label
+						htmlFor="amount"
+						className="text-xs font-medium uppercase tracking-wider text-muted-foreground"
+					>
+						Enter amount
 					</Label>
 					<label
 						htmlFor="amount"
-						className="flex cursor-text items-baseline justify-center"
+						className={cn(
+							"flex w-full max-w-[280px] cursor-text items-center justify-center gap-1 rounded-xl border-2 bg-background px-4 py-2 transition-colors focus-within:border-primary focus-within:ring-4 focus-within:ring-ring/20",
+							amountValidationMessage
+								? "border-destructive focus-within:border-destructive focus-within:ring-destructive/20"
+								: "border-input hover:border-muted-foreground/50",
+						)}
 					>
 						<span className="text-3xl font-light text-muted-foreground">$</span>
 						<input
@@ -311,23 +326,37 @@ function AmountStep({
 							pattern="[0-9]*"
 							autoComplete="off"
 							maxLength={4}
+							placeholder="0"
 							value={amount || ""}
+							onFocus={(e) => e.target.select()}
 							onChange={(e) => {
 								const digits = e.target.value
 									.replace(/[^0-9]/g, "")
 									.slice(0, 4);
 								setAmount(digits === "" ? 0 : Number(digits));
 							}}
-							className="ml-1 w-[4ch] border-0 bg-transparent p-0 text-left text-5xl font-bold tabular-nums tracking-tight caret-primary focus:outline-none focus:ring-0"
+							className="w-[4ch] border-0 bg-transparent p-0 text-center text-5xl font-bold tabular-nums tracking-tight caret-primary placeholder:text-muted-foreground/40 focus:outline-none focus:ring-0"
 							aria-invalid={Boolean(amountValidationMessage)}
+							aria-describedby="amount-hint"
 							required
 						/>
+						<Pencil
+							className="h-4 w-4 shrink-0 text-muted-foreground"
+							aria-hidden="true"
+						/>
 					</label>
-					{amountValidationMessage ? (
-						<p className="text-xs text-destructive">
-							{amountValidationMessage}
-						</p>
-					) : null}
+					<p
+						id="amount-hint"
+						className={cn(
+							"text-xs",
+							amountValidationMessage
+								? "text-destructive"
+								: "text-muted-foreground",
+						)}
+					>
+						{amountValidationMessage ??
+							`Type any amount from $${CREDIT_TOP_UP_MIN_AMOUNT} to $${CREDIT_TOP_UP_MAX_AMOUNT.toLocaleString("en-US")}`}
+					</p>
 				</div>
 
 				{/* Preset grid */}


### PR DESCRIPTION
## Problem

In the credit top-up dialog the amount was rendered as a plain, borderless number. It looked like a read-only summary of the selected preset, so there was no signal that you can type your own amount — people just picked one of the four presets.

## Change

The amount is now presented as an actual input:

- bordered field with hover, focus-ring and invalid states
- an "Enter amount" label above it and a pencil affordance inside
- a hint under the field spelling out the accepted range (min/max come from the shared `CREDIT_TOP_UP_*` constants, so it can't drift)
- focusing selects the current value, so typing replaces it instead of appending
- the validation message now takes the place of the hint and turns the field red

No behavior change beyond that — same state, same presets, same fee calculation.

## Screenshots

| Before | After |
| --- | --- |
| <img width="500" alt="Top up dialog, light theme, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/3b8536c9221d5716045ae0fec63cef9d5432d4d1/before-light.png" /> | <img width="500" alt="Top up dialog, light theme, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/3b8536c9221d5716045ae0fec63cef9d5432d4d1/after-light.png" /> |
| <img width="500" alt="Top up dialog, dark theme, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/3b8536c9221d5716045ae0fec63cef9d5432d4d1/before-dark.png" /> | <img width="500" alt="Top up dialog, dark theme, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/3b8536c9221d5716045ae0fec63cef9d5432d4d1/after-dark.png" /> |

Invalid amount:

<img width="500" alt="Top up dialog showing the minimum-amount validation state" src="https://raw.githubusercontent.com/theopenco/llmgateway/3b8536c9221d5716045ae0fec63cef9d5432d4d1/after-invalid.png" />

## Verification

Ran the dashboard locally against seeded data: typing a custom amount updates the total and the CTA (250 → $262.50), presets still select, and an out-of-range amount shows the range error and disables checkout. `pnpm lint` and `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the credit top-up amount input with clearer labeling, enhanced focus styling, and a pencil icon.

* **Bug Fixes**
  * Added contextual guidance showing validation errors or the permitted credit range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->