### PR TITLE
feat(admin): devpass refunds and plan cancel

### DIFF
--- a/apps/api/src/lib/account-deletion.ts
+++ b/apps/api/src/lib/account-deletion.ts
@@ -36,6 +36,23 @@ export function getOrganizationSubscriptionIds(
 }
 
 /**
+ * Whether a Stripe error means the subscription is already in the terminal
+ * state a cancel was aiming for — gone, or cancelled earlier. Callers treat
+ * this as success rather than failing an otherwise-complete teardown.
+ */
+export function isTerminalSubscriptionError(
+	error: unknown,
+): error is Stripe.errors.StripeInvalidRequestError {
+	return (
+		error instanceof Stripe.errors.StripeInvalidRequestError &&
+		(error.code === "resource_missing" ||
+			error.statusCode === 404 ||
+			error.message.includes("already been canceled") ||
+			error.message.includes("already canceled"))
+	);
+}
+
+/**
  * Cancels every Stripe subscription an organization holds, immediately and
  * without a final proration invoice.
  *
@@ -57,13 +74,7 @@ export async function cancelOrganizationSubscriptions(
 			});
 			cancelled.push(subscriptionId);
 		} catch (error) {
-			if (
-				error instanceof Stripe.errors.StripeInvalidRequestError &&
-				(error.code === "resource_missing" ||
-					error.statusCode === 404 ||
-					error.message.includes("already been canceled") ||
-					error.message.includes("already canceled"))
-			) {
+			if (isTerminalSubscriptionError(error)) {
 				logger.info(
 					`Stripe subscription ${subscriptionId} already terminal, skipping cancel: ${error.message}`,
 				);

--- a/apps/api/src/lib/admin-refund.spec.ts
+++ b/apps/api/src/lib/admin-refund.spec.ts
@@ -1,0 +1,262 @@
+import { Decimal } from "decimal.js";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db, tables } from "@llmgateway/db";
+
+import {
+	computeAdminRefundability,
+	executeAdminRefund,
+	sumRefundsByTransaction,
+} from "./admin-refund.js";
+
+import type * as PaymentsModule from "@/routes/payments.js";
+
+const stripeMock = vi.hoisted(() => ({
+	refunds: { create: vi.fn() },
+	invoices: { retrieve: vi.fn() },
+	invoicePayments: { list: vi.fn() },
+}));
+
+vi.mock("@/routes/payments.js", async (importOriginal) => {
+	const original = await importOriginal<typeof PaymentsModule>();
+	return {
+		...original,
+		getStripe: () => stripeMock,
+	};
+});
+
+const ORG_ID = "test-org-id";
+
+async function seedOrg() {
+	await db.insert(tables.organization).values({
+		id: ORG_ID,
+		name: "Test Organization",
+		billingEmail: "test@example.com",
+		kind: "devpass",
+	});
+	await db.insert(tables.userOrganization).values({
+		userId: "test-user-id",
+		organizationId: ORG_ID,
+		role: "owner",
+	});
+}
+
+async function seedTransaction(overrides: Record<string, unknown> = {}) {
+	const [row] = await db
+		.insert(tables.transaction)
+		.values({
+			organizationId: ORG_ID,
+			type: "dev_plan_start",
+			amount: "100",
+			status: "completed",
+			stripePaymentIntentId: "pi_test_1",
+			...overrides,
+		} as typeof tables.transaction.$inferInsert)
+		.returning();
+	return row;
+}
+
+type RefundabilityInput = Parameters<
+	typeof computeAdminRefundability
+>[0]["transaction"];
+
+describe("computeAdminRefundability", () => {
+	const payment: RefundabilityInput = {
+		type: "dev_plan_renewal",
+		status: "completed",
+		amount: "100",
+		stripePaymentIntentId: "pi_test_1",
+		stripeInvoiceId: null,
+	};
+
+	test("a completed payment with nothing refunded yet is refundable", () => {
+		expect(
+			computeAdminRefundability({
+				transaction: payment,
+				refundedAmount: new Decimal(0),
+			}),
+		).toEqual({
+			refundable: true,
+			reason: null,
+			refundedAmount: "0.00",
+			refundableAmount: "100.00",
+		});
+	});
+
+	test("a partially refunded payment stays refundable for the remainder", () => {
+		expect(
+			computeAdminRefundability({
+				transaction: payment,
+				refundedAmount: new Decimal("40"),
+			}),
+		).toMatchObject({
+			refundable: true,
+			refundableAmount: "60.00",
+			refundedAmount: "40.00",
+		});
+	});
+
+	test("a fully refunded payment is not refundable again", () => {
+		expect(
+			computeAdminRefundability({
+				transaction: payment,
+				refundedAmount: new Decimal("100"),
+			}),
+		).toMatchObject({
+			refundable: false,
+			reason: "fully_refunded",
+			refundableAmount: "0.00",
+		});
+	});
+
+	test("bookkeeping rows are not refundable", () => {
+		expect(
+			computeAdminRefundability({
+				transaction: { ...payment, type: "dev_plan_cancel", amount: null },
+				refundedAmount: new Decimal(0),
+			}),
+		).toMatchObject({ refundable: false, reason: "unsupported_type" });
+	});
+
+	test("a pending payment is not refundable", () => {
+		expect(
+			computeAdminRefundability({
+				transaction: { ...payment, status: "pending" },
+				refundedAmount: new Decimal(0),
+			}),
+		).toMatchObject({ refundable: false, reason: "not_completed" });
+	});
+
+	test("a payment without any Stripe reference is not refundable", () => {
+		expect(
+			computeAdminRefundability({
+				transaction: { ...payment, stripePaymentIntentId: null },
+				refundedAmount: new Decimal(0),
+			}),
+		).toMatchObject({ refundable: false, reason: "no_payment" });
+	});
+
+	test("an invoice-only payment is refundable", () => {
+		expect(
+			computeAdminRefundability({
+				transaction: {
+					...payment,
+					stripePaymentIntentId: null,
+					stripeInvoiceId: "in_test_1",
+				},
+				refundedAmount: new Decimal(0),
+			}),
+		).toMatchObject({ refundable: true });
+	});
+});
+
+describe("admin refund execution", () => {
+	beforeEach(async () => {
+		await createTestUser();
+		await seedOrg();
+		stripeMock.refunds.create.mockReset();
+		stripeMock.invoices.retrieve.mockReset();
+		stripeMock.refunds.create.mockResolvedValue({ id: "re_test_1" });
+	});
+
+	afterEach(async () => {
+		await deleteAll();
+	});
+
+	test("sumRefundsByTransaction totals completed refunds per payment", async () => {
+		const payment = await seedTransaction();
+		await seedTransaction({
+			type: "credit_refund",
+			amount: "30",
+			relatedTransactionId: payment.id,
+		});
+		await seedTransaction({
+			type: "credit_refund",
+			amount: "20",
+			relatedTransactionId: payment.id,
+		});
+		// Pending refunds haven't moved any money yet.
+		await seedTransaction({
+			type: "credit_refund",
+			amount: "50",
+			status: "pending",
+			relatedTransactionId: payment.id,
+		});
+
+		const totals = await sumRefundsByTransaction(ORG_ID, [payment.id]);
+
+		expect(totals.get(payment.id)?.toFixed(2)).toBe("50.00");
+	});
+
+	test("refunds the full remaining amount by default", async () => {
+		const payment = await seedTransaction();
+
+		const result = await executeAdminRefund({
+			organization: (await db.query.organization.findFirst({
+				where: { id: { eq: ORG_ID } },
+			}))!,
+			transaction: payment,
+			adminUserId: "test-user-id",
+			refundedAmount: new Decimal("25"),
+			reason: "requested_by_customer",
+		});
+
+		expect(result).toEqual({ stripeRefundId: "re_test_1", amount: "75.00" });
+		expect(stripeMock.refunds.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				payment_intent: "pi_test_1",
+				amount: 7500,
+				reason: "requested_by_customer",
+			}),
+			expect.objectContaining({ idempotencyKey: expect.any(String) }),
+		);
+	});
+
+	test("rejects an amount above what is left to refund", async () => {
+		const payment = await seedTransaction();
+		const organization = (await db.query.organization.findFirst({
+			where: { id: { eq: ORG_ID } },
+		}))!;
+
+		await expect(
+			executeAdminRefund({
+				organization,
+				transaction: payment,
+				adminUserId: "test-user-id",
+				amount: 80,
+				refundedAmount: new Decimal("25"),
+				reason: "requested_by_customer",
+			}),
+		).rejects.toThrow("between $0.01 and $75.00");
+		expect(stripeMock.refunds.create).not.toHaveBeenCalled();
+	});
+
+	test("records an audit log entry for the refund", async () => {
+		const payment = await seedTransaction();
+
+		await executeAdminRefund({
+			organization: (await db.query.organization.findFirst({
+				where: { id: { eq: ORG_ID } },
+			}))!,
+			transaction: payment,
+			adminUserId: "test-user-id",
+			refundedAmount: new Decimal(0),
+			reason: "duplicate",
+			comment: "charged twice",
+		});
+
+		const auditEntry = await db.query.auditLog.findFirst({
+			where: { organizationId: { eq: ORG_ID } },
+		});
+
+		expect(auditEntry?.action).toBe("payment.admin_refund");
+		expect(auditEntry?.metadata).toMatchObject({
+			stripeRefundId: "re_test_1",
+			refundAmount: "100.00",
+			reason: "duplicate",
+			comment: "charged twice",
+		});
+	});
+});

--- a/apps/api/src/lib/admin-refund.ts
+++ b/apps/api/src/lib/admin-refund.ts
@@ -1,0 +1,233 @@
+import { Decimal } from "decimal.js";
+import { HTTPException } from "hono/http-exception";
+
+import { getStripe } from "@/routes/payments.js";
+import { getPaymentIntentFromInvoicePayments } from "@/stripe.js";
+
+import { logAuditEvent } from "@llmgateway/audit";
+import { and, db, eq, inArray, tables } from "@llmgateway/db";
+
+type OrganizationRow = typeof tables.organization.$inferSelect;
+type TransactionRow = typeof tables.transaction.$inferSelect;
+
+/**
+ * Purchase types an administrator may refund from the admin panel. Mirrors the
+ * types `handleChargeRefunded` knows how to book back, minus the chat-plan ones
+ * (a DevPass org never holds a chat plan): anything outside this list would be
+ * refunded at Stripe with no matching ledger row on our side.
+ */
+export const ADMIN_REFUNDABLE_TX_TYPES = [
+	"dev_plan_start",
+	"dev_plan_renewal",
+	"dev_plan_upgrade",
+	"dev_plan_reset_pass",
+	// PAYG overflow top-ups are DevPass purchases too.
+	"credit_topup",
+	// Legacy pre-rename DevPass rows, still the only payment record for the
+	// earliest subscribers.
+	"subscription_start",
+] as const;
+
+export type AdminRefundableType = (typeof ADMIN_REFUNDABLE_TX_TYPES)[number];
+
+export function isAdminRefundableType(
+	type: string,
+): type is AdminRefundableType {
+	return (ADMIN_REFUNDABLE_TX_TYPES as readonly string[]).includes(type);
+}
+
+export type AdminRefundIneligibilityReason =
+	"unsupported_type" | "not_completed" | "no_payment" | "fully_refunded";
+
+export interface AdminRefundability {
+	refundable: boolean;
+	reason: AdminRefundIneligibilityReason | null;
+	/** Amount already refunded against this payment, in dollars. */
+	refundedAmount: string;
+	/** What is still refundable, in dollars. */
+	refundableAmount: string;
+}
+
+/**
+ * Whether an administrator can still refund a payment, and how much of it is
+ * left. Deliberately looser than the customer-facing rules in `self-refund.ts`:
+ * no time window, no usage threshold, no owner check — support decides, the
+ * only hard requirements are a completed charge we can reach at Stripe and
+ * money left to give back.
+ */
+export function computeAdminRefundability({
+	transaction,
+	refundedAmount,
+}: {
+	transaction: Pick<
+		TransactionRow,
+		"type" | "status" | "amount" | "stripePaymentIntentId" | "stripeInvoiceId"
+	>;
+	refundedAmount: Decimal;
+}): AdminRefundability {
+	const amount = new Decimal(transaction.amount ?? 0);
+	const remaining = Decimal.max(0, amount.minus(refundedAmount));
+	const base = {
+		refundedAmount: refundedAmount.toFixed(2),
+		refundableAmount: remaining.toFixed(2),
+	};
+
+	if (!isAdminRefundableType(transaction.type)) {
+		return { refundable: false, reason: "unsupported_type", ...base };
+	}
+	if (transaction.status !== "completed") {
+		return { refundable: false, reason: "not_completed", ...base };
+	}
+	if (
+		!amount.gt(0) ||
+		(!transaction.stripePaymentIntentId && !transaction.stripeInvoiceId)
+	) {
+		return { refundable: false, reason: "no_payment", ...base };
+	}
+	if (!remaining.gt(0)) {
+		return { refundable: false, reason: "fully_refunded", ...base };
+	}
+	return { refundable: true, reason: null, ...base };
+}
+
+/**
+ * Total already refunded per payment, keyed by the refunded transaction's id.
+ * `credit_refund` rows carry the refunded dollar amount as a positive `amount`
+ * and point back at the original purchase via `relatedTransactionId`.
+ */
+export async function sumRefundsByTransaction(
+	organizationId: string,
+	transactionIds: string[],
+): Promise<Map<string, Decimal>> {
+	const totals = new Map<string, Decimal>();
+	if (transactionIds.length === 0) {
+		return totals;
+	}
+
+	const rows = await db
+		.select({
+			relatedTransactionId: tables.transaction.relatedTransactionId,
+			amount: tables.transaction.amount,
+		})
+		.from(tables.transaction)
+		.where(
+			and(
+				eq(tables.transaction.organizationId, organizationId),
+				eq(tables.transaction.type, "credit_refund"),
+				eq(tables.transaction.status, "completed"),
+				inArray(tables.transaction.relatedTransactionId, transactionIds),
+			),
+		);
+
+	for (const row of rows) {
+		if (!row.relatedTransactionId) {
+			continue;
+		}
+		const current = totals.get(row.relatedTransactionId) ?? new Decimal(0);
+		totals.set(row.relatedTransactionId, current.plus(row.amount ?? 0));
+	}
+
+	return totals;
+}
+
+export const ADMIN_REFUND_REASONS = [
+	"requested_by_customer",
+	"duplicate",
+	"fraudulent",
+] as const;
+
+export type AdminRefundReason = (typeof ADMIN_REFUND_REASONS)[number];
+
+/**
+ * Issue a Stripe refund on behalf of a customer. Like the self-service path,
+ * every bookkeeping side effect is left to the `charge.refunded` webhook: it
+ * writes the `credit_refund` row, deducts top-up credits, claws back an unused
+ * Reset Pass, and cancels the subscription when a plan payment is refunded in
+ * full.
+ *
+ * `amount` refunds only part of the payment; omitting it refunds the rest.
+ */
+export async function executeAdminRefund({
+	organization,
+	transaction,
+	adminUserId,
+	amount,
+	refundedAmount,
+	reason,
+	comment,
+}: {
+	organization: OrganizationRow;
+	transaction: TransactionRow;
+	adminUserId: string;
+	amount?: number;
+	refundedAmount: Decimal;
+	reason: AdminRefundReason;
+	comment?: string;
+}): Promise<{ stripeRefundId: string; amount: string }> {
+	const eligibility = computeAdminRefundability({
+		transaction,
+		refundedAmount,
+	});
+	if (!eligibility.refundable) {
+		throw new HTTPException(400, {
+			message: `This payment cannot be refunded: ${eligibility.reason}`,
+		});
+	}
+
+	const remaining = new Decimal(eligibility.refundableAmount);
+	const refundAmount = amount === undefined ? remaining : new Decimal(amount);
+	if (!refundAmount.gt(0) || refundAmount.gt(remaining)) {
+		throw new HTTPException(400, {
+			message: `Refund amount must be between $0.01 and $${remaining.toFixed(2)}`,
+		});
+	}
+
+	const stripe = getStripe();
+
+	let paymentIntentId = transaction.stripePaymentIntentId;
+	if (!paymentIntentId && transaction.stripeInvoiceId) {
+		// Plan payments record only the invoice id; resolve the payment intent
+		// through the invoice's payments (stripe 18.x dropped invoice.payment_intent).
+		const invoice = await stripe.invoices.retrieve(transaction.stripeInvoiceId);
+		const paymentIntent = await getPaymentIntentFromInvoicePayments(invoice);
+		paymentIntentId = paymentIntent?.id ?? null;
+	}
+	if (!paymentIntentId) {
+		throw new HTTPException(400, {
+			message: "No refundable payment found for this transaction",
+		});
+	}
+
+	// Keyed on how much had already been refunded when the request came in, so a
+	// double-click returns the first refund instead of issuing a second one,
+	// while a deliberate follow-up partial refund (after the webhook recorded the
+	// previous one) gets a key of its own.
+	const idempotencyKey = `admin-refund-${transaction.id}-${refundedAmount.toFixed(2)}-${refundAmount.toFixed(2)}`;
+
+	const refund = await stripe.refunds.create(
+		{
+			payment_intent: paymentIntentId,
+			amount: refundAmount.times(100).toDecimalPlaces(0).toNumber(),
+			reason,
+		},
+		{ idempotencyKey },
+	);
+
+	await logAuditEvent({
+		organizationId: organization.id,
+		userId: adminUserId,
+		action: "payment.admin_refund",
+		resourceType: "payment",
+		resourceId: transaction.id,
+		metadata: {
+			stripeRefundId: refund.id,
+			transactionType: transaction.type,
+			originalAmount: transaction.amount,
+			refundAmount: refundAmount.toFixed(2),
+			reason,
+			comment,
+		},
+	});
+
+	return { stripeRefundId: refund.id, amount: refundAmount.toFixed(2) };
+}

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1,9 +1,19 @@
 import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
