### PR TITLE
feat(ui): project cost breakdown by user

### DIFF
--- a/apps/docs/content/learn/analytics.mdx
+++ b/apps/docs/content/learn/analytics.mdx
@@ -6,11 +6,29 @@ icon: ChartArea
 
 import { ThemedImage } from "@/components/themed-image";
 
-The Analytics page shows where a project's spend actually goes. It breaks usage down by model — as a ranking and over time — so you can see which models drive cost, requests, and tokens across any date range.
+The Analytics page shows where a project's spend actually goes. It leads with the project's totals for the range, then breaks usage down — as a ranking and over time — so you can see what drives cost, requests, and tokens across any date range.
 
 <ThemedImage alt="Project Analytics" basePath="/learn/analytics" />
 
 Open it from the **Analytics** item in the project sidebar. Like the rest of the dashboard, the page respects the shared date-range picker at the top, so every chart reflects the same window.
+
+## Totals
+
+Three cards at the top show the project's **total cost**, **requests**, and **tokens** for the selected range, each with a sparkline of its daily values. They are computed from the same data as the charts below, so the total and the breakdown always agree.
+
+## Choosing a breakdown
+
+The **Group by** selector switches which dimension the two charts break the project down by:
+
+| Breakdown   | What it shows                                              |
+| ----------- | ---------------------------------------------------------- |
+| **Model**   | Spend per model (the default)                              |
+| **API key** | Spend per API key in the project                           |
+| **User**    | Spend per team member — Enterprise, owners and admins only |
+
+**Breakdown by user** answers "what is each person on this team costing us?" in the same view as the project total. It is available to organization owners and admins on the Enterprise plan — see [Member Analytics](/learn/member-analytics).
+
+Spend is attributed to whoever **created** the API key that made each request. Traffic from platform keys has no member behind it, so it is shown as **Unattributed** rather than dropped, keeping the per-member rows summing to the project total.
 
 ## Cost by Model
 
@@ -32,6 +50,8 @@ A stacked area chart that plots the same three metrics across the date range, wi
 - **Canonical** — variants of the same underlying model are collapsed into one canonical model (the provider prefix and tag are dropped), so `openai/gpt-5.5` and a custom mapping of it count as a single line.
 
 Switch to **Canonical** when you care about the underlying model's total footprint; stay on **Mappings** when you need to compare specific routes.
+
+The **Mappings / Canonical** toggle is specific to models — the API key and user breakdowns rank named entities, so there is nothing to collapse.
 
 ## How the data is computed
 

--- a/apps/ui/src/components/analytics/analytics-client.tsx
+++ b/apps/ui/src/components/analytics/analytics-client.tsx
@@ -1,36 +1,104 @@
 "use client";
 
 import { format, subDays } from "date-fns";
+import { Coins, Hash, Layers } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 
 import {
 	AnalyticsDateRange,
 	getAnalyticsRange,
 } from "@/components/analytics/analytics-date-range";
+import {
+	currencyFormatter,
+	toDimensionRows,
+	UNATTRIBUTED_NOTE,
+} from "@/components/analytics/chart-helpers";
 import { CostByModelCard } from "@/components/analytics/cost-by-model-card";
 import { CostByModelOverTimeCard } from "@/components/analytics/cost-by-model-over-time-card";
+import { DimensionUsageCard } from "@/components/analytics/dimension-usage-card";
+import { DimensionUsageOverTimeCard } from "@/components/analytics/dimension-usage-over-time-card";
+import { MetricCard } from "@/components/dashboard/metric-card";
 import {
 	UsageModeSelector,
 	useUsageMode,
 } from "@/components/shared/usage-mode-selector";
+import {
+	parseGroupBy,
+	resolveGroupBy,
+	type GroupBy,
+} from "@/components/usage/group-by";
 import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
