### PR TITLE
docs: use native GitHub stacked pull requests

### DIFF
--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -49,6 +49,28 @@ EOF
 - When checking out someone else's PR or a remote branch, set upstream so plain `git pull`/`git push` work: `gh pr checkout <n>`, or `git checkout -B <branch> FETCH_HEAD && git branch --set-upstream-to=origin/<branch>`.
 - Force-push only on feature branches, never on `main`. Do not `--amend` a commit that is already pushed.
 
+## Stacked pull requests
+
+When a change has layers worth reviewing separately — a UI feature plus the permission model it needs, a refactor plus the behaviour built on it — split it into a **native GitHub stack** rather than one large PR. Each layer gets its own PR showing only its own diff, and layers can be reviewed in parallel.
+
+Use the `gh stack` extension (`gh extension install github/gh-stack`). Do **not** hand-roll a stack by opening a PR whose `--base` points at another feature branch: it looks the same on day one, but GitHub then won't rebase or retarget the upper layers for you, and this repo squash-merges (merge commits are disabled), so the lower layer's commit lingers in the upper branch and turns into a conflict.
+
+```bash
+gh stack init feat/lower feat/upper   # adopts existing branches, bottom to top
+gh stack submit                       # pushes and creates/links the PRs (--auto to skip the editor)
+gh stack view                         # see the stack and its PR links
+gh stack rebase && gh stack push      # cascading restack onto the latest main
+gh stack merge                        # land the stack, or merge layers individually
+```
+
+Notes worth knowing:
+
+- `gh stack init` **adopts** branches that already exist and finds their open PRs, so an already-split pair of PRs can be converted into a stack without losing descriptions, screenshots, or review history. `gh stack submit` then reports them "up to date" and just links them.
+- Order the layers so each one is independently shippable: the bottom layer must make sense on its own even if the top never lands.
+- Keep a file that both layers touch to a minimal edit in the upper one — that is where a restack conflict would surface.
+- `gh stack rebase` rebases onto `origin/main`. It warns and falls back harmlessly if another worktree has `main` checked out, which is normal in Conductor.
+- Once merged, GitHub rebases and retargets every layer above automatically; you do not need to retarget bases by hand.
+
 ## Syncing a feature branch with main
 
 **Default to a merge commit.** `git fetch origin && git merge origin/main` — it preserves the branch's existing commits and their pushed hashes, so review comments stay anchored, CI results stay valid, and nobody working from the branch has to recover from rewritten history.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,6 +305,7 @@ When creating a new package in `packages/`, include these config files. Copy the
 - When syncing a feature branch with main, default to a merge commit; only rebase when it is required or clearly the better choice, and say why
 - When resolving conflicts involving `pnpm-lock.yaml`, just run `pnpm install` to automatically resolve them
 - Use the local `pull-request` skill for opening pull requests, writing/updating PR titles and descriptions, embedding screenshots in a PR body, and triggering e2e CI on a PR.
+- When a change splits into layers that are worth reviewing separately (e.g. a UI feature plus the new permission it needs), use GitHub's **native stacked pull requests** via the `gh stack` extension — never hand-roll a stack by pointing one PR's base at another branch. `gh stack init <bottom> <top>` adopts existing branches, `gh stack submit` creates/links the PRs, `gh stack rebase && gh stack push` restacks onto main, and `gh stack merge` lands the stack. GitHub rebases and retargets the layers above automatically as each one merges, which is what keeps a squash-merge repo like this one from conflicting
 - When writing pull request titles, use the conventional commit message format and limit to max 50 characters
 - Always open pull requests as normal ready-for-review PRs, not draft PRs, unless the user explicitly asks for a draft PR
 - When creating a pull request, always write/update both the PR title and description; if the PR's scope changes in later commits, update the title and description to reflect the final scope before handing it off


### PR DESCRIPTION
GitHub shipped stacked pull requests natively (public preview, 30 July 2026), and the `gh stack` extension is already installed here. This documents it so agents reach for it instead of hand-rolling a stack.

## Why it matters for this repo specifically

Hand-rolling a stack — opening a PR whose `--base` points at another feature branch — looks equivalent on day one, and GitHub even shows the correct per-layer diff. The difference shows up at merge time: GitHub won't rebase or retarget the upper layers for you.

This repo has merge commits **disabled** and squash enabled, so the lower layer lands on `main` as a single new commit with a different SHA than the one still sitting in the upper branch. Any file both layers touch is then a conflict waiting to happen. With a native stack, GitHub rebases and retargets every layer above automatically as each one merges.

## Changes

- `AGENTS.md` — one bullet next to the existing pull-request guidance.
- `.agents/skills/pull-request/SKILL.md` — a "Stacked pull requests" section with the command flow and the non-obvious bits:
  - `gh stack init` **adopts** existing branches and finds their open PRs, so an already-split pair of PRs converts into a stack without losing descriptions, screenshots, or review history.
  - Order layers so the bottom one is independently shippable.
  - Keep any file touched by both layers to a minimal edit in the upper one — that's where a restack conflict would surface.
  - `gh stack rebase` warns harmlessly when another worktree has `main` checked out, which is the norm in Conductor.

Verified against a real two-layer stack (#3562 → #3563): `gh stack init` adopted both existing branches and matched their PRs, `gh stack submit` linked them without touching either description, and `gh stack rebase && gh stack push` restacked both onto the latest `main` with no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for creating and managing stacked pull requests with GitHub’s native stack workflow.
  * Documented setup, branch adoption, submission, rebasing, pushing, merging, conflict resolution, and automatic retargeting.
  * Clarified expectations for keeping each pull request independently shippable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->