+import { Decimal } from "decimal.js";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
 import { deleteResendContact } from "@/auth/config.js";
-import { cancelOrganizationSubscriptions } from "@/lib/account-deletion.js";
+import {
+	cancelOrganizationSubscriptions,
+	isTerminalSubscriptionError,
+} from "@/lib/account-deletion.js";
+import {
+	ADMIN_REFUND_REASONS,
+	computeAdminRefundability,
+	executeAdminRefund,
+	sumRefundsByTransaction,
+} from "@/lib/admin-refund.js";
 import { modeSplitFields } from "@/lib/mode-split.js";
 import { parseReferralBonusPercent } from "@/lib/referral-bonus.js";
 import {
@@ -12,6 +22,7 @@ import {
 	tokenWindowSchema,
 } from "@/lib/stats-window.js";
 import { adminMiddleware } from "@/middleware/admin.js";
+import { getStripe } from "@/routes/payments.js";
 import {
 	CHAT_PLAN_TX_TYPES,
 	DEV_PLAN_SUBSCRIPTION_TX_TYPES,
@@ -12327,6 +12338,12 @@ const devpassTransactionSchema = z.object({
 	currency: z.string(),
 	status: z.string(),
 	description: z.string().nullable(),
+	// Whether an admin can refund this payment, and how much of it is left.
+	// `refundIneligibleReason` is null when `refundable` is true.
+	refundable: z.boolean(),
+	refundIneligibleReason: z.string().nullable(),
+	refundedAmount: z.string(),
+	refundableAmount: z.string(),
 });
 
 const devpassPaymentFailureSchema = z.object({
@@ -12413,6 +12430,130 @@ const giftResetPassesRoute = createRoute({
 				},
 			},
 			description: "Reset Passes gifted successfully.",
+		},
+		404: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						message: z.string(),
+					}),
+				},
+			},
+			description: "Subscriber not found.",
+		},
+	},
+});
+
+// Refund a DevPass payment on behalf of the subscriber. The Stripe refund is
+// all this does directly: the `charge.refunded` webhook records the
+// `credit_refund` row, deducts top-up credits, claws back an unused Reset Pass,
+// and cancels the subscription when a plan payment is refunded in full.
+const refundDevpassPaymentRoute = createRoute({
+	method: "post",
+	path: "/devpass/{orgId}/refund",
+	request: {
+		params: z.object({
+			orgId: z.string(),
+		}),
+		body: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						transactionId: z.string(),
+						// Omit for a full refund of whatever is left on the payment.
+						amount: z.number().positive().optional(),
+						reason: z
+							.enum(ADMIN_REFUND_REASONS)
+							.default("requested_by_customer"),
+						comment: z.string().max(500).optional(),
+					}),
+				},
+			},
+		},
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						message: z.string(),
+						stripeRefundId: z.string(),
+						amount: z.string(),
+					}),
+				},
+			},
+			description:
+				"Refund created; bookkeeping is applied when Stripe confirms via webhook.",
+		},
+		400: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						message: z.string(),
+					}),
+				},
+			},
+			description: "Payment is not refundable.",
+		},
+		404: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						message: z.string(),
+					}),
+				},
+			},
+			description: "Subscriber or transaction not found.",
+		},
+	},
+});
+
+// Cancel a DevPass subscription on behalf of the subscriber, either at the end
+// of the paid period (the default, same as the customer-facing cancel) or
+// immediately. Plan state is updated by the resulting Stripe webhook.
+const cancelDevpassSubscriptionRoute = createRoute({
+	method: "post",
+	path: "/devpass/{orgId}/cancel-subscription",
+	request: {
+		params: z.object({
+			orgId: z.string(),
+		}),
+		body: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						// Immediate cancellation ends access right away without
+						// refunding the current period — pair it with a refund when the
+						// customer should get their money back.
+						immediate: z.boolean().default(false),
+						comment: z.string().max(500).optional(),
+					}),
+				},
+			},
+		},
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						message: z.string(),
+						immediate: z.boolean(),
+						subscriptionId: z.string(),
+					}),
+				},
+			},
+			description: "DevPass subscription cancelled.",
+		},
+		400: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						message: z.string(),
+					}),
+				},
+			},
+			description: "No active DevPass subscription.",
 		},
 		404: {
 			content: {
@@ -14350,6 +14491,8 @@ admin.openapi(getDevpassSubscriber, async (c) => {
 			currency: tables.transaction.currency,
 			status: tables.transaction.status,
 			description: tables.transaction.description,
+			stripePaymentIntentId: tables.transaction.stripePaymentIntentId,
+			stripeInvoiceId: tables.transaction.stripeInvoiceId,
 		})
 		.from(tables.transaction)
 		.where(
@@ -14377,6 +14520,13 @@ admin.openapi(getDevpassSubscriber, async (c) => {
 		)
 		.orderBy(desc(tables.transaction.createdAt))
 		.limit(100);
+
+	// Refunds already issued against those payments, so the panel can show what
+	// is left to refund instead of offering a button that Stripe would reject.
+	const refundedByTransactionId = await sumRefundsByTransaction(
+		orgId,
+		transactions.map((t) => t.id),
+	);
 
 	const paymentFailures = await db
 		.select({
@@ -14407,16 +14557,26 @@ admin.openapi(getDevpassSubscriber, async (c) => {
 							org.devPlanIncludedResetPassesUsed,
 						),
 		},
-		transactions: transactions.map((t) => ({
-			id: t.id,
-			createdAt: t.createdAt.toISOString(),
-			type: t.type,
-			amount: t.amount ?? null,
-			creditAmount: t.creditAmount ?? null,
-			currency: t.currency,
-			status: t.status,
-			description: t.description ?? null,
-		})),
+		transactions: transactions.map((t) => {
+			const refundability = computeAdminRefundability({
+				transaction: t,
+				refundedAmount: refundedByTransactionId.get(t.id) ?? new Decimal(0),
+			});
+			return {
+				id: t.id,
+				createdAt: t.createdAt.toISOString(),
+				type: t.type,
+				amount: t.amount ?? null,
+				creditAmount: t.creditAmount ?? null,
+				currency: t.currency,
+				status: t.status,
+				description: t.description ?? null,
+				refundable: refundability.refundable,
+				refundIneligibleReason: refundability.reason,
+				refundedAmount: refundability.refundedAmount,
+				refundableAmount: refundability.refundableAmount,
+			};
+		}),
 		paymentFailures: paymentFailures.map((p) => ({
 			id: p.id,
 			createdAt: p.createdAt.toISOString(),
@@ -14499,6 +14659,123 @@ admin.openapi(giftResetPassesRoute, async (c) => {
 	return c.json({
 		message: "Reset Passes gifted successfully",
 		resetPasses,
+	});
+});
+
+admin.openapi(refundDevpassPaymentRoute, async (c) => {
+	const user = c.get("user");
+	const { orgId } = c.req.valid("param");
+	const { transactionId, amount, reason, comment } = c.req.valid("json");
+
+	const org = await db.query.organization.findFirst({
+		where: { id: { eq: orgId }, kind: { eq: "devpass" } },
+	});
+
+	if (!org) {
+		throw new HTTPException(404, { message: "Subscriber not found" });
+	}
+
+	const transaction = await db.query.transaction.findFirst({
+		where: { id: { eq: transactionId }, organizationId: { eq: orgId } },
+	});
+
+	if (!transaction) {
+		throw new HTTPException(404, { message: "Transaction not found" });
+	}
+
+	const refundedByTransactionId = await sumRefundsByTransaction(orgId, [
+		transaction.id,
+	]);
+
+	const { stripeRefundId, amount: refundedAmount } = await executeAdminRefund({
+		organization: org,
+		transaction,
+		adminUserId: user!.id,
+		amount,
+		refundedAmount:
+			refundedByTransactionId.get(transaction.id) ?? new Decimal(0),
+		reason,
+		comment,
+	});
+
+	return c.json({
+		message: `Refund of $${refundedAmount} created. Credits, Reset Passes and plan status update once Stripe confirms.`,
+		stripeRefundId,
+		amount: refundedAmount,
+	});
+});
+
+admin.openapi(cancelDevpassSubscriptionRoute, async (c) => {
+	const user = c.get("user");
+	const { orgId } = c.req.valid("param");
+	const { immediate, comment } = c.req.valid("json");
+
+	const org = await db.query.organization.findFirst({
+		where: { id: { eq: orgId }, kind: { eq: "devpass" } },
+	});
+
+	if (!org) {
+		throw new HTTPException(404, { message: "Subscriber not found" });
+	}
+
+	const subscriptionId = org.devPlanStripeSubscriptionId;
+	if (!subscriptionId) {
+		throw new HTTPException(400, {
+			message: "This subscriber has no active DevPass subscription",
+		});
+	}
+
+	const cancellationDetails = comment ? { comment } : undefined;
+
+	try {
+		if (immediate) {
+			await getStripe().subscriptions.cancel(subscriptionId, {
+				invoice_now: false,
+				prorate: false,
+				...(cancellationDetails
+					? { cancellation_details: cancellationDetails }
+					: {}),
+			});
+		} else {
+			await getStripe().subscriptions.update(subscriptionId, {
+				cancel_at_period_end: true,
+				...(cancellationDetails
+					? { cancellation_details: cancellationDetails }
+					: {}),
+			});
+		}
+	} catch (error) {
+		// A subscription Stripe has already ended is exactly the state we want;
+		// the plan columns are reset by the webhook (or the customer's next
+		// dashboard visit), so report success instead of failing the action.
+		if (isTerminalSubscriptionError(error)) {
+			logger.info(
+				`DevPass subscription ${subscriptionId} already terminal, skipping admin cancel`,
+			);
+		} else {
+			throw error;
+		}
+	}
+
+	await logAuditEvent({
+		organizationId: orgId,
+		userId: user!.id,
+		action: "dev_plan.admin_cancel",
+		resourceType: "dev_plan",
+		resourceId: subscriptionId,
+		metadata: {
+			tier: org.devPlan,
+			immediate,
+			comment,
+		},
+	});
+
+	return c.json({
+		message: immediate
+			? "DevPass subscription cancelled immediately"
+			: "DevPass subscription will end at the end of the current period",
+		immediate,
+		subscriptionId,
 	});
 });
 

--- a/ee/admin/src/app/devpass/[orgId]/cancel-subscription-dialog.tsx
+++ b/ee/admin/src/app/devpass/[orgId]/cancel-subscription-dialog.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { Ban, Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+
+interface CancelSubscriptionDialogProps {
+	orgName: string;
+	tier: string;
+	expiresAt: string | null;
+	alreadyCancelled: boolean;
+	onCancel: (data: {
+		immediate: boolean;
+		comment?: string;
+	}) => Promise<{ success: boolean; message?: string; error?: string }>;
+}
+
+export function CancelSubscriptionDialog({
+	orgName,
+	tier,
+	expiresAt,
+	alreadyCancelled,
+	onCancel,
+}: CancelSubscriptionDialogProps) {
+	const router = useRouter();
+	const [open, setOpen] = useState(false);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [timing, setTiming] = useState<"period_end" | "immediate">(
+		"period_end",
+	);
+	const [comment, setComment] = useState("");
+
+	const handleSubmit = async () => {
+		setLoading(true);
+		setError(null);
+
+		const result = await onCancel({
+			immediate: timing === "immediate",
+			comment: comment.trim() || undefined,
+		});
+
+		setLoading(false);
+
+		if (result.success) {
+			setOpen(false);
+			setComment("");
+			router.refresh();
+		} else {
+			setError(result.error ?? "Failed to cancel subscription");
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger asChild>
+				<Button variant="outline" size="sm">
+					<Ban className="mr-1.5 h-4 w-4" />
+					Cancel subscription
+				</Button>
+			</DialogTrigger>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Cancel DevPass subscription</DialogTitle>
+					<DialogDescription>
+						Cancel the {tier} subscription of {orgName} on behalf of the
+						subscriber. Cancelling does not refund anything — refund the latest
+						payment separately if the customer should get their money back.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-4 py-4">
+					{alreadyCancelled && (
+						<p className="text-sm text-amber-600">
+							This subscription is already set to end
+							{expiresAt
+								? ` on ${new Date(expiresAt).toLocaleDateString("en-US")}`
+								: ""}
+							. Cancelling immediately ends access right away.
+						</p>
+					)}
+
+					<div className="space-y-2">
+						<Label htmlFor="timing">When</Label>
+						<Select
+							value={timing}
+							onValueChange={(v) => setTiming(v as "period_end" | "immediate")}
+						>
+							<SelectTrigger id="timing">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="period_end">
+									At the end of the paid period
+								</SelectItem>
+								<SelectItem value="immediate">Immediately</SelectItem>
+							</SelectContent>
+						</Select>
+						<p className="text-xs text-muted-foreground">
+							{timing === "period_end"
+								? expiresAt
+									? `Access continues until ${new Date(expiresAt).toLocaleDateString("en-US")}, then the plan ends.`
+									: "Access continues until the current period ends."
+								: "Access ends now. No proration invoice is created."}
+						</p>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor="comment">Comment (Optional)</Label>
+						<Textarea
+							id="comment"
+							value={comment}
+							onChange={(e) => setComment(e.target.value)}
+							placeholder="e.g. Cancelled on request via support"
+							rows={3}
+						/>
+						<p className="text-xs text-muted-foreground">
+							Stored in the audit log and sent to Stripe as the cancellation
+							comment
+						</p>
+					</div>
+
+					{error && <p className="text-sm text-destructive">{error}</p>}
+				</div>
+
+				<DialogFooter>
+					<Button
+						variant="outline"
+						onClick={() => setOpen(false)}
+						disabled={loading}
+					>
+						Back
+					</Button>
+					<Button
+						variant="destructive"
+						onClick={handleSubmit}
+						disabled={loading}
+					>
+						{loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+						{timing === "immediate"
+							? "Cancel immediately"
+							: "Cancel at period end"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/ee/admin/src/app/devpass/[orgId]/page.tsx
+++ b/ee/admin/src/app/devpass/[orgId]/page.tsx
@@ -21,13 +21,19 @@ import {
 	TableRow,
 } from "@/components/ui/table";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { giftResetPasses } from "@/lib/admin-devpass";
+import {
+	cancelDevpassSubscription,
+	giftResetPasses,
+	refundDevpassPayment,
+} from "@/lib/admin-devpass";
 import { giftCreditsToOrganization } from "@/lib/admin-organizations";
 import { requireSession } from "@/lib/require-session";
 import { createServerApiClient } from "@/lib/server-api";
 import { cn } from "@/lib/utils";
 
+import { CancelSubscriptionDialog } from "./cancel-subscription-dialog";
 import { GiftResetPassesDialog } from "./gift-reset-passes-dialog";
+import { RefundPaymentDialog } from "./refund-payment-dialog";
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {
 	style: "currency",
@@ -308,9 +314,23 @@ export default async function DevpassDetailPage({
 						)}
 					</div>
 				</div>
-				<Button variant="outline" size="sm" asChild>
-					<Link href={`/organizations/${sub.id}`}>Open in Organizations</Link>
-				</Button>
+				<div className="flex flex-wrap items-center gap-2">
+					{sub.tier !== "none" && (
+						<CancelSubscriptionDialog
+							orgName={sub.name}
+							tier={sub.tier}
+							expiresAt={sub.expiresAt}
+							alreadyCancelled={sub.cancelled}
+							onCancel={async (cancelData) => {
+								"use server";
+								return await cancelDevpassSubscription(orgId, cancelData);
+							}}
+						/>
+					)}
+					<Button variant="outline" size="sm" asChild>
+						<Link href={`/organizations/${sub.id}`}>Open in Organizations</Link>
+					</Button>
+				</div>
 			</header>
 
 			<section className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
@@ -513,13 +533,14 @@ export default async function DevpassDetailPage({
 									<TableHead>Credits</TableHead>
 									<TableHead>Status</TableHead>
 									<TableHead>Description</TableHead>
+									<TableHead className="text-right">Actions</TableHead>
 								</TableRow>
 							</TableHeader>
 							<TableBody>
 								{data.transactions.length === 0 ? (
 									<TableRow>
 										<TableCell
-											colSpan={7}
+											colSpan={8}
 											className="h-24 text-center text-muted-foreground"
 										>
 											No subscription events recorded
@@ -564,6 +585,34 @@ export default async function DevpassDetailPage({
 											</TableCell>
 											<TableCell className="max-w-[300px] truncate text-muted-foreground">
 												{t.description ?? "—"}
+											</TableCell>
+											<TableCell className="text-right">
+												<div className="flex items-center justify-end gap-2">
+													{parseFloat(t.refundedAmount) > 0 && (
+														<Badge variant="outline">
+															refunded{" "}
+															{currencyFormatter.format(
+																parseFloat(t.refundedAmount),
+															)}
+														</Badge>
+													)}
+													<RefundPaymentDialog
+														transactionId={t.id}
+														transactionLabel={formatTransactionType(t.type)}
+														amount={t.amount ?? "0"}
+														refundedAmount={t.refundedAmount}
+														refundableAmount={t.refundableAmount}
+														refundable={t.refundable}
+														refundIneligibleReason={t.refundIneligibleReason}
+														onRefund={async (refundData) => {
+															"use server";
+															return await refundDevpassPayment(
+																orgId,
+																refundData,
+															);
+														}}
+													/>
+												</div>
 											</TableCell>
 										</TableRow>
 									))

--- a/ee/admin/src/app/devpass/[orgId]/refund-payment-dialog.tsx
+++ b/ee/admin/src/app/devpass/[orgId]/refund-payment-dialog.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { Loader2, Undo2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+type RefundReason = "requested_by_customer" | "duplicate" | "fraudulent";
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+	maximumFractionDigits: 2,
+});
+
+function formatUsd(amount: string) {
+	return currencyFormatter.format(parseFloat(amount));
+}
+
+const REFUND_INELIGIBLE_LABELS: Record<string, string> = {
+	not_completed: "Payment never completed",
+	no_payment: "No Stripe payment recorded on this row",
+	fully_refunded: "Already fully refunded",
+};
+
+interface RefundPaymentDialogProps {
+	transactionId: string;
+	transactionLabel: string;
+	amount: string;
+	refundableAmount: string;
+	refundedAmount: string;
+	refundable: boolean;
+	refundIneligibleReason: string | null;
+	onRefund: (data: {
+		transactionId: string;
+		amount?: number;
+		reason: RefundReason;
+		comment?: string;
+	}) => Promise<{ success: boolean; message?: string; error?: string }>;
+}
+
+export function RefundPaymentDialog({
+	transactionId,
+	transactionLabel,
+	amount,
+	refundableAmount,
+	refundedAmount,
+	refundable,
+	refundIneligibleReason,
+	onRefund,
+}: RefundPaymentDialogProps) {
+	const router = useRouter();
+	const [open, setOpen] = useState(false);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [partial, setPartial] = useState(false);
+	const [partialAmount, setPartialAmount] = useState(refundableAmount);
+	const [reason, setReason] = useState<RefundReason>("requested_by_customer");
+	const [comment, setComment] = useState("");
+
+	if (!refundable) {
+		const label = refundIneligibleReason
+			? REFUND_INELIGIBLE_LABELS[refundIneligibleReason]
+			: undefined;
+		// An unrefundable *type* (a cancel/end bookkeeping row) gets no control at
+		// all; a real payment that merely failed a check gets a disabled one that
+		// says why.
+		if (!label) {
+			return null;
+		}
+		return (
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<span>
+						<Button variant="ghost" size="sm" disabled>
+							<Undo2 className="mr-1.5 h-4 w-4" />
+							Refund
+						</Button>
+					</span>
+				</TooltipTrigger>
+				<TooltipContent>{label}</TooltipContent>
+			</Tooltip>
+		);
+	}
+
+	const handleSubmit = async () => {
+		let requestedAmount: number | undefined;
+		if (partial) {
+			requestedAmount = parseFloat(partialAmount);
+			if (
+				isNaN(requestedAmount) ||
+				requestedAmount <= 0 ||
+				requestedAmount > parseFloat(refundableAmount)
+			) {
+				setError(
+					`Amount must be between $0.01 and ${formatUsd(refundableAmount)}`,
+				);
+				return;
+			}
+		}
+
+		setLoading(true);
+		setError(null);
+
+		const result = await onRefund({
+			transactionId,
+			amount: requestedAmount,
+			reason,
+			comment: comment.trim() || undefined,
+		});
+
+		setLoading(false);
+
+		if (result.success) {
+			setOpen(false);
+			setPartial(false);
+			setPartialAmount(refundableAmount);
+			setComment("");
+			router.refresh();
+		} else {
+			setError(result.error ?? "Failed to refund payment");
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger asChild>
+				<Button variant="ghost" size="sm">
+					<Undo2 className="mr-1.5 h-4 w-4" />
+					Refund
+				</Button>
+			</DialogTrigger>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Refund payment</DialogTitle>
+					<DialogDescription>
+						Refund {transactionLabel} of {formatUsd(amount)} on behalf of the
+						subscriber. Credits, Reset Passes and plan status are updated once
+						Stripe confirms the refund — a full refund of a plan payment also
+						cancels the DevPass subscription.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-4 py-4">
+					{parseFloat(refundedAmount) > 0 && (
+						<p className="text-sm text-muted-foreground">
+							{formatUsd(refundedAmount)} of {formatUsd(amount)} has already
+							been refunded. {formatUsd(refundableAmount)} is still refundable.
+						</p>
+					)}
+
+					<div className="space-y-2">
+						<Label htmlFor="amount">Amount</Label>
+						<div className="flex items-center gap-2">
+							<Button
+								type="button"
+								variant={partial ? "outline" : "default"}
+								size="sm"
+								onClick={() => setPartial(false)}
+							>
+								Full ({formatUsd(refundableAmount)})
+							</Button>
+							<Button
+								type="button"
+								variant={partial ? "default" : "outline"}
+								size="sm"
+								onClick={() => setPartial(true)}
+							>
+								Partial
+							</Button>
+						</div>
+						{partial && (
+							<Input
+								id="amount"
+								type="number"
+								min="0.01"
+								max={refundableAmount}
+								step="0.01"
+								value={partialAmount}
+								onChange={(e) => setPartialAmount(e.target.value)}
+							/>
+						)}
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor="reason">Reason</Label>
+						<Select
+							value={reason}
+							onValueChange={(v) => setReason(v as RefundReason)}
+						>
+							<SelectTrigger id="reason">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="requested_by_customer">
+									Requested by customer
+								</SelectItem>
+								<SelectItem value="duplicate">Duplicate</SelectItem>
+								<SelectItem value="fraudulent">Fraudulent</SelectItem>
+							</SelectContent>
+						</Select>
+						<p className="text-xs text-muted-foreground">
+							Sent to Stripe as the refund reason
+						</p>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor="comment">Comment (Optional)</Label>
+						<Textarea
+							id="comment"
+							value={comment}
+							onChange={(e) => setComment(e.target.value)}
+							placeholder="e.g. Goodwill refund after a provider outage"
+							rows={3}
+						/>
+						<p className="text-xs text-muted-foreground">
+							Stored in the audit log
+						</p>
+					</div>
+
+					{error && <p className="text-sm text-destructive">{error}</p>}
+				</div>
+
+				<DialogFooter>
+					<Button
+						variant="outline"
+						onClick={() => setOpen(false)}
+						disabled={loading}
+					>
+						Cancel
+					</Button>
+					<Button
+						variant="destructive"
+						onClick={handleSubmit}
+						disabled={loading}
+					>
+						{loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+						Refund payment
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/ee/admin/src/lib/admin-devpass.ts
+++ b/ee/admin/src/lib/admin-devpass.ts
@@ -24,3 +24,51 @@ export async function giftResetPasses(
 
 	return { success: true };
 }
+
+export async function refundDevpassPayment(
+	orgId: string,
+	body: {
+		transactionId: string;
+		amount?: number;
+		reason: "requested_by_customer" | "duplicate" | "fraudulent";
+		comment?: string;
+	},
+): Promise<{ success: boolean; message?: string; error?: string }> {
+	const $api = await createServerApiClient();
+	const { data, error } = await $api.POST("/admin/devpass/{orgId}/refund", {
+		params: { path: { orgId } },
+		body,
+	});
+
+	if (error || !data) {
+		const message =
+			(error as { message?: string } | undefined)?.message ??
+			"Failed to refund payment";
+		return { success: false, error: message };
+	}
+
+	return { success: true, message: data.message };
+}
+
+export async function cancelDevpassSubscription(
+	orgId: string,
+	body: { immediate: boolean; comment?: string },
+): Promise<{ success: boolean; message?: string; error?: string }> {
+	const $api = await createServerApiClient();
+	const { data, error } = await $api.POST(
+		"/admin/devpass/{orgId}/cancel-subscription",
+		{
+			params: { path: { orgId } },
+			body,
+		},
+	);
+
+	if (error || !data) {
+		const message =
+			(error as { message?: string } | undefined)?.message ??
+			"Failed to cancel subscription";
+		return { success: false, error: message };
+	}
+
+	return { success: true, message: data.message };
+}

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -3607,6 +3607,8 @@ export const auditLogActions = [
 	"payment.auto_topup.update",
 	"payment.auto_topup.disable",
 	"payment.self_refund",
+	// Refund issued by an administrator on behalf of the customer.
+	"payment.admin_refund",
 	// Credits
 	"credits.gift",
 	"credits.manual_payment",
@@ -3627,6 +3629,8 @@ export const auditLogActions = [
 	// Free Reset Pass granted for a quarterly model-survey response.
 	"dev_plan.reset_pass_reward",
 	"dev_plan.reset_pass_gift",
+	// Cancellation performed by an administrator on behalf of the subscriber.
+	"dev_plan.admin_cancel",
 	// Chat Plan
 	"chat_plan.subscribe",
 	"chat_plan.cancel",


### PR DESCRIPTION
## Problem

The DevPass admin detail page is read-only for billing: when a subscriber asks support for a refund or a cancellation, the only options were the Stripe dashboard (which leaves our own bookkeeping to chance) or telling the customer to do it themselves — and the self-service refund path deliberately refuses anything outside a 14-day, barely-used window.

## Approach

Two admin actions on `/devpass/{orgId}`, both of which only talk to Stripe and let the existing webhooks do the bookkeeping:

- **Refund a payment** — `POST /admin/devpass/{orgId}/refund`. Full or partial, with a Stripe reason and an optional comment. `charge.refunded` already records the `credit_refund` row, deducts top-up credits, claws back an unused Reset Pass, and cancels the subscription when a plan payment is refunded in full, so nothing is duplicated here.
- **Cancel the subscription** — `POST /admin/devpass/{orgId}/cancel-subscription`, at period end (the default, same as the customer-facing cancel) or immediately. Plan columns follow from `customer.subscription.updated` / `.deleted`.

Admin eligibility is deliberately looser than `self-refund.ts`: no time window, no usage threshold, no owner check. What it does still require is a completed charge reachable at Stripe and money left to refund — the detail endpoint now returns per-transaction `refundable` / `refundedAmount` / `refundableAmount`, so a bookkeeping row shows no button, an already-refunded payment shows a disabled one with the reason, and a partially refunded payment offers only the remainder.

Both actions are audit-logged under new `payment.admin_refund` and `dev_plan.admin_cancel` actions. `isTerminalSubscriptionError` was lifted out of `account-deletion.ts` so an already-cancelled subscription reports success instead of failing the action.

Cancelling never refunds and refunding never leaves an active-but-refunded plan — the two actions are independent on purpose, and the dialogs say so.

## Verification

- New unit specs for the refundability rules, the refund total per payment, the amount guard, and the audit entry (`apps/api/src/lib/admin-refund.spec.ts`, 11 tests).
- `pnpm format`, `pnpm build`, and the touched specs pass.
- Screenshots below are from a locally seeded database.

## Screenshots

### DevPass subscriber detail — before / after (light)

<img width="1680" alt="DevPass detail page before, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/a80951b39186eda99ccce5038c9edbb29db86424/devpass-detail-before-light.png" />
<img width="1680" alt="DevPass detail page after, light theme, with Cancel subscription and per-payment Refund actions" src="https://raw.githubusercontent.com/theopenco/llmgateway/a80951b39186eda99ccce5038c9edbb29db86424/devpass-detail-after-light.png" />

### DevPass subscriber detail — before / after (dark)

<img width="1680" alt="DevPass detail page before, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/a80951b39186eda99ccce5038c9edbb29db86424/devpass-detail-before-dark.png" />
<img width="1680" alt="DevPass detail page after, dark theme, with Cancel subscription and per-payment Refund actions" src="https://raw.githubusercontent.com/theopenco/llmgateway/a80951b39186eda99ccce5038c9edbb29db86424/devpass-detail-after-dark.png" />

### Refund dialog (light / dark)

<img width="1680" alt="Refund payment dialog, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/a80951b39186eda99ccce5038c9edbb29db86424/refund-dialog-light.png" />
<img width="1680" alt="Refund payment dialog, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/a80951b39186eda99ccce5038c9edbb29db86424/refund-dialog-dark.png" />

### Cancel subscription dialog (light / dark)

<img width="1680" alt="Cancel DevPass subscription dialog, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/a80951b39186eda99ccce5038c9edbb29db86424/cancel-dialog-light.png" />
<img width="1680" alt="Cancel DevPass subscription dialog, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/a80951b39186eda99ccce5038c9edbb29db86424/cancel-dialog-dark.png" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Administrators can issue full or partial refunds for eligible DevPass payments.
  - Refunds display prior, refunded, and remaining amounts, with validation and audit comments.
  - Administrators can cancel DevPass subscriptions immediately or at the end of the billing period.
  - Cancellation status and expiration details are shown in the administration interface.

- **Bug Fixes**
  - Improved handling of already-cancelled or missing subscriptions during cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->