### PR TITLE
docs(legal): add company info to terms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,10 @@ When you are done writing code features or bug fixes, ALWAYS commit your changes
 - NEVER hardcode a list of models, providers, provider countries/headquarters, or any other catalogue-derived enumeration into documentation (`apps/docs`), changelog entries, or marketing copy. These lists go stale the moment the catalogue changes and are annoying to keep in sync. Instead, link to the relevant live page that is generated from the catalogue (e.g. the [models page](https://llmgateway.io/models) or [providers page](https://llmgateway.io/providers)).
 - The ONLY exception is video generation and image generation models: their per-model requirements (supported sizes, durations, resolutions, etc.) are how users figure out how to call them, so listing those specific models and their constraints in the docs is acceptable and preferred there.
 
+### Legal pages
+
+- The Terms of Use and Privacy Policy are not single documents: the base versions live in `apps/ui/src/content/legal/` and each product layers **supplemental terms and policies** on top — most importantly DevPass, at `apps/code/src/app/legal/terms/page.tsx` and `apps/code/src/app/legal/privacy/page.tsx`. When changing anything in a legal page, ALWAYS check the supplemental documents for the same change and apply it consistently; a fact stated only in the base terms (company details, contact address, retention behaviour, plan rules) leaves the DevPass version stale and contradictory. Grep all of `apps/*/src/**/legal` before concluding a legal edit is complete.
+
 ### Testing
 
 NOTE: these commands can only be run in the root directory of the repository, not in individual app directories.

--- a/apps/code/src/app/legal/terms/page.tsx
+++ b/apps/code/src/app/legal/terms/page.tsx
@@ -21,9 +21,10 @@ export default function TermsPage() {
 			<p>
 				<strong>DevPass</strong> is a service operated by{" "}
 				<strong>LLM Gateway</strong> (&ldquo;we&rdquo;, &ldquo;our&rdquo;, or
-				&ldquo;us&rdquo;). These DevPass Supplemental Terms of Use
-				(&ldquo;DevPass Terms&rdquo;) govern your access to and use of DevPass,
-				including the website at{" "}
+				&ldquo;us&rdquo;), a service of <strong>Polar Lights LLC</strong>, 16192
+				Coastal Highway, Lewes, DE 19958, United States. These DevPass
+				Supplemental Terms of Use (&ldquo;DevPass Terms&rdquo;) govern your
+				access to and use of DevPass, including the website at{" "}
 				<a href="https://devpass.llmgateway.io">devpass.llmgateway.io</a>, the
 				DevPass dashboard, related APIs, SDKs, and any DevPass-branded products
 				or services (collectively, the &ldquo;Service&rdquo;).
@@ -272,6 +273,20 @@ export default function TermsPage() {
 			<p>
 				Questions about these DevPass Terms or the Base Terms? Email{" "}
 				<a href="mailto:contact@llmgateway.io">contact@llmgateway.io</a>.
+			</p>
+			<p>
+				<strong>LLM Gateway</strong>
+				<br />
+				on behalf of
+			</p>
+			<p>
+				<strong>Polar Lights LLC</strong>
+				<br />
+				16192 Coastal Highway
+				<br />
+				Lewes, DE 19958
+				<br />
+				United States
 			</p>
 			<p>© 2026 LLM Gateway. All rights reserved.</p>
 		</>

--- a/apps/code/src/app/legal/terms/page.tsx
+++ b/apps/code/src/app/legal/terms/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 
+import { LegalSummary } from "@/components/LegalSummary";
+
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -18,6 +20,7 @@ export default function TermsPage() {
 				<br />
 				<strong>Last Updated:</strong> August 2, 2026
 			</p>
+			<LegalSummary />
 			<p>
 				<strong>DevPass</strong> is a service operated by{" "}
 				<strong>LLM Gateway</strong> (&ldquo;we&rdquo;, &ldquo;our&rdquo;, or

--- a/apps/code/src/components/LegalSummary.tsx
+++ b/apps/code/src/components/LegalSummary.tsx
@@ -1,0 +1,129 @@
+import {
+	Ban,
+	DatabaseZap,
+	Info,
+	Terminal,
+	UserRound,
+	Wallet,
+} from "lucide-react";
+
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface SummaryCard {
+	icon: LucideIcon;
+	title: string;
+	body: ReactNode;
+}
+
+const termsCards: SummaryCard[] = [
+	{
+		icon: Info,
+		title: "An addendum to the main terms",
+		body: (
+			<>
+				These DevPass terms add to the LLM Gateway Terms of Use, which still
+				govern everything not covered here — eligibility, accounts, liability
+				and dispute resolution.
+			</>
+		),
+	},
+	{
+		icon: Wallet,
+		title: "Flat monthly subscription",
+		body: (
+			<>
+				Lite, Pro and Max each include a monthly usage allowance measured in
+				provider cost. Allowances reset every cycle and don&rsquo;t roll over,
+				except when you upgrade mid-cycle.
+			</>
+		),
+	},
+	{
+		icon: Terminal,
+		title: "For approved coding tools only",
+		body: (
+			<>
+				Your key works from whitelisted tools like Claude Code, Codex, Cursor
+				and Cline — not from your own apps, backends or scripts. Embeddings,
+				image and video generation aren&rsquo;t included.
+			</>
+		),
+	},
+	{
+		icon: UserRound,
+		title: "One account per developer",
+		body: (
+			<>
+				DevPass is for private, individual use — no teams, multi-seat or company
+				accounts. Extra accounts or reused payment cards get cancelled without
+				notice.
+			</>
+		),
+	},
+	{
+		icon: DatabaseZap,
+		title: "Metadata only, no payloads",
+		body: (
+			<>
+				We store per-agent metadata — tokens, cost, model and routing — to power
+				your dashboard. Requests and responses aren&rsquo;t retained, except
+				stateful Responses API requests, kept up to 30 days.
+			</>
+		),
+	},
+	{
+		icon: Ban,
+		title: "Fair use",
+		body: (
+			<>
+				Abuse, fraud, key sharing or bad-faith payment disputes can get every
+				related account banned immediately, with no refund for the cycle in
+				progress.
+			</>
+		),
+	},
+];
+
+export function LegalSummary() {
+	return (
+		<section className="my-10">
+			<div className="mb-6">
+				<h2 className="text-xl font-semibold tracking-tight text-foreground mb-2">
+					DevPass terms in plain English
+				</h2>
+				<p className="text-sm text-muted-foreground">
+					A human-readable summary of the key points. This overview is for
+					convenience only and is{" "}
+					<span className="text-foreground font-medium">
+						not legally binding
+					</span>{" "}
+					— the full text below is what governs.
+				</p>
+			</div>
+			<div className="grid gap-4 sm:grid-cols-2">
+				{termsCards.map((card) => {
+					const Icon = card.icon;
+					return (
+						<div
+							key={card.title}
+							className="flex gap-3 rounded-xl border bg-card p-5"
+						>
+							<div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+								<Icon className="h-5 w-5" />
+							</div>
+							<div className="space-y-1">
+								<div className="font-semibold leading-snug text-foreground">
+									{card.title}
+								</div>
+								<p className="text-sm leading-6 text-muted-foreground">
+									{card.body}
+								</p>
+							</div>
+						</div>
+					);
+				})}
+			</div>
+		</section>
+	);
+}

--- a/apps/ui/src/content/legal/terms.md
+++ b/apps/ui/src/content/legal/terms.md
@@ -11,7 +11,7 @@ description: "Review the Terms of Use for LLM Gateway. Learn about account eligi
 **Effective Date:** June 11, 2026  
 **Last Updated:** June 11, 2026
 
-Welcome to **LLM Gateway** (“we”, “our”, or “us”). These Terms of Use (“Terms”) form a binding legal agreement between you (“you” or “Customer”) and LLM Gateway and govern your access to and use of the LLM Gateway platform, including our website **[llmgateway.io](https://llmgateway.io)**, APIs, SDKs, dashboards, and any related products or services (collectively, the “Service”).
+Welcome to **LLM Gateway** (“we”, “our”, or “us”), operated by **Polar Lights LLC**, 16192 Coastal Highway, Lewes, DE 19958, United States. These Terms of Use (“Terms”) form a binding legal agreement between you (“you” or “Customer”) and LLM Gateway and govern your access to and use of the LLM Gateway platform, including our website **[llmgateway.io](https://llmgateway.io)**, APIs, SDKs, dashboards, and any related products or services (collectively, the “Service”).
 
 **By clicking “I agree,” creating an account, or accessing or using the Service, you acknowledge that you have read, understood, and agree to be bound by these Terms and by our [Privacy Policy](https://llmgateway.io/privacy), which is incorporated by reference. If you do not agree, do not access or use the Service.**
 
@@ -259,6 +259,14 @@ We may update or modify these Terms at any time. The latest version will always 
 If you have questions about these Terms, contact us at:  
 📧 **[contact@llmgateway.io](mailto:contact@llmgateway.io)**  
 🌐 **[llmgateway.io](https://llmgateway.io)**
+
+**LLM Gateway**  
+on behalf of
+
+**Polar Lights LLC**  
+16192 Coastal Highway  
+Lewes, DE 19958  
+United States
 
 ---
 


### PR DESCRIPTION
## Problem

Neither the LLM Gateway Terms of Use nor the DevPass supplemental terms named the legal entity behind the service or its registered address, so the agreements did not identify the contracting party. The DevPass terms also had no at-a-glance summary, unlike the main terms page.

## Approach

Company details, in both documents:

- Name the operating company and its registered address in the opening paragraph, where the counterparty is first introduced.
- Add the full company block to the contact section at the end.

DevPass summary cards:

- New `LegalSummary` component in `apps/code`, mirroring the "in plain English" card grid the main terms page already renders, with six DevPass-specific points: addendum status, flat subscription and allowances, approved-tools-only usage, one account per developer, metadata-only retention, and fair use. It carries the same "not legally binding — the full text below is what governs" disclaimer.
- Built with plain `div`s rather than the `Card` primitive, since `apps/code` has no card component and styles cards inline elsewhere.

Files:

- `apps/ui/src/content/legal/terms.md` — base Terms of Use, rendered at `/terms` via the `/legal/[slug]` route.
- `apps/code/src/app/legal/terms/page.tsx` and `apps/code/src/components/LegalSummary.tsx` — DevPass supplemental terms.

Also adds a "Legal pages" rule to `AGENTS.md`: legal documents are layered (base terms plus per-product supplements, DevPass in particular), so any change to a legal page has to be checked against the supplemental terms and policies before it is considered done. This change is exactly the case that motivates it — the base terms alone would have left the DevPass version stale.

The effective/last-updated dates are deliberately unchanged: identifying the operator is not a substantive revision of the terms, and bumping the dates would signal to users that the agreement had changed.

## Screenshots

DevPass terms page, light and dark:

<img width="1280" alt="DevPass supplemental terms with summary cards, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/cd791d1089e275f7c40f23c882130ddd74489baa/devpass-terms-light.png" />

<img width="1280" alt="DevPass supplemental terms with summary cards, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/cd791d1089e275f7c40f23c882130ddd74489baa/devpass-terms-dark.png" />

The base terms change is markdown prose only, so its rendering is unchanged apart from the added text.

## Verification

`pnpm format` and `pnpm build` both pass; the DevPass page was rendered locally in both themes for the screenshots above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a plain-English overview of DevPass terms, including subscription allowances, approved tools, account limits, metadata retention, and fair-use enforcement.
  * Improved the terms page with responsive summary cards and clearer business identification for DevPass and LLM Gateway.

* **Documentation**
  * Updated legal terms with Polar Lights LLC’s operator details and mailing address.
  * Documented the requirement to keep base legal documents and product-specific supplemental terms aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->