### PR TITLE
feat(devpass): premium PAYG overflow at weekly cap

### DIFF
--- a/apps/code/src/app/dashboard/components/PayAsYouGoCard.tsx
+++ b/apps/code/src/app/dashboard/components/PayAsYouGoCard.tsx
@@ -113,7 +113,7 @@ export default function PayAsYouGoCard({
 					: "Pay-as-you-go overflow disabled",
 				{
 					description: enabled
-						? "Once your monthly allowance is used, requests bill your credits balance."
+						? "Usage past your monthly allowance — and premium models past the weekly cap — bills your credits balance."
 						: "Your plan allowance is a hard cap again.",
 				},
 			);
@@ -233,8 +233,8 @@ export default function PayAsYouGoCard({
 					<>
 						<p className="mt-2 max-w-xl text-sm text-muted-foreground">
 							{monthlyExhausted
-								? "Your monthly allowance is fully used, so requests are being rejected until renewal. Enable pay-as-you-go overflow to keep coding right now — extra usage bills a credits balance at the same provider rates, only when your allowance is gone."
-								: "Off by default: your plan allowance is a hard cap. Opt in and, once the monthly allowance runs out, requests keep flowing and bill a credits balance at the same provider rates instead — no plan change, no interruption mid-session."}
+								? "Your monthly allowance is fully used, so requests are being rejected until renewal. Enable pay-as-you-go overflow to keep coding right now — extra usage bills a credits balance at the same provider rates, only when your plan wouldn't cover it."
+								: "Off by default: your plan allowance is a hard cap. Opt in and requests keep flowing past it — usage beyond the monthly allowance, and premium models past the weekly cap, bill a credits balance at the same provider rates instead. No plan change, no interruption mid-session."}
 						</p>
 						{/* A balance can arrive without the user ever buying one —
 						    support gifts credits, referrals pay out, a plan starts on
@@ -284,7 +284,7 @@ export default function PayAsYouGoCard({
 										? regularCredits > 0
 											? "Covering overflow now — your allowance is used up."
 											: "Balance empty — top up to resume requests."
-										: "Used only after your monthly allowance runs out."}
+										: "Covers usage past your monthly allowance — and premium models past the weekly cap."}
 								</p>
 							</div>
 							<Button

--- a/apps/code/src/app/dashboard/components/UsageOverview.tsx
+++ b/apps/code/src/app/dashboard/components/UsageOverview.tsx
@@ -89,9 +89,10 @@ function WeeklyAllowanceMeter({
 	// replaced by the upgrade/PAYG promo, so don't point at a card that isn't
 	// there — and "standard models keep working" no longer holds either.
 	resetPassAvailable: boolean;
-	// True when PAYG overflow is actively billing usage (monthly pool gone,
-	// balance positive): premium usage keeps accruing past the cap, so the
-	// meter can legitimately exceed 100% and must not read as an error.
+	// True when PAYG overflow can bill premium usage past the weekly cap
+	// (opt-in on, balance positive): premium keeps accruing past the cap on
+	// the credits balance, so the meter can legitimately exceed 100% and must
+	// not read as an error.
 	overflowCovering: boolean;
 }) {
 	const percentage = limit > 0 ? (used / limit) * 100 : 0;
@@ -377,7 +378,7 @@ export default function UsageOverview({
 							limit={premiumWeeklyLimit}
 							resetsAt={premiumWeekResetsAt}
 							resetPassAvailable={!monthlyExhausted}
-							overflowCovering={monthlyExhausted && paygAvailable}
+							overflowCovering={paygAvailable}
 						/>
 						{!monthlyExhausted && (
 							<ResetPassCard

--- a/apps/docs/content/learn/model-categories.mdx
+++ b/apps/docs/content/learn/model-categories.mdx
@@ -48,7 +48,7 @@ Premium models are the most expensive to run, so DevPass plans apply a **weekly 
 
 Once a DevPass plan reaches its weekly premium cap, premium requests are paused until the current 7-day window ends — usage does not gradually free up over time. The reset countdown runs from when the window opened, not from when you hit the cap, so the full allowance can return anywhere from moments to 7 days after you reach the limit. Standard models keep working normally the whole time. Upgrading the DevPass plan raises the weekly cap.
 
-The fair-use window is a limiter on the plan allowance, so it stops applying once that allowance is gone: with [pay-as-you-go overflow](/learn/payg-overflow) enabled and the monthly pool fully used, premium models bill your credits balance at provider rates instead of being capped.
+The fair-use window is a limiter on the plan allowance, not on your own money: with [pay-as-you-go overflow](/learn/payg-overflow) enabled and a positive credits balance, premium requests past the weekly cap keep flowing and bill that balance at provider rates — mid-cycle with monthly allowance remaining, or after the monthly pool is fully used alike. Standard models keep drawing from the plan allowance as usual.
 
 ## Reset Passes
 

--- a/apps/docs/content/learn/payg-overflow.mdx
+++ b/apps/docs/content/learn/payg-overflow.mdx
@@ -17,7 +17,8 @@ By default a DevPass plan is a hard cap: once the monthly allowance is fully use
 <Callout type="info">
 	Overflow is **off by default** — until you enable it, nothing ever charges
 	past your subscription price. It never touches your plan allowance either:
-	credits are spent only after the monthly pool is fully used.
+	credits cover only usage the plan itself wouldn't serve — spend past the
+	monthly pool, and premium usage past the weekly cap.
 </Callout>
 
 ## When overflow applies
@@ -26,11 +27,11 @@ By default a DevPass plan is a hard cap: once the monthly allowance is fully use
 | ------------------------------------------- | ---------------------------- | ---------------------------------- |
 | Within the monthly allowance                | Plan credits                 | Plan credits                       |
 | Monthly allowance exhausted                 | Requests rejected with `402` | Requests bill your credits balance |
-| Weekly premium cap hit, allowance remaining | Reset Pass or wait           | Reset Pass or wait — unchanged     |
+| Weekly premium cap hit, allowance remaining | Reset Pass or wait           | Premium models bill your balance   |
 | Weekly premium cap hit, allowance exhausted | Requests rejected with `402` | Premium models bill your balance   |
 | Credits balance empty                       | —                            | Requests rejected with `402`       |
 
-Mid-cycle, the weekly premium fair-use cap still applies even with overflow on — a [Reset Pass](/learn/reset-passes) remains the way to more premium usage inside your plan. Overflow takes over only once the monthly pool itself is gone: at that point you are paying provider rates from your own balance, so the fair-use cap no longer gates premium models.
+The weekly premium fair-use cap limits what the **plan allowance** pays for, not what your own balance can: with overflow on and a positive balance, premium requests past the cap keep flowing and bill your credits at provider rates, while standard models keep drawing from the monthly allowance as usual. A [Reset Pass](/learn/reset-passes) is still the way to keep that premium spend inside your already-paid plan allowance instead of on the balance. Once the monthly pool itself is gone, overflow covers everything.
 
 If the allowance runs out with overflow off (or with an empty balance), the gateway's `402` says what to do:
 

--- a/apps/docs/content/learn/reset-passes.mdx
+++ b/apps/docs/content/learn/reset-passes.mdx
@@ -18,9 +18,11 @@ DevPass plans include a [weekly fair-use allowance](/learn/model-categories) for
 	A Reset Pass removes the weekly limit — it does **not** add credits. Premium
 	usage after a reset draws from your plan's monthly credit allowance exactly as
 	before; the pass just lets you keep using premium models now instead of
-	waiting for the window. Once the monthly allowance itself is exhausted,
-	[pay-as-you-go overflow](/learn/payg-overflow) is what keeps requests flowing,
-	not a pass.
+	waiting for the window. With [pay-as-you-go overflow](/learn/payg-overflow)
+	enabled, premium usage past the cap bills your credits balance at provider
+	rates instead — a pass is what brings that spend back inside the plan
+	allowance you already paid for. And once the monthly allowance itself is
+	exhausted, overflow is what keeps requests flowing, not a pass.
 </Callout>
 
 <Callout type="info">

--- a/apps/gateway/src/chat/tools/resolve-provider-context.ts
+++ b/apps/gateway/src/chat/tools/resolve-provider-context.ts
@@ -338,15 +338,19 @@ export function assertDevPlanPremiumCapNotExceeded(
 	if (remaining > 0) {
 		return;
 	}
-	// PAYG overflow: once the monthly pool is exhausted, an opted-in org is
-	// paying provider rates from its own credits, so the weekly premium cap
-	// (a fair-use limiter on the plan allowance) no longer applies — the
-	// regular credit gate downstream takes over. Mid-cycle, with monthly
-	// allowance remaining, the cap still bites so Reset Passes remain the
-	// path to more premium usage within the plan.
+	// PAYG overflow: the weekly premium cap is a fair-use limiter on the plan
+	// allowance, not on the org's own money. An opted-in org gets premium
+	// requests admitted past the cap whenever overflow can actually pay:
+	// either the monthly pool is already exhausted (the regular credit gate
+	// downstream takes over), or the org holds a positive credits balance —
+	// in which case the worker routes the over-cap premium spend to that
+	// balance at provider rates, so the plan pool still never pays past the
+	// cap and Reset Passes remain the way to keep premium usage inside the
+	// plan. Opted in with an empty balance mid-cycle, the cap still bites.
 	if (organization.devPlanPaygEnabled) {
-		const { devPlanCreditsRemaining } = getAvailableCredits(organization);
-		if (devPlanCreditsRemaining <= 0) {
+		const { regularCredits, devPlanCreditsRemaining } =
+			getAvailableCredits(organization);
+		if (devPlanCreditsRemaining <= 0 || regularCredits > 0) {
 			return;
 		}
 	}
@@ -382,8 +386,13 @@ export function assertDevPlanPremiumCapNotExceeded(
 			// billing gate, and a capture failure must not turn it into a 500.
 		}
 	}
+	// Reaching here with the opt-in means the balance is empty, so a top-up is
+	// the one action that unblocks premium immediately.
+	const paygHint = organization.devPlanPaygEnabled
+		? " Pay-as-you-go overflow is enabled but your credits balance is empty — top up from your DevPass dashboard to keep premium models flowing."
+		: "";
 	throw new HTTPException(402, {
-		message: `You've used your weekly allowance for premium-tier models on the ${tier} plan. Redeem a Reset Pass from your dashboard for an instant reset, upgrade for a higher allowance, or use any standard model now. Resets in ${formatTimeUntilReset(msUntilReset)}.`,
+		message: `You've used your weekly allowance for premium-tier models on the ${tier} plan. Redeem a Reset Pass from your dashboard for an instant reset, upgrade for a higher allowance, or use any standard model now. Resets in ${formatTimeUntilReset(msUntilReset)}.${paygHint}`,
 	});
 }
 

--- a/apps/gateway/src/dev-plan-payg.spec.ts
+++ b/apps/gateway/src/dev-plan-payg.spec.ts
@@ -8,7 +8,9 @@ import { createGatewayApiTestHarness } from "./test-utils/gateway-api-test-harne
 // PAYG overflow for DevPass orgs: once the monthly allowance is exhausted,
 // an org that opted in (devPlanPaygEnabled) keeps flowing on its regular
 // credits balance; without the opt-in the plan allowance is a hard cap even
-// when the org holds credits.
+// when the org holds credits. The weekly premium fair-use cap follows the
+// same logic: with the opt-in and a positive balance, premium requests past
+// the cap proceed and bill the balance — mid-cycle included.
 describe("dev-plan PAYG overflow", () => {
 	const harness = createGatewayApiTestHarness();
 
@@ -130,9 +132,11 @@ describe("dev-plan PAYG overflow", () => {
 		expect(body).toContain("pay-as-you-go balance is empty");
 	});
 
-	test("weekly premium cap still rejects mid-cycle even with the opt-in (Reset Pass path preserved)", async () => {
+	test("weekly premium cap yields to PAYG overflow mid-cycle when the org holds credits", async () => {
 		await setupCreditsApiKey("payg-premium-midcycle-token");
-		// Monthly pool has room, so PAYG must not bypass the weekly premium cap.
+		// Monthly pool has room, weekly premium cap is exhausted, PAYG opted in
+		// with a positive balance (the seed leaves credits "100.00"): the excess
+		// premium spend bills the balance, so the request proceeds.
 		await harness.setDevPlan({
 			devPlan: "pro",
 			creditsUsed: "50",
@@ -144,9 +148,53 @@ describe("dev-plan PAYG overflow", () => {
 
 		const res = await chatRequest("payg-premium-midcycle-token", "gpt-5.5");
 
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		expect(json.choices?.[0]?.message).toBeTruthy();
+	});
+
+	test("weekly premium cap still rejects mid-cycle when the PAYG balance is empty", async () => {
+		await setupCreditsApiKey("payg-premium-midcycle-empty-token");
+		// Opted in but nothing to overflow onto: the cap still bites, and the
+		// rejection points at the top-up instead of only the Reset Pass.
+		await harness.setDevPlan({
+			devPlan: "pro",
+			creditsUsed: "50",
+			creditsLimit: "100",
+			premiumCreditsUsed: "999",
+			premiumWeekStart: new Date(),
+			paygEnabled: true,
+		});
+		await harness.setOrganizationCredits("0");
+
+		const res = await chatRequest(
+			"payg-premium-midcycle-empty-token",
+			"gpt-5.5",
+		);
+
 		expect(res.status).toBe(402);
 		const body = JSON.stringify(await res.json());
 		expect(body).toContain("weekly allowance for premium-tier models");
+		expect(body).toContain("credits balance is empty");
+	});
+
+	test("weekly premium cap still rejects mid-cycle without the opt-in even with credits", async () => {
+		await setupCreditsApiKey("payg-premium-midcycle-off-token");
+		// No opt-in: the seed's credits balance must not soften the cap.
+		await harness.setDevPlan({
+			devPlan: "pro",
+			creditsUsed: "50",
+			creditsLimit: "100",
+			premiumCreditsUsed: "999",
+			premiumWeekStart: new Date(),
+		});
+
+		const res = await chatRequest("payg-premium-midcycle-off-token", "gpt-5.5");
+
+		expect(res.status).toBe(402);
+		const body = JSON.stringify(await res.json());
+		expect(body).toContain("weekly allowance for premium-tier models");
+		expect(body).not.toContain("credits balance is empty");
 	});
 
 	test("weekly premium cap yields to PAYG once the monthly pool is exhausted", async () => {

--- a/apps/worker/src/log-processing.spec.ts
+++ b/apps/worker/src/log-processing.spec.ts
@@ -276,6 +276,154 @@ describe("Log Processing", () => {
 			expect(Number(updatedOrg!.credits)).toBe(initialCredits - 0.25);
 		});
 
+		test("should route premium spend past the weekly allowance to regular credits when PAYG is enabled", async () => {
+			// The pro weekly premium allowance is 15% of the monthly pool
+			// (237 * 0.15 = 35.55). With the counter already at the cap, an
+			// over-cap premium request admitted via PAYG overflow must bill the
+			// org's balance — draining the monthly pool here would make the
+			// weekly cap meaningless.
+			await db
+				.update(organization)
+				.set({
+					kind: "devpass",
+					devPlan: "pro",
+					devPlanCreditsLimit: "237",
+					devPlanCreditsUsed: "50",
+					devPlanPremiumCreditsUsed: "35.55",
+					devPlanPremiumWeekStart: new Date(),
+					devPlanPaygEnabled: true,
+				})
+				.where(eq(organization.id, testOrg.id));
+			const initialCredits = Number(testOrg.credits);
+
+			await db.insert(log).values({
+				requestId: "test-request-premium-weekly-overflow",
+				organizationId: testOrg.id,
+				projectId: testProject.id,
+				apiKeyId: testApiKey.id,
+				cost: 0.5,
+				cached: false,
+				usedMode: "credits",
+				duration: 2000,
+				requestedModel: "anthropic/claude-fable-5",
+				requestedProvider: "anthropic",
+				usedModel: "anthropic/claude-fable-5",
+				usedProvider: "anthropic",
+				responseSize: 150,
+				mode: "credits",
+			});
+
+			await batchProcessLogs();
+
+			const updatedOrg = await db.query.organization.findFirst({
+				where: { id: { eq: testOrg.id } },
+			});
+
+			// Plan pool and premium counter untouched; the balance paid.
+			expect(Number(updatedOrg!.devPlanCreditsUsed)).toBe(50);
+			expect(Number(updatedOrg!.devPlanPremiumCreditsUsed)).toBe(35.55);
+			expect(Number(updatedOrg!.credits)).toBe(initialCredits - 0.5);
+		});
+
+		test("should split premium spend across the weekly allowance boundary when PAYG is enabled", async () => {
+			// 0.30 of weekly premium allowance left (35.55 - 35.25): a 0.50
+			// premium charge takes 0.30 from the plan pool and overflows the
+			// remaining 0.20 to the balance.
+			await db
+				.update(organization)
+				.set({
+					kind: "devpass",
+					devPlan: "pro",
+					devPlanCreditsLimit: "237",
+					devPlanCreditsUsed: "50",
+					devPlanPremiumCreditsUsed: "35.25",
+					devPlanPremiumWeekStart: new Date(),
+					devPlanPaygEnabled: true,
+				})
+				.where(eq(organization.id, testOrg.id));
+			const initialCredits = Number(testOrg.credits);
+
+			await db.insert(log).values({
+				requestId: "test-request-premium-weekly-split",
+				organizationId: testOrg.id,
+				projectId: testProject.id,
+				apiKeyId: testApiKey.id,
+				cost: 0.5,
+				cached: false,
+				usedMode: "credits",
+				duration: 2000,
+				requestedModel: "anthropic/claude-fable-5",
+				requestedProvider: "anthropic",
+				usedModel: "anthropic/claude-fable-5",
+				usedProvider: "anthropic",
+				responseSize: 150,
+				mode: "credits",
+			});
+
+			await batchProcessLogs();
+
+			const updatedOrg = await db.query.organization.findFirst({
+				where: { id: { eq: testOrg.id } },
+			});
+
+			expect(Number(updatedOrg!.devPlanCreditsUsed)).toBeCloseTo(50.3, 6);
+			expect(Number(updatedOrg!.devPlanPremiumCreditsUsed)).toBeCloseTo(
+				35.55,
+				6,
+			);
+			expect(Number(updatedOrg!.credits)).toBeCloseTo(initialCredits - 0.2, 6);
+		});
+
+		test("should keep over-cap premium spend on the plan pool when PAYG is disabled", async () => {
+			// Without the opt-in the gateway never admits over-cap premium
+			// requests, but requests already in flight when the cap was crossed
+			// can land here. The balance is unspendable without the opt-in, so
+			// the spend stays on the plan pool exactly as before.
+			await db
+				.update(organization)
+				.set({
+					kind: "devpass",
+					devPlan: "pro",
+					devPlanCreditsLimit: "237",
+					devPlanCreditsUsed: "50",
+					devPlanPremiumCreditsUsed: "35.55",
+					devPlanPremiumWeekStart: new Date(),
+					devPlanPaygEnabled: false,
+				})
+				.where(eq(organization.id, testOrg.id));
+			const initialCredits = Number(testOrg.credits);
+
+			await db.insert(log).values({
+				requestId: "test-request-premium-weekly-payg-off",
+				organizationId: testOrg.id,
+				projectId: testProject.id,
+				apiKeyId: testApiKey.id,
+				cost: 0.5,
+				cached: false,
+				usedMode: "credits",
+				duration: 2000,
+				requestedModel: "anthropic/claude-fable-5",
+				requestedProvider: "anthropic",
+				usedModel: "anthropic/claude-fable-5",
+				usedProvider: "anthropic",
+				responseSize: 150,
+				mode: "credits",
+			});
+
+			await batchProcessLogs();
+
+			const updatedOrg = await db.query.organization.findFirst({
+				where: { id: { eq: testOrg.id } },
+			});
+
+			expect(Number(updatedOrg!.devPlanCreditsUsed)).toBeCloseTo(50.5, 6);
+			expect(Number(updatedOrg!.devPlanPremiumCreditsUsed)).toBeCloseTo(
+				36.05,
+				6,
+			);
+			expect(Number(updatedOrg!.credits)).toBe(initialCredits);
+		});
+
 		test("should keep overflow on the plan pool when PAYG is disabled", async () => {
 			// Without the overflow opt-in the gateway zeroes the credits pool,
 			// so a balance the org holds (an admin gift, a referral payout) is

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -38,6 +38,7 @@ import { hasErrorCode } from "@llmgateway/models";
 import {
 	assertSafeWebhookUrl,
 	calculateFees,
+	getRemainingPremiumWeeklyAllowance,
 	isCreditTopUpAmountInRange,
 	isPremiumUsedModel,
 	isPremiumWeekExpired,
@@ -76,6 +77,8 @@ import {
 	requestStop,
 	resetShutdown,
 } from "./shutdown.js";
+
+import type { DevPlanTier } from "@llmgateway/shared";
 
 // Configuration for current minute history calculation interval (defaults to 5 seconds)
 const CURRENT_MINUTE_HISTORY_INTERVAL_SECONDS =
@@ -1365,6 +1368,37 @@ export async function batchProcessLogs(): Promise<number> {
 				): Promise<{ remaining: Decimal; remainingPremium: Decimal }> => {
 					let remaining = bucketCost;
 					let remainingPremium = premiumCost;
+					// With PAYG overflow enabled, premium spend past the weekly
+					// fair-use allowance must not consume the plan pools: the gateway
+					// admits those requests on the strength of the credits balance, so
+					// the excess is held out of the pool drain here and falls through
+					// to the regular-credits remainder below. Without this the cap
+					// would stop limiting anything — over-cap premium would just keep
+					// draining the monthly pool.
+					// Scoped to buckets whose spend is the dev pool's to pay (its own
+					// bucket, or any bucket when there is no chat pool) — a dual-plan
+					// org's chat-sourced premium keeps draining the chat pool as before.
+					let premiumOverflow = new Decimal(0);
+					if (
+						org?.devPlanPaygEnabled &&
+						devPool &&
+						(preferred === devPool || !chatPool) &&
+						remainingPremium.greaterThan(0)
+					) {
+						const allowanceLeft = new Decimal(
+							getRemainingPremiumWeeklyAllowance(
+								org.devPlan as DevPlanTier,
+								devPool.premiumCreditsUsed?.toNumber() ?? 0,
+								devPool.premiumWeekStart,
+							),
+						);
+						premiumOverflow = Decimal.max(
+							0,
+							remainingPremium.minus(allowanceLeft),
+						);
+						remaining = remaining.minus(premiumOverflow);
+						remainingPremium = remainingPremium.minus(premiumOverflow);
+					}
 					for (const pool of [preferred, fallback]) {
 						if (!pool || remaining.lessThanOrEqualTo(0)) {
 							continue;
@@ -1381,7 +1415,10 @@ export async function batchProcessLogs(): Promise<number> {
 						remaining = remaining.minus(take);
 						remainingPremium = remainingPremium.minus(premiumTake);
 					}
-					return { remaining, remainingPremium };
+					return {
+						remaining: remaining.plus(premiumOverflow),
+						remainingPremium,
+					};
 				};
 
 				const fromChat = buckets.chat.greaterThan(0)


### PR DESCRIPTION
## Problem

A DevPass subscriber with pay-as-you-go overflow enabled asked why hitting the weekly premium fair-use cap still blocks premium models while their monthly allowance has room — they expected their credits balance to take over, the way it does once the monthly pool is exhausted, and instead fell back to calling the provider directly for the rest of the week.

## Approach

The weekly cap is a fair-use limiter on what the **plan allowance** pays for — it was never meant to limit what an org's own money can buy. So with the overflow opt-in and a positive balance, over-cap premium spend now bills the credits balance at provider rates, mid-cycle included, while the plan pool still never pays past the cap:

- **Gateway** (`assertDevPlanPremiumCapNotExceeded`): admit over-cap premium requests when the org has opted in and overflow can actually pay — positive balance, or monthly pool already exhausted (existing behavior). Opted in with an empty balance, the 402 now carries a top-up hint.
- **Worker** (`drainBucket`): premium spend past the remaining weekly allowance is held out of the plan-pool drain and falls through to the regular-credits remainder, so the weekly counter and monthly pool stay capped and the balance pays the excess. A charge straddling the boundary splits: the allowance remainder stays on the plan pool, the excess bills the balance. Scoped so a dual-plan org's chat-sourced traffic keeps its existing chat-pool routing, and PAYG-off orgs keep today's keep-on-pool behavior.
- **Dashboard** (`apps/code`): the weekly meter's amber "overflow is billing premium usage" state now shows whenever overflow can pay (not only after monthly exhaustion), and the PAYG card / toggle copy says credits cover premium past the weekly cap too.
- **Docs**: `payg-overflow`, `model-categories`, and `reset-passes` updated — the overflow table row for "weekly cap hit, allowance remaining" flips to "premium models bill your balance", and Reset Passes are framed as the way to bring premium spend back inside the already-paid plan allowance.

Reset Passes stay fully relevant: a pass is cheaper than paying provider rates from the balance, and redemption still restores plan-pool premium.

## Tests

- Gateway: mid-cycle cap now yields with a positive balance; still rejects with an empty balance (with the top-up hint) and without the opt-in; monthly-exhausted cases unchanged.
- Worker: over-cap premium routes to regular credits with PAYG on; a straddling charge splits across the boundary; PAYG-off orgs keep spend on the plan pool.
- `pnpm test:unit apps/gateway/src/dev-plan-payg.spec.ts apps/worker/src/log-processing.spec.ts` — 36 passed.

## Screenshots

Weekly meter at 100% with overflow enabled and a positive balance (before / after, dark):

<img width="1440" alt="Before: red cap-reached state pointing only at Reset Pass" src="https://raw.githubusercontent.com/theopenco/llmgateway/87bae6c4caeb8165754f8285204d10fab6a8a41d/before-dark.png" />
<img width="1440" alt="After: amber overflow state, premium billing the credits balance" src="https://raw.githubusercontent.com/theopenco/llmgateway/87bae6c4caeb8165754f8285204d10fab6a8a41d/after-dark.png" />

Light:

<img width="1440" alt="Before: light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/87bae6c4caeb8165754f8285204d10fab6a8a41d/before-light.png" />
<img width="1440" alt="After: light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/87bae6c4caeb8165754f8285204d10fab6a8a41d/after-light.png" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7dtWBeeD1JX1mkh6VdfAm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Premium usage beyond the weekly cap can now use pay-as-you-go credits when enabled and a balance is available.
  * Usage is billed appropriately across plan allowances and credits, including when monthly allowances remain or are exhausted.
  * Clearer prompts explain when users need to add credits.

* **Bug Fixes**
  * Corrected premium usage tracking and billing for weekly-cap overflow.

* **Documentation**
  * Updated guidance on pay-as-you-go overflow and Reset Passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## End-to-end verification

Ran the built gateway and the worker's real log pipeline (Redis log queue drain → `batchProcessLogs`) against a seeded local stack, driving actual provider calls through `/v1/chat/completions` with the seeded DevPass Pro key, and asserting org balances in Postgres after each billing pass:

| Case | State (weekly cap .55) | Result |
| --- | --- | --- |
| Over-cap premium, PAYG on, balance $25 | monthly pool has room | ✅ 200; cost billed to credits, plan pool + premium counter untouched |
| Over-cap premium, PAYG on, balance $0 | monthly pool has room | ✅ 402 with the new top-up hint |
| Over-cap premium, PAYG off, balance $25 | monthly pool has room | ✅ 402, no top-up hint |
| Premium within allowance | PAYG off | ✅ 200; plan pool debited, premium counter accrues, credits untouched |
| Standard model at premium cap | PAYG on | ✅ 200; plan pool debited, counter frozen, credits untouched |
| Straddling charge ($0.0005 allowance left, $0.000765 cost) | PAYG on | ✅ splits exactly: pool +$0.0005 (counter lands on the cap), credits −$0.000265 |
| Over-cap premium, monthly pool exhausted, PAYG on | regression | ✅ 200; credits pay, pools untouched (pre-existing behavior preserved) |

Pool-delta sums matched the logged request cost to the last digit in every billed case; no unprocessed logs, queue drained, no negative balances left behind.