### PR TITLE
fix(auth): clearer no-account social sign-in error

### DIFF
--- a/apps/api/src/auth/config.spec.ts
+++ b/apps/api/src/auth/config.spec.ts
@@ -3,7 +3,12 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { db, eq, tables } from "@llmgateway/db";
 import { randomInt } from "@llmgateway/shared/random";
 
-import { apiAuth, isClientJsonError, redisClient } from "./config.js";
+import {
+	apiAuth,
+	isClientAuthError,
+	isClientJsonError,
+	redisClient,
+} from "./config.js";
 
 describe("isClientJsonError", () => {
 	test("matches the real Better Auth malformed-JSON messages from production", () => {
@@ -47,6 +52,21 @@ describe("isClientJsonError", () => {
 		expect(isClientJsonError("Redis pipeline execution failed", [])).toBe(
 			false,
 		);
+	});
+});
+
+describe("isClientAuthError", () => {
+	test("matches the bare signup_disabled code Better Auth logs", () => {
+		expect(isClientAuthError("signup_disabled")).toBe(true);
+		expect(isClientAuthError(" signup_disabled ")).toBe(true);
+	});
+
+	test("does not match genuine server errors", () => {
+		expect(isClientAuthError("Database connection failed")).toBe(false);
+		expect(isClientAuthError("unable_to_create_user")).toBe(false);
+		expect(
+			isClientAuthError("Failed to send verification email signup_disabled"),
+		).toBe(false);
 	});
 });
 

--- a/apps/api/src/auth/config.ts
+++ b/apps/api/src/auth/config.ts
@@ -596,6 +596,20 @@ export function isClientJsonError(message: string, args: unknown[]): boolean {
 	);
 }
 
+/**
+ * Better Auth logs failed OAuth callbacks at error severity even when the
+ * failure is ordinary user state rather than a server fault. `signup_disabled`
+ * is emitted every time someone uses social sign-in on a login page with an
+ * email that has no account yet — expected, because both social providers run
+ * with `disableImplicitSignUp: true` — and the UI turns it into a "sign up
+ * instead?" prompt. Logging it at error severity only trips production alerting.
+ */
+const clientAuthErrorCodes = new Set(["signup_disabled"]);
+
+export function isClientAuthError(message: string): boolean {
+	return clientAuthErrorCodes.has(message.trim());
+}
+
 function extractLogExtra(args: unknown[]): object | undefined {
 	const errArg = args.find((arg) => arg instanceof Error);
 	if (errArg) {
@@ -616,7 +630,8 @@ export const apiAuth: ReturnType<typeof instrumentBetterAuth> =
 				) => {
 					const text = `[Better Auth] ${message}`;
 					const effectiveLevel =
-						level === "error" && isClientJsonError(message, args)
+						level === "error" &&
+						(isClientJsonError(message, args) || isClientAuthError(message))
 							? "warn"
 							: level;
 					switch (effectiveLevel) {

--- a/apps/code/src/app/login/page.tsx
+++ b/apps/code/src/app/login/page.tsx
@@ -33,6 +33,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { useUser } from "@/hooks/useUser";
 import { useAuth } from "@/lib/auth-client";
+import { useAuthErrorToast } from "@/lib/auth-errors";
 import { useAppConfig } from "@/lib/config";
 
 const formSchema = z.object({
@@ -73,6 +74,10 @@ function LoginForm() {
 		}
 		posthog.capture("page_viewed_login");
 	}, [posthog, posthogKey]);
+
+	// `signup_disabled` is handled by SocialAuthButtons, which turns it into a
+	// "you need to sign up" dialog instead of an error toast.
+	useAuthErrorToast(["signup_disabled"]);
 
 	const form = useForm<z.infer<typeof formSchema>>({
 		resolver: zodResolver(formSchema),

--- a/apps/code/src/app/signup/page.tsx
+++ b/apps/code/src/app/signup/page.tsx
@@ -25,6 +25,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { useUser } from "@/hooks/useUser";
 import { useAuth } from "@/lib/auth-client";
+import { useAuthErrorToast } from "@/lib/auth-errors";
 import { useAppConfig } from "@/lib/config";
 import { trackSignupConversion } from "@/lib/google-tag";
 
@@ -68,6 +69,8 @@ function SignupForm() {
 		}
 		posthog.capture("page_viewed_signup", { plan: selectedPlan });
 	}, [posthog, posthogKey, selectedPlan]);
+
+	useAuthErrorToast();
 
 	const form = useForm<z.infer<typeof formSchema>>({
 		resolver: zodResolver(formSchema),

--- a/apps/code/src/components/social-auth-buttons.tsx
+++ b/apps/code/src/components/social-auth-buttons.tsx
@@ -60,8 +60,8 @@ export function SocialAuthButtons({
 
 	// Captured lazily during the first render, before any effect strips
 	// `?error=` from the URL. `provider: null` means the round trip that failed
-	// with `signup_disabled` can't be retried (no stored provider), so we fall
-	// back to a toast instead of the confirmation dialog.
+	// with `signup_disabled` can't be retried (no stored provider), so the dialog
+	// sends the user to the signup page instead of re-running the same provider.
 	const [signupDisabledState, setSignupDisabledState] = useState<{
 		provider: SocialProvider | null;
 	} | null>(() => {
@@ -88,15 +88,6 @@ export function SocialAuthButtons({
 			params.delete("error");
 			const query = params.toString();
 			router.replace(window.location.pathname + (query ? `?${query}` : ""));
-		}
-		if (!signupDisabledState.provider) {
-			setSignupDisabledState(null);
-			toast.error("No account found for that sign-in. Please sign up first.", {
-				style: {
-					backgroundColor: "var(--destructive)",
-					color: "var(--destructive-foreground)",
-				},
-			});
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
@@ -150,7 +141,7 @@ export function SocialAuthButtons({
 	return (
 		<>
 			<AlertDialog
-				open={Boolean(confirmProvider)}
+				open={Boolean(signupDisabledState)}
 				onOpenChange={(open) => {
 					if (!open) {
 						setSignupDisabledState(null);
@@ -159,11 +150,11 @@ export function SocialAuthButtons({
 			>
 				<AlertDialogContent>
 					<AlertDialogHeader>
-						<AlertDialogTitle>Create a new account?</AlertDialogTitle>
+						<AlertDialogTitle>No account found</AlertDialogTitle>
 						<AlertDialogDescription>
-							No account exists for the{" "}
-							{confirmProvider ? PROVIDER_LABELS[confirmProvider] : "provider"}{" "}
-							login you used. Would you like to create a new account with it?
+							{confirmProvider
+								? `There is no account for the ${PROVIDER_LABELS[confirmProvider]} login you used. You need to sign up first — we can create your account with that ${PROVIDER_LABELS[confirmProvider]} login right now.`
+								: "There is no account for the login you used. You need to sign up first to create one."}
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>
@@ -174,11 +165,15 @@ export function SocialAuthButtons({
 									void handleSocialSignIn(confirmProvider, {
 										requestSignUp: true,
 									});
+								} else {
+									router.push("/signup");
 								}
 								setSignupDisabledState(null);
 							}}
 						>
-							Create account
+							{confirmProvider
+								? `Sign up with ${PROVIDER_LABELS[confirmProvider]}`
+								: "Go to sign up"}
 						</AlertDialogAction>
 					</AlertDialogFooter>
 				</AlertDialogContent>

--- a/apps/code/src/lib/auth-errors.ts
+++ b/apps/code/src/lib/auth-errors.ts
@@ -2,8 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
-
-import { toast } from "@/lib/components/use-toast";
+import { toast } from "sonner";
 
 // Error codes emitted by better-auth's social OAuth callback as the `?error=`
 // query param. The callback derives them from `result.error.split(" ").join("_")`
@@ -59,9 +58,11 @@ export function useAuthErrorToast(ignoredCodes: string[] = []): void {
 		if (!error || ignoredCodes.includes(error)) {
 			return;
 		}
-		toast({
-			title: getAuthErrorMessage(error),
-			variant: "destructive",
+		toast.error(getAuthErrorMessage(error), {
+			style: {
+				backgroundColor: "var(--destructive)",
+				color: "var(--destructive-foreground)",
+			},
 		});
 		params.delete("error");
 		const query = params.toString();

--- a/apps/playground/src/app/login/page.tsx
+++ b/apps/playground/src/app/login/page.tsx
@@ -30,6 +30,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { useUser } from "@/hooks/useUser";
 import { useAuth } from "@/lib/auth-client";
+import { useAuthErrorToast } from "@/lib/auth-errors";
 
 const formSchema = z.object({
 	email: z.string().email({ message: "Please enter a valid email address" }),
@@ -74,6 +75,10 @@ function Login() {
 	useEffect(() => {
 		posthog.capture("page_viewed_login");
 	}, [posthog]);
+
+	// `signup_disabled` is handled by SocialAuthButtons, which turns it into a
+	// "you need to sign up" dialog instead of an error toast.
+	useAuthErrorToast(["signup_disabled"]);
 
 	const form = useForm<z.infer<typeof formSchema>>({
 		resolver: zodResolver(formSchema),

--- a/apps/playground/src/app/signup/page.tsx
+++ b/apps/playground/src/app/signup/page.tsx
@@ -30,6 +30,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { useUser } from "@/hooks/useUser";
 import { useAuth } from "@/lib/auth-client";
+import { useAuthErrorToast } from "@/lib/auth-errors";
 
 const formSchema = z.object({
 	name: z.string().optional(),
@@ -74,6 +75,8 @@ function Signup() {
 	useEffect(() => {
 		posthog.capture("page_viewed_signup");
 	}, [posthog]);
+
+	useAuthErrorToast();
 
 	const form = useForm<z.infer<typeof formSchema>>({
 		resolver: zodResolver(formSchema),

--- a/apps/playground/src/components/social-auth-buttons.tsx
+++ b/apps/playground/src/components/social-auth-buttons.tsx
@@ -58,8 +58,8 @@ export function SocialAuthButtons({
 
 	// Captured lazily during the first render, before any effect strips
 	// `?error=` from the URL. `provider: null` means the round trip that failed
-	// with `signup_disabled` can't be retried (no stored provider), so we fall
-	// back to a toast instead of the confirmation dialog.
+	// with `signup_disabled` can't be retried (no stored provider), so the dialog
+	// sends the user to the signup page instead of re-running the same provider.
 	const [signupDisabledState, setSignupDisabledState] = useState<{
 		provider: SocialProvider | null;
 	} | null>(() => {
@@ -86,15 +86,6 @@ export function SocialAuthButtons({
 			params.delete("error");
 			const query = params.toString();
 			router.replace(window.location.pathname + (query ? `?${query}` : ""));
-		}
-		if (!signupDisabledState.provider) {
-			setSignupDisabledState(null);
-			toast.error("No account found for that sign-in. Please sign up first.", {
-				style: {
-					backgroundColor: "var(--destructive)",
-					color: "var(--destructive-foreground)",
-				},
-			});
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
@@ -138,7 +129,7 @@ export function SocialAuthButtons({
 	return (
 		<>
 			<AlertDialog
-				open={Boolean(confirmProvider)}
+				open={Boolean(signupDisabledState)}
 				onOpenChange={(open) => {
 					if (!open) {
 						setSignupDisabledState(null);
@@ -147,11 +138,11 @@ export function SocialAuthButtons({
 			>
 				<AlertDialogContent>
 					<AlertDialogHeader>
-						<AlertDialogTitle>Create a new account?</AlertDialogTitle>
+						<AlertDialogTitle>No account found</AlertDialogTitle>
 						<AlertDialogDescription>
-							No account exists for the{" "}
-							{confirmProvider ? PROVIDER_LABELS[confirmProvider] : "provider"}{" "}
-							login you used. Would you like to create a new account with it?
+							{confirmProvider
+								? `There is no account for the ${PROVIDER_LABELS[confirmProvider]} login you used. You need to sign up first — we can create your account with that ${PROVIDER_LABELS[confirmProvider]} login right now.`
+								: "There is no account for the login you used. You need to sign up first to create one."}
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>
@@ -162,11 +153,15 @@ export function SocialAuthButtons({
 									void handleSocialSignIn(confirmProvider, {
 										requestSignUp: true,
 									});
+								} else {
+									router.push("/signup");
 								}
 								setSignupDisabledState(null);
 							}}
 						>
-							Create account
+							{confirmProvider
+								? `Sign up with ${PROVIDER_LABELS[confirmProvider]}`
+								: "Go to sign up"}
 						</AlertDialogAction>
 					</AlertDialogFooter>
 				</AlertDialogContent>

--- a/apps/playground/src/lib/auth-errors.ts
+++ b/apps/playground/src/lib/auth-errors.ts
@@ -2,8 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
-
-import { toast } from "@/lib/components/use-toast";
+import { toast } from "sonner";
 
 // Error codes emitted by better-auth's social OAuth callback as the `?error=`
 // query param. The callback derives them from `result.error.split(" ").join("_")`
@@ -59,9 +58,11 @@ export function useAuthErrorToast(ignoredCodes: string[] = []): void {
 		if (!error || ignoredCodes.includes(error)) {
 			return;
 		}
-		toast({
-			title: getAuthErrorMessage(error),
-			variant: "destructive",
+		toast.error(getAuthErrorMessage(error), {
+			style: {
+				backgroundColor: "var(--destructive)",
+				color: "var(--destructive-foreground)",
+			},
 		});
 		params.delete("error");
 		const query = params.toString();

--- a/apps/ui/src/app/login/page.tsx
+++ b/apps/ui/src/app/login/page.tsx
@@ -22,7 +22,7 @@ import { z } from "zod";
 import { SocialAuthButtons } from "@/components/social-auth-buttons";
 import { useSessionStatus, useUser } from "@/hooks/useUser";
 import { useAuth } from "@/lib/auth-client";
-import { getAuthErrorMessage } from "@/lib/auth-errors";
+import { useAuthErrorToast } from "@/lib/auth-errors";
 import { Button } from "@/lib/components/button";
 import {
 	Form,
@@ -81,21 +81,9 @@ export default function Login() {
 		posthog.capture("page_viewed_login");
 	}, [posthog]);
 
-	useEffect(() => {
-		const params = new URLSearchParams(window.location.search);
-		const error = params.get("error");
-		// `signup_disabled` is handled by SocialAuthButtons, which turns it into
-		// a create-account confirmation dialog instead of an error toast.
-		if (error && error !== "signup_disabled") {
-			toast({
-				title: getAuthErrorMessage(error),
-				variant: "destructive",
-			});
-			params.delete("error");
-			const query = params.toString();
-			router.replace(window.location.pathname + (query ? `?${query}` : ""));
-		}
-	}, [router]);
+	// `signup_disabled` is handled by SocialAuthButtons, which turns it into a
+	// "you need to sign up" dialog instead of an error toast.
+	useAuthErrorToast(["signup_disabled"]);
 
 	const form = useForm<z.infer<typeof formSchema>>({
 		resolver: zodResolver(formSchema),

--- a/apps/ui/src/app/signup/page.tsx
+++ b/apps/ui/src/app/signup/page.tsx
@@ -14,7 +14,7 @@ import { z } from "zod";
 import { SocialAuthButtons } from "@/components/social-auth-buttons";
 import { useSessionStatus, useUser } from "@/hooks/useUser";
 import { useAuth } from "@/lib/auth-client";
-import { getAuthErrorMessage } from "@/lib/auth-errors";
+import { useAuthErrorToast } from "@/lib/auth-errors";
 import { Button } from "@/lib/components/button";
 import {
 	Form,
@@ -76,19 +76,7 @@ export default function Signup() {
 		posthog.capture("page_viewed_signup");
 	}, [posthog]);
 
-	useEffect(() => {
-		const params = new URLSearchParams(window.location.search);
-		const error = params.get("error");
-		if (error) {
-			toast({
-				title: getAuthErrorMessage(error),
-				variant: "destructive",
-			});
-			params.delete("error");
-			const query = params.toString();
-			router.replace(window.location.pathname + (query ? `?${query}` : ""));
-		}
-	}, [router]);
+	useAuthErrorToast();
 
 	const form = useForm<z.infer<typeof formSchema>>({
 		resolver: zodResolver(formSchema),

--- a/apps/ui/src/components/social-auth-buttons.tsx
+++ b/apps/ui/src/components/social-auth-buttons.tsx
@@ -58,8 +58,8 @@ export function SocialAuthButtons({
 
 	// Captured lazily during the first render, before any effect strips
 	// `?error=` from the URL. `provider: null` means the round trip that failed
-	// with `signup_disabled` can't be retried (no stored provider), so we fall
-	// back to a toast instead of the confirmation dialog.
+	// with `signup_disabled` can't be retried (no stored provider), so the dialog
+	// sends the user to the signup page instead of re-running the same provider.
 	const [signupDisabledState, setSignupDisabledState] = useState<{
 		provider: SocialProvider | null;
 	} | null>(() => {
@@ -86,13 +86,6 @@ export function SocialAuthButtons({
 			params.delete("error");
 			const query = params.toString();
 			router.replace(window.location.pathname + (query ? `?${query}` : ""));
-		}
-		if (!signupDisabledState.provider) {
-			setSignupDisabledState(null);
-			toast({
-				title: "No account found for that sign-in. Please sign up first.",
-				variant: "destructive",
-			});
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
@@ -134,7 +127,7 @@ export function SocialAuthButtons({
 	return (
 		<>
 			<AlertDialog
-				open={Boolean(confirmProvider)}
+				open={Boolean(signupDisabledState)}
 				onOpenChange={(open) => {
 					if (!open) {
 						setSignupDisabledState(null);
@@ -143,11 +136,11 @@ export function SocialAuthButtons({
 			>
 				<AlertDialogContent>
 					<AlertDialogHeader>
-						<AlertDialogTitle>Create a new account?</AlertDialogTitle>
+						<AlertDialogTitle>No account found</AlertDialogTitle>
 						<AlertDialogDescription>
-							No LLM Gateway account exists for the{" "}
-							{confirmProvider ? PROVIDER_LABELS[confirmProvider] : "provider"}{" "}
-							login you used. Would you like to create a new account with it?
+							{confirmProvider
+								? `There is no LLM Gateway account for the ${PROVIDER_LABELS[confirmProvider]} login you used. You need to sign up first — we can create your account with that ${PROVIDER_LABELS[confirmProvider]} login right now.`
+								: "There is no LLM Gateway account for the login you used. You need to sign up first to create one."}
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>
@@ -158,11 +151,15 @@ export function SocialAuthButtons({
 									void handleSocialSignIn(confirmProvider, {
 										requestSignUp: true,
 									});
+								} else {
+									router.push("/signup");
 								}
 								setSignupDisabledState(null);
 							}}
 						>
-							Create account
+							{confirmProvider
+								? `Sign up with ${PROVIDER_LABELS[confirmProvider]}`
+								: "Go to sign up"}
 						</AlertDialogAction>
 					</AlertDialogFooter>
 				</AlertDialogContent>


### PR DESCRIPTION
## Problem

Social sign-in runs with `disableImplicitSignUp: true`, so signing in with Google/GitHub from a **login** page using an email that has no account aborts the OAuth callback with `?error=signup_disabled`. Three things were wrong with how that surfaced:

- When the attempted provider could not be recovered from `sessionStorage`, the user only got a toast — easy to miss, and it offered no way forward.
- The code and playground login/signup pages surfaced **no** OAuth callback error at all: every failure code (`account_not_linked`, `email_not_found`, …) dropped the user back on the login page as if nothing had happened.
- Better Auth logs `signup_disabled` at error severity even though it is ordinary user state, so normal traffic trips production error alerting.

## Changes

- The confirmation dialog now always renders for `signup_disabled`. It states that no account was found, says the user needs to sign up, and either re-runs the same provider with `requestSignUp: true` or sends them to `/signup` when the provider is unknown.
- Ported the `auth-errors` code→message map to `apps/code` and `apps/playground`, and extracted a shared `useAuthErrorToast()` hook (used by all three apps' login and signup pages) that surfaces the `?error=` code and strips it from the URL. Login pages ignore `signup_disabled` because the dialog owns it.
- The API's Better Auth logger bridge downgrades `signup_disabled` from error to warn, alongside the existing malformed-JSON downgrade.

## Verification

`pnpm format`, `pnpm build`, and `apps/api/src/auth/config.spec.ts` (23 tests, including new `isClientAuthError` cases) all pass. Screenshots taken locally against a seeded stack.

## Screenshots

### Main dashboard login — provider known

| Before | After |
| --- | --- |
| <img width="600" alt="login dialog before, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/1f252180e7b69206becb0ce52ed4b7575c01fa20/ui-before-provider-light.png" /> | <img width="600" alt="login dialog after, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/1f252180e7b69206becb0ce52ed4b7575c01fa20/ui-after-provider-light.png" /> |
| <img width="600" alt="login dialog before, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/1f252180e7b69206becb0ce52ed4b7575c01fa20/ui-before-provider-dark.png" /> | <img width="600" alt="login dialog after, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/1f252180e7b69206becb0ce52ed4b7575c01fa20/ui-after-provider-dark.png" /> |

### Main dashboard login — provider unknown (previously only a toast)

| Light | Dark |
| --- | --- |
| <img width="600" alt="no-provider dialog, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/1f252180e7b69206becb0ce52ed4b7575c01fa20/ui-after-noprovider-light.png" /> | <img width="600" alt="no-provider dialog, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/1f252180e7b69206becb0ce52ed4b7575c01fa20/ui-after-noprovider-dark.png" /> |

### DevPass login

| Light | Dark |
| --- | --- |
| <img width="600" alt="DevPass login dialog, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/1f252180e7b69206becb0ce52ed4b7575c01fa20/code-after-provider-light.png" /> | <img width="600" alt="DevPass login dialog, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/1f252180e7b69206becb0ce52ed4b7575c01fa20/code-after-provider-dark.png" /> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)