### PR TITLE
feat(gateway): attribute more coding agent UAs

### DIFF
--- a/apps/gateway/src/chat/tools/detect-coding-agent.spec.ts
+++ b/apps/gateway/src/chat/tools/detect-coding-agent.spec.ts
@@ -25,6 +25,11 @@ describe("detectCodingAgentFromUserAgent", () => {
 		expect(detectCodingAgentFromUserAgent("codex_cli_rs/0.4.2")).toBe("codex");
 		expect(detectCodingAgentFromUserAgent("codex-cli/2.1.0")).toBe("codex");
 		expect(detectCodingAgentFromUserAgent("codex/3.0.0 node/22")).toBe("codex");
+		expect(
+			detectCodingAgentFromUserAgent(
+				"codex_vscode/0.147.0-alpha.6.5 (Ubuntu 24.4.0; x86_64) unknown (VS Code; 26.803.41515)",
+			),
+		).toBe("codex");
 	});
 
 	it("detects OpenCode", () => {
@@ -64,6 +69,7 @@ describe("detectCodingAgentFromUserAgent", () => {
 	it("detects n8n", () => {
 		expect(detectCodingAgentFromUserAgent("n8n/1.50.0")).toBe("n8n");
 		expect(detectCodingAgentFromUserAgent("n8n-workflow runner")).toBe("n8n");
+		expect(detectCodingAgentFromUserAgent("n8n")).toBe("n8n");
 	});
 
 	it("detects OpenClaw", () => {
@@ -126,6 +132,37 @@ describe("detectCodingAgentFromUserAgent", () => {
 	it("detects Pi Agent", () => {
 		expect(detectCodingAgentFromUserAgent("pi-agent/1.0.0")).toBe("pi-agent");
 		expect(detectCodingAgentFromUserAgent("pi_agent/2.0")).toBe("pi-agent");
+		expect(detectCodingAgentFromUserAgent("pi-coding-agent")).toBe("pi-agent");
+	});
+
+	it("detects Crush", () => {
+		expect(
+			detectCodingAgentFromUserAgent(
+				"Charm-Crush/v0.87.0 (https://charm.land/crush)",
+			),
+		).toBe("crush");
+		expect(detectCodingAgentFromUserAgent("crush/0.88.0")).toBe("crush");
+	});
+
+	it("detects Kimi Code", () => {
+		expect(detectCodingAgentFromUserAgent("kimi-code-cli/0.34.0")).toBe(
+			"kimi-code",
+		);
+		expect(detectCodingAgentFromUserAgent("kimi-cli/1.0.0")).toBe("kimi-code");
+	});
+
+	it("detects Qwen Code", () => {
+		expect(detectCodingAgentFromUserAgent("QwenCode/0.21.5 (linux; x64)")).toBe(
+			"qwen-code",
+		);
+		expect(detectCodingAgentFromUserAgent("qwen-code/1.0")).toBe("qwen-code");
+	});
+
+	it("detects Factory Droid", () => {
+		expect(detectCodingAgentFromUserAgent("factory-cli/0.190.0")).toBe(
+			"factory-droid",
+		);
+		expect(detectCodingAgentFromUserAgent("droid/1.2.3")).toBe("factory-droid");
 	});
 
 	it("detects Hermes Agent", () => {
@@ -155,6 +192,27 @@ describe("detectCodingAgentFromUserAgent", () => {
 		expect(detectCodingAgentFromUserAgent("axios/1.6.5")).toBeUndefined();
 		expect(
 			detectCodingAgentFromUserAgent("python-requests/2.31"),
+		).toBeUndefined();
+	});
+
+	it("leaves generic SDKs and proxies unattributed", () => {
+		expect(
+			detectCodingAgentFromUserAgent(
+				"ai/6.0.168 ai-sdk/provider-utils/4.0.23 runtime/node.js/26",
+			),
+		).toBeUndefined();
+		expect(
+			detectCodingAgentFromUserAgent("AsyncOpenAI/Python 2.32.0"),
+		).toBeUndefined();
+		expect(detectCodingAgentFromUserAgent("OpenAI/JS 6.47.0")).toBeUndefined();
+		expect(detectCodingAgentFromUserAgent("litellm/1.90.1")).toBeUndefined();
+		expect(
+			detectCodingAgentFromUserAgent("cli-proxy-openai-compat"),
+		).toBeUndefined();
+		expect(
+			detectCodingAgentFromUserAgent(
+				"langchainjs-openai/1.0.0 ((node/v24.16.0; linux; x64))",
+			),
 		).toBeUndefined();
 	});
 });

--- a/packages/shared/src/coding-agents.spec.ts
+++ b/packages/shared/src/coding-agents.spec.ts
@@ -31,6 +31,10 @@ describe("isRecognizedCodingAgent", () => {
 		expect(isRecognizedCodingAgent("pi-agent")).toBe(true);
 		expect(isRecognizedCodingAgent("hermes-agent")).toBe(true);
 		expect(isRecognizedCodingAgent("hermes")).toBe(true);
+		expect(isRecognizedCodingAgent("crush")).toBe(true);
+		expect(isRecognizedCodingAgent("kimi-code")).toBe(true);
+		expect(isRecognizedCodingAgent("qwen-code")).toBe(true);
+		expect(isRecognizedCodingAgent("factory-droid")).toBe(true);
 	});
 
 	it("recognizes *claw forks via pattern", () => {
@@ -57,6 +61,11 @@ describe("normalizeSourceToAgentId", () => {
 		expect(normalizeSourceToAgentId("roo-cline")).toBe("roo-code");
 		expect(normalizeSourceToAgentId("copilot")).toBe("github-copilot");
 		expect(normalizeSourceToAgentId("hermes")).toBe("hermes-agent");
+		expect(normalizeSourceToAgentId("charm-crush")).toBe("crush");
+		expect(normalizeSourceToAgentId("kimi-cli")).toBe("kimi-code");
+		expect(normalizeSourceToAgentId("qwencode")).toBe("qwen-code");
+		expect(normalizeSourceToAgentId("droid")).toBe("factory-droid");
+		expect(normalizeSourceToAgentId("pi-coding-agent")).toBe("pi-agent");
 	});
 
 	it("returns the same value for canonical IDs", () => {

--- a/packages/shared/src/coding-agents.ts
+++ b/packages/shared/src/coding-agents.ts
@@ -24,10 +24,13 @@ export const CODING_AGENTS: CodingAgentDefinition[] = [
 		id: "codex",
 		label: "Codex CLI",
 		xSourceValues: ["codex"],
+		// The IDE extension identifies as "codex_vscode/<version> (<os>) …", which
+		// none of the CLI-shaped patterns match.
 		userAgentPatterns: [
 			/^codex[-_]cli/i,
 			/^codex_cli_rs\//i,
 			/^codex[-_]tui\//i,
+			/^codex[-_]vscode\//i,
 			/^codex\//i,
 		],
 	},
@@ -83,7 +86,8 @@ export const CODING_AGENTS: CodingAgentDefinition[] = [
 		id: "n8n",
 		label: "n8n",
 		xSourceValues: ["n8n"],
-		userAgentPatterns: [/^n8n\//i, /\bn8n-workflow\b/i],
+		// n8n's OpenAI node sends a bare "n8n" with no version suffix.
+		userAgentPatterns: [/^n8n$/i, /^n8n\//i, /\bn8n-workflow\b/i],
 	},
 	{
 		id: "openclaw",
@@ -133,8 +137,13 @@ export const CODING_AGENTS: CodingAgentDefinition[] = [
 	{
 		id: "pi-agent",
 		label: "Pi Agent",
-		xSourceValues: ["pi-agent"],
-		userAgentPatterns: [/^pi-agent\//i, /\bpi[-_]agent\b/i],
+		xSourceValues: ["pi-agent", "pi-coding-agent"],
+		// The CLI sends a bare "pi-coding-agent" with no version suffix.
+		userAgentPatterns: [
+			/^pi-agent\//i,
+			/\bpi[-_]agent\b/i,
+			/\bpi[-_]coding[-_]agent\b/i,
+		],
 	},
 	{
 		id: "hermes-agent",
@@ -147,6 +156,38 @@ export const CODING_AGENTS: CodingAgentDefinition[] = [
 		],
 		titleValues: ["hermes agent"],
 		refererPatterns: [/hermes-agent\.nousresearch\.com/i],
+	},
+	{
+		id: "crush",
+		label: "Crush",
+		xSourceValues: ["crush", "charm-crush"],
+		userAgentPatterns: [
+			/^charm[-_]crush\//i,
+			/^crush\//i,
+			/charm\.land\/crush/i,
+		],
+	},
+	{
+		id: "kimi-code",
+		label: "Kimi Code",
+		xSourceValues: ["kimi-code", "kimi-cli"],
+		userAgentPatterns: [/^kimi[-_]code/i, /^kimi[-_]cli\//i],
+	},
+	{
+		id: "qwen-code",
+		label: "Qwen Code",
+		xSourceValues: ["qwen-code", "qwencode"],
+		userAgentPatterns: [/^qwencode\//i, /\bqwen[-_]code\b/i],
+	},
+	{
+		id: "factory-droid",
+		label: "Factory Droid",
+		xSourceValues: ["factory-droid", "factory", "droid"],
+		userAgentPatterns: [
+			/^factory[-_]cli\//i,
+			/^droid\//i,
+			/\bfactory[-_]droid\b/i,
+		],
 	},
 	{
 		id: "openai-sdk",


### PR DESCRIPTION
## Problem

A review of the top user agents hitting the gateway showed several well-known coding agents landing in the unattributed bucket, because the User-Agent shape they actually send does not match any pattern in `CODING_AGENTS`. That means their traffic is missing from the Agents dashboard, and — more importantly — those requests fail the `isRecognizedCodingAgent` gate on DevPass coding plans.

## Changes

New agent definitions (previously unattributed):

| Agent | Observed User-Agent |
| --- | --- |
| Crush | `Charm-Crush/v0.87.0 (https://charm.land/crush)` |
| Kimi Code | `kimi-code-cli/0.34.0` |
| Qwen Code | `QwenCode/0.21.5 (linux; x64)` |
| Factory Droid | `factory-cli/0.190.0` |

All four already ship an integration guide and icon in this repo, so they were recognized everywhere except in attribution.

Extra patterns on existing definitions:

- **Codex** — the IDE extension identifies as `codex_vscode/<version> (<os>) …`, which none of the CLI-shaped patterns (`codex-cli`, `codex_cli_rs`, `codex-tui`, `codex/`) matched.
- **Pi Agent** — the CLI sends a bare `pi-coding-agent` with no version suffix, which `\bpi[-_]agent\b` does not match.
- **n8n** — the OpenAI node sends a bare `n8n`, which `^n8n\/` does not match.

Generic HTTP clients, SDKs and proxies stay unattributed on purpose (AI SDK, OpenAI/Anthropic SDKs, litellm, LangChain, `cli-proxy-openai-compat`, curl/undici/okhttp, browsers). A test locks that in so a future broad pattern cannot quietly start attributing them.

## Notes

- Adding an entry also widens the `x-source` allowlist that gates DevPass coding plans — intended here, since each addition is a genuine coding agent.
- The Agents dashboard renders these from `CODING_AGENTS` and falls back to the terminal icon for agents without a dedicated entry in `AGENT_ICONS`, same as the other icon-less agents already in the list; no UI change was needed.

## Verification

`pnpm format`, `pnpm build`, and the unit specs for `packages/shared` plus the gateway UA detector all pass, with new cases asserting on the exact User-Agent strings observed in traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recognition for additional coding agents, including Codex in VS Code, n8n, Pi Coding Agent, Crush, Kimi Code, Qwen Code, and Factory Droid.
  * Added support for alternate source identifiers and normalized agent names.

* **Bug Fixes**
  * Improved attribution accuracy by preventing generic SDKs, proxies, and OpenAI-compatible clients from being incorrectly identified as coding agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->