### PR TITLE
feat: move Lounge to lounge.llmgateway.io

### DIFF
--- a/apps/api/src/lib/rag.ts
+++ b/apps/api/src/lib/rag.ts
@@ -2,6 +2,8 @@ import { HTTPException } from "hono/http-exception";
 
 import { getGatewayUrl } from "@/utils/playground-key.js";
 
+import { LOUNGE_SOURCE } from "@llmgateway/shared/lounge-source";
+
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 
 export const EMBEDDING_MODEL = "openai/text-embedding-3-small";
@@ -103,7 +105,7 @@ export async function embedTexts(
 			headers: {
 				authorization: `Bearer ${token}`,
 				"content-type": "application/json",
-				"x-source": "chat.llmgateway.io",
+				"x-source": LOUNGE_SOURCE,
 			},
 			body: JSON.stringify({ model: EMBEDDING_MODEL, input: batch }),
 			signal: AbortSignal.timeout(EMBEDDING_TIMEOUT_MS),

--- a/apps/api/src/routes/chat-projects.ts
+++ b/apps/api/src/routes/chat-projects.ts
@@ -12,6 +12,7 @@ import {
 
 import { createLLMGateway } from "@llmgateway/ai-sdk-provider";
 import { db, tables, eq, and, count, desc, asc } from "@llmgateway/db";
+import { LOUNGE_SOURCE } from "@llmgateway/shared/lounge-source";
 
 import type { ServerTypes } from "@/vars.js";
 
@@ -1017,7 +1018,7 @@ chatProjects.openapi(extractMemories, async (c) => {
 		apiKey: token,
 		baseURL: getGatewayUrl(),
 		headers: {
-			"x-source": "chat.llmgateway.io",
+			"x-source": LOUNGE_SOURCE,
 		},
 	});
 

--- a/apps/api/src/routes/organization.ts
+++ b/apps/api/src/routes/organization.ts
@@ -143,7 +143,7 @@ const organizationSchema = z.object({
 	referralBonusEnabled: z.boolean(),
 	referralBonusPercent: z.string(),
 	// Organization kind: "default" (regular dashboard org), "devpass" (per-user
-	// Dev Plans org), or "chat" (per-user chat.llmgateway.io org).
+	// Dev Plans org), or "chat" (per-user lounge.llmgateway.io org).
 	kind: z.enum(["default", "chat", "devpass"]),
 	devPlan: z.enum(["none", "lite", "pro", "max"]),
 	devPlanCycle: z.enum(["monthly", "annual"]),
@@ -1027,7 +1027,7 @@ organization.openapi(deleteOrganization, async (c) => {
 	if (userOrganization.organization?.kind === "chat") {
 		throw new HTTPException(403, {
 			message:
-				"The Chat organization cannot be deleted. Please cancel your chat plan from the chat.llmgateway.io pricing page instead.",
+				"The Chat organization cannot be deleted. Please cancel your chat plan from the lounge.llmgateway.io pricing page instead.",
 		});
 	}
 

--- a/apps/api/src/routes/public-chat-support.ts
+++ b/apps/api/src/routes/public-chat-support.ts
@@ -67,7 +67,7 @@ const MAX_CONTEXT_MESSAGES = 30;
 
 const DOCS_BASE_URL = "https://docs.llmgateway.io";
 
-const BASE_SYSTEM_PROMPT = `You are the LLM Gateway support assistant. You ONLY answer questions related to LLM Gateway — the unified API gateway for multiple LLM providers — and its products (the dashboard at llmgateway.io, DevPass at devpass.llmgateway.io, the docs at docs.llmgateway.io, and Lounge, the AI chat app at chat.llmgateway.io).
+const BASE_SYSTEM_PROMPT = `You are the LLM Gateway support assistant. You ONLY answer questions related to LLM Gateway — the unified API gateway for multiple LLM providers — and its products (the dashboard at llmgateway.io, DevPass at devpass.llmgateway.io, the docs at docs.llmgateway.io, and Lounge, the AI chat app at lounge.llmgateway.io).
 
 Your knowledge covers:
 - Getting started, quick start, and setup
@@ -115,7 +115,7 @@ ${overviewSections}`;
 		const urlList = urls.map((u) => `- ${u}`).join("\n");
 		prompt += `
 
-Available pages (sourced from the live sitemaps and llms.txt files of llmgateway.io, devpass.llmgateway.io, docs.llmgateway.io and chat.llmgateway.io). Use these for accurate links and as targets for the \`fetchPage\` tool:
+Available pages (sourced from the live sitemaps and llms.txt files of llmgateway.io, devpass.llmgateway.io, docs.llmgateway.io and lounge.llmgateway.io). Use these for accurate links and as targets for the \`fetchPage\` tool:
 ${urlList}`;
 	}
 
@@ -538,7 +538,7 @@ publicChatSupport.post("/", async (c) => {
 		tools: {
 			fetchPage: tool({
 				description:
-					"Fetch the readable text content of an LLM Gateway page (llmgateway.io, devpass/docs/chat.llmgateway.io) to ground your answer in accurate, up-to-date information. Pass a full https URL from the available pages list.",
+					"Fetch the readable text content of an LLM Gateway page (llmgateway.io, devpass/docs/lounge.llmgateway.io) to ground your answer in accurate, up-to-date information. Pass a full https URL from the available pages list.",
 				inputSchema: z.object({
 					url: z
 						.string()

--- a/apps/api/src/routes/skills.ts
+++ b/apps/api/src/routes/skills.ts
@@ -9,6 +9,7 @@ import {
 
 import { createLLMGateway } from "@llmgateway/ai-sdk-provider";
 import { db, tables, eq, and } from "@llmgateway/db";
+import { LOUNGE_SOURCE } from "@llmgateway/shared/lounge-source";
 
 import type { ServerTypes } from "@/vars.js";
 
@@ -394,7 +395,7 @@ skills.openapi(generateSkill, async (c) => {
 		apiKey: token,
 		baseURL: gatewayUrl,
 		headers: {
-			"x-source": "chat.llmgateway.io",
+			"x-source": LOUNGE_SOURCE,
 		},
 	});
 

--- a/apps/api/src/utils/chat-support-knowledge.spec.ts
+++ b/apps/api/src/utils/chat-support-knowledge.spec.ts
@@ -11,6 +11,8 @@ describe("isAllowedKnowledgeUrl", () => {
 			true,
 		);
 		expect(isAllowedKnowledgeUrl("https://devpass.llmgateway.io/")).toBe(true);
+		expect(isAllowedKnowledgeUrl("https://lounge.llmgateway.io/")).toBe(true);
+		// Kept allowed after the move: the old host still 301s to lounge.
 		expect(isAllowedKnowledgeUrl("https://chat.llmgateway.io/")).toBe(true);
 	});
 

--- a/apps/api/src/utils/chat-support-knowledge.ts
+++ b/apps/api/src/utils/chat-support-knowledge.ts
@@ -9,7 +9,7 @@ const KNOWLEDGE_SITEMAPS = [
 	"https://llmgateway.io/sitemap.xml",
 	"https://devpass.llmgateway.io/sitemap.xml",
 	"https://docs.llmgateway.io/sitemap.xml",
-	"https://chat.llmgateway.io/sitemap.xml",
+	"https://lounge.llmgateway.io/sitemap.xml",
 ];
 
 // llms.txt overviews are short, curated markdown summaries of a product —
@@ -18,14 +18,17 @@ const KNOWLEDGE_SITEMAPS = [
 // plans) are answerable without a tool call.
 const KNOWLEDGE_LLMS_TXT = [
 	"https://devpass.llmgateway.io/llms.txt",
-	"https://chat.llmgateway.io/llms.txt",
+	"https://lounge.llmgateway.io/llms.txt",
 ];
 
 // Only pages on these hosts may be fetched by the agent's grounding tool.
+// chat.llmgateway.io stays on the list after the move to lounge.llmgateway.io
+// because links to the old host are still in the wild; it 301s to the new one.
 const ALLOWED_HOSTS = [
 	"llmgateway.io",
 	"devpass.llmgateway.io",
 	"docs.llmgateway.io",
+	"lounge.llmgateway.io",
 	"chat.llmgateway.io",
 ];
 

--- a/apps/api/src/utils/personal-org.ts
+++ b/apps/api/src/utils/personal-org.ts
@@ -55,7 +55,7 @@ export async function getOrCreatePersonalOrg(user: PersonalOrgUser) {
 }
 
 // Get or create the dedicated "Chat" organization for a user. This backs
-// chat.llmgateway.io (apps/playground): the chat plan, pay-as-you-go top-ups,
+// lounge.llmgateway.io (apps/playground): the chat plan, pay-as-you-go top-ups,
 // and all playground billing live here, kept separate from the DevPass personal
 // org used by the coding product.
 //

--- a/apps/docs/components/ai/page-actions.tsx
+++ b/apps/docs/components/ai/page-actions.tsx
@@ -147,7 +147,7 @@ export function ViewOptions({
 						? `http://localhost:3003?${new URLSearchParams({
 								q,
 							})}&hints=search&model=google-ai-studio/gemini-3-flash-preview`
-						: `https://chat.llmgateway.io?${new URLSearchParams({
+						: `https://lounge.llmgateway.io?${new URLSearchParams({
 								q,
 							})}&hints=search&model=google-ai-studio/gemini-3-flash-preview`,
 				icon: <Logo />,

--- a/apps/docs/content/features/realtime.mdx
+++ b/apps/docs/content/features/realtime.mdx
@@ -20,8 +20,8 @@ key, and keep your existing event handling.
 
 <Callout type="info">
 	Want to talk to a model right now? The [Realtime
-	page](https://chat.llmgateway.io/realtime) in Lounge runs a full voice call in
-	the browser using this API.
+	page](https://lounge.llmgateway.io/realtime) in Lounge runs a full voice call
+	in the browser using this API.
 </Callout>
 
 ## Available Models

--- a/apps/docs/content/features/speech-generation.mdx
+++ b/apps/docs/content/features/speech-generation.mdx
@@ -14,7 +14,7 @@ and Alibaba Qwen speech models.
 
 <Callout type="info">
 	Want to hear the voices before writing code? The [Audio
-	Studio](https://chat.llmgateway.io/audio) in Lounge generates speech from up
+	Studio](https://lounge.llmgateway.io/audio) in Lounge generates speech from up
 	to three models side by side, with per-model voice, format, and speed
 	controls.
 </Callout>

--- a/apps/docs/content/learn/chat-plans.mdx
+++ b/apps/docs/content/learn/chat-plans.mdx
@@ -7,7 +7,7 @@ icon: Sparkles
 import { Callout } from "fumadocs-ui/components/callout";
 import { ThemedImage } from "@/components/themed-image";
 
-Lounge memberships (formerly Chat Plans) are optional monthly subscriptions for [Lounge](https://chat.llmgateway.io), the LLM Gateway chat app. Instead of paying per request from your pay-as-you-go balance, a membership gives you a pool of monthly credits worth more than you pay — so heavy chat usage costs less.
+Lounge memberships (formerly Chat Plans) are optional monthly subscriptions for [Lounge](https://lounge.llmgateway.io), the LLM Gateway chat app. Instead of paying per request from your pay-as-you-go balance, a membership gives you a pool of monthly credits worth more than you pay — so heavy chat usage costs less.
 
 <ThemedImage
 	alt="Lounge membership pricing with Starter, Plus, and Pro tiers"

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2743,7 +2743,7 @@ chat.openapi(completions, async (c) => {
 	);
 	if (isStarterChatPlan && !isChatPlanModelAllowed("starter", modelInfo.id)) {
 		throw new HTTPException(403, {
-			message: `Model ${modelInfo.id} is not available on the Starter chat plan. Upgrade to Plus or Pro at chat.llmgateway.io/pricing to access frontier models.`,
+			message: `Model ${modelInfo.id} is not available on the Starter chat plan. Upgrade to Plus or Pro at lounge.llmgateway.io/pricing to access frontier models.`,
 		});
 	}
 

--- a/apps/gateway/src/realtime/client-secrets.spec.ts
+++ b/apps/gateway/src/realtime/client-secrets.spec.ts
@@ -74,7 +74,7 @@ describe("parseClientSecretRecord", () => {
 		token: "llmgtwy_test",
 		model: "openai/gpt-realtime-2.1-mini",
 		transcriptionModel: "gpt-4o-mini-transcribe",
-		source: "chat.llmgateway.io",
+		source: "lounge.llmgateway.io",
 		createdAt: 1_784_800_000,
 		expiresAt: 1_784_800_060,
 	};

--- a/apps/gateway/src/realtime/gemini-session.spec.ts
+++ b/apps/gateway/src/realtime/gemini-session.spec.ts
@@ -179,7 +179,7 @@ function createSession(preflightOverrides: Record<string, unknown> = {}) {
 			"google-ai-studio/gemini-2.5-flash-native-audio-preview-12-2025",
 		sessionRecordId: "rts_g1",
 		lease: { sessionId: "rts_g1", organizationId: "org_1", apiKeyId: "key_1" },
-		source: "chat.llmgateway.io",
+		source: "lounge.llmgateway.io",
 		userAgent: "vitest",
 		onClosed: () => {},
 	});

--- a/apps/gateway/src/realtime/session.spec.ts
+++ b/apps/gateway/src/realtime/session.spec.ts
@@ -175,7 +175,7 @@ function createSession(preflightOverrides: Record<string, unknown> = {}) {
 		requestedModel: "openai/gpt-realtime-2.1-mini",
 		sessionRecordId: "rts_1",
 		lease: { sessionId: "rts_1", organizationId: "org_1", apiKeyId: "key_1" },
-		source: "chat.llmgateway.io",
+		source: "lounge.llmgateway.io",
 		userAgent: "vitest",
 		allowedTranscription: null,
 		onClosed: () => {},

--- a/apps/gateway/src/speech/speech.spec.ts
+++ b/apps/gateway/src/speech/speech.spec.ts
@@ -295,7 +295,7 @@ describe("speech", () => {
 				headers: {
 					"Content-Type": "application/json",
 					Authorization: "Bearer real-token-speech-chat-plan",
-					"x-source": "chat.llmgateway.io",
+					"x-source": "lounge.llmgateway.io",
 				},
 				body: JSON.stringify({
 					model: "gemini-2.5-flash-preview-tts",

--- a/apps/playground/public/llms.txt
+++ b/apps/playground/public/llms.txt
@@ -1,6 +1,6 @@
 # LLM Gateway Chat
 
-> LLM Gateway Chat (chat.llmgateway.io) is an AI chat playground for talking to 200+ models from OpenAI, Anthropic, Google, xAI, DeepSeek, Meta, Mistral, and other providers in one place. It supports text chat, image and video generation, side-by-side multi-model group chats, and projects with knowledge files — on transparent provider-rate credits.
+> LLM Gateway Chat (lounge.llmgateway.io) is an AI chat playground for talking to 200+ models from OpenAI, Anthropic, Google, xAI, DeepSeek, Meta, Mistral, and other providers in one place. It supports text chat, image and video generation, side-by-side multi-model group chats, and projects with knowledge files — on transparent provider-rate credits.
 
 ## Plans
 
@@ -11,7 +11,7 @@
 
 ## Key pages
 
-- [Chat](https://chat.llmgateway.io): The chat playground.
+- [Chat](https://lounge.llmgateway.io): The chat playground.
 - [Models](https://llmgateway.io/models): Every supported model with pricing and capabilities.
 - [LLM Gateway](https://llmgateway.io): The open-source gateway platform behind Chat.
 - [Pricing (machine-readable)](https://llmgateway.io/pricing.md): Plain-markdown pricing for the whole platform.

--- a/apps/playground/src/app/api/audio/route.ts
+++ b/apps/playground/src/app/api/audio/route.ts
@@ -4,6 +4,8 @@ import { NextResponse } from "next/server";
 import { PLAYGROUND_KEY_COOKIE_NAME } from "@/lib/constants";
 import { getUser } from "@/lib/getUser";
 
+import { LOUNGE_SOURCE } from "@llmgateway/shared/lounge-source";
+
 export const maxDuration = 120;
 
 interface AudioRequestBody {
@@ -89,7 +91,7 @@ export async function POST(req: Request) {
 			headers: {
 				"Content-Type": "application/json",
 				Authorization: `Bearer ${apiKey}`,
-				"x-source": "chat.llmgateway.io",
+				"x-source": LOUNGE_SOURCE,
 				...(noFallback ? { "x-no-fallback": noFallback } : {}),
 			},
 			body: JSON.stringify({

--- a/apps/playground/src/app/api/canvas/generate/route.ts
+++ b/apps/playground/src/app/api/canvas/generate/route.ts
@@ -6,6 +6,7 @@ import { PLAYGROUND_KEY_COOKIE_NAME } from "@/lib/constants";
 import { getUser } from "@/lib/getUser";
 
 import { createLLMGateway } from "@llmgateway/ai-sdk-provider";
+import { LOUNGE_SOURCE } from "@llmgateway/shared/lounge-source";
 
 export const maxDuration = 300;
 
@@ -65,7 +66,7 @@ export async function POST(req: Request) {
 		apiKey: finalApiKey,
 		baseURL: gatewayUrl,
 		headers: {
-			"x-source": "chat.llmgateway.io",
+			"x-source": LOUNGE_SOURCE,
 		},
 	});
 

--- a/apps/playground/src/app/api/chat/route.ts
+++ b/apps/playground/src/app/api/chat/route.ts
@@ -28,6 +28,7 @@ import {
 import { fetchServerData } from "@/lib/server-api";
 
 import { createLLMGateway } from "@llmgateway/ai-sdk-provider";
+import { LOUNGE_SOURCE } from "@llmgateway/shared/lounge-source";
 
 export const maxDuration = 300; // 5 minutes
 
@@ -786,7 +787,7 @@ export async function POST(req: Request) {
 		baseURL: gatewayUrl,
 		fetch: gatewayFetch,
 		headers: {
-			"x-source": "chat.llmgateway.io",
+			"x-source": LOUNGE_SOURCE,
 			...(noFallbackHeader ? { "x-no-fallback": noFallbackHeader } : {}),
 		},
 		extraBody: {

--- a/apps/playground/src/app/api/escape/move/route.ts
+++ b/apps/playground/src/app/api/escape/move/route.ts
@@ -5,6 +5,7 @@ import { PLAYGROUND_KEY_COOKIE_NAME } from "@/lib/constants";
 import { getUser } from "@/lib/getUser";
 
 import { createLLMGateway } from "@llmgateway/ai-sdk-provider";
+import { LOUNGE_SOURCE } from "@llmgateway/shared/lounge-source";
 import {
 	applyMove,
 	buildTurnPrompt,
@@ -119,7 +120,7 @@ export async function POST(req: Request) {
 	const llmgateway = createLLMGateway({
 		apiKey,
 		baseURL: gatewayUrl,
-		headers: { "x-source": "chat.llmgateway.io" },
+		headers: { "x-source": LOUNGE_SOURCE },
 		// Picking one of five directions is a decision, not an essay. Left at
 		// their default effort, reasoning models spend ~1.3k thinking tokens per
 		// move, which makes a single level cost more and take minutes. Providers

--- a/apps/playground/src/app/api/image/route.ts
+++ b/apps/playground/src/app/api/image/route.ts
@@ -6,6 +6,7 @@ import { getUser } from "@/lib/getUser";
 import { describeImageGenerationError } from "@/lib/image-gen";
 
 import { createLLMGateway } from "@llmgateway/ai-sdk-provider";
+import { LOUNGE_SOURCE } from "@llmgateway/shared/lounge-source";
 
 export const maxDuration = 300; // 5 minutes
 
@@ -88,7 +89,7 @@ export async function POST(req: Request) {
 		apiKey: finalApiKey,
 		baseURL: gatewayUrl,
 		headers: {
-			"x-source": "chat.llmgateway.io",
+			"x-source": LOUNGE_SOURCE,
 			...(noFallbackHeader ? { "x-no-fallback": noFallbackHeader } : {}),
 		},
 		extraBody: {

--- a/apps/playground/src/app/api/ocr/route.ts
+++ b/apps/playground/src/app/api/ocr/route.ts
@@ -3,6 +3,8 @@ import { cookies } from "next/headers";
 import { PLAYGROUND_KEY_COOKIE_NAME } from "@/lib/constants";
 import { getUser } from "@/lib/getUser";
 
+import { LOUNGE_SOURCE } from "@llmgateway/shared/lounge-source";
+
 export const maxDuration = 300; // 5 minutes
 
 // Abort the upstream OCR call before the route's max duration so a hung
@@ -87,7 +89,7 @@ export async function POST(req: Request) {
 			headers: {
 				"Content-Type": "application/json",
 				Authorization: `Bearer ${finalApiKey}`,
-				"x-source": "chat.llmgateway.io",
+				"x-source": LOUNGE_SOURCE,
 				...(noFallbackHeader ? { "x-no-fallback": noFallbackHeader } : {}),
 			},
 			body: JSON.stringify({

--- a/apps/playground/src/app/api/realtime/session/route.ts
+++ b/apps/playground/src/app/api/realtime/session/route.ts
@@ -5,6 +5,7 @@ import { PLAYGROUND_KEY_COOKIE_NAME } from "@/lib/constants";
 import { getUser } from "@/lib/getUser";
 
 import { models as modelDefinitions } from "@llmgateway/models";
+import { LOUNGE_SOURCE } from "@llmgateway/shared/lounge-source";
 
 import type { ModelDefinition, ProviderModelMapping } from "@llmgateway/models";
 
@@ -198,7 +199,7 @@ export async function POST(req: Request) {
 			headers: {
 				"Content-Type": "application/json",
 				Authorization: `Bearer ${apiKey}`,
-				"x-source": "chat.llmgateway.io",
+				"x-source": LOUNGE_SOURCE,
 				...(forwardedFor ? { "x-forwarded-for": forwardedFor } : {}),
 			},
 			body: JSON.stringify({

--- a/apps/playground/src/app/api/video/[videoId]/route.ts
+++ b/apps/playground/src/app/api/video/[videoId]/route.ts
@@ -8,6 +8,8 @@ import {
 import { PLAYGROUND_KEY_COOKIE_NAME } from "@/lib/constants";
 import { getUser } from "@/lib/getUser";
 
+import { LOUNGE_SOURCE } from "@llmgateway/shared/lounge-source";
+
 export const dynamic = "force-dynamic";
 export const maxDuration = 15;
 
@@ -65,7 +67,7 @@ export async function GET(
 			{
 				headers: {
 					Authorization: `Bearer ${apiKey}`,
-					"x-source": "chat.llmgateway.io",
+					"x-source": LOUNGE_SOURCE,
 				},
 				cache: "no-store",
 				signal: AbortSignal.timeout(API_TIMEOUT_MS),

--- a/apps/playground/src/app/api/video/route.ts
+++ b/apps/playground/src/app/api/video/route.ts
@@ -4,6 +4,8 @@ import { NextResponse } from "next/server";
 import { PLAYGROUND_KEY_COOKIE_NAME } from "@/lib/constants";
 import { getUser } from "@/lib/getUser";
 
+import { LOUNGE_SOURCE } from "@llmgateway/shared/lounge-source";
+
 import { getGatewayErrorMessage, readGatewayResponseBody } from "./utils";
 
 export const maxDuration = 60;
@@ -37,7 +39,7 @@ export async function POST(req: Request) {
 		headers: {
 			"Content-Type": "application/json",
 			Authorization: `Bearer ${apiKey}`,
-			"x-source": "chat.llmgateway.io",
+			"x-source": LOUNGE_SOURCE,
 			...(noFallback ? { "x-no-fallback": noFallback } : {}),
 		},
 		body: JSON.stringify(requestBody),

--- a/apps/playground/src/app/compare/[slug]/opengraph-image.tsx
+++ b/apps/playground/src/app/compare/[slug]/opengraph-image.tsx
@@ -169,7 +169,7 @@ export default async function CompareOgImage({
 					<Pill>${plusCredits} credits on Plus</Pill>
 				</div>
 				<span style={{ color: "#A1A1AA", fontSize: 21, fontWeight: 500 }}>
-					chat.llmgateway.io
+					lounge.llmgateway.io
 				</span>
 			</div>
 		</div>,

--- a/apps/playground/src/app/compare/[slug]/page.tsx
+++ b/apps/playground/src/app/compare/[slug]/page.tsx
@@ -39,7 +39,7 @@ export async function generateMetadata({
 			title: comparison.metaTitle,
 			description: comparison.metaDescription,
 			type: "article",
-			url: `https://chat.llmgateway.io${canonical}`,
+			url: `https://lounge.llmgateway.io${canonical}`,
 		},
 		twitter: {
 			card: "summary_large_image",
@@ -76,13 +76,13 @@ export default async function ComparePage({ params }: PageProps) {
 				"@type": "ListItem",
 				position: 1,
 				name: "Compare",
-				item: "https://chat.llmgateway.io/compare",
+				item: "https://lounge.llmgateway.io/compare",
 			},
 			{
 				"@type": "ListItem",
 				position: 2,
 				name: `Lounge vs ${comparison.competitor}`,
-				item: `https://chat.llmgateway.io/compare/${comparison.slug}`,
+				item: `https://lounge.llmgateway.io/compare/${comparison.slug}`,
 			},
 		],
 	};

--- a/apps/playground/src/app/compare/opengraph-image.tsx
+++ b/apps/playground/src/app/compare/opengraph-image.tsx
@@ -164,7 +164,7 @@ export default function CompareIndexOgImage() {
 					<Pill>Perplexity</Pill>
 				</div>
 				<span style={{ color: "#A1A1AA", fontSize: 21, fontWeight: 500 }}>
-					chat.llmgateway.io
+					lounge.llmgateway.io
 				</span>
 			</div>
 		</div>,

--- a/apps/playground/src/app/compare/page.tsx
+++ b/apps/playground/src/app/compare/page.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
 		description:
 			"One subscription, every frontier model. See how Lounge stacks up against the AI chat apps you're evaluating.",
 		type: "website",
-		url: "https://chat.llmgateway.io/compare",
+		url: "https://lounge.llmgateway.io/compare",
 	},
 	twitter: {
 		card: "summary_large_image",
@@ -58,7 +58,7 @@ export default function CompareIndexPage() {
 			"@type": "ListItem",
 			position: index + 1,
 			name: `Lounge vs ${c.competitor}`,
-			url: `https://chat.llmgateway.io/compare/${c.slug}`,
+			url: `https://lounge.llmgateway.io/compare/${c.slug}`,
 		})),
 	};
 

--- a/apps/playground/src/app/escape/r/[runId]/opengraph-image.tsx
+++ b/apps/playground/src/app/escape/r/[runId]/opengraph-image.tsx
@@ -228,7 +228,7 @@ export default async function EscapeRunOgImage({
 							color: "rgba(52,211,153,0.55)",
 						}}
 					>
-						chat.llmgateway.io/escape — one API call per step
+						lounge.llmgateway.io/escape — one API call per step
 					</span>
 				</div>
 

--- a/apps/playground/src/app/robots.ts
+++ b/apps/playground/src/app/robots.ts
@@ -9,6 +9,6 @@ export default function robots(): MetadataRoute.Robots {
 				disallow: ["/login", "/signup", "/api/"],
 			},
 		],
-		sitemap: "https://chat.llmgateway.io/sitemap.xml",
+		sitemap: "https://lounge.llmgateway.io/sitemap.xml",
 	};
 }

--- a/apps/playground/src/app/share/[shareId]/opengraph-image.tsx
+++ b/apps/playground/src/app/share/[shareId]/opengraph-image.tsx
@@ -242,7 +242,7 @@ function Footer({ model }: { model: string }) {
 					fontWeight: 500,
 				}}
 			>
-				chat.llmgateway.io
+				lounge.llmgateway.io
 			</span>
 		</div>
 	);
@@ -451,7 +451,7 @@ function ImagePreview({ preview }: { preview: SharePreview }) {
 					marginTop: 20,
 				}}
 			>
-				chat.llmgateway.io
+				lounge.llmgateway.io
 			</span>
 		</div>
 	);

--- a/apps/playground/src/app/share/[shareId]/page.tsx
+++ b/apps/playground/src/app/share/[shareId]/page.tsx
@@ -201,7 +201,7 @@ export default async function SharedChatPage({
 	const data = (await response.json()) as SharedChatResponse;
 	const messages = data.share.messages.map(toUiMessage);
 
-	const shareUrl = `https://chat.llmgateway.io/share/${data.share.id}`;
+	const shareUrl = `https://lounge.llmgateway.io/share/${data.share.id}`;
 	const { description: articleDescription } = deriveShareDescription(
 		data.share.messages,
 	);
@@ -230,7 +230,7 @@ export default async function SharedChatPage({
 				"@type": "ListItem",
 				position: 1,
 				name: "Home",
-				item: "https://chat.llmgateway.io",
+				item: "https://lounge.llmgateway.io",
 			},
 			{
 				"@type": "ListItem",

--- a/apps/playground/src/app/sitemap.ts
+++ b/apps/playground/src/app/sitemap.ts
@@ -30,7 +30,7 @@ async function fetchPublicShares(): Promise<ShareListItem[]> {
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-	const baseUrl = "https://chat.llmgateway.io";
+	const baseUrl = "https://lounge.llmgateway.io";
 	const now = new Date();
 
 	const staticEntries: MetadataRoute.Sitemap = [

--- a/apps/playground/src/components/auth/chat-brand-panel.tsx
+++ b/apps/playground/src/components/auth/chat-brand-panel.tsx
@@ -68,7 +68,7 @@ export function ChatBrandPanel({
 						<div className="h-2.5 w-2.5 rounded-full bg-zinc-700" />
 						<div className="h-2.5 w-2.5 rounded-full bg-zinc-700" />
 						<span className="ml-2 text-xs text-zinc-600">
-							chat.llmgateway.io
+							lounge.llmgateway.io
 						</span>
 					</div>
 					<div className="space-y-3 p-4 text-sm">

--- a/apps/playground/src/components/playground/audio-sidebar.tsx
+++ b/apps/playground/src/components/playground/audio-sidebar.tsx
@@ -380,7 +380,7 @@ export function AudioSidebar({
 					router.push(
 						process.env.NODE_ENV === "development"
 							? "http://localhost:3003/login"
-							: "https://chat.llmgateway.io/login",
+							: "https://lounge.llmgateway.io/login",
 					);
 				},
 			},

--- a/apps/playground/src/components/playground/canvas-sidebar.tsx
+++ b/apps/playground/src/components/playground/canvas-sidebar.tsx
@@ -79,7 +79,7 @@ export function CanvasSidebar({
 					router.push(
 						process.env.NODE_ENV === "development"
 							? "http://localhost:3003/login"
-							: "https://chat.llmgateway.io/login",
+							: "https://lounge.llmgateway.io/login",
 					);
 				},
 			},

--- a/apps/playground/src/components/playground/chat-sidebar.tsx
+++ b/apps/playground/src/components/playground/chat-sidebar.tsx
@@ -567,7 +567,7 @@ export const ChatSidebar = function ChatSidebar({
 					router.push(
 						process.env.NODE_ENV === "development"
 							? "http://localhost:3003/login"
-							: "https://chat.llmgateway.io/login",
+							: "https://lounge.llmgateway.io/login",
 					);
 				},
 			},

--- a/apps/playground/src/components/playground/escape-sidebar.tsx
+++ b/apps/playground/src/components/playground/escape-sidebar.tsx
@@ -70,7 +70,7 @@ export function EscapeSidebar({
 					router.push(
 						process.env.NODE_ENV === "development"
 							? "http://localhost:3003/login"
-							: "https://chat.llmgateway.io/login",
+							: "https://lounge.llmgateway.io/login",
 					);
 				},
 			},

--- a/apps/playground/src/components/playground/image-sidebar.tsx
+++ b/apps/playground/src/components/playground/image-sidebar.tsx
@@ -382,7 +382,7 @@ export function ImageSidebar({
 					router.push(
 						process.env.NODE_ENV === "development"
 							? "http://localhost:3003/login"
-							: "https://chat.llmgateway.io/login",
+							: "https://lounge.llmgateway.io/login",
 					);
 				},
 			},

--- a/apps/playground/src/components/playground/org-sidebar.tsx
+++ b/apps/playground/src/components/playground/org-sidebar.tsx
@@ -267,7 +267,7 @@ export function OrgSidebar({
 					router.push(
 						process.env.NODE_ENV === "development"
 							? "http://localhost:3003/login"
-							: "https://chat.llmgateway.io/login",
+							: "https://lounge.llmgateway.io/login",
 					);
 				},
 			},

--- a/apps/playground/src/components/playground/projects-sidebar.tsx
+++ b/apps/playground/src/components/playground/projects-sidebar.tsx
@@ -90,7 +90,7 @@ export function ProjectsSidebar({
 					router.push(
 						process.env.NODE_ENV === "development"
 							? "http://localhost:3003/login"
-							: "https://chat.llmgateway.io/login",
+							: "https://lounge.llmgateway.io/login",
 					);
 				},
 			},

--- a/apps/playground/src/components/playground/realtime-sidebar.tsx
+++ b/apps/playground/src/components/playground/realtime-sidebar.tsx
@@ -98,7 +98,7 @@ export function RealtimeSidebar({
 					router.push(
 						process.env.NODE_ENV === "development"
 							? "http://localhost:3003/login"
-							: "https://chat.llmgateway.io/login",
+							: "https://lounge.llmgateway.io/login",
 					);
 				},
 			},

--- a/apps/playground/src/components/playground/skills-sidebar.tsx
+++ b/apps/playground/src/components/playground/skills-sidebar.tsx
@@ -98,7 +98,7 @@ export function SkillsSidebar({
 					router.push(
 						process.env.NODE_ENV === "development"
 							? "http://localhost:3003/login"
-							: "https://chat.llmgateway.io/login",
+							: "https://lounge.llmgateway.io/login",
 					);
 				},
 			},

--- a/apps/playground/src/components/playground/video-sidebar.tsx
+++ b/apps/playground/src/components/playground/video-sidebar.tsx
@@ -392,7 +392,7 @@ export function VideoSidebar({
 					router.push(
 						process.env.NODE_ENV === "development"
 							? "http://localhost:3003/login"
-							: "https://chat.llmgateway.io/login",
+							: "https://lounge.llmgateway.io/login",
 					);
 				},
 			},

--- a/apps/playground/src/components/pricing/chat-pricing-plans.tsx
+++ b/apps/playground/src/components/pricing/chat-pricing-plans.tsx
@@ -441,7 +441,7 @@ export function ChatPricingPlans({
 										}}
 									/>
 									<div className="mt-1.5 flex items-center justify-between font-mono text-[9px] uppercase tracking-[0.28em] text-muted-foreground">
-										<span>chat.llmgateway.io</span>
+										<span>lounge.llmgateway.io</span>
 										<span>{plan.tier} · monthly</span>
 									</div>
 								</div>

--- a/apps/playground/src/lib/brand.spec.ts
+++ b/apps/playground/src/lib/brand.spec.ts
@@ -11,7 +11,7 @@ describe("Lounge brand", () => {
 		expect(BRAND.fullName).toBe("Lounge by LLM Gateway");
 		expect(BRAND.publisher).toBe("LLM Gateway");
 		expect(BRAND.tagline).toBe("Every frontier model. One membership.");
-		expect(BRAND.url).toBe("https://chat.llmgateway.io");
+		expect(BRAND.url).toBe("https://lounge.llmgateway.io");
 	});
 
 	test("web manifest uses the Lounge lockup", () => {

--- a/apps/playground/src/lib/brand.ts
+++ b/apps/playground/src/lib/brand.ts
@@ -14,5 +14,5 @@ export const BRAND = {
 	/** Parent brand, unchanged by the rebrand. */
 	publisher: "LLM Gateway",
 	tagline: "Every frontier model. One membership.",
-	url: "https://chat.llmgateway.io",
+	url: "https://lounge.llmgateway.io",
 } as const;

--- a/apps/playground/src/lib/comparisons.ts
+++ b/apps/playground/src/lib/comparisons.ts
@@ -101,7 +101,7 @@ function planFacts(tier: ChatPlanTier) {
 
 export const US = {
 	name: "Lounge",
-	url: "https://chat.llmgateway.io",
+	url: "https://lounge.llmgateway.io",
 	modelCount: "200+",
 	plans: {
 		starter: planFacts("starter"),
@@ -213,7 +213,7 @@ export const comparisons: Comparison[] = [
 			"You want to compare answers across models before you trust one",
 		],
 		migration:
-			"There's nothing to migrate — start a chat at chat.llmgateway.io, pick GPT-5 if that's your habit, and add Claude or Gemini to the same thread when you need them. Keep ChatGPT too; many people drop the second subscription once one balance reaches every model.",
+			"There's nothing to migrate — start a chat at lounge.llmgateway.io, pick GPT-5 if that's your habit, and add Claude or Gemini to the same thread when you need them. Keep ChatGPT too; many people drop the second subscription once one balance reaches every model.",
 		faq: [
 			{
 				q: "Is Lounge a ChatGPT alternative?",
@@ -336,7 +336,7 @@ export const comparisons: Comparison[] = [
 			"You'd rather see exactly what each message costs",
 		],
 		migration:
-			"Keep using Claude exactly as you do — Opus and Sonnet are right here. Start a thread at chat.llmgateway.io, pick Claude, and when you hit a wall or want a comparison, switch to GPT or Gemini in the same conversation. Most people keep Claude as their default model and drop the standalone subscription.",
+			"Keep using Claude exactly as you do — Opus and Sonnet are right here. Start a thread at lounge.llmgateway.io, pick Claude, and when you hit a wall or want a comparison, switch to GPT or Gemini in the same conversation. Most people keep Claude as their default model and drop the standalone subscription.",
 		faq: [
 			{
 				q: "Does Lounge include Claude?",
@@ -386,7 +386,7 @@ export const comparisons: Comparison[] = [
 			},
 			{
 				label: "Ecosystem lock-in",
-				us: "None — works on its own at chat.llmgateway.io",
+				us: "None — works on its own at lounge.llmgateway.io",
 				them: "Most value comes through your Google account and Workspace",
 				usWins: true,
 			},
@@ -459,7 +459,7 @@ export const comparisons: Comparison[] = [
 			"The overlapping Ultra plan tiers are hard to reason about",
 		],
 		migration:
-			"Sign in at chat.llmgateway.io and pick Gemini — the long-context model you already use is there. Add GPT or Claude to the same thread whenever you want a second take. Nothing is tied to your Google account, so you keep full control of your data.",
+			"Sign in at lounge.llmgateway.io and pick Gemini — the long-context model you already use is there. Add GPT or Claude to the same thread whenever you want a second take. Nothing is tied to your Google account, so you keep full control of your data.",
 		faq: [
 			{
 				q: "Is Lounge a Google Gemini alternative?",
@@ -580,7 +580,7 @@ export const comparisons: Comparison[] = [
 			"You want to know what each message actually costs",
 		],
 		migration:
-			"Bring the same habit — one balance, every model — minus the points math. Sign in at chat.llmgateway.io, and instead of translating messages into points, you spend credits priced at provider rates with each message's cost shown plainly.",
+			"Bring the same habit — one balance, every model — minus the points math. Sign in at lounge.llmgateway.io, and instead of translating messages into points, you spend credits priced at provider rates with each message's cost shown plainly.",
 		faq: [
 			{
 				q: "How is Lounge different from Poe?",
@@ -701,7 +701,7 @@ export const comparisons: Comparison[] = [
 			"You want to compare model answers side by side",
 		],
 		migration:
-			"If you like fast multi-model chat, you'll feel at home — pick a model, start typing at chat.llmgateway.io. The difference is what surrounds the chat: image, video, and audio generation, group chat, persistent and shareable conversations, all on one credit balance.",
+			"If you like fast multi-model chat, you'll feel at home — pick a model, start typing at lounge.llmgateway.io. The difference is what surrounds the chat: image, video, and audio generation, group chat, persistent and shareable conversations, all on one credit balance.",
 		faq: [
 			{
 				q: "Is Lounge worth more than T3 Chat's $8?",
@@ -821,7 +821,7 @@ export const comparisons: Comparison[] = [
 			"You want to generate images, video, and audio too",
 		],
 		migration:
-			"Many people keep Perplexity for cited research and use Lounge for everything else — writing, coding, brainstorming, and media. Sign in at chat.llmgateway.io, pick any frontier model, and you've got a conversation tool Perplexity was never built to be.",
+			"Many people keep Perplexity for cited research and use Lounge for everything else — writing, coding, brainstorming, and media. Sign in at lounge.llmgateway.io, pick any frontier model, and you've got a conversation tool Perplexity was never built to be.",
 		faq: [
 			{
 				q: "Is Lounge a Perplexity alternative?",

--- a/apps/ui/next.config.ts
+++ b/apps/ui/next.config.ts
@@ -124,13 +124,18 @@ const nextConfig: NextConfig = {
 				permanent: true,
 			},
 			{
+				source: "/lounge",
+				destination: "https://lounge.llmgateway.io",
+				permanent: true,
+			},
+			{
 				source: "/chat",
-				destination: "https://chat.llmgateway.io",
+				destination: "https://lounge.llmgateway.io",
 				permanent: true,
 			},
 			{
 				source: "/playground",
-				destination: "https://chat.llmgateway.io",
+				destination: "https://lounge.llmgateway.io",
 				permanent: true,
 			},
 			{

--- a/apps/ui/public/pricing.md
+++ b/apps/ui/public/pricing.md
@@ -28,7 +28,7 @@ Last updated: 2026-07-10
 ## Related products
 
 - DevPass — flat-price dev plans for AI coding tools: Lite $29/month ($87 model usage included), Pro $79/month ($237 included), Max $179/month ($537 included). https://devpass.llmgateway.io
-- Lounge — consumer AI chat memberships, billed monthly: Starter $9, Plus $19, Pro $49. https://chat.llmgateway.io
+- Lounge — consumer AI chat memberships, billed monthly: Starter $9, Plus $19, Pro $49. https://lounge.llmgateway.io
 
 ## Notes
 

--- a/apps/ui/src/app/models/page.tsx
+++ b/apps/ui/src/app/models/page.tsx
@@ -185,7 +185,7 @@ export default async function ModelsPage() {
 											API — switch models by changing a single string. Chat with
 											any of them first in the{" "}
 											<a
-												href="https://chat.llmgateway.io"
+												href="https://lounge.llmgateway.io"
 												className="text-foreground underline underline-offset-4"
 											>
 												Lounge

--- a/apps/ui/src/components/dashboard/dashboard-client.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-client.tsx
@@ -717,7 +717,7 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 															href={
 																process.env.NODE_ENV === "development"
 																	? "http://localhost:3003"
-																	: "https://chat.llmgateway.io"
+																	: "https://lounge.llmgateway.io"
 															}
 															target="_blank"
 															rel="noopener noreferrer"
@@ -773,7 +773,7 @@ export function DashboardClient({ initialActivityData }: DashboardClientProps) {
 														href={
 															process.env.NODE_ENV === "development"
 																? "http://localhost:3003"
-																: "https://chat.llmgateway.io"
+																: "https://lounge.llmgateway.io"
 														}
 														target="_blank"
 														rel="noopener noreferrer"

--- a/apps/ui/src/components/dashboard/dashboard-sidebar.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-sidebar.tsx
@@ -1220,7 +1220,7 @@ export function DashboardSidebar({
 				href:
 					process.env.NODE_ENV === "development"
 						? "http://localhost:3003"
-						: "https://chat.llmgateway.io",
+						: "https://lounge.llmgateway.io",
 				label: "Lounge",
 				icon: AnimatedBotMessageSquare,
 				internal: false,

--- a/apps/ui/src/content/blog/2025-10-14-introducing-llmgateway-playground.md
+++ b/apps/ui/src/content/blog/2025-10-14-introducing-llmgateway-playground.md
@@ -14,7 +14,7 @@ image:
 
 Choosing the right LLM used to mean signing up for multiple accounts, managing different API keys, and switching between interfaces. Not anymore.
 
-[**LLM Gateway Chat**](https://chat.llmgateway.io) lets you test any model in our catalog—GPT-5, Claude, Gemini, Llama, and 180+ others—from one interface. Compare outputs, test prompts, and find the best model for your use case before writing a single line of code.
+[**LLM Gateway Chat**](https://lounge.llmgateway.io) lets you test any model in our catalog—GPT-5, Claude, Gemini, Llama, and 180+ others—from one interface. Compare outputs, test prompts, and find the best model for your use case before writing a single line of code.
 
 ## Built for Speed
 
@@ -61,7 +61,7 @@ Drag and drop images or documents into any conversation. Vision models analyze t
 
 ## Try It Now
 
-1. Go to [chat.llmgateway.io](https://chat.llmgateway.io)
+1. Go to [lounge.llmgateway.io](https://lounge.llmgateway.io)
 2. Sign in with your LLM Gateway account
 3. Pick a model and start chatting
 
@@ -80,6 +80,6 @@ Every request in the playground appears in your analytics dashboard—same track
 
 ---
 
-**[Try the Playground →](https://chat.llmgateway.io)**
+**[Try the Playground →](https://lounge.llmgateway.io)**
 
 Questions or feedback? Find us on [GitHub](https://github.com/theopenco/llmgateway) or [Discord](https://llmgateway.io/discord).

--- a/apps/ui/src/content/blog/2025-12-18-q4-2025.md
+++ b/apps/ui/src/content/blog/2025-12-18-q4-2025.md
@@ -120,7 +120,7 @@ Compare models side-by-side with our new **comparison page**:
 - **Redirect after signin** — Return to your original URL after authentication
 - **Image configuration** — Set image parameters and reasoning effort options
 
-[Try out Chat Playground](https://chat.llmgateway.io)
+[Try out Chat Playground](https://lounge.llmgateway.io)
 
 ## 📈 Analytics & Metrics
 
@@ -214,4 +214,4 @@ We've added support for major cloud providers and new partners:
 
 ---
 
-**[Explore all models](/models)** | **[Try the Playground](https://chat.llmgateway.io)** | **[Get started now](/signup)** 🚀
+**[Explore all models](/models)** | **[Try the Playground](https://lounge.llmgateway.io)** | **[Get started now](/signup)** 🚀

--- a/apps/ui/src/content/blog/2026-02-08-getting-started-in-5-minutes.md
+++ b/apps/ui/src/content/blog/2026-02-08-getting-started-in-5-minutes.md
@@ -147,7 +147,7 @@ Same API, same code. Just a different model string.
 
 ## What's Next
 
-- **[Try models in the Playground](https://chat.llmgateway.io)** — test any model with a chat interface before integrating
+- **[Try models in the Playground](https://lounge.llmgateway.io)** — test any model with a chat interface before integrating
 - **[Browse all models](/models)** — compare pricing, context windows, and capabilities
 - **[Read the full docs](https://docs.llmgateway.io)** — streaming, tool calling, structured output, and more
 - **[Join our Discord](https://llmgateway.io/discord)** — get help and share what you're building

--- a/apps/ui/src/content/blog/2026-02-10-alibaba-cloud-qwen-models-20-percent-off.md
+++ b/apps/ui/src/content/blog/2026-02-10-alibaba-cloud-qwen-models-20-percent-off.md
@@ -30,69 +30,69 @@ All 26 Alibaba Cloud models below now include the 20% discount, applied automati
 
 The core Qwen models for general-purpose AI tasks — from content generation to complex reasoning.
 
-| Model                                                | Context | Discounted Input | Discounted Output |                                                                          |
-| ---------------------------------------------------- | ------- | ---------------- | ----------------- | ------------------------------------------------------------------------ |
-| [Qwen3 Max 2026-01-23](/models/qwen3-max-2026-01-23) | 262K    | $0.96/M          | $4.80/M           | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen3-max-2026-01-23) |
-| [Qwen3 Max](/models/qwen3-max)                       | 256K    | $2.40/M          | $12.00/M          | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen3-max)            |
-| [Qwen Max](/models/qwen-max)                         | 128K    | $1.28/M          | $5.12/M           | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen-max)             |
-| [Qwen Max Latest](/models/qwen-max-latest)           | 128K    | $1.28/M          | $5.12/M           | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen-max-latest)      |
-| [Qwen Plus](/models/qwen-plus)                       | 128K    | $0.32/M          | $0.96/M           | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen-plus)            |
-| [Qwen Plus Latest](/models/qwen-plus-latest)         | 1M      | $0.32/M          | $0.96/M           | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen-plus-latest)     |
+| Model                                                | Context | Discounted Input | Discounted Output |                                                                            |
+| ---------------------------------------------------- | ------- | ---------------- | ----------------- | -------------------------------------------------------------------------- |
+| [Qwen3 Max 2026-01-23](/models/qwen3-max-2026-01-23) | 262K    | $0.96/M          | $4.80/M           | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen3-max-2026-01-23) |
+| [Qwen3 Max](/models/qwen3-max)                       | 256K    | $2.40/M          | $12.00/M          | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen3-max)            |
+| [Qwen Max](/models/qwen-max)                         | 128K    | $1.28/M          | $5.12/M           | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen-max)             |
+| [Qwen Max Latest](/models/qwen-max-latest)           | 128K    | $1.28/M          | $5.12/M           | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen-max-latest)      |
+| [Qwen Plus](/models/qwen-plus)                       | 128K    | $0.32/M          | $0.96/M           | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen-plus)            |
+| [Qwen Plus Latest](/models/qwen-plus-latest)         | 1M      | $0.32/M          | $0.96/M           | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen-plus-latest)     |
 
 ### Fast & Cost-Effective Models
 
 High-speed models optimized for low-latency, high-volume workloads — ideal for real-time applications and batch processing.
 
-| Model                                      | Context | Discounted Input | Discounted Output |                                                                     |
-| ------------------------------------------ | ------- | ---------------- | ----------------- | ------------------------------------------------------------------- |
-| [Qwen Flash](/models/qwen-flash)           | 1M      | $0.04/M          | $0.32/M           | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen-flash)      |
-| [Qwen Turbo](/models/qwen-turbo)           | 1M      | $0.04/M          | $0.16/M           | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen-turbo)      |
-| [Qwen Omni Turbo](/models/qwen-omni-turbo) | 32K     | $0.16/M          | $0.64/M           | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen-omni-turbo) |
+| Model                                      | Context | Discounted Input | Discounted Output |                                                                       |
+| ------------------------------------------ | ------- | ---------------- | ----------------- | --------------------------------------------------------------------- |
+| [Qwen Flash](/models/qwen-flash)           | 1M      | $0.04/M          | $0.32/M           | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen-flash)      |
+| [Qwen Turbo](/models/qwen-turbo)           | 1M      | $0.04/M          | $0.16/M           | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen-turbo)      |
+| [Qwen Omni Turbo](/models/qwen-omni-turbo) | 32K     | $0.16/M          | $0.64/M           | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen-omni-turbo) |
 
 ### Coding Models
 
 Purpose-built for code generation, completion, and analysis. Qwen3 Coder Plus supports up to 1M tokens of context — enough for entire codebases.
 
-| Model                                          | Context | Discounted Input | Discounted Output |                                                                       |
-| ---------------------------------------------- | ------- | ---------------- | ----------------- | --------------------------------------------------------------------- |
-| [Qwen3 Coder Plus](/models/qwen3-coder-plus)   | 1M      | $4.80/M          | $48.00/M          | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen3-coder-plus)  |
-| [Qwen3 Coder Flash](/models/qwen3-coder-flash) | 1M      | $0.24/M          | $1.20/M           | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen3-coder-flash) |
-| [Qwen Coder Plus](/models/qwen-coder-plus)     | 128K    | $0.80/M          | $4.00/M           | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen-coder-plus)   |
+| Model                                          | Context | Discounted Input | Discounted Output |                                                                         |
+| ---------------------------------------------- | ------- | ---------------- | ----------------- | ----------------------------------------------------------------------- |
+| [Qwen3 Coder Plus](/models/qwen3-coder-plus)   | 1M      | $4.80/M          | $48.00/M          | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen3-coder-plus)  |
+| [Qwen3 Coder Flash](/models/qwen3-coder-flash) | 1M      | $0.24/M          | $1.20/M           | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen3-coder-flash) |
+| [Qwen Coder Plus](/models/qwen-coder-plus)     | 128K    | $0.80/M          | $4.00/M           | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen-coder-plus)   |
 
 ### Vision-Language Models
 
 Multimodal models that understand both text and images — useful for document analysis, visual Q&A, and image-based reasoning.
 
-| Model                                                              | Context | Discounted Input | Discounted Output |                                                                                 |
-| ------------------------------------------------------------------ | ------- | ---------------- | ----------------- | ------------------------------------------------------------------------------- |
-| [Qwen3 VL 235B A22B Instruct](/models/qwen3-vl-235b-a22b-instruct) | 128K    | $0.40/M          | $1.60/M           | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen3-vl-235b-a22b-instruct) |
-| [Qwen3 VL 235B A22B Thinking](/models/qwen3-vl-235b-a22b-thinking) | 128K    | $0.40/M          | $1.60/M           | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen3-vl-235b-a22b-thinking) |
-| [Qwen3 VL Plus](/models/qwen3-vl-plus)                             | 256K    | $0.16/M          | $1.28/M           | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen3-vl-plus)               |
-| [Qwen3 VL Flash](/models/qwen3-vl-flash)                           | 256K    | $0.04/M          | $0.32/M           | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen3-vl-flash)              |
-| [Qwen VL Max](/models/qwen-vl-max)                                 | 128K    | $0.64/M          | $2.56/M           | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen-vl-max)                 |
-| [Qwen VL Plus](/models/qwen-vl-plus)                               | 128K    | $0.17/M          | $0.51/M           | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen-vl-plus)                |
-| [Qwen2.5 VL 32B Instruct](/models/qwen2-5-vl-32b-instruct)         | 128K    | $1.12/M          | $3.36/M           | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen2-5-vl-32b-instruct)     |
+| Model                                                              | Context | Discounted Input | Discounted Output |                                                                                   |
+| ------------------------------------------------------------------ | ------- | ---------------- | ----------------- | --------------------------------------------------------------------------------- |
+| [Qwen3 VL 235B A22B Instruct](/models/qwen3-vl-235b-a22b-instruct) | 128K    | $0.40/M          | $1.60/M           | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen3-vl-235b-a22b-instruct) |
+| [Qwen3 VL 235B A22B Thinking](/models/qwen3-vl-235b-a22b-thinking) | 128K    | $0.40/M          | $1.60/M           | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen3-vl-235b-a22b-thinking) |
+| [Qwen3 VL Plus](/models/qwen3-vl-plus)                             | 256K    | $0.16/M          | $1.28/M           | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen3-vl-plus)               |
+| [Qwen3 VL Flash](/models/qwen3-vl-flash)                           | 256K    | $0.04/M          | $0.32/M           | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen3-vl-flash)              |
+| [Qwen VL Max](/models/qwen-vl-max)                                 | 128K    | $0.64/M          | $2.56/M           | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen-vl-max)                 |
+| [Qwen VL Plus](/models/qwen-vl-plus)                               | 128K    | $0.17/M          | $0.51/M           | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen-vl-plus)                |
+| [Qwen2.5 VL 32B Instruct](/models/qwen2-5-vl-32b-instruct)         | 128K    | $1.12/M          | $3.36/M           | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen2-5-vl-32b-instruct)     |
 
 ### Reasoning Models
 
 Models with built-in chain-of-thought reasoning — designed for math, logic, and multi-step problem solving.
 
-| Model                                                              | Context | Discounted Input | Discounted Output |                                                                                 |
-| ------------------------------------------------------------------ | ------- | ---------------- | ----------------- | ------------------------------------------------------------------------------- |
-| [QwQ Plus](/models/qwq-plus)                                       | 128K    | $0.64/M          | $1.92/M           | [Try it](https://chat.llmgateway.io/?model=alibaba/qwq-plus)                    |
-| [Qwen3 Next 80B A3B Thinking](/models/qwen3-next-80b-a3b-thinking) | 128K    | $0.40/M          | $4.80/M           | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen3-next-80b-a3b-thinking) |
-| [Qwen3 Next 80B A3B Instruct](/models/qwen3-next-80b-a3b-instruct) | 128K    | $0.40/M          | $1.60/M           | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen3-next-80b-a3b-instruct) |
+| Model                                                              | Context | Discounted Input | Discounted Output |                                                                                   |
+| ------------------------------------------------------------------ | ------- | ---------------- | ----------------- | --------------------------------------------------------------------------------- |
+| [QwQ Plus](/models/qwq-plus)                                       | 128K    | $0.64/M          | $1.92/M           | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwq-plus)                    |
+| [Qwen3 Next 80B A3B Thinking](/models/qwen3-next-80b-a3b-thinking) | 128K    | $0.40/M          | $4.80/M           | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen3-next-80b-a3b-thinking) |
+| [Qwen3 Next 80B A3B Instruct](/models/qwen3-next-80b-a3b-instruct) | 128K    | $0.40/M          | $1.60/M           | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen3-next-80b-a3b-instruct) |
 
 ### Image Generation & Editing Models
 
 Text-to-image and image editing models for visual content creation.
 
-| Model                                                | Price per Request |                                                                          |
-| ---------------------------------------------------- | ----------------- | ------------------------------------------------------------------------ |
-| [Qwen Image](/models/qwen-image)                     | $0.028            | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen-image)           |
-| [Qwen Image Plus](/models/qwen-image-plus)           | $0.024            | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen-image-plus)      |
-| [Qwen Image Edit Plus](/models/qwen-image-edit-plus) | $0.032            | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen-image-edit-plus) |
-| [Qwen Image Edit Max](/models/qwen-image-edit-max)   | $0.064            | [Try it](https://chat.llmgateway.io/?model=alibaba/qwen-image-edit-max)  |
+| Model                                                | Price per Request |                                                                            |
+| ---------------------------------------------------- | ----------------- | -------------------------------------------------------------------------- |
+| [Qwen Image](/models/qwen-image)                     | $0.028            | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen-image)           |
+| [Qwen Image Plus](/models/qwen-image-plus)           | $0.024            | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen-image-plus)      |
+| [Qwen Image Edit Plus](/models/qwen-image-edit-plus) | $0.032            | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen-image-edit-plus) |
+| [Qwen Image Edit Max](/models/qwen-image-edit-max)   | $0.064            | [Try it](https://lounge.llmgateway.io/?model=alibaba/qwen-image-edit-max)  |
 
 ## How It Works
 
@@ -114,10 +114,10 @@ All Qwen models support our full feature set: smart routing, automatic fallback,
 
 1. **[Sign up](https://llmgateway.io/signup)** for a free LLM Gateway account
 2. **[Browse all Alibaba Cloud models](/models?provider=alibaba)** to compare pricing and capabilities
-3. **[Try any model in the Playground](https://chat.llmgateway.io)** before integrating
+3. **[Try any model in the Playground](https://lounge.llmgateway.io)** before integrating
 
 If you have questions, reach out on [GitHub](https://github.com/theopenco/llmgateway) or [Discord](https://llmgateway.io/discord).
 
 ---
 
-**[Browse all discounted models](/models?discounted=true)** | **[Try Qwen3 Max in the Playground](https://chat.llmgateway.io/?model=alibaba/qwen3-max-2026-01-23)** | **[Get started](/signup)**
+**[Browse all discounted models](/models?discounted=true)** | **[Try Qwen3 Max in the Playground](https://lounge.llmgateway.io/?model=alibaba/qwen3-max-2026-01-23)** | **[Get started](/signup)**

--- a/apps/ui/src/content/blog/2026-02-11-openai-vs-anthropic-vs-google-cost-comparison.md
+++ b/apps/ui/src/content/blog/2026-02-11-openai-vs-anthropic-vs-google-cost-comparison.md
@@ -96,6 +96,6 @@ With intelligent routing through an LLM gateway, you can achieve flagship-qualit
 
 ## Compare Models Side-by-Side
 
-Want to explore pricing for all 200+ models we support? Use our [model comparison tool](/models) to filter by provider, price, context window, and capabilities — then test any model in the [Playground](https://chat.llmgateway.io).
+Want to explore pricing for all 200+ models we support? Use our [model comparison tool](/models) to filter by provider, price, context window, and capabilities — then test any model in the [Playground](https://lounge.llmgateway.io).
 
-**[Browse all models](/models)** | **[Run the Token Cost Calculator](/token-cost-calculator)** | **[Try the Playground](https://chat.llmgateway.io)** | **[Get started](/signup)**
+**[Browse all models](/models)** | **[Run the Token Cost Calculator](/token-cost-calculator)** | **[Try the Playground](https://lounge.llmgateway.io)** | **[Get started](/signup)**

--- a/apps/ui/src/content/blog/2026-03-23-q1-2026.md
+++ b/apps/ui/src/content/blog/2026-03-23-q1-2026.md
@@ -152,4 +152,4 @@ New Codex and Chat variants for the GPT-5 family added with Bedrock and direct m
 
 ---
 
-**[Explore all models](/models)** | **[Try the Playground](https://chat.llmgateway.io)** | **[Get started now](/signup)**
+**[Explore all models](/models)** | **[Try the Playground](https://lounge.llmgateway.io)** | **[Get started now](/signup)**

--- a/apps/ui/src/content/blog/2026-03-28-deepseek-discounts-on-llm-gateway.md
+++ b/apps/ui/src/content/blog/2026-03-28-deepseek-discounts-on-llm-gateway.md
@@ -32,7 +32,7 @@ The latest and most capable DeepSeek model. Unified chat and reasoning in a sing
 
 **Best price**: $0.182/M input via Canopywave — **35% cheaper than the official DeepSeek API**.
 
-[Try DeepSeek V3.2 in the Playground](https://chat.llmgateway.io/?model=deepseek/deepseek-v3.2)
+[Try DeepSeek V3.2 in the Playground](https://lounge.llmgateway.io/?model=deepseek/deepseek-v3.2)
 
 ### DeepSeek V3.1
 
@@ -42,7 +42,7 @@ The previous generation, still available for workloads that depend on it.
 | --------- | -------- | -------------- | --------------- | ------------ |
 | Bytedance | —        | $0.56          | $1.68           | $0.112       |
 
-[Try DeepSeek V3.1 in the Playground](https://chat.llmgateway.io/?model=deepseek/deepseek-v3.1)
+[Try DeepSeek V3.1 in the Playground](https://lounge.llmgateway.io/?model=deepseek/deepseek-v3.1)
 
 ### DeepSeek R1 (0528)
 
@@ -52,7 +52,7 @@ The May 2025 reasoning model, available through Nebius.
 | -------- | -------- | -------------- | --------------- |
 | Nebius   | —        | $0.80          | $2.40           |
 
-[Try DeepSeek R1 in the Playground](https://chat.llmgateway.io/?model=deepseek/deepseek-r1-0528)
+[Try DeepSeek R1 in the Playground](https://lounge.llmgateway.io/?model=deepseek/deepseek-r1-0528)
 
 ## How the Discounts Work
 
@@ -133,4 +133,4 @@ Smart routing picks the cheapest discounted provider automatically. No configura
 
 ---
 
-**[Browse discounted models](/models?discounted=true)** | **[Try DeepSeek V3.2](https://chat.llmgateway.io/?model=deepseek/deepseek-v3.2)** | **[Token Cost Calculator](https://llmgateway.io/token-cost-calculator)** | **[Get started free](https://llmgateway.io/signup)**
+**[Browse discounted models](/models?discounted=true)** | **[Try DeepSeek V3.2](https://lounge.llmgateway.io/?model=deepseek/deepseek-v3.2)** | **[Token Cost Calculator](https://llmgateway.io/token-cost-calculator)** | **[Get started free](https://llmgateway.io/signup)**

--- a/apps/ui/src/content/blog/2026-03-28-top-10-cheapest-providers-deepseek-v3-2.md
+++ b/apps/ui/src/content/blog/2026-03-28-top-10-cheapest-providers-deepseek-v3-2.md
@@ -109,4 +109,4 @@ No vendor lock-in. No platform fees. Just the cheapest path to every model.
 
 ---
 
-**[Calculate your costs](https://llmgateway.io/token-cost-calculator)** | **[Try DeepSeek V3.2 in the Playground](https://chat.llmgateway.io/?model=deepseek/deepseek-v3.2)** | **[Get started free](https://llmgateway.io/signup)**
+**[Calculate your costs](https://llmgateway.io/token-cost-calculator)** | **[Try DeepSeek V3.2 in the Playground](https://lounge.llmgateway.io/?model=deepseek/deepseek-v3.2)** | **[Get started free](https://llmgateway.io/signup)**

--- a/apps/ui/src/content/blog/2026-05-17-seedance-video-generation.md
+++ b/apps/ui/src/content/blog/2026-05-17-seedance-video-generation.md
@@ -76,8 +76,8 @@ No markup. No subscription tier required. The free credits on your account work 
 2. **Submit a generation job** to `/v1/videos/generations` (example above).
 3. **Poll the job** until it completes, then grab the video URL.
 
-If you'd rather click than curl, every Seedance model is live in the [chat playground](https://chat.llmgateway.io) right now — open the **Video Studio** tab, pick a model, and start prompting.
+If you'd rather click than curl, every Seedance model is live in the [chat playground](https://lounge.llmgateway.io) right now — open the **Video Studio** tab, pick a model, and start prompting.
 
 One API key. One bill. One dashboard. Three new video models — and a lot more coming.
 
-**[Try Seedance in the playground →](https://chat.llmgateway.io)** | **[Read the docs →](https://docs.llmgateway.io/features/video-generation)** | **[Sign up free →](https://llmgateway.io/signup)**
+**[Try Seedance in the playground →](https://lounge.llmgateway.io)** | **[Read the docs →](https://docs.llmgateway.io/features/video-generation)** | **[Sign up free →](https://llmgateway.io/signup)**

--- a/apps/ui/src/content/blog/2026-05-26-llm-gateway-vs-portkey.md
+++ b/apps/ui/src/content/blog/2026-05-26-llm-gateway-vs-portkey.md
@@ -97,7 +97,7 @@ LLM Gateway is free to self-host. On the managed tier it's a flat 5% platform fe
 
 ### Prompt Management Is Genuinely Strong
 
-This is Portkey's standout. Versioned prompt templates, a prompt registry, deployments, and a playground that ties into production — if your team treats prompts as first-class, versioned artifacts and wants non-engineers iterating on them, Portkey's prompt management is more mature than ours today. We expose a [Playground](https://chat.llmgateway.io) for testing, but not a full versioned prompt registry.
+This is Portkey's standout. Versioned prompt templates, a prompt registry, deployments, and a playground that ties into production — if your team treats prompts as first-class, versioned artifacts and wants non-engineers iterating on them, Portkey's prompt management is more mature than ours today. We expose a [Playground](https://lounge.llmgateway.io) for testing, but not a full versioned prompt registry.
 
 ### Deep, Enterprise-Grade Observability
 

--- a/apps/ui/src/content/blog/2026-06-10-speech-generation-and-audio-studio.md
+++ b/apps/ui/src/content/blog/2026-06-10-speech-generation-and-audio-studio.md
@@ -14,7 +14,7 @@ image:
 
 Adding voice to your app used to mean picking one TTS vendor, learning their SDK, and managing yet another API key and invoice. Today that's one decision lighter: **LLM Gateway now supports speech generation** through the OpenAI-compatible **`/v1/audio/speech`** endpoint — with models from **ElevenLabs, OpenAI, and Google Gemini** behind the same key, billing, and logs you already use for chat, images, and video.
 
-And if you'd rather hear the voices before writing a line of code, the new **[Audio Studio](https://chat.llmgateway.io/audio)** in the Playground lets you generate speech from up to three models side by side.
+And if you'd rather hear the voices before writing a line of code, the new **[Audio Studio](https://lounge.llmgateway.io/audio)** in the Playground lets you generate speech from up to three models side by side.
 
 ## One endpoint, nine models, 60+ voices
 
@@ -82,7 +82,7 @@ Full parameter reference, format support per family, and billing details are in 
 
 ## Audio Studio: hear it before you ship it
 
-Picking a voice from a table is hopeless — you need to listen. The new **Audio Studio** at [chat.llmgateway.io/audio](https://chat.llmgateway.io/audio) joins the Image and Video studios in the Playground:
+Picking a voice from a table is hopeless — you need to listen. The new **Audio Studio** at [lounge.llmgateway.io/audio](https://lounge.llmgateway.io/audio) joins the Image and Video studios in the Playground:
 
 - **Compare mode** — run the same script through up to **3 models in parallel** and listen side by side
 - **Per-model controls** — voice picker, output format, playback speed, and style instructions adapt to whatever each model supports
@@ -104,7 +104,7 @@ One note: streaming speech output isn't supported yet — the endpoint returns t
 
 ## Start talking
 
-- **[Open Audio Studio →](https://chat.llmgateway.io/audio)** — hear the models, no code required
+- **[Open Audio Studio →](https://lounge.llmgateway.io/audio)** — hear the models, no code required
 - **[Read the docs →](https://docs.llmgateway.io/features/speech-generation)** — parameters, formats, and examples
 - **[Browse speech models →](https://llmgateway.io/models?filters=1&audioGeneration=true)** — live pricing and capabilities
 - **[Get your API key →](https://llmgateway.io/dashboard)** — and make your first request in under a minute

--- a/apps/ui/src/content/blog/2026-06-22-best-chatgpt-alternatives.md
+++ b/apps/ui/src/content/blog/2026-06-22-best-chatgpt-alternatives.md
@@ -22,7 +22,7 @@ The pattern is clear: most "alternatives" just swap one walled garden for anothe
 
 **Best overall. Every model, one app, from $9/mo.**
 
-[Lounge](https://chat.llmgateway.io), LLM Gateway's chat app, is a ChatGPT-style app with one difference that changes everything: it runs **200+ models** — GPT-5, Claude Opus, Gemini, Grok and the open-weight field — and lets you switch between them in the same conversation.
+[Lounge](https://lounge.llmgateway.io), LLM Gateway's chat app, is a ChatGPT-style app with one difference that changes everything: it runs **200+ models** — GPT-5, Claude Opus, Gemini, Grok and the open-weight field — and lets you switch between them in the same conversation.
 
 **What sets it apart:**
 
@@ -41,7 +41,7 @@ The pattern is clear: most "alternatives" just swap one walled garden for anothe
 | **Plus** | **$19/mo** | **~$47.50 (2.5×)**        | All frontier models included                           |
 | Pro      | $49/mo     | ~$147 (3×)                | All frontier models, biggest allowance                 |
 
-**Best for:** Anyone who wants the best model for each task — not just one company's — in a single, familiar chat interface. ([Compare it to ChatGPT](https://chat.llmgateway.io/compare/chatgpt).)
+**Best for:** Anyone who wants the best model for each task — not just one company's — in a single, familiar chat interface. ([Compare it to ChatGPT](https://lounge.llmgateway.io/compare/chatgpt).)
 
 ---
 
@@ -65,7 +65,7 @@ Anthropic's Claude is a clean, ad-free assistant that's a favorite for long-form
 
 **Pricing:** Claude Pro $20/mo; Max tiers at $100 and $200/mo for heavy users.
 
-**Best for:** Writers and developers who are happy on Claude alone. ([Claude vs Lounge](https://chat.llmgateway.io/compare/claude).)
+**Best for:** Writers and developers who are happy on Claude alone. ([Claude vs Lounge](https://lounge.llmgateway.io/compare/claude).)
 
 ---
 
@@ -89,7 +89,7 @@ Gemini is Google's assistant, with a massive context window, native video genera
 
 **Pricing:** Google AI Pro $19.99/mo.
 
-**Best for:** Heavy Google Workspace users. ([Gemini vs Lounge](https://chat.llmgateway.io/compare/gemini).)
+**Best for:** Heavy Google Workspace users. ([Gemini vs Lounge](https://lounge.llmgateway.io/compare/gemini).)
 
 ---
 
@@ -113,7 +113,7 @@ Perplexity is built around answering questions with live web results and sources
 
 **Pricing:** Free tier; Pro around $20/mo.
 
-**Best for:** Research and questions that need current, cited answers. ([Perplexity vs Lounge](https://chat.llmgateway.io/compare/perplexity).)
+**Best for:** Research and questions that need current, cited answers. ([Perplexity vs Lounge](https://lounge.llmgateway.io/compare/perplexity).)
 
 ---
 
@@ -161,7 +161,7 @@ Poe, from Quora, was an early multi-model aggregator. It hosts a wide range of b
 
 **Pricing:** Free tier; Premium $19.99/mo.
 
-**Best for:** People who want to sample lots of models and bots and don't mind tracking points. ([Poe vs Lounge](https://chat.llmgateway.io/compare/poe).)
+**Best for:** People who want to sample lots of models and bots and don't mind tracking points. ([Poe vs Lounge](https://lounge.llmgateway.io/compare/poe).)
 
 ---
 
@@ -233,7 +233,7 @@ T3 Chat is a lightweight, developer-favorite app that puts several models behind
 
 **Pricing:** Around $8/mo.
 
-**Best for:** Developers who want a fast, cheap multi-model chat. ([T3 Chat vs Lounge](https://chat.llmgateway.io/compare/t3-chat).)
+**Best for:** Developers who want a fast, cheap multi-model chat. ([T3 Chat vs Lounge](https://lounge.llmgateway.io/compare/t3-chat).)
 
 ---
 
@@ -312,10 +312,10 @@ Yes. Image generation is built into the app, so you can create images alongside 
 
 Trade one company's models for all of them in under two minutes:
 
-1. **[Pick a plan](https://chat.llmgateway.io/pricing)** — Starter, Plus, or Pro
-2. Open [chat.llmgateway.io](https://chat.llmgateway.io) and start a conversation
+1. **[Pick a plan](https://lounge.llmgateway.io/pricing)** — Starter, Plus, or Pro
+2. Open [lounge.llmgateway.io](https://lounge.llmgateway.io) and start a conversation
 3. Switch models mid-chat, generate images, and watch the real cost per message
 
 One app. Every model. From $9/mo.
 
-**[Try Lounge](https://chat.llmgateway.io)** | **[Compare to ChatGPT](https://chat.llmgateway.io/compare/chatgpt)** | **[How to choose the right LLM](/blog/how-to-choose-the-right-llm)**
+**[Try Lounge](https://lounge.llmgateway.io)** | **[Compare to ChatGPT](https://lounge.llmgateway.io/compare/chatgpt)** | **[How to choose the right LLM](/blog/how-to-choose-the-right-llm)**

--- a/apps/ui/src/content/blog/2026-06-30-q2-2026-roundup.md
+++ b/apps/ui/src/content/blog/2026-06-30-q2-2026-roundup.md
@@ -139,7 +139,7 @@ The chat Playground gained **Starter, Plus, and Pro subscription plans** plus a 
 - **AI chat support** replacing Crisp, with suggested answers and one-click human escalation
 - **Image, Video, and Audio Studios** plus a **Canvas** page for longer-form work
 
-[Open the Playground](https://chat.llmgateway.io)
+[Open the Playground](https://lounge.llmgateway.io)
 
 ## Routing & Reliability
 
@@ -265,4 +265,4 @@ Q2 added more than 40 models across providers:
 
 ---
 
-**[Explore all models](/models)** | **[Try the Playground](https://chat.llmgateway.io)** | **[Get started now](/signup)**
+**[Explore all models](/models)** | **[Try the Playground](https://lounge.llmgateway.io)** | **[Get started now](/signup)**

--- a/apps/ui/src/content/blog/2026-07-05-chat-projects-knowledge-base.md
+++ b/apps/ui/src/content/blog/2026-07-05-chat-projects-knowledge-base.md
@@ -14,7 +14,7 @@ image:
 
 Every new chat starts from zero. You paste the same product spec for the third time this week, re-upload the same README, and re-explain the same context the model forgot the moment you closed the tab. The model is smart; your setup is amnesiac.
 
-Today we're adding **Projects** to [LLM Gateway Chat](https://chat.llmgateway.io) — a knowledge base and workspace for your chats. Create a project, drop in your files once — PDFs, spreadsheets, docs, code — and every chat inside it answers from those documents, with the source file cited in the reply. It's retrieval-augmented generation (RAG) without standing up a vector database, and it works with any of the 280+ models in the picker.
+Today we're adding **Projects** to [LLM Gateway Chat](https://lounge.llmgateway.io) — a knowledge base and workspace for your chats. Create a project, drop in your files once — PDFs, spreadsheets, docs, code — and every chat inside it answers from those documents, with the source file cited in the reply. It's retrieval-augmented generation (RAG) without standing up a vector database, and it works with any of the 280+ models in the picker.
 
 Projects also have memory. Mention once that you're hiring for the Stockholm team, and a brand-new chat in the same project next week still knows — without you repeating it and without the fact living in any uploaded file.
 
@@ -63,7 +63,7 @@ Current limits: 20 files per project, up to 500 KB of extracted text per file (b
 
 ## Get started in three steps
 
-1. Open [chat.llmgateway.io/projects](https://chat.llmgateway.io/projects) and create a project.
+1. Open [lounge.llmgateway.io/projects](https://lounge.llmgateway.io/projects) and create a project.
 2. Add files to its knowledge base — a PDF is fine as-is — and optionally write instructions.
 3. Hit **New chat** and ask a question your documents can answer.
 
@@ -93,6 +93,6 @@ No. Embeddings and memory extraction are billed to the same credits as your chat
 
 **Try it now:**
 
-- **[Open LLM Gateway Chat](https://chat.llmgateway.io/projects)** — create your first project free
-- **[Chat plans](https://chat.llmgateway.io/pricing)** — more credits for heavy use, from $9/mo
+- **[Open LLM Gateway Chat](https://lounge.llmgateway.io/projects)** — create your first project free
+- **[Chat plans](https://lounge.llmgateway.io/pricing)** — more credits for heavy use, from $9/mo
 - **[DevPass Code](/blog/devpass-code)** — our terminal coding agent, if your knowledge base is a codebase

--- a/apps/ui/src/content/blog/2026-07-26-generate-audio-api.md
+++ b/apps/ui/src/content/blog/2026-07-26-generate-audio-api.md
@@ -98,7 +98,7 @@ Not yet. The endpoint returns the complete audio file in a single response; ther
 
 ### How do I pick a voice without writing code?
 
-Use the [Audio Studio in Lounge](https://chat.llmgateway.io/audio) — it generates speech from up to three models side by side with per-model voice, format, and speed controls.
+Use the [Audio Studio in Lounge](https://lounge.llmgateway.io/audio) — it generates speech from up to three models side by side with per-model voice, format, and speed controls.
 
 ---
 

--- a/apps/ui/src/content/blog/2026-07-26-generate-images-api.md
+++ b/apps/ui/src/content/blog/2026-07-26-generate-images-api.md
@@ -144,7 +144,7 @@ Yes. Multimodal models like `gemini-3-pro-image-preview` can return images throu
 
 ### Is there a way to try models before writing code?
 
-The [Image Studio in Lounge](https://chat.llmgateway.io/image) generates 1, 2, or 4 images per prompt and lets you compare models side by side.
+The [Image Studio in Lounge](https://lounge.llmgateway.io/image) generates 1, 2, or 4 images per prompt and lets you compare models side by side.
 
 ---
 

--- a/apps/ui/src/content/blog/2026-07-26-generate-videos-api.md
+++ b/apps/ui/src/content/blog/2026-07-26-generate-videos-api.md
@@ -141,7 +141,7 @@ Prototype on a low-priced tier like Seedance 2.0 Mini at 480p or 720p, then re-r
 
 ### Can I generate videos without writing code first?
 
-Yes — the [Video Studio in Lounge](https://chat.llmgateway.io/video) runs the same models with resolution, duration, and audio controls in the browser.
+Yes — the [Video Studio in Lounge](https://lounge.llmgateway.io/video) runs the same models with resolution, duration, and audio controls in the browser.
 
 ---
 

--- a/apps/ui/src/content/changelog/2025-08-26-gemini-2-5-flash-image-preview.md
+++ b/apps/ui/src/content/changelog/2025-08-26-gemini-2-5-flash-image-preview.md
@@ -13,7 +13,7 @@ image:
 
 We're thrilled to announce the addition of **Gemini 2.5 Flash Image Preview** - our **first image generation model** on LLM Gateway! This marks a significant milestone as we expand beyond text generation to visual AI capabilities.
 
-**[Try it now in the Chat Playground](https://chat.llmgateway.io/?model=google-ai-studio/gemini-2.5-flash-image-preview)** 🎨
+**[Try it now in the Chat Playground](https://lounge.llmgateway.io/?model=google-ai-studio/gemini-2.5-flash-image-preview)** 🎨
 
 ## 🎨 Introducing Image Generation
 
@@ -68,4 +68,4 @@ This is just the beginning of our visual AI journey. We're excited to bring you 
 
 ---
 
-**[Try it now in the Chat playground](https://chat.llmgateway.io/?model=google-ai-studio/gemini-2.5-flash-image-preview)** 🎨
+**[Try it now in the Chat playground](https://lounge.llmgateway.io/?model=google-ai-studio/gemini-2.5-flash-image-preview)** 🎨

--- a/apps/ui/src/content/changelog/2025-09-05-qwen3-max-support.md
+++ b/apps/ui/src/content/changelog/2025-09-05-qwen3-max-support.md
@@ -92,4 +92,4 @@ curl -X POST https://api.llmgateway.io/v1/chat/completions \
 
 ---
 
-**[Try it now in the Playground](https://chat.llmgateway.io/?model=alibaba/qwen3-max)** 🚀
+**[Try it now in the Playground](https://lounge.llmgateway.io/?model=alibaba/qwen3-max)** 🚀

--- a/apps/ui/src/content/changelog/2025-09-11-alibaba-qwen-models.md
+++ b/apps/ui/src/content/changelog/2025-09-11-alibaba-qwen-models.md
@@ -20,14 +20,14 @@ We’ve added support for the latest Alibaba Qwen models through our unified API
 - Pricing: Input $0.50 / 1M tokens, Output $2.00 / 1M tokens
 - Context: 129,024 tokens, Max output: 32,768 tokens
 - Capabilities: Streaming, Tools, JSON output
-  [Try in Chat Playground](https://chat.llmgateway.io/?model=alibaba/qwen3-next-80b-a3b-instruct)
+  [Try in Chat Playground](https://lounge.llmgateway.io/?model=alibaba/qwen3-next-80b-a3b-instruct)
 
 **qwen3-next-80b-a3b-thinking** — next-gen reasoning model
 
 - Pricing: Input $0.50 / 1M tokens, Output $6.00 / 1M tokens
 - Context: 131,072 tokens, Max output: 32,768 tokens
 - Capabilities: Streaming, Reasoning, Tools, JSON output
-  [Try in Chat Playground](https://chat.llmgateway.io/?model=alibaba/qwen3-next-80b-a3b-thinking)
+  [Try in Chat Playground](https://lounge.llmgateway.io/?model=alibaba/qwen3-next-80b-a3b-thinking)
 
 ## 🚀 New Text Models
 
@@ -36,28 +36,28 @@ We’ve added support for the latest Alibaba Qwen models through our unified API
 - Pricing: Input $1.60 / 1M tokens, Output $6.40 / 1M tokens
 - Context: 131,072 tokens, Max output: 32,000 tokens
 - Capabilities: Streaming, Vision, Tools, JSON output
-  [Try in Chat Playground](https://chat.llmgateway.io/?model=alibaba/qwen-max)
+  [Try in Chat Playground](https://lounge.llmgateway.io/?model=alibaba/qwen-max)
 
 **qwen-max-latest** — rolling latest for Max:
 
 - Pricing: Input $1.60 / 1M tokens, Output $6.40 / 1M tokens
 - Context: 131,072 tokens, Max output: 32,000 tokens
 - Capabilities: Streaming, Vision, Tools, JSON output
-  [Try in Chat Playground](https://chat.llmgateway.io/?model=alibaba/qwen-max-latest)
+  [Try in Chat Playground](https://lounge.llmgateway.io/?model=alibaba/qwen-max-latest)
 
 **qwen-plus-latest** — balanced performance and cost
 
 - Pricing: Input $0.40 / 1M tokens, Output $1.20 / 1M tokens
 - Context: 1,000,000 tokens, Max output: 32,000 tokens
 - Capabilities: Streaming, Tools, JSON output
-  [Try in Chat Playground](https://chat.llmgateway.io/?model=alibaba/qwen-plus-latest)
+  [Try in Chat Playground](https://lounge.llmgateway.io/?model=alibaba/qwen-plus-latest)
 
 **qwen-flash** — fast, cost‑efficient responses
 
 - Pricing: Input $0.05 / 1M tokens, Output $0.40 / 1M tokens
 - Context: 1,000,000 tokens, Max output: 32,000 tokens
 - Capabilities: Streaming, Tools, JSON output
-  [Try in Chat Playground](https://chat.llmgateway.io/?model=alibaba/qwen-flash)
+  [Try in Chat Playground](https://lounge.llmgateway.io/?model=alibaba/qwen-flash)
 
 ## 👀 New Vision Models
 
@@ -66,14 +66,14 @@ We’ve added support for the latest Alibaba Qwen models through our unified API
 - Pricing: Input $0.80 / 1M tokens, Output $3.20 / 1M tokens
 - Context: 131,072 tokens, Max output: 32,000 tokens
 - Capabilities: Streaming, Vision, JSON output
-  [Try in Chat Playground](https://chat.llmgateway.io/?model=alibaba/qwen-vl-max)
+  [Try in Chat Playground](https://lounge.llmgateway.io/?model=alibaba/qwen-vl-max)
 
 **qwen-vl-plus** — balanced multimodal
 
 - Pricing: Input $0.21 / 1M tokens, Output $0.64 / 1M tokens
 - Context: 131,072 tokens, Max output: 32,000 tokens
 - Capabilities: Streaming, Vision, JSON output
-  [Try in Chat Playground](https://chat.llmgateway.io/?model=alibaba/qwen-vl-plus)
+  [Try in Chat Playground](https://lounge.llmgateway.io/?model=alibaba/qwen-vl-plus)
 
 ---
 

--- a/apps/ui/src/content/changelog/2025-09-29-claude-sonnet-4-5-support.md
+++ b/apps/ui/src/content/changelog/2025-09-29-claude-sonnet-4-5-support.md
@@ -58,4 +58,4 @@ curl -X POST https://api.llmgateway.io/v1/chat/completions \
 
 ---
 
-**[Try it now in the new Chat Playground](https://chat.llmgateway.io/?model=anthropic/claude-sonnet-4-5)** 🚀
+**[Try it now in the new Chat Playground](https://lounge.llmgateway.io/?model=anthropic/claude-sonnet-4-5)** 🚀

--- a/apps/ui/src/content/changelog/2025-10-18-canopywave-partnership-deepseek-90-off.md
+++ b/apps/ui/src/content/changelog/2025-10-18-canopywave-partnership-deepseek-90-off.md
@@ -67,4 +67,4 @@ curl -X POST https://api.llmgateway.io/v1/chat/completions \
 
 This partnership with CanopyWave demonstrates our commitment to making cutting-edge AI accessible to everyone. Start using `canopywave/deepseek-v3.1` today and experience premium reasoning capabilities at game-changing prices.
 
-**[Try it now in the Playground](https://chat.llmgateway.io/?model=canopywave/deepseek-v3.1)** 🚀
+**[Try it now in the Playground](https://lounge.llmgateway.io/?model=canopywave/deepseek-v3.1)** 🚀

--- a/apps/ui/src/content/changelog/2025-11-05-zai-google-discounts.md
+++ b/apps/ui/src/content/changelog/2025-11-05-zai-google-discounts.md
@@ -35,4 +35,4 @@ Get **20% off all Google models** including Gemini and other Google AI offerings
 
 These discounts are applied automatically to all requests through LLM Gateway. Start using these providers today and enjoy the savings!
 
-**[Try them now in the Playground](https://chat.llmgateway.io/?model=zai%2Fglm-4.5)** 🚀
+**[Try them now in the Playground](https://lounge.llmgateway.io/?model=zai%2Fglm-4.5)** 🚀

--- a/apps/ui/src/content/changelog/2025-11-07-kimi-k2-thinking-model.md
+++ b/apps/ui/src/content/changelog/2025-11-07-kimi-k2-thinking-model.md
@@ -40,4 +40,4 @@ moonshot/kimi-k2-thinking
 
 ---
 
-**[Try it now in the Playground](https://chat.llmgateway.io/?model=moonshot/kimi-k2-thinking)** 🚀
+**[Try it now in the Playground](https://lounge.llmgateway.io/?model=moonshot/kimi-k2-thinking)** 🚀

--- a/apps/ui/src/content/changelog/2025-11-11-canopywave-kimi-k2-thinking-75-off.md
+++ b/apps/ui/src/content/changelog/2025-11-11-canopywave-kimi-k2-thinking-75-off.md
@@ -41,6 +41,6 @@ curl -X POST https://api.llmgateway.io/v1/chat/completions \
 
 ---
 
-**[Try it now in the Playground](https://chat.llmgateway.io/?model=canopywave/kimi-k2-thinking)** 🚀
+**[Try it now in the Playground](https://lounge.llmgateway.io/?model=canopywave/kimi-k2-thinking)** 🚀
 
 **[Get started now](/signup)** 🚀

--- a/apps/ui/src/content/changelog/2025-11-17-sherlock-stealth-models.md
+++ b/apps/ui/src/content/changelog/2025-11-17-sherlock-stealth-models.md
@@ -86,6 +86,6 @@ curl -X POST https://api.llmgateway.io/v1/chat/completions \
 
 ---
 
-**[Try in Playground](https://chat.llmgateway.io/?model=sherlock/sherlock-dash-alpha)** 🚀
+**[Try in Playground](https://lounge.llmgateway.io/?model=sherlock/sherlock-dash-alpha)** 🚀
 
 **[Get started now](/signup)** 🚀

--- a/apps/ui/src/content/changelog/2025-11-18-gemini-3-pro-preview-support.md
+++ b/apps/ui/src/content/changelog/2025-11-18-gemini-3-pro-preview-support.md
@@ -77,6 +77,6 @@ curl -X POST https://api.llmgateway.io/v1/chat/completions \
 
 ---
 
-**[Try in Playground](https://chat.llmgateway.io/?model=google-ai-studio/gemini-3-pro-preview)** 🚀
+**[Try in Playground](https://lounge.llmgateway.io/?model=google-ai-studio/gemini-3-pro-preview)** 🚀
 
 **[Get started now](/signup)** 🚀

--- a/apps/ui/src/content/changelog/2025-12-14-cerebras-models-support.md
+++ b/apps/ui/src/content/changelog/2025-12-14-cerebras-models-support.md
@@ -35,6 +35,6 @@ curl -X POST https://api.llmgateway.io/v1/chat/completions \
 
 ---
 
-**[Try Cerebras models in the Playground](https://chat.llmgateway.io/?model=cerebras/gpt-oss-120b)** 🚀
+**[Try Cerebras models in the Playground](https://lounge.llmgateway.io/?model=cerebras/gpt-oss-120b)** 🚀
 
 **[Get started now](/signup)** 🚀

--- a/apps/ui/src/content/changelog/2026-01-02-qwen-image-max-support.md
+++ b/apps/ui/src/content/changelog/2026-01-02-qwen-image-max-support.md
@@ -13,7 +13,7 @@ image:
 
 We're excited to announce support for **Alibaba's Qwen Image model family**, a suite of text-to-image generation models that excel at rendering text within images. This addition expands our image generation capabilities with multiple model variants to fit your needs.
 
-**[Try them now in the Chat Playground](https://chat.llmgateway.io/?model=alibaba/qwen-image-max)** 🎨
+**[Try them now in the Chat Playground](https://lounge.llmgateway.io/?model=alibaba/qwen-image-max)** 🎨
 
 **[Learn more about Alibaba models in our docs](https://docs.llmgateway.io/features/image-generation#alibaba-models)** 📚
 
@@ -89,7 +89,7 @@ curl -X POST https://api.llmgateway.io/v1/chat/completions \
 
 ---
 
-**[Try Qwen Image Models in the Playground](https://chat.llmgateway.io/?model=alibaba/qwen-image-max)** 🎨
+**[Try Qwen Image Models in the Playground](https://lounge.llmgateway.io/?model=alibaba/qwen-image-max)** 🎨
 
 **[Read the full documentation](https://docs.llmgateway.io/features/image-generation#alibaba-models)** 📚
 

--- a/apps/ui/src/content/changelog/2026-01-29-dev-plans-web-search-minimax.md
+++ b/apps/ui/src/content/changelog/2026-01-29-dev-plans-web-search-minimax.md
@@ -110,7 +110,7 @@ The latest GLM models are now available across multiple providers:
 zai/glm-4.7-flash
 ```
 
-**[Try in Playground](https://chat.llmgateway.io/?model=zai/glm-4.7-flash)**
+**[Try in Playground](https://lounge.llmgateway.io/?model=zai/glm-4.7-flash)**
 
 **[zai/glm-4.7-flashx](/models/glm-4.7-flashx/zai)** — extended context
 
@@ -118,7 +118,7 @@ zai/glm-4.7-flash
 zai/glm-4.7-flashx
 ```
 
-**[Try in Playground](https://chat.llmgateway.io/?model=zai/glm-4.7-flashx)**
+**[Try in Playground](https://lounge.llmgateway.io/?model=zai/glm-4.7-flashx)**
 
 **[cerebras/glm-4.7](/models/glm-4.7/cerebras)** — ultra-low latency via Cerebras
 
@@ -126,7 +126,7 @@ zai/glm-4.7-flashx
 cerebras/glm-4.7
 ```
 
-**[Try in Playground](https://chat.llmgateway.io/?model=cerebras/glm-4.7)**
+**[Try in Playground](https://lounge.llmgateway.io/?model=cerebras/glm-4.7)**
 
 **[novita/glm-4.7-flash](/models/glm-4.7-flash/novita)** — cost-effective option
 
@@ -134,7 +134,7 @@ cerebras/glm-4.7
 novita/glm-4.7-flash
 ```
 
-**[Try in Playground](https://chat.llmgateway.io/?model=novita/glm-4.7-flash)**
+**[Try in Playground](https://lounge.llmgateway.io/?model=novita/glm-4.7-flash)**
 
 ### Image Generation
 

--- a/apps/ui/src/content/changelog/2026-02-27-image-studio-and-more.md
+++ b/apps/ui/src/content/changelog/2026-02-27-image-studio-and-more.md
@@ -31,7 +31,7 @@ Toggle **Compare** mode to select up to 3 image models and generate from all of 
 
 Image Studio works with every image generation model on LLM Gateway, including Gemini 3.1 Flash Image, Gemini 3 Pro Image, Qwen Image, Seedream, CogView, and more.
 
-**[Try it now](https://chat.llmgateway.io/image)**
+**[Try it now](https://lounge.llmgateway.io/image)**
 
 ---
 

--- a/apps/ui/src/content/changelog/2026-05-17-seedance-chat-product-roundup.md
+++ b/apps/ui/src/content/changelog/2026-05-17-seedance-chat-product-roundup.md
@@ -59,7 +59,7 @@ A new **team chat list** view surfaces chats shared inside your organization —
 
 ### Canvas Wrap-Up
 
-[Canvas](https://chat.llmgateway.io) graduated from preview. The JSON editor and live preview now ship with six chart types (bar, line, area, pie, radar, radial bar), streaming AI spec generation, PNG and PDF export, and reusable Card and Chart primitives. Canvas now has its own entry in the sidebar across mobile and desktop.
+[Canvas](https://lounge.llmgateway.io) graduated from preview. The JSON editor and live preview now ship with six chart types (bar, line, area, pie, radar, radial bar), streaming AI spec generation, PNG and PDF export, and reusable Card and Chart primitives. Canvas now has its own entry in the sidebar across mobile and desktop.
 
 ### Smarter Model Selector
 
@@ -100,4 +100,4 @@ A dedicated **vertex-anthropic** provider is live for routing Claude models thro
 
 ---
 
-**[Try Chat →](https://chat.llmgateway.io)** | **[Generate a video →](https://docs.llmgateway.io/features/video-generation)** | **[Browse all models →](https://llmgateway.io/models)**
+**[Try Chat →](https://lounge.llmgateway.io)** | **[Generate a video →](https://docs.llmgateway.io/features/video-generation)** | **[Browse all models →](https://llmgateway.io/models)**

--- a/apps/ui/src/content/changelog/2026-06-01-referrals-cache-controls-product-updates.md
+++ b/apps/ui/src/content/changelog/2026-06-01-referrals-cache-controls-product-updates.md
@@ -47,4 +47,4 @@ Request logs now break out **cache-write** and **audio** tokens and cost separat
 
 ---
 
-**[Open your dashboard →](https://llmgateway.io/dashboard)** | **[Try Chat →](https://chat.llmgateway.io)** | **[Talk to sales →](https://llmgateway.io/enterprise)**
+**[Open your dashboard →](https://llmgateway.io/dashboard)** | **[Try Chat →](https://lounge.llmgateway.io)** | **[Talk to sales →](https://llmgateway.io/enterprise)**

--- a/apps/ui/src/content/changelog/2026-06-10-chat-plans-service-tiers-product-roundup.md
+++ b/apps/ui/src/content/changelog/2026-06-10-chat-plans-service-tiers-product-roundup.md
@@ -15,7 +15,7 @@ A roundup of everything else that shipped recently — new ways to pay, new ways
 
 ## Chat Subscription Plans
 
-[Chat](https://chat.llmgateway.io) now has monthly plans, so you can use every studio without topping up credits manually:
+[Chat](https://lounge.llmgateway.io) now has monthly plans, so you can use every studio without topping up credits manually:
 
 - **Starter — $9/mo** with **2×** credits ($18 of usage)
 - **Plus — $19/mo** with **2.5×** credits ($47.50 of usage)
@@ -66,4 +66,4 @@ Claim a username and share your AI coding activity. Your profile shows your acti
 
 ---
 
-**[Open your dashboard →](https://llmgateway.io/dashboard)** | **[Try Chat →](https://chat.llmgateway.io)**
+**[Open your dashboard →](https://llmgateway.io/dashboard)** | **[Try Chat →](https://lounge.llmgateway.io)**

--- a/apps/ui/src/content/changelog/2026-06-10-claude-fable-5-reve-and-new-models.md
+++ b/apps/ui/src/content/changelog/2026-06-10-claude-fable-5-reve-and-new-models.md
@@ -28,7 +28,7 @@ anthropic/claude-fable-5
 
 ## Reve Create — New Image Provider
 
-[Reve](https://llmgateway.io/models?filters=1&imageGeneration=true) joins the gateway as a new image generation provider. `reve/reve-create` produces high-quality images with **native 4K resolution** at a flat **$0.024 per image** — works in the [Image Studio](https://chat.llmgateway.io/image) and through `/v1/chat/completions` like every other image model.
+[Reve](https://llmgateway.io/models?filters=1&imageGeneration=true) joins the gateway as a new image generation provider. `reve/reve-create` produces high-quality images with **native 4K resolution** at a flat **$0.024 per image** — works in the [Image Studio](https://lounge.llmgateway.io/image) and through `/v1/chat/completions` like every other image model.
 
 ## Grok Imagine Video 1.5 Preview
 
@@ -37,7 +37,7 @@ xAI's image-to-video model is available as `xai/grok-imagine-video-1-5-preview`:
 - Turns an input image into video clips of **6 to 15 seconds**, with audio
 - Resolutions from 480p up to 1080p
 - **$0.08/s** at 480p, **$0.14/s** at 720p+, plus $0.01 per input image
-- Try it in the [Video Studio](https://chat.llmgateway.io/video)
+- Try it in the [Video Studio](https://lounge.llmgateway.io/video)
 
 ## Nemotron 3 Ultra 550B
 

--- a/apps/ui/src/content/changelog/2026-06-10-speech-generation-and-audio-studio.md
+++ b/apps/ui/src/content/changelog/2026-06-10-speech-generation-and-audio-studio.md
@@ -51,7 +51,7 @@ The Playground gets a third studio at `/audio`, joining Image and Video:
 - **Org-scoped history** — every generation is saved; revisit, rename, or delete past takes
 - **One-click download** straight from the player
 
-**[Try Audio Studio →](https://chat.llmgateway.io/audio)**
+**[Try Audio Studio →](https://lounge.llmgateway.io/audio)**
 
 ---
 

--- a/apps/ui/src/content/changelog/2026-07-24-lounge-rebrand.md
+++ b/apps/ui/src/content/changelog/2026-07-24-lounge-rebrand.md
@@ -43,10 +43,10 @@ The rename runs through the whole product, not just the landing page:
 
 - **In the app** — a proper Lounge wordmark in every sidebar, the login and signup pages, shared-chat pages, and the PWA install name.
 - **On invoices and emails** — Stripe line items and billing history now read "Lounge PLUS membership renewed" instead of "Chat Plan PLUS renewed".
-- **Across the site and docs** — the dashboard, the [comparison pages](https://chat.llmgateway.io/compare), and the [docs](https://docs.llmgateway.io/learn/chat-plans) all say Lounge now.
+- **Across the site and docs** — the dashboard, the [comparison pages](https://lounge.llmgateway.io/compare), and the [docs](https://docs.llmgateway.io/learn/chat-plans) all say Lounge now.
 
 DevPass is your all-access pass for coding tools; Lounge is your seat for everything else. One account, one balance, both products.
 
 ---
 
-**[Take a seat →](https://chat.llmgateway.io)** | **[See memberships →](https://chat.llmgateway.io/pricing)**
+**[Take a seat →](https://lounge.llmgateway.io)** | **[See memberships →](https://lounge.llmgateway.io/pricing)**

--- a/apps/ui/src/content/changelog/2026-07-26-realtime-voice-api.md
+++ b/apps/ui/src/content/changelog/2026-07-26-realtime-voice-api.md
@@ -74,10 +74,10 @@ Sessions carry safety limits by default, and are closed gracefully once in-fligh
 
 ## Talk to a model right now
 
-Lounge ships a **Voice Calls** page at [chat.llmgateway.io/realtime](https://chat.llmgateway.io/realtime): pick a model and a voice, hit **Start call**, and talk. The live transcript builds as you speak, a voice activity indicator shows who has the floor, and every call is saved to your history with its duration, model, voice, and token usage so you can reopen the transcript later.
+Lounge ships a **Voice Calls** page at [lounge.llmgateway.io/realtime](https://lounge.llmgateway.io/realtime): pick a model and a voice, hit **Start call**, and talk. The live transcript builds as you speak, a voice activity indicator shows who has the floor, and every call is saved to your history with its duration, model, voice, and token usage so you can reopen the transcript later.
 
 Realtime runs on pay-as-you-go organizations — your credits, or your own provider key when the project uses [provider keys](https://docs.llmgateway.io/learn/provider-keys). WebSocket is the only transport for now; WebRTC, SIP, image input, and hosted tools are not supported yet.
 
 ---
 
-**[Realtime API docs →](https://docs.llmgateway.io/features/realtime)** | **[Try Voice Calls →](https://chat.llmgateway.io/realtime)**
+**[Realtime API docs →](https://docs.llmgateway.io/features/realtime)** | **[Try Voice Calls →](https://lounge.llmgateway.io/realtime)**

--- a/apps/worker/src/services/follow-up-emails.ts
+++ b/apps/worker/src/services/follow-up-emails.ts
@@ -110,7 +110,7 @@ If you're having trouble getting started, here are some resources:
 
 - Getting started in 5 minutes: https://llmgateway.io/blog/getting-started-in-5-minutes
 - Documentation: https://docs.llmgateway.io
-- Chat Playground: https://chat.llmgateway.io (test models without writing code)
+- Lounge: https://lounge.llmgateway.io (test models without writing code)
 
 If something isn't working as expected or you need help with your setup, reply to this email and we'll get you sorted out.
 
@@ -196,7 +196,7 @@ export async function processNoPurchaseEmails(): Promise<void> {
 				eq(organization.devPlan, "none"),
 				eq(organization.status, "active"),
 				// Only nudge normal pay-as-you-go team orgs. Personal orgs back the
-				// DevPass coding product and chat orgs back chat.llmgateway.io — both
+				// DevPass coding product and chat orgs back Lounge — both
 				// have their own billing and are hidden from the dashboard, so they
 				// should never receive the "add credits" email.
 				eq(organization.kind, "default"),

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -39,6 +39,7 @@ import {
 	assertSafeWebhookUrl,
 	calculateFees,
 	isCreditTopUpAmountInRange,
+	isLoungeSource,
 	isPremiumUsedModel,
 	isPremiumWeekExpired,
 	isPrivateOrReservedIp,
@@ -1060,8 +1061,8 @@ export async function batchProcessLogs(): Promise<number> {
 			// Group logs by organization and api key to calculate total costs.
 			// We split per-org costs into a chat bucket and a default bucket so
 			// the deduction step below can prefer chat-plan credits for requests
-			// originating from chat.llmgateway.io (matching how users mentally
-			// account for their plans), and dev-plan credits everywhere else.
+			// originating from Lounge (matching how users mentally account for
+			// their plans), and dev-plan credits everywhere else.
 			// Use Decimal.js to avoid floating point rounding errors.
 			interface OrgCostBuckets {
 				chat: Decimal;
@@ -1085,8 +1086,10 @@ export async function batchProcessLogs(): Promise<number> {
 			// adjustments on what the org pays us.
 			const providerKeyCosts = new Map<string, Decimal>();
 
-			const isChatSource = (source: string | null | undefined) =>
-				source === "chat.llmgateway.io";
+			// Accepts both the current and the pre-move Lounge host: logs written
+			// before the domain move are still queued here, and rewriting them is
+			// not an option.
+			const isChatSource = isLoungeSource;
 
 			for (const raw of unprocessedLogs.rows) {
 				const row = schema.parse(raw);
@@ -1237,7 +1240,7 @@ export async function batchProcessLogs(): Promise<number> {
 			// Also calculate referral earnings (1% of spent credits).
 			//
 			// Deduction order is source-aware:
-			//   • chat.llmgateway.io requests → chat plan → dev plan → regular
+			//   • Lounge requests → chat plan → dev plan → regular
 			//   • everything else → dev plan → chat plan → regular
 			// The non-preferred plan acts as a fallback if the preferred plan's
 			// cycle credits are exhausted, so a single org with both plans gets

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -256,7 +256,7 @@ export const organization = pgTable(
 		// Organization kind:
 		// - "default": regular dashboard/team org.
 		// - "devpass": per-user personal org backing the Dev Plans (DevPass) product.
-		// - "chat": dedicated per-user "Chat" org backing chat.llmgateway.io.
+		// - "chat": dedicated per-user "Chat" org backing lounge.llmgateway.io.
 		// "devpass" and "chat" orgs are hidden from the dashboard org switcher and
 		// cannot be deleted or managed as team orgs.
 		kind: text({
@@ -333,7 +333,7 @@ export const organization = pgTable(
 		// prevent a single card from claiming the DevPass usage allowance from
 		// multiple personal organizations.
 		devPlanCardFingerprint: text(),
-		// Chat Plans fields (for chat.llmgateway.io subscribers)
+		// Chat Plans fields (for lounge.llmgateway.io subscribers)
 		chatPlan: text({
 			enum: ["none", "starter", "plus", "pro"],
 		})

--- a/packages/scripts/src/traffic-report.ts
+++ b/packages/scripts/src/traffic-report.ts
@@ -61,7 +61,9 @@ interface ReportData {
 const PRODUCTS: ReadonlyArray<{ host: string; label: string }> = [
 	{ host: "llmgateway.io", label: "LLM Gateway" },
 	{ host: "devpass.llmgateway.io", label: "DevPass" },
-	{ host: "chat.llmgateway.io", label: "Chat" },
+	{ host: "lounge.llmgateway.io", label: "Lounge" },
+	// Pre-move Lounge host, kept so historical periods still report traffic.
+	{ host: "chat.llmgateway.io", label: "Lounge (legacy host)" },
 	{ host: "docs.llmgateway.io", label: "Docs" },
 ];
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -41,6 +41,10 @@
 			"types": "./dist/random.d.ts",
 			"import": "./dist/random.js"
 		},
+		"./lounge-source": {
+			"types": "./dist/lounge-source.d.ts",
+			"import": "./dist/lounge-source.js"
+		},
 		"./sandbox-escape": {
 			"types": "./dist/sandbox-escape.d.ts",
 			"import": "./dist/sandbox-escape.js"

--- a/packages/shared/src/coding-agents.spec.ts
+++ b/packages/shared/src/coding-agents.spec.ts
@@ -45,6 +45,7 @@ describe("isRecognizedCodingAgent", () => {
 		expect(isRecognizedCodingAgent("")).toBe(false);
 		expect(isRecognizedCodingAgent("curl")).toBe(false);
 		expect(isRecognizedCodingAgent("postman")).toBe(false);
+		expect(isRecognizedCodingAgent("lounge.llmgateway.io")).toBe(false);
 		expect(isRecognizedCodingAgent("chat.llmgateway.io")).toBe(false);
 		expect(isRecognizedCodingAgent("my-custom-app")).toBe(false);
 	});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -171,6 +171,12 @@ export {
 	type PlanTermThresholds,
 } from "./plan-term.js";
 
+export {
+	isLoungeSource,
+	LEGACY_LOUNGE_SOURCE,
+	LOUNGE_SOURCE,
+} from "./lounge-source.js";
+
 export { MARKETING_STATS, RUNWARE_PROMO } from "./marketing.js";
 
 export {

--- a/packages/shared/src/lounge-source.spec.ts
+++ b/packages/shared/src/lounge-source.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	isLoungeSource,
+	LEGACY_LOUNGE_SOURCE,
+	LOUNGE_SOURCE,
+} from "./lounge-source.js";
+
+describe("isLoungeSource", () => {
+	it("recognizes the current Lounge host", () => {
+		expect(isLoungeSource(LOUNGE_SOURCE)).toBe(true);
+		expect(isLoungeSource("lounge.llmgateway.io")).toBe(true);
+	});
+
+	it("still recognizes logs written before the domain move", () => {
+		expect(isLoungeSource(LEGACY_LOUNGE_SOURCE)).toBe(true);
+		expect(isLoungeSource("chat.llmgateway.io")).toBe(true);
+	});
+
+	it("rejects other sources", () => {
+		expect(isLoungeSource("llmgateway.io")).toBe(false);
+		expect(isLoungeSource("devpass.llmgateway.io")).toBe(false);
+		expect(isLoungeSource("claude-code")).toBe(false);
+		expect(isLoungeSource(null)).toBe(false);
+		expect(isLoungeSource(undefined)).toBe(false);
+		expect(isLoungeSource("")).toBe(false);
+	});
+});

--- a/packages/shared/src/lounge-source.ts
+++ b/packages/shared/src/lounge-source.ts
@@ -1,0 +1,20 @@
+/**
+ * The `x-source` header value every Lounge-originated gateway request carries.
+ * It is written to `log.source` and drives two things: the source breakdown in
+ * analytics, and the worker's credit deduction order (chat-plan credits are
+ * preferred for Lounge traffic).
+ */
+export const LOUNGE_SOURCE = "lounge.llmgateway.io";
+
+/**
+ * The host Lounge used before the move to lounge.llmgateway.io. Logs written
+ * before the cutover — and any request that arrives while a stale client or a
+ * cached page still posts from the old origin — carry this value, so anything
+ * that classifies a request as Lounge traffic has to keep accepting it.
+ * Historical rows are never rewritten, so this cannot be dropped later.
+ */
+export const LEGACY_LOUNGE_SOURCE = "chat.llmgateway.io";
+
+export function isLoungeSource(source: string | null | undefined): boolean {
+	return source === LOUNGE_SOURCE || source === LEGACY_LOUNGE_SOURCE;
+}


### PR DESCRIPTION
Lounge is served from `chat.llmgateway.io`, a name left over from before the product had one. This moves it to `lounge.llmgateway.io` so the URL matches the product, and repoints every link, canonical URL and OG target across the playground, dashboard, docs and marketing content.

The old host is not dropped — it gets a permanent redirect that preserves the path, so bookmarks, shared conversation links (`/share/<id>`) and inbound backlinks keep working.

**This ships last.** Everything here points at a host that does not resolve yet. The infra side is a two-PR stack that has to land first, with manual Cloudflare work in between:

1. theopenco/llmgateway-infra#1466 — creates the certificate and starts serving Lounge on the new host, additively. Cloudflare records are added after it merges; the old host keeps working throughout, so the new one can be verified in a browser before anything changes.
2. theopenco/llmgateway-infra#1463 — flips the old host to a 301 and moves the monitoring.
3. This PR.

The runbook for the manual steps is in `docs/lounge-domain-move.md` in the first of those.

## The part worth reviewing

Lounge sends `x-source: chat.llmgateway.io` on every gateway request. That value is written to `log.source`, and the worker's credit deduction reads it — Lounge traffic prefers chat-plan credits over dev-plan credits, everything else goes the other way round. Naively renaming the header would have silently sent Lounge spend down the wrong deduction path for anything still in the queue.

So the value is now a shared constant with an explicit legacy alias:

```ts
export const LOUNGE_SOURCE = "lounge.llmgateway.io";
export const LEGACY_LOUNGE_SOURCE = "chat.llmgateway.io";
export function isLoungeSource(source) { ... }  // accepts both
```

`isLoungeSource` replaces the inline comparison in the worker and accepts both hosts permanently. Logs written before the cutover are still queued for processing, and historical rows are never rewritten, so the legacy value can't be dropped later. The twelve `x-source` senders across the playground and API now import the constant instead of repeating the literal.

Two other places keep the old host for the same reason:

- the support assistant's fetch allowlist, because links to the old host are still in the wild
- `traffic-report.ts`, which gains the new host as `Lounge` and keeps the old one as `Lounge (legacy host)` so historical periods still report

Worth knowing for analytics: `project_hourly_source_stats` and friends group on the raw source string, so a Lounge breakdown spanning the cutover will show two rows until the old one ages out.

## Everything else

- **Playground** — `BRAND.url`, sitemap, robots, canonical and OG URLs, compare and share page metadata, `llms.txt`, sidebar login links
- **Dashboard / marketing** — Lounge links in the sidebar and dashboard, the models page, `pricing.md`, and the `/chat` and `/playground` redirects in `next.config.ts` (plus a new `/lounge` one)
- **Docs** — the realtime, speech-generation and chat-plans pages
- **Content** — CTAs across blog and changelog entries. The 2026-07-24 rebrand entry is the one exception: it states the URL did *not* change, which was true when it was published, so that sentence is left as written and only its live CTAs move.

Session cookies are issued on `COOKIE_DOMAIN=llmgateway.io` with `crossSubDomainCookies`, and `PASSKEY_RP_ID` is the apex domain, so signed-in users and passkeys carry across the move with no re-authentication.

No changelog entry here — one should land with the cutover, not before, or it would announce a host that does not resolve.

## Verification

- `pnpm format`, `pnpm build` — pass
- `pnpm test:unit` against an isolated per-worktree stack — 4641 passed, 1 failed:
  `apps/gateway/src/onboarding-sponsorship.spec.ts` expects 1 log and gets 2. Verified
  pre-existing: it fails identically on a clean `origin/main` checkout in the same stack,
  and nothing here touches that path.
- New spec covers `isLoungeSource` for both hosts and rejects everything else

No screenshots: every `apps/ui` change here is a link target or redirect destination, so a before/after pair would be two identical images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lounge is now the primary destination for chat, playground, audio, image, video, realtime, and related product links.
  * Added redirects from legacy chat and playground paths to Lounge.
  * Production logout and upgrade flows now direct users to Lounge.
  * Legacy chat addresses remain supported where applicable.

* **Bug Fixes**
  * Updated knowledge sources, sitemaps, metadata, and navigation to use current Lounge URLs.

* **Tests**
  * Added coverage for current and legacy Lounge address recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->