+import { useTeamMembers } from "@/hooks/useTeam";
+import { useUser } from "@/hooks/useUser";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/lib/components/select";
 import { useApi } from "@/lib/fetch-client";
 import { getBrowserTimeZone } from "@/lib/timezone";
 import { applyUsageModeToDaily } from "@/lib/usage-mode";
 
-import type { ActivityRow } from "@/components/analytics/chart-helpers";
+import type { DailyActivity } from "@/types/activity";
 
 interface AnalyticsClientProps {
 	projectId: string | undefined;
 }
 
+const COPY: Record<
+	GroupBy,
+	{ option: string; overTime: string; ranked: string; description: string }
+> = {
+	model: {
+		option: "Breakdown by model",
+		overTime: "Cost by model over time",
+		ranked: "Cost by model",
+		description: "Cost and usage broken down by model for this project",
+	},
+	apiKey: {
+		option: "Breakdown by API key",
+		overTime: "Cost by API key over time",
+		ranked: "Cost by API key",
+		description: "Cost and usage broken down by API key for this project",
+	},
+	user: {
+		option: "Breakdown by user",
+		overTime: "Cost by user over time",
+		ranked: "Cost by user",
+		description: UNATTRIBUTED_NOTE,
+	},
+};
+
+const compactNumber = new Intl.NumberFormat("en-US", { notation: "compact" });
+
 export function AnalyticsClient({ projectId }: AnalyticsClientProps) {
 	const router = useRouter();
 	const searchParams = useSearchParams();
-	const { buildUrl, selectedOrganization } = useDashboardNavigation();
+	const { buildUrl, orgId, selectedOrganization } = useDashboardNavigation();
 	const api = useApi();
+	const { user } = useUser();
 	const isEnterprise = selectedOrganization?.plan === "enterprise";
+
+	// The per-member breakdown exposes every member's spend, so it carries the
+	// same entitlement as the API gate: enterprise, and an org owner/admin. This
+	// only hides the option — the API enforces it independently.
+	const { data: teamData } = useTeamMembers(orgId, undefined, {
+		enabled: isEnterprise,
+	});
+	const currentUserRole = teamData?.members.find(
+		(member) => member.userId === user?.id,
+	)?.role;
+	const canGroupByUser =
+		isEnterprise &&
+		(currentUserRole === "owner" || currentUserRole === "admin");
+
+	const groupBy = resolveGroupBy(
+		parseGroupBy(searchParams.get("groupBy")),
+		canGroupByUser,
+	);
 
 	useEffect(() => {
 		if (!isEnterprise) {
@@ -45,6 +113,16 @@ export function AnalyticsClient({ projectId }: AnalyticsClientProps) {
 			router.replace(`${buildUrl("analytics")}?${params.toString()}`);
 		}
 	}, [searchParams, router, buildUrl, isEnterprise]);
+
+	const updateGroupBy = (newGroupBy: GroupBy) => {
+		const params = new URLSearchParams(searchParams);
+		if (newGroupBy === "model") {
+			params.delete("groupBy");
+		} else {
+			params.set("groupBy", newGroupBy);
+		}
+		router.push(`${buildUrl("analytics")}?${params.toString()}`);
+	};
 
 	const { fromStr, toStr } = getAnalyticsRange(
 		isEnterprise,
@@ -61,6 +139,7 @@ export function AnalyticsClient({ projectId }: AnalyticsClientProps) {
 					from: fromStr,
 					to: toStr,
 					timezone: getBrowserTimeZone(),
+					groupBy,
 					...(projectId ? { projectId } : {}),
 				},
 			},
@@ -73,9 +152,36 @@ export function AnalyticsClient({ projectId }: AnalyticsClientProps) {
 	);
 
 	const usageMode = useUsageMode();
-	const activity: ActivityRow[] = (data?.activity ?? []).map((day) =>
-		applyUsageModeToDaily(day, usageMode),
+	const activity: DailyActivity[] = useMemo(
+		() =>
+			(data?.activity ?? []).map((day) =>
+				applyUsageModeToDaily(day, usageMode),
+			),
+		[data, usageMode],
 	);
+
+	const rows = useMemo(
+		() => toDimensionRows(activity, groupBy),
+		[activity, groupBy],
+	);
+
+	// Totals come from the same rows the charts read, so the header and the
+	// breakdown can never disagree.
+	const totals = useMemo(
+		() =>
+			activity.reduce(
+				(acc, day) => ({
+					cost: acc.cost + day.cost,
+					requestCount: acc.requestCount + day.requestCount,
+					totalTokens: acc.totalTokens + day.totalTokens,
+				}),
+				{ cost: 0, requestCount: 0, totalTokens: 0 },
+			),
+		[activity],
+	);
+
+	const copy = COPY[groupBy];
+	const dimensionNoun = groupBy === "apiKey" ? "API key" : groupBy;
 
 	return (
 		<div className="flex flex-col">
@@ -83,11 +189,24 @@ export function AnalyticsClient({ projectId }: AnalyticsClientProps) {
 				<div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
 					<div>
 						<h2 className="text-3xl font-bold tracking-tight">Analytics</h2>
-						<p className="text-muted-foreground">
-							Cost and usage broken down by model for this project
-						</p>
+						<p className="text-muted-foreground">{copy.description}</p>
 					</div>
 					<div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+						<Select
+							value={groupBy}
+							onValueChange={(v) => updateGroupBy(v as GroupBy)}
+						>
+							<SelectTrigger size="sm" className="w-full sm:w-[180px]">
+								<SelectValue placeholder="Group by" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="model">{COPY.model.option}</SelectItem>
+								<SelectItem value="apiKey">{COPY.apiKey.option}</SelectItem>
+								{canGroupByUser && (
+									<SelectItem value="user">{COPY.user.option}</SelectItem>
+								)}
+							</SelectContent>
+						</Select>
 						<AnalyticsDateRange
 							isEnterprise={isEnterprise}
 							buildUrl={buildUrl}
@@ -97,8 +216,57 @@ export function AnalyticsClient({ projectId }: AnalyticsClientProps) {
 					</div>
 				</div>
 
-				<CostByModelOverTimeCard activity={activity} loading={isLoading} />
-				<CostByModelCard activity={activity} loading={isLoading} />
+				<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+					<MetricCard
+						label="Total cost"
+						value={currencyFormatter.format(totals.cost)}
+						accent="green"
+						icon={<Coins className="h-4 w-4" />}
+						trend={activity.map((day) => day.cost)}
+						isLoading={isLoading}
+					/>
+					<MetricCard
+						label="Requests"
+						value={compactNumber.format(totals.requestCount)}
+						accent="blue"
+						icon={<Hash className="h-4 w-4" />}
+						trend={activity.map((day) => day.requestCount)}
+						isLoading={isLoading}
+					/>
+					<MetricCard
+						label="Tokens"
+						value={compactNumber.format(totals.totalTokens)}
+						accent="purple"
+						icon={<Layers className="h-4 w-4" />}
+						trend={activity.map((day) => day.totalTokens)}
+						isLoading={isLoading}
+					/>
+				</div>
+
+				{/* The model dimension keeps its dedicated cards: they carry the
+				    Mappings/Canonical toggle, which is model-specific and has no
+				    equivalent for api keys or users. */}
+				{groupBy === "model" ? (
+					<>
+						<CostByModelOverTimeCard activity={activity} loading={isLoading} />
+						<CostByModelCard activity={activity} loading={isLoading} />
+					</>
+				) : (
+					<>
+						<DimensionUsageOverTimeCard
+							rows={rows}
+							loading={isLoading}
+							title={copy.overTime}
+							description={`Stacked ${dimensionNoun} spend across the selected range`}
+						/>
+						<DimensionUsageCard
+							rows={rows}
+							loading={isLoading}
+							title={copy.ranked}
+							description={`Ranked ${dimensionNoun} totals across the selected range`}
+						/>
+					</>
+				)}
 			</div>
 		</div>
 	);

--- a/apps/ui/src/components/analytics/chart-helpers.spec.ts
+++ b/apps/ui/src/components/analytics/chart-helpers.spec.ts
@@ -1,0 +1,286 @@
+import { describe, expect, test } from "vitest";
+
+import {
+	toDimensionRows,
+	UNATTRIBUTED_KEY,
+	aggregateByDimension,
+} from "./chart-helpers.js";
+
+const modeSplit = {
+	creditsRequestCount: 0,
+	apiKeysRequestCount: 0,
+	creditsCost: 0,
+	apiKeysCost: 0,
+};
+
+function day(overrides: {
+	cost: number;
+	requestCount: number;
+	totalTokens: number;
+	userBreakdown?: {
+		id: string;
+		name: string;
+		cost: number;
+		requestCount: number;
+		totalTokens: number;
+	}[];
+	apiKeyBreakdown?: {
+		id: string;
+		description: string;
+		cost: number;
+		requestCount: number;
+		totalTokens: number;
+	}[];
+	modelBreakdown?: {
+		id: string;
+		provider: string;
+		cost: number;
+		requestCount: number;
+		totalTokens: number;
+	}[];
+}) {
+	return {
+		date: "2026-08-10",
+		cost: overrides.cost,
+		requestCount: overrides.requestCount,
+		totalTokens: overrides.totalTokens,
+		modelBreakdown: (overrides.modelBreakdown ?? []).map((m) => ({
+			...m,
+			inputTokens: 0,
+			outputTokens: 0,
+			...modeSplit,
+		})),
+		apiKeyBreakdown: (overrides.apiKeyBreakdown ?? []).map((k) => ({
+			...k,
+			...modeSplit,
+		})),
+		userBreakdown: (overrides.userBreakdown ?? []).map((u) => ({
+			...u,
+			...modeSplit,
+		})),
+	};
+}
+
+describe("toDimensionRows", () => {
+	test("maps the model breakdown, prefixing the provider", () => {
+		const rows = toDimensionRows(
+			[
+				day({
+					cost: 3,
+					requestCount: 2,
+					totalTokens: 100,
+					modelBreakdown: [
+						{
+							id: "gpt-5.6",
+							provider: "openai",
+							cost: 3,
+							requestCount: 2,
+							totalTokens: 100,
+						},
+					],
+				}),
+			],
+			"model",
+		);
+
+		expect(rows[0].breakdown).toHaveLength(1);
+		expect(rows[0].breakdown[0].key).toBe("openai/gpt-5.6");
+		expect(rows[0].breakdown[0].label).toBe("openai/gpt-5.6");
+		expect(rows[0].breakdown[0].cost).toBe(3);
+	});
+
+	test("maps the api key breakdown using the key description as label", () => {
+		const rows = toDimensionRows(
+			[
+				day({
+					cost: 5,
+					requestCount: 1,
+					totalTokens: 10,
+					apiKeyBreakdown: [
+						{
+							id: "key_1",
+							description: "CI key",
+							cost: 5,
+							requestCount: 1,
+							totalTokens: 10,
+						},
+					],
+				}),
+			],
+			"apiKey",
+		);
+
+		expect(rows[0].breakdown[0]).toMatchObject({
+			key: "key_1",
+			label: "CI key",
+			cost: 5,
+		});
+	});
+
+	test("maps the user breakdown using the member name as label", () => {
+		const rows = toDimensionRows(
+			[
+				day({
+					cost: 8,
+					requestCount: 4,
+					totalTokens: 40,
+					userBreakdown: [
+						{
+							id: "user_1",
+							name: "Ada",
+							cost: 5,
+							requestCount: 3,
+							totalTokens: 30,
+						},
+						{
+							id: "user_2",
+							name: "Grace",
+							cost: 3,
+							requestCount: 1,
+							totalTokens: 10,
+						},
+					],
+				}),
+			],
+			"user",
+		);
+
+		expect(rows[0].breakdown.map((e) => e.label)).toEqual(["Ada", "Grace"]);
+		// Fully attributed: no residual series.
+		expect(rows[0].breakdown.some((e) => e.key === UNATTRIBUTED_KEY)).toBe(
+			false,
+		);
+	});
+
+	// Platform-key traffic never reaches the per-key rollups, so the per-user rows
+	// sum to less than the project total. Surface the gap rather than under-report.
+	test("adds an Unattributed entry for the residual", () => {
+		const rows = toDimensionRows(
+			[
+				day({
+					cost: 10,
+					requestCount: 10,
+					totalTokens: 100,
+					userBreakdown: [
+						{
+							id: "user_1",
+							name: "Ada",
+							cost: 4,
+							requestCount: 6,
+							totalTokens: 60,
+						},
+					],
+				}),
+			],
+			"user",
+		);
+
+		const residual = rows[0].breakdown.find((e) => e.key === UNATTRIBUTED_KEY);
+		expect(residual).toBeDefined();
+		expect(residual!.cost).toBe(6);
+		expect(residual!.requestCount).toBe(4);
+		expect(residual!.totalTokens).toBe(40);
+	});
+
+	// Free-model platform traffic costs nothing but still moves requests and
+	// tokens, so gating the residual on cost alone would hide it from those tabs.
+	test("adds an Unattributed entry for zero-cost platform traffic", () => {
+		const rows = toDimensionRows(
+			[
+				day({
+					cost: 4,
+					requestCount: 10,
+					totalTokens: 100,
+					userBreakdown: [
+						{
+							id: "user_1",
+							name: "Ada",
+							cost: 4,
+							requestCount: 6,
+							totalTokens: 60,
+						},
+					],
+				}),
+			],
+			"user",
+		);
+
+		const residual = rows[0].breakdown.find((e) => e.key === UNATTRIBUTED_KEY);
+		expect(residual).toBeDefined();
+		expect(residual!.cost).toBe(0);
+		expect(residual!.requestCount).toBe(4);
+		expect(residual!.totalTokens).toBe(40);
+	});
+
+	test("per-user costs sum back to the project total", () => {
+		const activity = [
+			day({
+				cost: 10,
+				requestCount: 10,
+				totalTokens: 100,
+				userBreakdown: [
+					{
+						id: "user_1",
+						name: "Ada",
+						cost: 4,
+						requestCount: 6,
+						totalTokens: 60,
+					},
+				],
+			}),
+		];
+
+		const { totalCost } = aggregateByDimension(
+			toDimensionRows(activity, "user"),
+		);
+		expect(totalCost).toBe(activity[0].cost);
+	});
+
+	test("ignores sub-cent rounding noise between the two rollups", () => {
+		const rows = toDimensionRows(
+			[
+				day({
+					cost: 1,
+					requestCount: 1,
+					totalTokens: 1,
+					userBreakdown: [
+						{
+							id: "user_1",
+							name: "Ada",
+							cost: 1 - 1e-12,
+							requestCount: 1,
+							totalTokens: 1,
+						},
+					],
+				}),
+			],
+			"user",
+		);
+
+		expect(rows[0].breakdown).toHaveLength(1);
+	});
+
+	test("never emits a negative residual when the per-key rollup runs ahead", () => {
+		const rows = toDimensionRows(
+			[
+				day({
+					cost: 4,
+					requestCount: 2,
+					totalTokens: 20,
+					userBreakdown: [
+						{
+							id: "user_1",
+							name: "Ada",
+							cost: 5,
+							requestCount: 3,
+							totalTokens: 30,
+						},
+					],
+				}),
+			],
+			"user",
+		);
+
+		expect(rows[0].breakdown).toHaveLength(1);
+	});
+});

--- a/apps/ui/src/components/analytics/chart-helpers.ts
+++ b/apps/ui/src/components/analytics/chart-helpers.ts
@@ -315,6 +315,126 @@ export function buildDimensionTimeseries(
 	};
 }
 
+// --- Project activity → generic dimension rows ----------------------------
+// The org endpoint (/analytics/activity) already returns a generic `breakdown`,
+// but the project endpoint (/activity) returns one field per dimension. This
+// maps the latter onto DimensionRow so both feed the same cards.
+
+export const UNATTRIBUTED_KEY = "__unattributed__";
+export const UNATTRIBUTED_LABEL = "Unattributed";
+
+// Sub-cent rounding noise between the project rollup and the per-key rollup
+// should not render as a series.
+const RESIDUAL_EPSILON = 1e-9;
+
+export const UNATTRIBUTED_NOTE =
+	"Spend is attributed to the member who created the API key that made each request. Traffic from platform keys cannot be attributed to a member and is shown as Unattributed.";
+
+interface ProjectActivityRow {
+	date: string;
+	cost: number;
+	requestCount: number;
+	totalTokens: number;
+	modelBreakdown: ModelBreakdownEntry[];
+	apiKeyBreakdown: {
+		id: string;
+		description: string;
+		cost: number;
+		requestCount: number;
+		totalTokens: number;
+		creditsRequestCount: number;
+		apiKeysRequestCount: number;
+		creditsCost: number;
+		apiKeysCost: number;
+	}[];
+	userBreakdown: {
+		id: string;
+		name: string;
+		cost: number;
+		requestCount: number;
+		totalTokens: number;
+		creditsRequestCount: number;
+		apiKeysRequestCount: number;
+		creditsCost: number;
+		apiKeysCost: number;
+	}[];
+}
+
+/**
+ * Pass the rows through `applyUsageModeToDaily` first: the residual below is
+ * computed against the day's own `cost`, so both sides must already be
+ * normalized to the same billing mode.
+ */
+export function toDimensionRows(
+	activity: ProjectActivityRow[],
+	groupBy: "model" | "apiKey" | "user",
+	view: ModelView = "mapping",
+): DimensionRow[] {
+	return activity.map((row) => {
+		if (groupBy === "model") {
+			return {
+				date: row.date,
+				breakdown: row.modelBreakdown.map((entry) => ({
+					...entry,
+					key: modelKey(entry, view),
+					label: modelKey(entry, view),
+				})),
+			};
+		}
+
+		if (groupBy === "apiKey") {
+			return {
+				date: row.date,
+				breakdown: row.apiKeyBreakdown.map((entry) => ({
+					...entry,
+					key: entry.id,
+					label: entry.description,
+				})),
+			};
+		}
+
+		const breakdown: DimensionEntry[] = row.userBreakdown.map((entry) => ({
+			...entry,
+			key: entry.id,
+			label: entry.name,
+		}));
+
+		// Per-key rollups only cover "user" and "end_user_customer" keys, so a
+		// project driven by platform keys sums to less than its own total. Surface
+		// the difference instead of letting the breakdown quietly under-report.
+		//
+		// Each metric is tested independently: free-model platform traffic adds
+		// requests and tokens at zero cost, and gating on cost alone would drop it
+		// from the Requests and Tokens views.
+		const residualCost = row.cost - sum(breakdown, "cost");
+		const residualRequests = row.requestCount - sum(breakdown, "requestCount");
+		const residualTokens = row.totalTokens - sum(breakdown, "totalTokens");
+		if (
+			residualCost > RESIDUAL_EPSILON ||
+			residualRequests > 0 ||
+			residualTokens > 0
+		) {
+			breakdown.push({
+				key: UNATTRIBUTED_KEY,
+				label: UNATTRIBUTED_LABEL,
+				cost: Math.max(0, residualCost),
+				requestCount: Math.max(0, residualRequests),
+				totalTokens: Math.max(0, residualTokens),
+				creditsRequestCount: 0,
+				apiKeysRequestCount: 0,
+				creditsCost: 0,
+				apiKeysCost: 0,
+			});
+		}
+
+		return { date: row.date, breakdown };
+	});
+}
+
+function sum(entries: DimensionEntry[], metric: ChartMetric): number {
+	return entries.reduce((total, entry) => total + entry[metric], 0);
+}
+
 export function sanitizeKey(model: string): string {
 	// Encode each non-alphanumeric char as its code point so distinct model ids
 	// (e.g. "claude-3.5" vs "claude-3-5") can't collapse into the same key and


### PR DESCRIPTION
Split out of #3522 for review clarity. This PR is the **cost breakdown** half; the **project lead role** is a separate stacked PR.

## Problem

A customer organization asked for project-level cost visibility: a project's total cost alongside a per-user breakdown, in one view, so a team lead can see what their own team is spending.

The data already existed — per-user attribution ships today, and `groupBy=user` is already supported at project scope for enterprise owners/admins. What was missing was the *view*: project total cost lived on the Dashboard, while the per-user breakdown lived on a different page (Model Usage) behind a dropdown, rendered as a stacked chart with no ranked figures.

## Approach

The project Analytics page now leads with **total cost / requests / tokens** for the range, and a **Group by** selector switches the two charts between model, API key, and user. Totals are summed from the same rows the charts read, so the header and the breakdown can't disagree.

The model dimension keeps `CostByModelCard`/`CostByModelOverTimeCard` rather than moving to the generic cards — they carry the **Mappings/Canonical** toggle, which is model-specific. The other two dimensions reuse the already-generic `DimensionUsageCard`/`DimensionUsageOverTimeCard` (previously wired only to the org-level page) through a new `toDimensionRows` adapter, since `/activity` returns per-dimension fields while `/analytics/activity` returns a generic `breakdown`.

### Unattributed spend is shown, not dropped

Attribution is `log.apiKeyId → api_key.created_by`, and the worker's per-key rollups only cover `user`/`end_user_customer` keys — so platform-key traffic has no member behind it and the per-member rows summed to **less** than the project total. The user breakdown now appends an **Unattributed** entry for the residual, tested per metric so zero-cost free-model traffic still appears under Requests and Tokens.

**No API or schema change.** `groupBy=user` already exists at project scope, gated to enterprise owners/admins — this PR does not touch that gate.

## Screenshots

### Before / after (light)

| Before | After |
| --- | --- |
| <img width="700" alt="Project Analytics before, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/a12b825770b1a5b8001e4568b84c2473f5008573/before-analytics-light.png" /> | <img width="700" alt="Project Analytics after, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/a12b825770b1a5b8001e4568b84c2473f5008573/after-analytics-model-light.png" /> |

### Before / after (dark)

| Before | After |
| --- | --- |
| <img width="700" alt="Project Analytics before, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/a12b825770b1a5b8001e4568b84c2473f5008573/before-analytics-dark.png" /> | <img width="700" alt="Project Analytics after, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/a12b825770b1a5b8001e4568b84c2473f5008573/after-analytics-model-dark.png" /> |

### Breakdown by user — the actual ask (light / dark)

Total cost sits above the per-member ranking, and `Unattributed` closes the gap to the project total.

<img width="900" alt="Breakdown by user, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/a12b825770b1a5b8001e4568b84c2473f5008573/after-analytics-user-light.png" />

<img width="900" alt="Breakdown by user, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/a12b825770b1a5b8001e4568b84c2473f5008573/after-analytics-user-dark.png" />

## Verification

- `pnpm format` and full `pnpm build` clean.
- New `chart-helpers.spec.ts` (8 tests): dimension mapping for all three dimensions, the Unattributed residual, the zero-cost residual, per-user costs summing to the project total, sub-cent rounding noise ignored, and no negative residual when the per-key rollup runs ahead.
- `group-by.spec.ts` (8) still green.
- Driven in a browser against a locally seeded enterprise org for every screenshot above.

Known follow-up: the `/learn/analytics` docs screenshot is now stale and should be regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
