### PR TITLE
fix(messages): explain OpenAI-body rejections, log them

### DIFF
--- a/apps/docs/content/features/anthropic-endpoint.mdx
+++ b/apps/docs/content/features/anthropic-endpoint.mdx
@@ -151,6 +151,8 @@ The detected markers are OpenAI-only parameters (`max_completion_tokens`, `respo
 
 A minimal `{ model, messages, max_tokens }` body is valid Anthropic and is accepted as such — it always returns an Anthropic-format response.
 
+Rejected requests are recorded in your logs with a `client_error` finish reason and zero cost, so a malformed client is visible in the activity feed rather than failing silently.
+
 ### Prompt Caching
 
 For Claude models, `cache_control` markers on `system` and message content blocks are forwarded to the provider unchanged, including the optional `ttl` (`5m` or `1h`):

--- a/apps/docs/content/features/anthropic-endpoint.mdx
+++ b/apps/docs/content/features/anthropic-endpoint.mdx
@@ -135,21 +135,21 @@ The endpoint returns responses in Anthropic's message format:
 
 ### Request Format
 
-`/v1/messages` accepts Anthropic Messages requests only. Because the two formats share `model` and `messages`, an OpenAI Chat Completions body used to pass validation: the OpenAI-only fields were silently dropped, the request was billed, and the answer came back in Anthropic's envelope, which OpenAI SDKs cannot read. The gateway now rejects such a body with a `400` before any provider is called, so nothing is charged:
+`/v1/messages` expects Anthropic Messages requests and always answers in Anthropic's format. Because the two formats share `model` and `messages`, an OpenAI Chat Completions body can reach this endpoint by accident — and since unknown parameters are ignored rather than rejected, the request succeeds and returns an Anthropic response body that OpenAI SDKs cannot read. If your client reports an empty completion here, check that it is pointed at `/v1/chat/completions`.
+
+Unknown parameters are deliberately ignored rather than rejected, so a valid Anthropic request is never denied for carrying an extra field. As a consequence, OpenAI-only parameters (`response_format`, `stream_options`, `max_completion_tokens`, `n`, `stop`, `seed`, `frequency_penalty`, and similar) have no effect here — the model will not honour them. Use `/v1/chat/completions` if you need them.
+
+A body that is _structurally_ OpenAI is rejected by the schema, as it always has been — OpenAI-shaped `tools` (`{"type": "function", "function": {…}}`), OpenAI content parts such as `image_url`, or assistant turns with `content: null`. Those rejections now name the mismatch and point at the right endpoint instead of returning an opaque validation error:
 
 ```json
 {
 	"type": "error",
 	"error": {
 		"type": "invalid_request_error",
-		"message": "This endpoint implements Anthropic's Messages API, but the request body uses OpenAI Chat Completions fields (response_format, stream_options), which have no Anthropic equivalent and would be silently dropped. Send OpenAI-format requests to /v1/chat/completions instead, or convert the body to Anthropic's Messages format."
+		"message": "This endpoint implements Anthropic's Messages API, and the request body uses OpenAI Chat Completions structures (tools[0].function) that Anthropic's format has no equivalent for. Send OpenAI-format requests to /v1/chat/completions instead, or convert the body to Anthropic's Messages format."
 	}
 }
 ```
-
-The detected markers are OpenAI-only parameters (`max_completion_tokens`, `response_format`, `stream_options`, `n`, `stop`, `seed`, `logprobs`, `frequency_penalty`, `presence_penalty`, and similar), OpenAI-shaped `tools`/`tool_choice`, OpenAI content parts such as `image_url`, and assistant turns with `content: null`. Send those requests to `/v1/chat/completions` instead.
-
-A minimal `{ model, messages, max_tokens }` body is valid Anthropic and is accepted as such — it always returns an Anthropic-format response.
 
 Rejected requests are recorded in your logs with a `client_error` finish reason and zero cost, so a malformed client is visible in the activity feed rather than failing silently.
 

--- a/apps/docs/content/features/anthropic-endpoint.mdx
+++ b/apps/docs/content/features/anthropic-endpoint.mdx
@@ -133,6 +133,24 @@ The endpoint returns responses in Anthropic's message format:
 }
 ```
 
+### Request Format
+
+`/v1/messages` accepts Anthropic Messages requests only. Because the two formats share `model` and `messages`, an OpenAI Chat Completions body used to pass validation: the OpenAI-only fields were silently dropped, the request was billed, and the answer came back in Anthropic's envelope, which OpenAI SDKs cannot read. The gateway now rejects such a body with a `400` before any provider is called, so nothing is charged:
+
+```json
+{
+	"type": "error",
+	"error": {
+		"type": "invalid_request_error",
+		"message": "This endpoint implements Anthropic's Messages API, but the request body uses OpenAI Chat Completions fields (response_format, stream_options), which have no Anthropic equivalent and would be silently dropped. Send OpenAI-format requests to /v1/chat/completions instead, or convert the body to Anthropic's Messages format."
+	}
+}
+```
+
+The detected markers are OpenAI-only parameters (`max_completion_tokens`, `response_format`, `stream_options`, `n`, `stop`, `seed`, `logprobs`, `frequency_penalty`, `presence_penalty`, and similar), OpenAI-shaped `tools`/`tool_choice`, OpenAI content parts such as `image_url`, and assistant turns with `content: null`. Send those requests to `/v1/chat/completions` instead.
+
+A minimal `{ model, messages, max_tokens }` body is valid Anthropic and is accepted as such — it always returns an Anthropic-format response.
+
 ### Prompt Caching
 
 For Claude models, `cache_control` markers on `system` and message content blocks are forwarded to the provider unchanged, including the optional `ttl` (`5m` or `1h`):

--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -59,6 +59,9 @@ function formatValidationIssues(error: z.ZodError): string {
 // ZodError }` body — a shape no Anthropic client can parse. Render every
 // validation failure in Anthropic's error envelope instead, and upgrade the
 // message when the body is recognisably an OpenAI Chat Completions request.
+//
+// This hook only runs once the schema has already rejected the request, so it
+// changes what a failure says, never whether one happens.
 export const anthropic = new OpenAPIHono<ServerTypes>({
 	defaultHook: async (result, c) => {
 		if (result.success) {
@@ -511,24 +514,12 @@ anthropic.openapi(messages, async (c) => {
 		});
 	}
 
-	// An OpenAI Chat Completions body can satisfy the Anthropic schema (the two
-	// formats share `model`/`messages`/`max_tokens`), with every OpenAI-only
-	// field silently stripped. Left alone, such a request reaches the provider,
-	// bills the completion, and comes back in an Anthropic envelope the OpenAI
-	// client cannot read — the caller pays for output they never see. Reject it
-	// here, before any provider call, and point at the endpoint that speaks
-	// their format.
-	const openAiFields = detectOpenAiChatCompletionsFields(rawRequest);
-	if (openAiFields.length > 0) {
-		const message = buildOpenAiRequestRejectionMessage(openAiFields);
-		await logAnthropicClientError(
-			c,
-			rawRequest,
-			message,
-			"openai_request_format",
-		);
-		throw new HTTPException(400, { message });
-	}
+	// Note: no OpenAI-format guard runs here. A body that reaches this point has
+	// already satisfied the Anthropic schema, and rejecting it for carrying an
+	// OpenAI-only parameter the schema stripped (`response_format`, `stop`,
+	// `n`, …) would deny requests that succeed today. Unknown parameters stay
+	// silently ignored; only structurally-OpenAI bodies are rejected, by the
+	// schema itself, and the validation hook explains those.
 
 	// Validate with our schema
 	const validation = anthropicRequestSchema.safeParse(rawRequest);

--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -14,12 +14,72 @@ import { extractAnthropicSessionId } from "@/lib/session-id.js";
 
 import { logger, toError } from "@llmgateway/logger";
 
+import {
+	buildOpenAiRequestRejectionMessage,
+	detectOpenAiChatCompletionsFields,
+} from "./openai-request-detection.js";
 import { buildAnthropicErrorEvent } from "./streaming-error-translation.js";
 import { mapAnthropicThinkingToReasoning } from "./thinking-to-reasoning.js";
 
 import type { ServerTypes } from "@/vars.js";
 
-export const anthropic = new OpenAPIHono<ServerTypes>();
+// Most of the request schema is built from unions (content blocks, tool
+// variants), and a union issue's own message is a useless "Invalid input" —
+// the actionable detail sits in its branch errors. Expand those, then dedupe
+// and cap so a body that mismatches every branch doesn't produce a wall of
+// text.
+const MAX_REPORTED_ISSUES = 12;
+
+function flattenZodIssues(issues: z.ZodIssue[], depth = 0): string[] {
+	const flattened: string[] = [];
+	for (const issue of issues) {
+		if (issue.code === "invalid_union" && depth < 3) {
+			for (const unionError of issue.unionErrors) {
+				flattened.push(...flattenZodIssues(unionError.issues, depth + 1));
+			}
+			continue;
+		}
+		flattened.push(`${issue.path.join(".")}: ${issue.message}`);
+	}
+	return flattened;
+}
+
+function formatValidationIssues(error: z.ZodError): string {
+	const unique = [...new Set(flattenZodIssues(error.issues))];
+	const reported = unique.slice(0, MAX_REPORTED_ISSUES);
+	if (unique.length > reported.length) {
+		reported.push(`… and ${unique.length - reported.length} more`);
+	}
+	return reported.join(", ");
+}
+
+// Request validation runs before the handler, so its failures never reached the
+// handler's own error formatting and leaked a raw `{ success: false, error:
+// ZodError }` body — a shape no Anthropic client can parse. Render every
+// validation failure in Anthropic's error envelope instead, and upgrade the
+// message when the body is recognisably an OpenAI Chat Completions request.
+export const anthropic = new OpenAPIHono<ServerTypes>({
+	defaultHook: async (result, c) => {
+		if (result.success) {
+			return;
+		}
+
+		let rawBody: unknown = null;
+		try {
+			rawBody = await c.req.json();
+		} catch {
+			rawBody = null;
+		}
+
+		const openAiFields = detectOpenAiChatCompletionsFields(rawBody);
+		const message =
+			openAiFields.length > 0
+				? buildOpenAiRequestRejectionMessage(openAiFields)
+				: `Invalid request format: ${formatValidationIssues(result.error)}`;
+
+		return c.json(buildAnthropicErrorBody({ message, status: 400 }), 400);
+	},
+});
 
 const anthropicMessageSchema = z.object({
 	role: z.enum([
@@ -443,11 +503,25 @@ anthropic.openapi(messages, async (c) => {
 		});
 	}
 
+	// An OpenAI Chat Completions body can satisfy the Anthropic schema (the two
+	// formats share `model`/`messages`/`max_tokens`), with every OpenAI-only
+	// field silently stripped. Left alone, such a request reaches the provider,
+	// bills the completion, and comes back in an Anthropic envelope the OpenAI
+	// client cannot read — the caller pays for output they never see. Reject it
+	// here, before any provider call, and point at the endpoint that speaks
+	// their format.
+	const openAiFields = detectOpenAiChatCompletionsFields(rawRequest);
+	if (openAiFields.length > 0) {
+		throw new HTTPException(400, {
+			message: buildOpenAiRequestRejectionMessage(openAiFields),
+		});
+	}
+
 	// Validate with our schema
 	const validation = anthropicRequestSchema.safeParse(rawRequest);
 	if (!validation.success) {
 		throw new HTTPException(400, {
-			message: `Invalid request format: ${validation.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`).join(", ")}`,
+			message: `Invalid request format: ${formatValidationIssues(validation.error)}`,
 		});
 	}
 

--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -14,6 +14,7 @@ import { extractAnthropicSessionId } from "@/lib/session-id.js";
 
 import { logger, toError } from "@llmgateway/logger";
 
+import { logAnthropicClientError } from "./client-error-log.js";
 import {
 	buildOpenAiRequestRejectionMessage,
 	detectOpenAiChatCompletionsFields,
@@ -72,10 +73,17 @@ export const anthropic = new OpenAPIHono<ServerTypes>({
 		}
 
 		const openAiFields = detectOpenAiChatCompletionsFields(rawBody);
-		const message =
-			openAiFields.length > 0
-				? buildOpenAiRequestRejectionMessage(openAiFields)
-				: `Invalid request format: ${formatValidationIssues(result.error)}`;
+		const isOpenAiBody = openAiFields.length > 0;
+		const message = isOpenAiBody
+			? buildOpenAiRequestRejectionMessage(openAiFields)
+			: `Invalid request format: ${formatValidationIssues(result.error)}`;
+
+		await logAnthropicClientError(
+			c,
+			rawBody,
+			message,
+			isOpenAiBody ? "openai_request_format" : "invalid_request_format",
+		);
 
 		return c.json(buildAnthropicErrorBody({ message, status: 400 }), 400);
 	},
@@ -512,17 +520,27 @@ anthropic.openapi(messages, async (c) => {
 	// their format.
 	const openAiFields = detectOpenAiChatCompletionsFields(rawRequest);
 	if (openAiFields.length > 0) {
-		throw new HTTPException(400, {
-			message: buildOpenAiRequestRejectionMessage(openAiFields),
-		});
+		const message = buildOpenAiRequestRejectionMessage(openAiFields);
+		await logAnthropicClientError(
+			c,
+			rawRequest,
+			message,
+			"openai_request_format",
+		);
+		throw new HTTPException(400, { message });
 	}
 
 	// Validate with our schema
 	const validation = anthropicRequestSchema.safeParse(rawRequest);
 	if (!validation.success) {
-		throw new HTTPException(400, {
-			message: `Invalid request format: ${formatValidationIssues(validation.error)}`,
-		});
+		const message = `Invalid request format: ${formatValidationIssues(validation.error)}`;
+		await logAnthropicClientError(
+			c,
+			rawRequest,
+			message,
+			"invalid_request_format",
+		);
+		throw new HTTPException(400, { message });
 	}
 
 	const anthropicRequest: AnthropicRequest = validation.data;

--- a/apps/gateway/src/anthropic/client-error-log.ts
+++ b/apps/gateway/src/anthropic/client-error-log.ts
@@ -1,0 +1,173 @@
+// `/v1/messages` rejects malformed requests before the internal
+// `/v1/chat/completions` hop, so the inner handler — which owns all log
+// writing — never sees them. Without an explicit log here the caller gets a
+// 400 and nothing in their activity feed, which is exactly the case that made
+// an OpenAI-format body look like it had silently vanished.
+//
+// Mirrors the equivalent client-error logging on the images endpoint.
+
+import { createLogEntry } from "@/chat/tools/create-log-entry.js";
+import { extractCustomHeaders } from "@/chat/tools/extract-custom-headers.js";
+import {
+	findApiKeyByToken,
+	findOrganizationById,
+	findProjectById,
+} from "@/lib/cached-queries.js";
+import { parseApiToken } from "@/lib/extract-api-token.js";
+import { calculateDataStorageCost, insertLog } from "@/lib/logs.js";
+
+import { shortid } from "@llmgateway/db";
+import { logger, toError } from "@llmgateway/logger";
+
+import type { Context } from "hono";
+
+interface AnthropicClientErrorLogContext {
+	apiKey: NonNullable<Awaited<ReturnType<typeof findApiKeyByToken>>>;
+	project: NonNullable<Awaited<ReturnType<typeof findProjectById>>>;
+	requestId: string;
+	retentionLevel: "retain" | "none";
+}
+
+async function resolveLogContext(
+	c: Context,
+): Promise<AnthropicClientErrorLogContext | null> {
+	const token = parseApiToken(c);
+	if (!token) {
+		return null;
+	}
+
+	const apiKey = await findApiKeyByToken(token);
+	if (!apiKey || apiKey.status !== "active") {
+		return null;
+	}
+
+	const project = await findProjectById(apiKey.projectId);
+	if (!project || project.status === "deleted") {
+		return null;
+	}
+
+	const organization = await findOrganizationById(project.organizationId);
+
+	const requestId = c.req.header("x-request-id")?.trim() || shortid(40);
+	c.header("x-request-id", requestId);
+
+	return {
+		apiKey,
+		project,
+		requestId,
+		retentionLevel: organization?.retentionLevel ?? "none",
+	};
+}
+
+function readString(raw: unknown, key: string): string | undefined {
+	if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+		return undefined;
+	}
+	const value = (raw as Record<string, unknown>)[key];
+	return typeof value === "string" ? value : undefined;
+}
+
+function readMessages(raw: unknown): any[] {
+	if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+		return [];
+	}
+	const messages = (raw as Record<string, unknown>).messages;
+	return Array.isArray(messages) ? messages : [];
+}
+
+/**
+ * Writes a `client_error` log row for a `/v1/messages` request rejected before
+ * it reached a provider, so the user sees it in their activity feed. Nothing is
+ * billed: every cost field is zero and no tokens are recorded.
+ *
+ * Best-effort — an unauthenticated request (no resolvable API key) has no
+ * project to attribute the log to and is skipped, and a logging failure never
+ * masks the original 400.
+ */
+export async function logAnthropicClientError(
+	c: Context,
+	rawBody: unknown,
+	message: string,
+	cause: string,
+): Promise<void> {
+	try {
+		const logContext = await resolveLogContext(c);
+		if (!logContext) {
+			return;
+		}
+
+		const requestedModel = readString(rawBody, "model") ?? "unknown";
+
+		await insertLog(
+			{
+				...createLogEntry({
+					requestId: logContext.requestId,
+					project: logContext.project,
+					apiKey: logContext.apiKey,
+					// The request never reached routing, so no provider was chosen and
+					// the requested model is the only model information available.
+					usedModel: requestedModel,
+					usedProvider: "llmgateway",
+					requestedModel,
+					messages: readMessages(rawBody),
+					source: c.req.header("x-source") ?? undefined,
+					apiOrigin: "messages",
+					customHeaders: extractCustomHeaders(c),
+					debugMode: false,
+					userAgent: c.req.header("user-agent"),
+				}),
+				duration: 0,
+				timeToFirstToken: null,
+				timeToFirstReasoningToken: null,
+				responseSize: message.length,
+				content: null,
+				reasoningContent: null,
+				finishReason: "client_error",
+				promptTokens: null,
+				completionTokens: null,
+				totalTokens: null,
+				reasoningTokens: null,
+				cachedTokens: null,
+				cacheWriteTokens: null,
+				hasError: true,
+				streamed: false,
+				canceled: false,
+				errorDetails: {
+					statusCode: 400,
+					statusText: "Bad Request",
+					responseText: message,
+					cause,
+				},
+				inputCost: 0,
+				outputCost: 0,
+				cachedInputCost: 0,
+				cacheWriteInputCost: 0,
+				requestCost: 0,
+				webSearchCost: 0,
+				contentFilterCost: null,
+				imageInputTokens: null,
+				imageOutputTokens: null,
+				imageInputCost: null,
+				imageOutputCost: null,
+				audioInputTokens: null,
+				audioInputCost: null,
+				cost: 0,
+				estimatedCost: false,
+				discount: null,
+				pricingTier: null,
+				requestedServiceTier: null,
+				usedServiceTier: null,
+				dataStorageCost: calculateDataStorageCost(null, null, null, null),
+				cached: false,
+				tools: null,
+				toolResults: null,
+				toolChoice: null,
+			},
+			{ retentionLevel: logContext.retentionLevel },
+		);
+	} catch (error) {
+		logger.warn("Messages API - failed to log client error", {
+			err: toError(error),
+		});
+	}
+}

--- a/apps/gateway/src/anthropic/openai-request-detection.spec.ts
+++ b/apps/gateway/src/anthropic/openai-request-detection.spec.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "vitest";
+
+import { detectOpenAiChatCompletionsFields } from "./openai-request-detection.js";
+
+describe("detectOpenAiChatCompletionsFields", () => {
+	test("does not flag a native Anthropic request", () => {
+		expect(
+			detectOpenAiChatCompletionsFields({
+				model: "claude-sonnet-5",
+				max_tokens: 1024,
+				system: "be concise",
+				temperature: 0.7,
+				top_p: 0.9,
+				stream: true,
+				metadata: { user_id: "u-1" },
+				thinking: { type: "enabled", budget_tokens: 2048 },
+				tool_choice: { type: "auto" },
+				messages: [
+					{ role: "user", content: "hi" },
+					{
+						role: "assistant",
+						content: [
+							{ type: "thinking", thinking: "…", signature: "sig" },
+							{ type: "text", text: "hello" },
+							{ type: "tool_use", id: "toolu_1", name: "f", input: {} },
+						],
+					},
+					{
+						role: "user",
+						content: [
+							{ type: "tool_result", tool_use_id: "toolu_1", content: "ok" },
+							{
+								type: "image",
+								source: { type: "base64", media_type: "image/png", data: "x" },
+							},
+						],
+					},
+				],
+				tools: [{ name: "f", input_schema: { type: "object" } }],
+			}),
+		).toEqual([]);
+	});
+
+	test("does not flag a body that is valid in both formats", () => {
+		// `{ model, messages, max_tokens }` is a legal Anthropic request, so it
+		// must not be rejected even though an OpenAI client could have sent it.
+		expect(
+			detectOpenAiChatCompletionsFields({
+				model: "gpt-5",
+				max_tokens: 100,
+				messages: [{ role: "user", content: "hi" }],
+			}),
+		).toEqual([]);
+	});
+
+	test("flags OpenAI-only top-level parameters", () => {
+		expect(
+			detectOpenAiChatCompletionsFields({
+				model: "gpt-5",
+				messages: [{ role: "user", content: "hi" }],
+				max_completion_tokens: 100,
+				response_format: { type: "json_object" },
+				stream_options: { include_usage: true },
+				frequency_penalty: 0.5,
+				presence_penalty: 0.5,
+				logprobs: true,
+				top_logprobs: 3,
+				logit_bias: {},
+				n: 1,
+				seed: 7,
+				stop: ["\n"],
+				store: false,
+				parallel_tool_calls: true,
+			}),
+		).toEqual([
+			"frequency_penalty",
+			"logit_bias",
+			"logprobs",
+			"max_completion_tokens",
+			"n",
+			"parallel_tool_calls",
+			"presence_penalty",
+			"response_format",
+			"seed",
+			"stop",
+			"store",
+			"stream_options",
+			"top_logprobs",
+		]);
+	});
+
+	test("flags OpenAI-shaped tools", () => {
+		expect(
+			detectOpenAiChatCompletionsFields({
+				model: "gpt-5",
+				max_tokens: 100,
+				messages: [{ role: "user", content: "hi" }],
+				tools: [
+					{ name: "anthropic_tool", input_schema: { type: "object" } },
+					{
+						type: "function",
+						function: { name: "openai_tool", parameters: { type: "object" } },
+					},
+				],
+			}),
+		).toEqual(["tools[1].function"]);
+	});
+
+	test("flags OpenAI-shaped tool_choice but not the Anthropic object form", () => {
+		expect(
+			detectOpenAiChatCompletionsFields({ tool_choice: "required" }),
+		).toEqual(["tool_choice (string form)"]);
+		expect(
+			detectOpenAiChatCompletionsFields({
+				tool_choice: { type: "function", function: { name: "f" } },
+			}),
+		).toEqual(["tool_choice.function"]);
+		expect(
+			detectOpenAiChatCompletionsFields({
+				tool_choice: { type: "tool", name: "f" },
+			}),
+		).toEqual([]);
+	});
+
+	test("flags OpenAI-only content parts and null assistant content", () => {
+		expect(
+			detectOpenAiChatCompletionsFields({
+				model: "gpt-5",
+				max_tokens: 100,
+				messages: [
+					{
+						role: "user",
+						content: [
+							{ type: "text", text: "what is this?" },
+							{ type: "image_url", image_url: { url: "https://x/y.png" } },
+						],
+					},
+					{
+						role: "assistant",
+						content: null,
+						tool_calls: [
+							{
+								id: "call_1",
+								type: "function",
+								function: { name: "f", arguments: "{}" },
+							},
+						],
+					},
+				],
+			}),
+		).toEqual([
+			'messages[0].content[].type "image_url"',
+			"messages[1].content (null)",
+		]);
+	});
+
+	test("ignores non-object bodies", () => {
+		expect(detectOpenAiChatCompletionsFields(null)).toEqual([]);
+		expect(detectOpenAiChatCompletionsFields("nope")).toEqual([]);
+		expect(detectOpenAiChatCompletionsFields([])).toEqual([]);
+	});
+});

--- a/apps/gateway/src/anthropic/openai-request-detection.spec.ts
+++ b/apps/gateway/src/anthropic/openai-request-detection.spec.ts
@@ -43,7 +43,7 @@ describe("detectOpenAiChatCompletionsFields", () => {
 
 	test("does not flag a body that is valid in both formats", () => {
 		// `{ model, messages, max_tokens }` is a legal Anthropic request, so it
-		// must not be rejected even though an OpenAI client could have sent it.
+		// must not be flagged even though an OpenAI client could have sent it.
 		expect(
 			detectOpenAiChatCompletionsFields({
 				model: "gpt-5",
@@ -53,10 +53,15 @@ describe("detectOpenAiChatCompletionsFields", () => {
 		).toEqual([]);
 	});
 
-	test("flags OpenAI-only top-level parameters", () => {
+	test("does not flag OpenAI-only parameters on an otherwise valid body", () => {
+		// These are strong evidence of an OpenAI client, but the Anthropic schema
+		// strips unknown keys, so such a body is accepted today. Flagging them
+		// would turn requests that currently succeed into 400s — a request must
+		// never be denied for carrying a stray parameter.
 		expect(
 			detectOpenAiChatCompletionsFields({
 				model: "gpt-5",
+				max_tokens: 100,
 				messages: [{ role: "user", content: "hi" }],
 				max_completion_tokens: 100,
 				response_format: { type: "json_object" },
@@ -71,25 +76,15 @@ describe("detectOpenAiChatCompletionsFields", () => {
 				stop: ["\n"],
 				store: false,
 				parallel_tool_calls: true,
+				tool_choice: "required",
+				user: "u-1",
 			}),
-		).toEqual([
-			"frequency_penalty",
-			"logit_bias",
-			"logprobs",
-			"max_completion_tokens",
-			"n",
-			"parallel_tool_calls",
-			"presence_penalty",
-			"response_format",
-			"seed",
-			"stop",
-			"store",
-			"stream_options",
-			"top_logprobs",
-		]);
+		).toEqual([]);
 	});
 
 	test("flags OpenAI-shaped tools", () => {
+		// The Anthropic tool union already rejects these; the label only
+		// explains why.
 		expect(
 			detectOpenAiChatCompletionsFields({
 				model: "gpt-5",
@@ -104,22 +99,6 @@ describe("detectOpenAiChatCompletionsFields", () => {
 				],
 			}),
 		).toEqual(["tools[1].function"]);
-	});
-
-	test("flags OpenAI-shaped tool_choice but not the Anthropic object form", () => {
-		expect(
-			detectOpenAiChatCompletionsFields({ tool_choice: "required" }),
-		).toEqual(["tool_choice (string form)"]);
-		expect(
-			detectOpenAiChatCompletionsFields({
-				tool_choice: { type: "function", function: { name: "f" } },
-			}),
-		).toEqual(["tool_choice.function"]);
-		expect(
-			detectOpenAiChatCompletionsFields({
-				tool_choice: { type: "tool", name: "f" },
-			}),
-		).toEqual([]);
 	});
 
 	test("flags OpenAI-only content parts and null assistant content", () => {

--- a/apps/gateway/src/anthropic/openai-request-detection.ts
+++ b/apps/gateway/src/anthropic/openai-request-detection.ts
@@ -1,48 +1,26 @@
 // `/v1/messages` speaks Anthropic's Messages API, but the two request formats
 // overlap enough (`model` + `messages`) that an OpenAI Chat Completions body
-// can pass Anthropic validation. When that happened the gateway forwarded the
-// request, billed the completion, and answered with an Anthropic envelope the
-// OpenAI client cannot read — the caller saw an empty response but still paid.
-// Any OpenAI-only field the Anthropic schema strips has the same effect for
-// the fields themselves: `response_format`, `stop`, `n` etc. silently vanish,
-// so the model answers a different question than the one that was asked.
+// reaches this endpoint by accident. When the body is structurally OpenAI the
+// schema rejects it anyway, but with a union error ("tools.0: Invalid input")
+// that says nothing about the real problem — so the caller retries the same
+// request instead of moving to `/v1/chat/completions`.
 //
-// These helpers detect the OpenAI shape from the raw body so the request can
-// be rejected before a provider is ever called (i.e. free), with a message
-// that points at `/v1/chat/completions`.
-
-// Top-level parameters that exist in OpenAI's Chat Completions API and have no
-// counterpart in Anthropic's Messages API. A native Anthropic client never
-// sends these, so their presence identifies the caller's format unambiguously.
+// This detects the OpenAI shape purely to *explain* an existing rejection. It
+// deliberately does NOT decide whether to reject:
 //
-// Deliberately excluded because they are shared, or because a caller could
-// plausibly mean them as gateway extensions: `top_p`, `service_tier`,
-// `metadata`, `user`, `reasoning_effort`.
-const OPENAI_ONLY_PARAMETERS = [
-	"audio",
-	"frequency_penalty",
-	"function_call",
-	"functions",
-	"logit_bias",
-	"logprobs",
-	"max_completion_tokens",
-	"modalities",
-	"n",
-	"parallel_tool_calls",
-	"prediction",
-	"presence_penalty",
-	"prompt",
-	"response_format",
-	"seed",
-	"stop",
-	"store",
-	"stream_options",
-	"top_logprobs",
-	"web_search_options",
-] as const;
+// Only structural markers are matched — shapes the Anthropic schema already
+// fails on. OpenAI-only *parameters* (`response_format`, `stop`, `n`,
+// `stream_options`, `max_completion_tokens`, a string `tool_choice`, …) are
+// NOT matched, even though they are equally strong evidence of an OpenAI
+// client. The schema strips unknown keys, so a body carrying them is accepted
+// today; matching them would turn requests that currently succeed into 400s.
+// A caller sending a fundamentally sound Anthropic request with one stray
+// OpenAI-ish field must keep working, and that outweighs diagnosing the
+// misdirected-client case more thoroughly.
 
 // Content-part discriminators from OpenAI's Chat Completions and Responses
-// APIs. Anthropic uses `image`/`document`/`text` instead.
+// APIs. Anthropic uses `image`/`document`/`text` instead, so the content-block
+// union rejects all of these.
 const OPENAI_ONLY_CONTENT_PART_TYPES = new Set([
 	"file",
 	"image_url",
@@ -58,11 +36,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Returns the OpenAI-only markers found in a raw `/v1/messages` body, as
- * human-readable labels (e.g. `response_format`, `tools[0].function`). Empty
- * when the body carries no OpenAI-specific shape — note that a minimal
- * `{ model, messages, max_tokens }` body is valid in both formats and is
- * therefore (correctly) not flagged.
+ * Returns the OpenAI-only structural markers found in a raw `/v1/messages`
+ * body, as human-readable labels (e.g. `tools[0].function`). Empty when the
+ * body carries no such marker.
+ *
+ * Every marker it reports is a shape the Anthropic request schema rejects on
+ * its own, so a non-empty result never changes whether a request is accepted —
+ * only how the rejection is explained. Callers must treat it as diagnostic and
+ * never as a rejection trigger.
  */
 export function detectOpenAiChatCompletionsFields(raw: unknown): string[] {
 	if (!isRecord(raw)) {
@@ -71,14 +52,9 @@ export function detectOpenAiChatCompletionsFields(raw: unknown): string[] {
 
 	const found: string[] = [];
 
-	for (const parameter of OPENAI_ONLY_PARAMETERS) {
-		if (raw[parameter] !== undefined) {
-			found.push(parameter);
-		}
-	}
-
 	// OpenAI wraps tool definitions in a `function` object; Anthropic puts
-	// `name`/`input_schema` at the top level of the tool.
+	// `name`/`input_schema` at the top level of the tool, so the tool union
+	// fails on this.
 	if (Array.isArray(raw.tools)) {
 		raw.tools.forEach((tool, index) => {
 			if (
@@ -89,15 +65,6 @@ export function detectOpenAiChatCompletionsFields(raw: unknown): string[] {
 				found.push(`tools[${index}].function`);
 			}
 		});
-	}
-
-	// Anthropic's `tool_choice` is always an object (`{ type: "auto" | "any" |
-	// "tool" | "none" }`); OpenAI allows the bare strings and a `function`
-	// wrapper.
-	if (typeof raw.tool_choice === "string") {
-		found.push("tool_choice (string form)");
-	} else if (isRecord(raw.tool_choice) && isRecord(raw.tool_choice.function)) {
-		found.push("tool_choice.function");
 	}
 
 	if (Array.isArray(raw.messages)) {
@@ -131,12 +98,12 @@ export function detectOpenAiChatCompletionsFields(raw: unknown): string[] {
 }
 
 /**
- * The 400 message returned for a body detected as OpenAI Chat Completions.
+ * The message used for an already-failing request whose body is recognisably
+ * OpenAI Chat Completions, in place of the raw schema error.
  */
 export function buildOpenAiRequestRejectionMessage(fields: string[]): string {
 	return (
-		`This endpoint implements Anthropic's Messages API, but the request body uses OpenAI Chat Completions fields (${fields.join(", ")}), ` +
-		`which have no Anthropic equivalent and would be silently dropped. ` +
+		`This endpoint implements Anthropic's Messages API, and the request body uses OpenAI Chat Completions structures (${fields.join(", ")}) that Anthropic's format has no equivalent for. ` +
 		`Send OpenAI-format requests to /v1/chat/completions instead, or convert the body to Anthropic's Messages format.`
 	);
 }

--- a/apps/gateway/src/anthropic/openai-request-detection.ts
+++ b/apps/gateway/src/anthropic/openai-request-detection.ts
@@ -1,0 +1,142 @@
+// `/v1/messages` speaks Anthropic's Messages API, but the two request formats
+// overlap enough (`model` + `messages`) that an OpenAI Chat Completions body
+// can pass Anthropic validation. When that happened the gateway forwarded the
+// request, billed the completion, and answered with an Anthropic envelope the
+// OpenAI client cannot read — the caller saw an empty response but still paid.
+// Any OpenAI-only field the Anthropic schema strips has the same effect for
+// the fields themselves: `response_format`, `stop`, `n` etc. silently vanish,
+// so the model answers a different question than the one that was asked.
+//
+// These helpers detect the OpenAI shape from the raw body so the request can
+// be rejected before a provider is ever called (i.e. free), with a message
+// that points at `/v1/chat/completions`.
+
+// Top-level parameters that exist in OpenAI's Chat Completions API and have no
+// counterpart in Anthropic's Messages API. A native Anthropic client never
+// sends these, so their presence identifies the caller's format unambiguously.
+//
+// Deliberately excluded because they are shared, or because a caller could
+// plausibly mean them as gateway extensions: `top_p`, `service_tier`,
+// `metadata`, `user`, `reasoning_effort`.
+const OPENAI_ONLY_PARAMETERS = [
+	"audio",
+	"frequency_penalty",
+	"function_call",
+	"functions",
+	"logit_bias",
+	"logprobs",
+	"max_completion_tokens",
+	"modalities",
+	"n",
+	"parallel_tool_calls",
+	"prediction",
+	"presence_penalty",
+	"prompt",
+	"response_format",
+	"seed",
+	"stop",
+	"store",
+	"stream_options",
+	"top_logprobs",
+	"web_search_options",
+] as const;
+
+// Content-part discriminators from OpenAI's Chat Completions and Responses
+// APIs. Anthropic uses `image`/`document`/`text` instead.
+const OPENAI_ONLY_CONTENT_PART_TYPES = new Set([
+	"file",
+	"image_url",
+	"input_audio",
+	"input_image",
+	"input_text",
+	"output_text",
+	"refusal",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Returns the OpenAI-only markers found in a raw `/v1/messages` body, as
+ * human-readable labels (e.g. `response_format`, `tools[0].function`). Empty
+ * when the body carries no OpenAI-specific shape — note that a minimal
+ * `{ model, messages, max_tokens }` body is valid in both formats and is
+ * therefore (correctly) not flagged.
+ */
+export function detectOpenAiChatCompletionsFields(raw: unknown): string[] {
+	if (!isRecord(raw)) {
+		return [];
+	}
+
+	const found: string[] = [];
+
+	for (const parameter of OPENAI_ONLY_PARAMETERS) {
+		if (raw[parameter] !== undefined) {
+			found.push(parameter);
+		}
+	}
+
+	// OpenAI wraps tool definitions in a `function` object; Anthropic puts
+	// `name`/`input_schema` at the top level of the tool.
+	if (Array.isArray(raw.tools)) {
+		raw.tools.forEach((tool, index) => {
+			if (
+				isRecord(tool) &&
+				tool.type === "function" &&
+				isRecord(tool.function)
+			) {
+				found.push(`tools[${index}].function`);
+			}
+		});
+	}
+
+	// Anthropic's `tool_choice` is always an object (`{ type: "auto" | "any" |
+	// "tool" | "none" }`); OpenAI allows the bare strings and a `function`
+	// wrapper.
+	if (typeof raw.tool_choice === "string") {
+		found.push("tool_choice (string form)");
+	} else if (isRecord(raw.tool_choice) && isRecord(raw.tool_choice.function)) {
+		found.push("tool_choice.function");
+	}
+
+	if (Array.isArray(raw.messages)) {
+		raw.messages.forEach((message, index) => {
+			if (!isRecord(message)) {
+				return;
+			}
+			// OpenAI assistant turns that only call tools carry `content: null`;
+			// Anthropic requires a string or a content-block array.
+			if (message.content === null) {
+				found.push(`messages[${index}].content (null)`);
+				return;
+			}
+			if (!Array.isArray(message.content)) {
+				return;
+			}
+			for (const part of message.content) {
+				if (
+					isRecord(part) &&
+					typeof part.type === "string" &&
+					OPENAI_ONLY_CONTENT_PART_TYPES.has(part.type)
+				) {
+					found.push(`messages[${index}].content[].type "${part.type}"`);
+					break;
+				}
+			}
+		});
+	}
+
+	return found;
+}
+
+/**
+ * The 400 message returned for a body detected as OpenAI Chat Completions.
+ */
+export function buildOpenAiRequestRejectionMessage(fields: string[]): string {
+	return (
+		`This endpoint implements Anthropic's Messages API, but the request body uses OpenAI Chat Completions fields (${fields.join(", ")}), ` +
+		`which have no Anthropic equivalent and would be silently dropped. ` +
+		`Send OpenAI-format requests to /v1/chat/completions instead, or convert the body to Anthropic's Messages format.`
+	);
+}

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -914,6 +914,25 @@ describe("api", () => {
 			expect(body.error.message).toContain("stream_options");
 			expect(body.error.message).toContain("/v1/chat/completions");
 			expect(upstreamCalls).toBe(0);
+
+			// The rejection happens before the internal /v1/chat/completions hop
+			// that owns log writing, so it must be logged here — otherwise the
+			// caller sees a 400 and nothing in their activity feed, which is the
+			// symptom that made the dropped output so hard to diagnose.
+			const logs = await waitForLogs(1);
+			// Exactly one row: the validation hook and the handler guard must not
+			// both log the same rejection.
+			expect(logs.length).toBe(1);
+			const log = logs[0];
+			expect(log.finishReason).toBe("client_error");
+			expect(log.hasError).toBe(true);
+			expect(log.errorDetails?.statusCode).toBe(400);
+			expect(log.errorDetails?.responseText).toContain("response_format");
+			expect(log.requestedModel).toBe("llmgateway/custom");
+			// A rejected request never reached a provider, so it costs nothing.
+			expect(Number(log.cost ?? 0)).toBe(0);
+			expect(log.promptTokens).toBeNull();
+			expect(log.completionTokens).toBeNull();
 		} finally {
 			fetchSpy.mockRestore();
 		}
@@ -951,6 +970,10 @@ describe("api", () => {
 		expect(body.type).toBe("error");
 		expect(body.error.type).toBe("invalid_request_error");
 		expect(body.error.message).toContain("max_tokens");
+
+		const logs = await waitForLogs(1);
+		expect(logs[0].finishReason).toBe("client_error");
+		expect(logs[0].errorDetails?.responseText).toContain("max_tokens");
 	});
 
 	test("/v1/messages rejects OpenAI-format tools with a pointer to /v1/chat/completions", async () => {

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -847,6 +847,153 @@ describe("api", () => {
 		expect(body.error.message).toContain("thinking.type.adaptive");
 	});
 
+	test("/v1/messages rejects an OpenAI-format body without calling a provider", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-test-key",
+			provider: "llmgateway",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const originalFetch = globalThis.fetch;
+		let upstreamCalls = 0;
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockImplementation(async (input, init) => {
+				const url =
+					typeof input === "string"
+						? input
+						: input instanceof URL
+							? input.toString()
+							: input.url;
+
+				if (url.startsWith(mockServerUrl)) {
+					upstreamCalls++;
+				}
+
+				return await originalFetch(input as any, init);
+			});
+
+		try {
+			// `response_format`/`stream_options` have no Anthropic equivalent, so the
+			// schema stripped them and the request was forwarded, billed, and
+			// answered in Anthropic's envelope — which the OpenAI client that sent
+			// this body cannot read. It must be rejected before any provider call.
+			const res = await app.request("/v1/messages", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer real-token`,
+				},
+				body: JSON.stringify({
+					model: "llmgateway/custom",
+					max_tokens: 100,
+					messages: [{ role: "user", content: "Hello!" }],
+					response_format: { type: "json_object" },
+					stream_options: { include_usage: true },
+				}),
+			});
+
+			expect(res.status).toBe(400);
+			const body = (await res.json()) as {
+				type: string;
+				error: { type: string; message: string };
+			};
+			expect(body.type).toBe("error");
+			expect(body.error.type).toBe("invalid_request_error");
+			expect(body.error.message).toContain("response_format");
+			expect(body.error.message).toContain("stream_options");
+			expect(body.error.message).toContain("/v1/chat/completions");
+			expect(upstreamCalls).toBe(0);
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
+	test("/v1/messages renders schema validation failures as Anthropic errors", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		// Anthropic requires `max_tokens`. Validation runs before the handler, so
+		// this used to leak a raw `{ success: false, error: ZodError }` body that
+		// no Anthropic client can parse.
+		const res = await app.request("/v1/messages", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer real-token`,
+			},
+			body: JSON.stringify({
+				model: "llmgateway/custom",
+				messages: [{ role: "user", content: "Hello!" }],
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as {
+			type: string;
+			error: { type: string; message: string };
+		};
+		expect(body.type).toBe("error");
+		expect(body.error.type).toBe("invalid_request_error");
+		expect(body.error.message).toContain("max_tokens");
+	});
+
+	test("/v1/messages rejects OpenAI-format tools with a pointer to /v1/chat/completions", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		const res = await app.request("/v1/messages", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer real-token`,
+			},
+			body: JSON.stringify({
+				model: "llmgateway/custom",
+				max_tokens: 100,
+				messages: [{ role: "user", content: "Hello!" }],
+				tools: [
+					{
+						type: "function",
+						function: {
+							name: "get_weather",
+							parameters: { type: "object", properties: {} },
+						},
+					},
+				],
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as {
+			type: string;
+			error: { type: string; message: string };
+		};
+		expect(body.type).toBe("error");
+		expect(body.error.message).toContain("tools[0].function");
+		expect(body.error.message).toContain("/v1/chat/completions");
+	});
+
 	test("/v1/chat/completions blocks providers failing the compliance policy", async () => {
 		// OpenAI's dataPolicy has promptLogging: true, so blockPromptLogging removes
 		// it. gpt-4o's only other (azure) mapping is deactivated, leaving no provider.

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -847,7 +847,7 @@ describe("api", () => {
 		expect(body.error.message).toContain("thinking.type.adaptive");
 	});
 
-	test("/v1/messages rejects an OpenAI-format body without calling a provider", async () => {
+	test("/v1/messages still accepts a valid body carrying OpenAI-only parameters", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id",
 			token: "real-token",
@@ -864,78 +864,37 @@ describe("api", () => {
 			baseUrl: mockServerUrl,
 		});
 
-		const originalFetch = globalThis.fetch;
-		let upstreamCalls = 0;
-		const fetchSpy = vi
-			.spyOn(globalThis, "fetch")
-			.mockImplementation(async (input, init) => {
-				const url =
-					typeof input === "string"
-						? input
-						: input instanceof URL
-							? input.toString()
-							: input.url;
+		// The messages endpoint must never deny a request that is otherwise a
+		// sound Anthropic body just because it carries a stray OpenAI-only
+		// parameter: the schema strips unknown keys, so these all succeed today
+		// and a caller relying on that must not start seeing 400s. Diagnosing a
+		// misdirected OpenAI client is not worth breaking them.
+		const res = await app.request("/v1/messages", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer real-token`,
+			},
+			body: JSON.stringify({
+				model: "llmgateway/custom",
+				max_tokens: 100,
+				messages: [{ role: "user", content: "Hello!" }],
+				response_format: { type: "json_object" },
+				stream_options: { include_usage: true },
+				max_completion_tokens: 100,
+				frequency_penalty: 0.5,
+				presence_penalty: 0.5,
+				tool_choice: "auto",
+				seed: 7,
+				stop: ["\n"],
+				n: 1,
+			}),
+		});
 
-				if (url.startsWith(mockServerUrl)) {
-					upstreamCalls++;
-				}
-
-				return await originalFetch(input as any, init);
-			});
-
-		try {
-			// `response_format`/`stream_options` have no Anthropic equivalent, so the
-			// schema stripped them and the request was forwarded, billed, and
-			// answered in Anthropic's envelope — which the OpenAI client that sent
-			// this body cannot read. It must be rejected before any provider call.
-			const res = await app.request("/v1/messages", {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-					Authorization: `Bearer real-token`,
-				},
-				body: JSON.stringify({
-					model: "llmgateway/custom",
-					max_tokens: 100,
-					messages: [{ role: "user", content: "Hello!" }],
-					response_format: { type: "json_object" },
-					stream_options: { include_usage: true },
-				}),
-			});
-
-			expect(res.status).toBe(400);
-			const body = (await res.json()) as {
-				type: string;
-				error: { type: string; message: string };
-			};
-			expect(body.type).toBe("error");
-			expect(body.error.type).toBe("invalid_request_error");
-			expect(body.error.message).toContain("response_format");
-			expect(body.error.message).toContain("stream_options");
-			expect(body.error.message).toContain("/v1/chat/completions");
-			expect(upstreamCalls).toBe(0);
-
-			// The rejection happens before the internal /v1/chat/completions hop
-			// that owns log writing, so it must be logged here — otherwise the
-			// caller sees a 400 and nothing in their activity feed, which is the
-			// symptom that made the dropped output so hard to diagnose.
-			const logs = await waitForLogs(1);
-			// Exactly one row: the validation hook and the handler guard must not
-			// both log the same rejection.
-			expect(logs.length).toBe(1);
-			const log = logs[0];
-			expect(log.finishReason).toBe("client_error");
-			expect(log.hasError).toBe(true);
-			expect(log.errorDetails?.statusCode).toBe(400);
-			expect(log.errorDetails?.responseText).toContain("response_format");
-			expect(log.requestedModel).toBe("llmgateway/custom");
-			// A rejected request never reached a provider, so it costs nothing.
-			expect(Number(log.cost ?? 0)).toBe(0);
-			expect(log.promptTokens).toBeNull();
-			expect(log.completionTokens).toBeNull();
-		} finally {
-			fetchSpy.mockRestore();
-		}
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { type: string; content: any[] };
+		expect(body.type).toBe("message");
+		expect(body.content[0].type).toBe("text");
 	});
 
 	test("/v1/messages renders schema validation failures as Anthropic errors", async () => {
@@ -976,7 +935,7 @@ describe("api", () => {
 		expect(logs[0].errorDetails?.responseText).toContain("max_tokens");
 	});
 
-	test("/v1/messages rejects OpenAI-format tools with a pointer to /v1/chat/completions", async () => {
+	test("/v1/messages explains an OpenAI-format tools rejection", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id",
 			token: "real-token",
@@ -985,6 +944,9 @@ describe("api", () => {
 			createdBy: "user-id",
 		});
 
+		// OpenAI-shaped tools already failed the Anthropic tool union before this
+		// change — the 400 is unchanged, only the message is, from an opaque
+		// "tools.0: Invalid input" to something that names the actual mismatch.
 		const res = await app.request("/v1/messages", {
 			method: "POST",
 			headers: {
@@ -1015,6 +977,22 @@ describe("api", () => {
 		expect(body.type).toBe("error");
 		expect(body.error.message).toContain("tools[0].function");
 		expect(body.error.message).toContain("/v1/chat/completions");
+
+		// The rejection happens before the internal /v1/chat/completions hop that
+		// owns log writing, so it must be logged here — otherwise the caller sees
+		// a 400 and nothing in their activity feed.
+		const logs = await waitForLogs(1);
+		expect(logs.length).toBe(1);
+		const log = logs[0];
+		expect(log.finishReason).toBe("client_error");
+		expect(log.hasError).toBe(true);
+		expect(log.errorDetails?.statusCode).toBe(400);
+		expect(log.errorDetails?.responseText).toContain("tools[0].function");
+		expect(log.requestedModel).toBe("llmgateway/custom");
+		// A rejected request never reached a provider, so it costs nothing.
+		expect(Number(log.cost ?? 0)).toBe(0);
+		expect(log.promptTokens).toBeNull();
+		expect(log.completionTokens).toBeNull();
 	});
 
 	test("/v1/chat/completions blocks providers failing the compliance policy", async () => {


### PR DESCRIPTION
## Problem

Sending an OpenAI Chat Completions body to `/v1/messages` produces no usable output. The two formats overlap on `model`, `messages` and `max_tokens`, so such a body validates, gets forwarded, is billed, and comes back in Anthropic's `{ id, type, role, content[] }` envelope — which the OpenAI SDK that sent it cannot read. The caller sees an empty completion and pays for it.

Two things made this hard to diagnose:

- Nothing appeared in the caller's logs when a request *was* rejected, because rejection happens before the internal `/v1/chat/completions` hop that owns all log writing.
- Structurally-OpenAI bodies were rejected with an opaque `tools.0: Invalid input`, and in a `{"success":false,"error":{…ZodError}}` envelope no Anthropic client can parse — request validation runs *before* the handler, so the handler's own error formatting was dead code for schema failures.

## What this does

**Explains rejections instead of causing them.** A body that is *structurally* OpenAI — OpenAI-shaped `tools` (`{type:"function", function:{…}}`), OpenAI content parts (`image_url`, `input_text`, …), or assistant turns with `content: null` — was already rejected by the Anthropic schema. Those rejections now name the mismatch and point at `/v1/chat/completions`:

```json
{
  "type": "error",
  "error": {
    "type": "invalid_request_error",
    "message": "This endpoint implements Anthropic's Messages API, and the request body uses OpenAI Chat Completions structures (tools[0].function) that Anthropic's format has no equivalent for. Send OpenAI-format requests to /v1/chat/completions instead, or convert the body to Anthropic's Messages format."
  }
}
```

**No request that succeeds today can start failing.** An earlier revision of this PR also rejected OpenAI-only *parameters* (`response_format`, `stream_options`, `max_completion_tokens`, `n`, `stop`, `seed`, a string `tool_choice`, …). That was dropped: the schema strips unknown keys, so a fundamentally sound Anthropic request carrying one stray field is accepted today, and denying it would break a working integration. Silently ignoring a parameter is recoverable; a denial is not. The handler-side guard is gone entirely — it was the only path that could newly reject, since it ran *after* the schema had already passed. Detection now lives only in the validation hook, where it can only rephrase a failure the schema already decided on.

A test pins this: a valid Anthropic body loaded with `response_format`, `stream_options`, `max_completion_tokens`, `tool_choice: "auto"`, `stop`, `seed`, `n` and `frequency_penalty` must return **200**.

**Rejected requests are logged.** Both the OpenAI-structure case and ordinary schema failures now write a `client_error` row, tagged in `errorDetails.cause` as `openai_request_format` or `invalid_request_format`. `client-error-log.ts` mirrors the existing client-error logging on the images endpoint: resolve API key → project → org from the token, best-effort (an unauthenticated request has no project to attribute to and is skipped; a logging failure never masks the 400).

Nothing is billed. `client_error` is a billable failure class (`costs.ts` — a malformed request that consumed upstream inference must not become a free-inference path), but that bills from recorded tokens, and these rows carry null token counts with every cost field at zero since no provider was ever called. Asserted in the test.

**Anthropic error envelope for all validation failures**, via a `defaultHook`, with union issues expanded (deduped, capped at 12) so `tools.0: Invalid input` becomes the actual mismatch.

## Verification

Reproduced against a local stack with a mocked upstream, asserting upstream call counts.

- Detector unit spec (6 cases), including a full native-Anthropic body and an OpenAI-parameter-laden body that must both come back clean
- Integration tests in `api.spec.ts`: the 200 guarantee above; the tools rejection asserting `finishReason: client_error`, `cost === 0`, and exactly one log row
- `apps/gateway/src/api.spec.ts`, `anthropic/`, `fallback.spec.ts`, `stealth-error-redaction.spec.ts`, `iam-endpoints.spec.ts` — 269 passed, 2 skipped
- `pnpm format` and `pnpm build` (17/17) clean

## Known limitation

The original symptom is documented, not prevented. A bare `{ model, messages, max_tokens }` OpenAI request is indistinguishable from a valid Anthropic one, and a body with OpenAI-only parameters is deliberately accepted — both still return an Anthropic-format response. The docs now tell callers seeing an empty completion to check they are pointed at `/v1/chat/completions`.

Separately, `stop_sequences`, `top_k` and `tool_choice` are silently dropped on this endpoint (`stop`/`stop_sequences` are unsupported on `/v1/chat/completions` too) — same silent-drop family, but a distinct change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)