### PR TITLE
fix(code): break down usage tokens and cost by class

### DIFF
--- a/apps/code/src/app/dashboard/components/AgentModelUsageChart.tsx
+++ b/apps/code/src/app/dashboard/components/AgentModelUsageChart.tsx
@@ -75,6 +75,14 @@ interface ChartRow {
 	totalRequests: number;
 	totalCost: number;
 	totalTokens: number;
+	inputTokens: number;
+	cachedTokens: number;
+	cacheWriteTokens: number;
+	outputTokens: number;
+	inputCost: number;
+	cachedInputCost: number;
+	cacheWriteInputCost: number;
+	outputCost: number;
 	[key: string]: string | number;
 }
 
@@ -107,8 +115,33 @@ function ChartTooltipContent({
 	const dateLabel = label
 		? format(parseISO(label), hourly ? "MMM d, HH:mm" : "MMM d, yyyy")
 		: "";
+	// Token classes bill at very different rates (cached input is often 10x
+	// cheaper than fresh input, output 6x more expensive), so a flat token
+	// total makes cost look uncorrelated with usage. Break both down per class.
+	const tokenBreakdown = [
+		{
+			label: "Input",
+			tokens: first.inputTokens,
+			cost: first.inputCost,
+		},
+		{
+			label: "Cached input",
+			tokens: first.cachedTokens,
+			cost: first.cachedInputCost,
+		},
+		{
+			label: "Cache writes",
+			tokens: first.cacheWriteTokens,
+			cost: first.cacheWriteInputCost,
+		},
+		{
+			label: "Output",
+			tokens: first.outputTokens,
+			cost: first.outputCost,
+		},
+	].filter((row) => row.tokens > 0 || row.cost > 0);
 	return (
-		<div className="rounded-lg border border-border/60 bg-popover p-2.5 text-xs text-popover-foreground shadow-md">
+		<div className="min-w-[210px] rounded-lg border border-border/60 bg-popover p-2.5 text-xs text-popover-foreground shadow-md">
 			<div className="font-medium">{dateLabel}</div>
 			<div className="mt-1 space-y-0.5 text-[11px] text-muted-foreground">
 				<div>
@@ -130,6 +163,24 @@ function ChartTooltipContent({
 					cost
 				</div>
 			</div>
+			{tokenBreakdown.length > 0 ? (
+				<div className="mt-2 space-y-0.5 border-t border-border/40 pt-2">
+					{tokenBreakdown.map((row) => (
+						<div
+							key={row.label}
+							className="flex items-center gap-3 text-[11px]"
+						>
+							<span className="text-muted-foreground">{row.label}</span>
+							<span className="ml-auto tabular-nums text-muted-foreground">
+								{formatTokens(row.tokens)}
+							</span>
+							<span className="w-16 text-right tabular-nums text-foreground">
+								${row.cost.toFixed(4)}
+							</span>
+						</div>
+					))}
+				</div>
+			) : null}
 			<div className="mt-2 space-y-0.5 border-t border-border/40 pt-2">
 				{typed
 					.filter((p) => typeof p.value === "number" && (p.value as number) > 0)
@@ -208,6 +259,20 @@ export function AgentModelUsageChart({ projectId }: AgentModelUsageChartProps) {
 				totalRequests: row.requestCount,
 				totalCost: row.cost,
 				totalTokens: row.totalTokens,
+				// The rollup's inputTokens is the full prompt count including cache
+				// reads/writes; subtract them so "Input" is only what was billed at
+				// the full input rate.
+				inputTokens: Math.max(
+					0,
+					row.inputTokens - row.cachedTokens - row.cacheWriteTokens,
+				),
+				cachedTokens: row.cachedTokens,
+				cacheWriteTokens: row.cacheWriteTokens,
+				outputTokens: row.outputTokens,
+				inputCost: row.inputCost,
+				cachedInputCost: row.cachedInputCost,
+				cacheWriteInputCost: row.cacheWriteInputCost,
+				outputCost: row.outputCost,
 				models: perModel,
 			};
 		});
@@ -228,6 +293,14 @@ export function AgentModelUsageChart({ projectId }: AgentModelUsageChartProps) {
 					totalRequests: row.totalRequests,
 					totalCost: row.totalCost,
 					totalTokens: row.totalTokens,
+					inputTokens: row.inputTokens,
+					cachedTokens: row.cachedTokens,
+					cacheWriteTokens: row.cacheWriteTokens,
+					outputTokens: row.outputTokens,
+					inputCost: row.inputCost,
+					cachedInputCost: row.cachedInputCost,
+					cacheWriteInputCost: row.cacheWriteInputCost,
+					outputCost: row.outputCost,
 				};
 				for (const modelId of models) {
 					const m = row.models[modelId];

--- a/apps/code/src/app/dashboard/components/UsageOverview.tsx
+++ b/apps/code/src/app/dashboard/components/UsageOverview.tsx
@@ -270,6 +270,14 @@ export default function UsageOverview({
 		(sum, d) => sum + (d.totalTokens ?? 0),
 		0,
 	);
+	const totalCachedTokens = cycleItems.reduce(
+		(sum, d) => sum + (d.cachedTokens ?? 0),
+		0,
+	);
+	// Cached input bills at a fraction of the fresh-input rate, so the cached
+	// share is what reconciles a big token number with a small spend.
+	const cachedShare =
+		totalTokens > 0 ? Math.round((totalCachedTokens / totalTokens) * 100) : 0;
 	const peakDay = cycleItems.reduce<ActivityItem | null>(
 		(best, d) => (best && (best.cost ?? 0) >= (d.cost ?? 0) ? best : d),
 		null,
@@ -423,6 +431,11 @@ export default function UsageOverview({
 							: totalTokens >= 1_000
 								? `${(totalTokens / 1_000).toFixed(0)}K`
 								: totalTokens.toLocaleString()
+					}
+					hint={
+						cachedShare > 0
+							? `${cachedShare}% served from cache at a reduced rate`
+							: undefined
 					}
 					icon={Cpu}
 				/>

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1911,8 +1911,17 @@ async function seed() {
 		const streamedCount = Math.floor(baseRequests * randomFloat(0.6, 0.95));
 		const inputTokens = baseRequests * randomInt(900, 6000);
 		const outputTokens = baseRequests * randomInt(200, 2200);
-		const costPerReq = randomFloat(0.02, 0.18);
-		const totalCost = baseRequests * costPerReq;
+		// Vary the cache-hit share widely so the usage chart's token/cost
+		// breakdown shows hours where a big token total is cheap (mostly cached)
+		// next to hours where a smaller total is expensive (fresh input + output).
+		const hourCachedTokens = Math.floor(inputTokens * randomFloat(0.05, 0.85));
+		// Derive costs from the token mix at plausible per-token rates so the
+		// per-class costs and the total reconcile ($3/M fresh input, $0.30/M
+		// cached input, $15/M output).
+		const hourInputCost = (inputTokens - hourCachedTokens) * 3e-6;
+		const hourCachedInputCost = hourCachedTokens * 0.3e-6;
+		const hourOutputCost = outputTokens * 15e-6;
+		const totalCost = hourInputCost + hourCachedInputCost + hourOutputCost;
 		devpassHourlyStats.push({
 			id: `devpass-phs-${h}`,
 			projectId: "test-personal-project-id",
@@ -1935,16 +1944,16 @@ async function seed() {
 			outputTokens: String(outputTokens),
 			totalTokens: String(inputTokens + outputTokens),
 			reasoningTokens: "0",
-			cachedTokens: String(Math.floor(inputTokens * 0.15)),
+			cachedTokens: String(hourCachedTokens),
 			cost: Number(totalCost.toFixed(4)),
-			inputCost: Number((totalCost * 0.55).toFixed(4)),
-			outputCost: Number((totalCost * 0.4).toFixed(4)),
-			requestCost: Number((totalCost * 0.05).toFixed(4)),
+			inputCost: Number(hourInputCost.toFixed(4)),
+			outputCost: Number(hourOutputCost.toFixed(4)),
+			requestCost: 0,
 			dataStorageCost: 0,
 			discountSavings: 0,
 			imageInputCost: 0,
 			imageOutputCost: 0,
-			cachedInputCost: 0,
+			cachedInputCost: Number(hourCachedInputCost.toFixed(4)),
 			creditsRequestCount: baseRequests,
 			apiKeysRequestCount: 0,
 			creditsCost: Number(totalCost.toFixed(4)),


### PR DESCRIPTION
## Problem

A customer organization asked why two adjacent hours on the DevPass usage chart with the same request count looked inverted: the hour with the **larger** token total showed a much **smaller** cost. Investigation confirmed billing is correct — the token *mix* differed. Cached input bills at ~10% of the fresh-input rate while output tokens bill at several times it (e.g. $0.50/M cached vs $5/M input vs $30/M output on current frontier models), so an hour dominated by cache reads is legitimately far cheaper than a smaller hour of fresh input + output. The dashboard just never showed that: the tooltip reported one flat token total next to the cost, making correct billing look wrong.

## Changes

- **Usage chart tooltip** (`AgentModelUsageChart`): below the existing requests/tokens/cost summary, add a per-class breakdown — fresh input, cached input, cache writes (when present), and output — each with its token count **and** its cost, so the cost composition is visible at a glance. Classes with no usage are omitted.
- **Tokens metric card** (`UsageOverview`): add a hint with the share of cycle tokens served from cache at the reduced rate.
- **Seed** (`packages/db`): the DevPass demo project's hourly stats now derive costs from the token mix (with a widely varying cache-hit share) instead of flat percentages of a random total, so the new breakdown reconciles locally; `cachedInputCost` was previously seeded as 0 despite nonzero cached tokens.

No API changes — `/activity` already returned `inputTokens` / `outputTokens` / `cachedTokens` / `cacheWriteTokens` and the per-class costs; the dashboard just wasn't showing them.

## Screenshots

Before / after (dark):

<img width="1440" alt="Before: tooltip shows only a flat token total" src="https://raw.githubusercontent.com/theopenco/llmgateway/e8517493f905333d8360db48e0cef6d16dc2a761/before-dark.png" />
<img width="1440" alt="After: tooltip breaks tokens and cost down by class" src="https://raw.githubusercontent.com/theopenco/llmgateway/e8517493f905333d8360db48e0cef6d16dc2a761/after-dark.png" />

Before / after (light):

<img width="1440" alt="Before: light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/e8517493f905333d8360db48e0cef6d16dc2a761/before-light.png" />
<img width="1440" alt="After: light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/e8517493f905333d8360db48e0cef6d16dc2a761/after-light.png" />

## Verification

Ran the full stack locally against the updated seed and exercised the usage page in both themes; `turbo run build --filter=code` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7dtWBeeD1JX1mkh6VdfAm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detailed token and cost breakdowns for input, cached input, cache writes, and output usage.
  - Updated chart tooltips to show nonzero usage breakdowns alongside total usage.
  - Added cached-token metrics and percentage information for the selected billing cycle.
  - Usage summaries now indicate when cached tokens were served at a reduced rate.

- **Improvements**
  - Improved tooltip readability with a wider display area.
  - Updated usage calculations to more accurately distinguish fresh input, cached input, and output tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->