### PR TITLE
fix(code): surface reasoning tokens in usage chart

### DIFF
--- a/apps/api/src/routes/activity.spec.ts
+++ b/apps/api/src/routes/activity.spec.ts
@@ -87,6 +87,7 @@ describe("activity endpoint", () => {
 				responseSize: 1000,
 				promptTokens: "10",
 				completionTokens: "20",
+				reasoningTokens: "40",
 				totalTokens: "30",
 				messages: JSON.stringify([{ role: "user", content: "Hello" }]),
 				mode: "api-keys",
@@ -129,6 +130,7 @@ describe("activity endpoint", () => {
 				responseSize: 1200,
 				promptTokens: "15",
 				completionTokens: "25",
+				reasoningTokens: "7",
 				totalTokens: "40",
 				messages: JSON.stringify([{ role: "user", content: "Test" }]),
 				mode: "api-keys",
@@ -207,10 +209,20 @@ describe("activity endpoint", () => {
 		expect(firstDay).toHaveProperty("requestCount");
 		expect(firstDay).toHaveProperty("inputTokens");
 		expect(firstDay).toHaveProperty("outputTokens");
+		expect(firstDay).toHaveProperty("reasoningTokens");
 		expect(firstDay).toHaveProperty("totalTokens");
 		expect(firstDay).toHaveProperty("cost");
 		expect(firstDay).toHaveProperty("modelBreakdown");
 		expect(Array.isArray(firstDay.modelBreakdown)).toBe(true);
+
+		// Reasoning tokens from the seeded logs (40 today + 7 yesterday) must
+		// survive aggregation into the project rollups and back out.
+		const totalReasoning = data.activity.reduce(
+			(sum: number, day: { reasoningTokens: number }) =>
+				sum + day.reasoningTokens,
+			0,
+		);
+		expect(totalReasoning).toBe(47);
 
 		// Check model breakdown
 		const modelData = firstDay.modelBreakdown[0];
@@ -278,6 +290,27 @@ describe("activity endpoint", () => {
 		const data = await res.json();
 		expect(Array.isArray(data.activity)).toBe(true);
 		expect(data.activity.length).toBe(1);
+	});
+
+	test("GET /activity should return reasoning tokens for api-key scope", async () => {
+		const params = new URLSearchParams({
+			days: "7",
+			apiKeyId: "test-api-key-id",
+		});
+		const res = await app.request("/activity?" + params, {
+			headers: {
+				Cookie: token,
+			},
+		});
+
+		expect(res.status).toBe(200);
+		const data = await res.json();
+		const totalReasoning = data.activity.reduce(
+			(sum: number, day: { reasoningTokens: number }) =>
+				sum + day.reasoningTokens,
+			0,
+		);
+		expect(totalReasoning).toBe(47);
 	});
 
 	test("GET /activity should default to 7 days when no date params provided", async () => {

--- a/apps/api/src/routes/activity.ts
+++ b/apps/api/src/routes/activity.ts
@@ -89,6 +89,10 @@ const dailyActivitySchema = z.object({
 	requestCount: z.number(),
 	inputTokens: z.number(),
 	outputTokens: z.number(),
+	// Reasoning tokens are billed at the output rate but, depending on the
+	// provider, may not be part of outputTokens — surfacing them separately is
+	// what lets clients explain an output cost larger than outputTokens alone.
+	reasoningTokens: z.number(),
 	cachedTokens: z.number(),
 	cacheWriteTokens: z.number(),
 	totalTokens: z.number(),
@@ -128,6 +132,7 @@ function buildEmptyActivityRow(date: string): ActivityRow {
 		requestCount: 0,
 		inputTokens: 0,
 		outputTokens: 0,
+		reasoningTokens: 0,
 		cachedTokens: 0,
 		cacheWriteTokens: 0,
 		totalTokens: 0,
@@ -365,6 +370,10 @@ activity.openapi(getActivity, async (c) => {
 				outputTokens:
 					sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyStats.outputTokens} AS NUMERIC)), 0)`.as(
 						"outputTokens",
+					),
+				reasoningTokens:
+					sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyStats.reasoningTokens} AS NUMERIC)), 0)`.as(
+						"reasoningTokens",
 					),
 				totalTokens:
 					sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyStats.totalTokens} AS NUMERIC)), 0)`.as(
@@ -621,6 +630,7 @@ activity.openapi(getActivity, async (c) => {
 			const requestCount = Number(day.requestCount);
 			const inputTokens = Number(day.inputTokens);
 			const outputTokens = Number(day.outputTokens);
+			const reasoningTokens = Number(day.reasoningTokens);
 			const cachedTokens = Number(day.cachedTokens);
 			const cacheWriteTokens = Number(day.cacheWriteTokens);
 			const totalTokens = Number(day.totalTokens);
@@ -657,6 +667,7 @@ activity.openapi(getActivity, async (c) => {
 				requestCount,
 				inputTokens,
 				outputTokens,
+				reasoningTokens,
 				cachedTokens,
 				cacheWriteTokens,
 				totalTokens,
@@ -722,6 +733,10 @@ activity.openapi(getActivity, async (c) => {
 			outputTokens:
 				sql<number>`COALESCE(SUM(CAST(${projectHourlyStats.outputTokens} AS NUMERIC)), 0)`.as(
 					"outputTokens",
+				),
+			reasoningTokens:
+				sql<number>`COALESCE(SUM(CAST(${projectHourlyStats.reasoningTokens} AS NUMERIC)), 0)`.as(
+					"reasoningTokens",
 				),
 			cachedTokens:
 				sql<number>`COALESCE(SUM(CAST(${projectHourlyStats.cachedTokens} AS NUMERIC)), 0)`.as(
@@ -1004,6 +1019,7 @@ activity.openapi(getActivity, async (c) => {
 		const requestCount = Number(day.requestCount);
 		const inputTokens = Number(day.inputTokens);
 		const outputTokens = Number(day.outputTokens);
+		const reasoningTokens = Number(day.reasoningTokens);
 		const cachedTokens = Number(day.cachedTokens);
 		const cacheWriteTokens = Number(day.cacheWriteTokens);
 		const totalTokens = Number(day.totalTokens);
@@ -1038,6 +1054,7 @@ activity.openapi(getActivity, async (c) => {
 			requestCount,
 			inputTokens,
 			outputTokens,
+			reasoningTokens,
 			cachedTokens,
 			cacheWriteTokens,
 			totalTokens,

--- a/apps/code/src/app/dashboard/components/AgentModelUsageChart.tsx
+++ b/apps/code/src/app/dashboard/components/AgentModelUsageChart.tsx
@@ -79,6 +79,7 @@ interface ChartRow {
 	cachedTokens: number;
 	cacheWriteTokens: number;
 	outputTokens: number;
+	reasoningTokens: number;
 	inputCost: number;
 	cachedInputCost: number;
 	cacheWriteInputCost: number;
@@ -118,7 +119,15 @@ function ChartTooltipContent({
 	// Token classes bill at very different rates (cached input is often 10x
 	// cheaper than fresh input, output 6x more expensive), so a flat token
 	// total makes cost look uncorrelated with usage. Break both down per class.
-	const tokenBreakdown = [
+	// Reasoning tokens are billed at the output rate and their cost is part of
+	// the Output row; depending on the provider they may not be counted in the
+	// output tokens, so without this row an output cost can look several times
+	// too large for its token count.
+	const tokenBreakdown: {
+		label: string;
+		tokens: number;
+		cost: number | null;
+	}[] = [
 		{
 			label: "Input",
 			tokens: first.inputTokens,
@@ -139,7 +148,13 @@ function ChartTooltipContent({
 			tokens: first.outputTokens,
 			cost: first.outputCost,
 		},
-	].filter((row) => row.tokens > 0 || row.cost > 0);
+		{
+			label: "Reasoning",
+			tokens: first.reasoningTokens,
+			cost: null,
+		},
+	].filter((row) => row.tokens > 0 || (row.cost ?? 0) > 0);
+	const hasReasoning = first.reasoningTokens > 0;
 	return (
 		<div className="min-w-[210px] rounded-lg border border-border/60 bg-popover p-2.5 text-xs text-popover-foreground shadow-md">
 			<div className="font-medium">{dateLabel}</div>
@@ -175,10 +190,20 @@ function ChartTooltipContent({
 								{formatTokens(row.tokens)}
 							</span>
 							<span className="w-16 text-right tabular-nums text-foreground">
-								${row.cost.toFixed(4)}
+								{row.cost === null ? (
+									<span className="text-muted-foreground">—</span>
+								) : (
+									`$${row.cost.toFixed(4)}`
+								)}
 							</span>
 						</div>
 					))}
+					{hasReasoning ? (
+						<div className="pt-1 text-[10px] leading-snug text-muted-foreground/80">
+							Reasoning is billed at the output rate; its cost is included in
+							Output.
+						</div>
+					) : null}
 				</div>
 			) : null}
 			<div className="mt-2 space-y-0.5 border-t border-border/40 pt-2">
@@ -269,6 +294,7 @@ export function AgentModelUsageChart({ projectId }: AgentModelUsageChartProps) {
 				cachedTokens: row.cachedTokens,
 				cacheWriteTokens: row.cacheWriteTokens,
 				outputTokens: row.outputTokens,
+				reasoningTokens: row.reasoningTokens,
 				inputCost: row.inputCost,
 				cachedInputCost: row.cachedInputCost,
 				cacheWriteInputCost: row.cacheWriteInputCost,
@@ -297,6 +323,7 @@ export function AgentModelUsageChart({ projectId }: AgentModelUsageChartProps) {
 					cachedTokens: row.cachedTokens,
 					cacheWriteTokens: row.cacheWriteTokens,
 					outputTokens: row.outputTokens,
+					reasoningTokens: row.reasoningTokens,
 					inputCost: row.inputCost,
 					cachedInputCost: row.cachedInputCost,
 					cacheWriteInputCost: row.cacheWriteInputCost,

--- a/apps/ui/src/types/activity.ts
+++ b/apps/ui/src/types/activity.ts
@@ -47,6 +47,7 @@ export interface DailyActivity {
 	requestCount: number;
 	inputTokens: number;
 	outputTokens: number;
+	reasoningTokens: number;
 	cachedTokens: number;
 	cacheWriteTokens: number;
 	totalTokens: number;

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1915,12 +1915,17 @@ async function seed() {
 		// breakdown shows hours where a big token total is cheap (mostly cached)
 		// next to hours where a smaller total is expensive (fresh input + output).
 		const hourCachedTokens = Math.floor(inputTokens * randomFloat(0.05, 0.85));
+		// Some hours are reasoning-heavy: reasoning tokens bill at the output
+		// rate without being part of outputTokens, so the tooltip's Reasoning row
+		// (and an output cost far larger than the output count alone) has data.
+		const hourReasoningTokens =
+			secureRandom() < 0.4 ? baseRequests * randomInt(1500, 22000) : 0;
 		// Derive costs from the token mix at plausible per-token rates so the
 		// per-class costs and the total reconcile ($3/M fresh input, $0.30/M
-		// cached input, $15/M output).
+		// cached input, $15/M output incl. reasoning).
 		const hourInputCost = (inputTokens - hourCachedTokens) * 3e-6;
 		const hourCachedInputCost = hourCachedTokens * 0.3e-6;
-		const hourOutputCost = outputTokens * 15e-6;
+		const hourOutputCost = (outputTokens + hourReasoningTokens) * 15e-6;
 		const totalCost = hourInputCost + hourCachedInputCost + hourOutputCost;
 		devpassHourlyStats.push({
 			id: `devpass-phs-${h}`,
@@ -1943,7 +1948,7 @@ async function seed() {
 			inputTokens: String(inputTokens),
 			outputTokens: String(outputTokens),
 			totalTokens: String(inputTokens + outputTokens),
-			reasoningTokens: "0",
+			reasoningTokens: String(hourReasoningTokens),
 			cachedTokens: String(hourCachedTokens),
 			cost: Number(totalCost.toFixed(4)),
 			inputCost: Number(hourInputCost.toFixed(4)),
@@ -2006,7 +2011,7 @@ async function seed() {
 				inputTokens: String(inTok),
 				outputTokens: String(outTok),
 				totalTokens: String(inTok + outTok),
-				reasoningTokens: "0",
+				reasoningTokens: String(Math.floor(Number(bucket.reasoningTokens) * w)),
 				cachedTokens: String(Math.floor(Number(bucket.cachedTokens) * w)),
 				cacheWriteTokens: "0",
 				cost: Number((bucket.cost * w).toFixed(4)),
@@ -2072,7 +2077,7 @@ async function seed() {
 				inputTokens: String(inTok),
 				outputTokens: String(outTok),
 				totalTokens: String(inTok + outTok),
-				reasoningTokens: "0",
+				reasoningTokens: String(Math.floor(Number(bucket.reasoningTokens) * w)),
 				cachedTokens: String(Math.floor(Number(bucket.cachedTokens) * w)),
 				cacheWriteTokens: "0",
 				cost: Number((bucket.cost * w).toFixed(4)),


### PR DESCRIPTION
## Problem

A DevPass customer's hourly usage tooltip showed an Output row that made no sense: ~67K output tokens next to a ~$7.30 output cost, while the next hour showed ~104K tokens for ~$1.56. The token/cost class breakdown added in #3557 exposed the gap rather than explaining it.

The missing piece is **reasoning tokens**: they are billed at the output rate (halved under OpenAI's flex tier), but depending on the provider they are not part of the output token count. In the reported hour, the output cost corresponded to ~490K billable output-class tokens at flex rates — ~423K of them reasoning — while the tooltip only displayed the 67K completion tokens. Billing was correct; the display omitted the largest token class in the hour.

## Approach

- **API**: `/activity` now returns `reasoningTokens` per bucket, on both the project-rollup and api-key-scoped paths. The column already exists and is aggregated in every hourly stats table; it was just never selected.
- **DevPass UI**: the usage chart tooltip gains a Reasoning row (only when > 0) with an em-dash in the cost column plus a footnote — "Reasoning is billed at the output rate; its cost is included in Output" — since the stored `outputCost` cannot be split retroactively.
- **Seed**: ~40% of seeded DevPass hours are now reasoning-heavy, with reasoning billed into the hour's output cost, so the mismatch scenario is reproducible locally.
- **apps/ui**: the hand-written `DailyActivity` type gains the new field (no UI rendering change there yet).

Note: for providers whose completion count already includes reasoning, the Reasoning row is a subset of Output rather than additive — the row is informational either way, and the note stays true in both cases.

## Verification

- `pnpm build` passes across all apps.
- `apps/api/src/routes/activity.spec.ts` (52 tests) passes, including new assertions that seeded reasoning tokens survive aggregation on both query paths.
- Tooltip verified against seeded data, light + dark below — note the Output row ($3.25 for 23.1K tokens) now explained by the 193.7K reasoning tokens.

| Light | Dark |
| --- | --- |
| <img width="1008" alt="usage tooltip with reasoning row, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/9d9dce2e16aa5aadb56ae102e05824dea725cbf1/reasoning-tooltip-light.png" /> | <img width="1008" alt="usage tooltip with reasoning row, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/9d9dce2e16aa5aadb56ae102e05824dea725cbf1/reasoning-tooltip-dark.png" /> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7dtWBeeD1JX1mkh6VdfAm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activity reports now include reasoning-token usage, with totals available across dates and API-key filters.
  * Model usage charts display reasoning tokens separately in usage breakdowns.
  * Tooltips explain that reasoning-token costs are included in Output costs and billed at the output rate.
* **Bug Fixes**
  * Reasoning-token values are now correctly aggregated and displayed, including when no activity is present.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->