### PR TITLE
feat(code): DevPass privacy summary cards

### DIFF
--- a/apps/code/src/app/legal/privacy/page.tsx
+++ b/apps/code/src/app/legal/privacy/page.tsx
@@ -1,3 +1,5 @@
+import { LegalSummary } from "@/components/LegalSummary";
+
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -16,6 +18,7 @@ export default function PrivacyPage() {
 				<br />
 				<strong>Last Updated:</strong> August 2, 2026
 			</p>
+			<LegalSummary variant="privacy" />
 			<p>
 				This Supplemental Privacy Policy describes how{" "}
 				<strong>LLM Gateway</strong> (&ldquo;we&rdquo;, &ldquo;our&rdquo;, or

--- a/apps/code/src/app/legal/terms/page.tsx
+++ b/apps/code/src/app/legal/terms/page.tsx
@@ -20,7 +20,7 @@ export default function TermsPage() {
 				<br />
 				<strong>Last Updated:</strong> August 2, 2026
 			</p>
-			<LegalSummary />
+			<LegalSummary variant="terms" />
 			<p>
 				<strong>DevPass</strong> is a service operated by{" "}
 				<strong>LLM Gateway</strong> (&ldquo;we&rdquo;, &ldquo;our&rdquo;, or

--- a/apps/code/src/components/LegalSummary.tsx
+++ b/apps/code/src/components/LegalSummary.tsx
@@ -1,7 +1,11 @@
 import {
+	BadgeCheck,
 	Ban,
+	Clock,
 	DatabaseZap,
 	Info,
+	Share2,
+	ShieldCheck,
 	Terminal,
 	UserRound,
 	Wallet,
@@ -85,12 +89,98 @@ const termsCards: SummaryCard[] = [
 	},
 ];
 
-export function LegalSummary() {
+const privacyCards: SummaryCard[] = [
+	{
+		icon: Info,
+		title: "An addendum to the main policy",
+		body: (
+			<>
+				This policy adds DevPass-specific detail to the LLM Gateway Privacy
+				Policy, which still governs everything else — legal bases, your GDPR and
+				CCPA rights, security and international transfers.
+			</>
+		),
+	},
+	{
+		icon: DatabaseZap,
+		title: "Metadata only, no prompt storage",
+		body: (
+			<>
+				We log tokens, cost, latency, model, provider and which coding tool sent
+				the request. Your prompts and the model&rsquo;s responses aren&rsquo;t
+				retained, and there is no setting to turn payload storage on.
+			</>
+		),
+	},
+	{
+		icon: Clock,
+		title: "One exception: the Responses API",
+		body: (
+			<>
+				Requests to <code>/v1/responses</code> are stateful, so their input and
+				output items are stored for up to 30 days to make response chaining
+				work. Send <code>store: false</code> to opt out.
+			</>
+		),
+	},
+	{
+		icon: Share2,
+		title: "Your request goes to the provider you pick",
+		body: (
+			<>
+				Prompts are forwarded to the AI provider behind the model you chose —
+				each applies its own retention policy. We pass through provider-side
+				&ldquo;no training&rdquo; flags where they exist.
+			</>
+		),
+	},
+	{
+		icon: ShieldCheck,
+		title: "Never sold, never used for training",
+		body: (
+			<>
+				We don&rsquo;t sell your personal data and we never train our own models
+				on your prompts or completions. Data is shared only with a small set of
+				vetted sub-processors.
+			</>
+		),
+	},
+	{
+		icon: BadgeCheck,
+		title: "Retention and your rights",
+		body: (
+			<>
+				Request metadata is kept for the life of your subscription and billing
+				records for 10 years where tax law requires it. You can access, export
+				or delete your data at any time.
+			</>
+		),
+	},
+];
+
+const summaries = {
+	terms: {
+		heading: "DevPass terms in plain English",
+		cards: termsCards,
+	},
+	privacy: {
+		heading: "DevPass privacy in plain English",
+		cards: privacyCards,
+	},
+} satisfies Record<string, { heading: string; cards: SummaryCard[] }>;
+
+export function LegalSummary({
+	variant = "terms",
+}: {
+	variant?: keyof typeof summaries;
+}) {
+	const summary = summaries[variant];
+
 	return (
 		<section className="my-10">
 			<div className="mb-6">
 				<h2 className="text-xl font-semibold tracking-tight text-foreground mb-2">
-					DevPass terms in plain English
+					{summary.heading}
 				</h2>
 				<p className="text-sm text-muted-foreground">
 					A human-readable summary of the key points. This overview is for
@@ -102,7 +192,7 @@ export function LegalSummary() {
 				</p>
 			</div>
 			<div className="grid gap-4 sm:grid-cols-2">
-				{termsCards.map((card) => {
+				{summary.cards.map((card) => {
 					const Icon = card.icon;
 					return (
 						<div


### PR DESCRIPTION
The DevPass terms page opens with a plain-English card summary, but the DevPass privacy policy page had none — the longest and least skimmable of the two legal documents was the one without a TL;DR.

`LegalSummary` now takes a `variant` prop (`terms` | `privacy`) and carries both card sets, so the privacy page renders six cards covering the same ground the policy does: it's an addendum to the base policy, metadata-only logging, the 30-day Responses API exception, provider routing, no selling/training, and retention plus your rights. Same "not legally binding, the full text below governs" disclaimer as the terms page.

Wording is derived directly from the policy sections below it — no new commitments were introduced.

### Before / after (light)

<img width="1280" alt="DevPass privacy policy before — no summary" src="https://raw.githubusercontent.com/theopenco/llmgateway/5769f59e721804d4fbe43aa849f11a96ea94f3fd/privacy-before-light.png" />

<img width="1280" alt="DevPass privacy policy after — summary cards" src="https://raw.githubusercontent.com/theopenco/llmgateway/5769f59e721804d4fbe43aa849f11a96ea94f3fd/privacy-after-light.png" />

### Dark

<img width="736" alt="DevPass privacy summary cards in dark mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/5769f59e721804d4fbe43aa849f11a96ea94f3fd/privacy-summary-dark.png" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)