### PR TITLE
feat(models): add Grok 4.6 and Grok Imagine 2.0

### DIFF
--- a/apps/gateway/src/chat/tools/extract-token-usage.spec.ts
+++ b/apps/gateway/src/chat/tools/extract-token-usage.spec.ts
@@ -683,6 +683,46 @@ describe("extractTokenUsage", () => {
 			expect(result.cachedTokens).toBe(150);
 		});
 	});
+
+	describe("xai", () => {
+		it("reads reasoning tokens from completion_tokens_details", () => {
+			// Real grok-4.6 usage payload. xAI reports reasoning only in the nested
+			// details object and leaves it OUT of completion_tokens — note
+			// total_tokens = 213 + 4 + 310 — so it has to be picked up here or the
+			// cost engine bills the 4 visible output tokens and nothing else.
+			const data = {
+				usage: {
+					prompt_tokens: 213,
+					completion_tokens: 4,
+					total_tokens: 527,
+					prompt_tokens_details: { cached_tokens: 128 },
+					completion_tokens_details: { reasoning_tokens: 310 },
+				},
+			};
+
+			const result = extractTokenUsage(data, "xai");
+
+			expect(result.promptTokens).toBe(213);
+			expect(result.completionTokens).toBe(4);
+			expect(result.reasoningTokens).toBe(310);
+			expect(result.cachedTokens).toBe(128);
+		});
+
+		it("returns null reasoning tokens for a non-reasoning response", () => {
+			const data = {
+				usage: {
+					prompt_tokens: 20,
+					completion_tokens: 8,
+					total_tokens: 28,
+				},
+			};
+
+			const result = extractTokenUsage(data, "xai");
+
+			expect(result.reasoningTokens).toBeNull();
+			expect(result.cachedTokens).toBeNull();
+		});
+	});
 });
 
 describe("adjustGoogleCandidateTokens", () => {

--- a/apps/gateway/src/chat/tools/extract-token-usage.ts
+++ b/apps/gateway/src/chat/tools/extract-token-usage.ts
@@ -234,6 +234,26 @@ export function extractTokenUsage(
 				}
 			}
 			break;
+		case "xai":
+			// xAI is one of the few providers whose `completion_tokens` EXCLUDES
+			// reasoning (total_tokens = prompt + completion + reasoning), so the
+			// reasoning count has to reach the cost engine to be billed at all.
+			// It only ever appears nested under `completion_tokens_details`, which
+			// the default OpenAI branch below does not read — it looks for a
+			// top-level `usage.reasoning_tokens` — so without this case every
+			// reasoning request is billed for its handful of visible output tokens
+			// and nothing else.
+			if (data.usage) {
+				promptTokens = data.usage.prompt_tokens ?? null;
+				completionTokens = data.usage.completion_tokens ?? null;
+				totalTokens = data.usage.total_tokens ?? null;
+				reasoningTokens =
+					data.usage.completion_tokens_details?.reasoning_tokens ??
+					data.usage.reasoning_tokens ??
+					null;
+				cachedTokens = data.usage.prompt_tokens_details?.cached_tokens ?? null;
+			}
+			break;
 		case "sakana":
 			// Fugu streams over Chat Completions and bills the orchestration tokens
 			// consumed by its underlying agent pool on top of the user-visible

--- a/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
@@ -1302,4 +1302,54 @@ describe("parseProviderResponse", () => {
 			expect(result.reasoningContent).toBe("structured reasoning");
 		});
 	});
+
+	describe("xai reasoning tokens", () => {
+		// Real grok-4.6 usage payload: reasoning is reported only in the nested
+		// details object and is NOT part of completion_tokens (note total_tokens =
+		// 213 + 4 + 310), so it has to be read here to be billed at all.
+		const xaiJson = {
+			choices: [
+				{
+					message: { role: "assistant", content: "Hello there friend." },
+					finish_reason: "stop",
+				},
+			],
+			usage: {
+				prompt_tokens: 213,
+				completion_tokens: 4,
+				total_tokens: 527,
+				prompt_tokens_details: { cached_tokens: 128 },
+				completion_tokens_details: { reasoning_tokens: 310 },
+			},
+		};
+
+		it("reads reasoning tokens from completion_tokens_details", () => {
+			const result = parseProviderResponse(
+				"xai",
+				"grok-4-6",
+				xaiJson,
+				[],
+				true,
+			);
+
+			expect(result.promptTokens).toBe(213);
+			expect(result.completionTokens).toBe(4);
+			expect(result.reasoningTokens).toBe(310);
+			expect(result.cachedTokens).toBe(128);
+		});
+
+		it("ignores the nested count for other OpenAI-compatible providers", () => {
+			// Everyone else folds reasoning into completion_tokens already, so
+			// reading the nested field would bill the same tokens twice.
+			const result = parseProviderResponse(
+				"openai",
+				"gpt-5.5",
+				xaiJson,
+				[],
+				true,
+			);
+
+			expect(result.reasoningTokens).toBeNull();
+		});
+	});
 });

--- a/apps/gateway/src/chat/tools/parse-provider-response.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.ts
@@ -1141,7 +1141,18 @@ export function parseProviderResponse(
 				// Standard OpenAI-style token parsing
 				promptTokens = json.usage?.prompt_tokens ?? null;
 				completionTokens = json.usage?.completion_tokens ?? null;
-				reasoningTokens = json.usage?.reasoning_tokens ?? null;
+				// xAI is the exception among the OpenAI-compatible providers: its
+				// `completion_tokens` EXCLUDES reasoning (total_tokens = prompt +
+				// completion + reasoning) and the count only ever appears nested
+				// under `completion_tokens_details`. Reading it here is what makes
+				// reasoning billable at all. Providers that fold reasoning into
+				// `completion_tokens` must keep reading the top-level field only,
+				// or the same tokens would be billed a second time.
+				reasoningTokens =
+					json.usage?.reasoning_tokens ??
+					(usedProvider === "xai"
+						? (json.usage?.completion_tokens_details?.reasoning_tokens ?? null)
+						: null);
 				cachedTokens = json.usage?.prompt_tokens_details?.cached_tokens ?? null;
 				totalTokens =
 					json.usage?.total_tokens ??

--- a/apps/gateway/src/lib/costs.spec.ts
+++ b/apps/gateway/src/lib/costs.spec.ts
@@ -1580,6 +1580,89 @@ describe("calculateCosts", () => {
 		expect(zeroPromptTokens.totalCost).toBeCloseTo(0.03);
 	});
 
+	it("bills grok-imagine-image-2.0 on the quality/resolution tier", async () => {
+		// Verified against xAI's own usage.cost_in_usd_ticks for each combination:
+		// low/1k $0.04, low/2k $0.06, medium/1k $0.06, medium/2k $0.08.
+		const grid: [string | undefined, string | undefined, number][] = [
+			["low", "1k", 0.04],
+			["low", "2k", 0.06],
+			["medium", "1k", 0.06],
+			["medium", "2k", 0.08],
+			// Omitted knobs fall back to what xAI serves by default: medium at 1k.
+			[undefined, undefined, 0.06],
+			[undefined, "2k", 0.08],
+			["low", undefined, 0.04],
+			// Pixel dimensions map onto the tier the request body sends.
+			["low", "1024x1024", 0.04],
+			["low", "2048x2048", 0.06],
+			// A quality the gateway drops as unsupported bills at xAI's default.
+			["auto", "1k", 0.06],
+		];
+
+		for (const [quality, size, expected] of grid) {
+			const result = await calculateCosts(
+				"grok-imagine-image-2-0",
+				"xai",
+				null,
+				100,
+				0,
+				null,
+				undefined,
+				null,
+				1,
+				size,
+				0,
+				null,
+				null,
+				quality,
+			);
+			expect(
+				result.imageOutputCost,
+				`quality=${quality} size=${size}`,
+			).toBeCloseTo(expected);
+		}
+	});
+
+	it("matches xAI's own reported cost for grok-4-6", async () => {
+		// Real grok-4.6 response: 213 prompt tokens (128 cached), 4 completion and
+		// 310 reasoning tokens, billed by xAI at 21180000 usd ticks = $0.002118.
+		// xAI reports reasoning tokens outside completion_tokens, so they are
+		// billed on top of the completion count.
+		const result = await calculateCosts(
+			"grok-4-6",
+			"xai",
+			null,
+			213,
+			4,
+			128,
+			undefined,
+			310,
+		);
+		expect(result.totalCost).toBeCloseTo(0.002118, 9);
+	});
+
+	it("multiplies the grok-imagine-image-2.0 tier by the image count", async () => {
+		// n=2 at low/1k billed $0.08 upstream, i.e. 2 x $0.04.
+		const result = await calculateCosts(
+			"grok-imagine-image-2-0",
+			"xai",
+			null,
+			100,
+			0,
+			null,
+			undefined,
+			null,
+			2,
+			"1k",
+			0,
+			null,
+			null,
+			"low",
+		);
+		expect(result.imageOutputCost).toBeCloseTo(0.08);
+		expect(result.outputCost).toBeCloseTo(0.08);
+	});
+
 	it("should include image costs in totalCost sum", async () => {
 		// totalCost = inputCost + outputCost + cachedInputCost + requestCost + webSearchCost
 		// (inputCost already includes imageInputCost, outputCost already includes imageOutputCost)

--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -3,6 +3,7 @@ import { Decimal } from "decimal.js";
 import { estimateTokensFromContent } from "@/chat/tools/estimate-tokens-from-content.js";
 import { encodeChatMessages } from "@/chat/tools/tokenizer.js";
 
+import { mapXaiImageQuality, mapXaiImageResolution } from "@llmgateway/actions";
 import { getEffectiveDiscount } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
 import {
@@ -771,11 +772,25 @@ export async function calculateCosts(
 	const imageOutputPricePerToken = providerInfo.imageOutputPrice;
 	const perImagePriceMap = providerInfo.perImagePrice;
 	if (perImagePriceMap && outputImageCount > 0) {
+		// xAI's Grok Imagine 2.0 bills a flat per-image rate that varies with both
+		// the requested quality (low/medium) and resolution (1k/2k), so its tier
+		// keys are "<quality>/<resolution>". xAI serves medium quality at 1k when
+		// the request omits either knob, so fill those defaults in before the
+		// lookup rather than falling through to the map's "default" tier.
+		// Both knobs go through the same mappers the request body used, so a value
+		// the gateway dropped as unsupported (e.g. quality "auto") bills at the
+		// tier xAI actually served rather than missing the map entirely.
+		const perImageTier =
+			provider === "xai"
+				? `${(imageQuality ? mapXaiImageQuality(imageQuality) : undefined) ?? "medium"}/${
+						(imageSize ? mapXaiImageResolution(imageSize) : undefined) ?? "1k"
+					}`
+				: imageSize;
 		// A map without a "default" key falls back to its most expensive tier so
 		// a lookup miss can only overcharge, never bill a generated image at $0
 		// (same stance as the unknown-size → "default" fallback).
 		const perImagePrice =
-			resolveByResolution(perImagePriceMap, imageSize) ??
+			resolveByResolution(perImagePriceMap, perImageTier) ??
 			Object.values(perImagePriceMap).reduce(
 				(max, v) => (new Decimal(v).gt(max) ? v : max),
 				"0",

--- a/apps/playground/src/components/playground/chat-page-client.tsx
+++ b/apps/playground/src/components/playground/chat-page-client.tsx
@@ -764,8 +764,10 @@ export default function ChatPageClient({
 
 			// Always forward the user's quality choice (including "auto") so it
 			// surfaces in the activity log; the gateway treats "auto" as a no-op
-			// upstream.
-			const includeQuality = isGptImage && !!imageQuality;
+			// upstream. getModelImageConfig owns which models expose the control,
+			// so it stays the single source of truth for both playground surfaces.
+			const includeQuality =
+				getModelImageConfig(selectedModel).supportsQuality && !!imageQuality;
 
 			// Always send n explicitly to prevent providers from defaulting to >1
 			const imageConfig = useImageGen
@@ -786,6 +788,7 @@ export default function ChatPageClient({
 								aspect_ratio: imageAspectRatio,
 							}),
 							...(imageSize !== "1K" && { image_size: imageSize }),
+							...(includeQuality && { image_quality: imageQuality }),
 							n: imageCount,
 						}
 				: undefined;
@@ -2770,8 +2773,10 @@ function ExtraChatPanel({
 
 			// Always forward the user's quality choice (including "auto") so it
 			// surfaces in the activity log; the gateway treats "auto" as a no-op
-			// upstream.
-			const includeQuality = isGptImage && !!imageQuality;
+			// upstream. getModelImageConfig owns which models expose the control,
+			// so it stays the single source of truth for both playground surfaces.
+			const includeQuality =
+				getModelImageConfig(selectedModel).supportsQuality && !!imageQuality;
 
 			// Always send n explicitly to prevent providers from defaulting to >1
 			const imageConfig = useImageGen
@@ -2792,6 +2797,7 @@ function ExtraChatPanel({
 								aspect_ratio: imageAspectRatio,
 							}),
 							...(imageSize !== "1K" && { image_size: imageSize }),
+							...(includeQuality && { image_quality: imageQuality }),
 							n: imageCount,
 						}
 				: undefined;

--- a/apps/playground/src/components/playground/chat-ui.tsx
+++ b/apps/playground/src/components/playground/chat-ui.tsx
@@ -95,7 +95,7 @@ import {
 	sampleSuggestions,
 	type HeroSuggestionGroup,
 } from "@/lib/hero-suggestions";
-import { GPT_IMAGE_SIZES } from "@/lib/image-gen";
+import { getModelImageConfig, GPT_IMAGE_SIZES } from "@/lib/image-gen";
 import { parseImagePartToDataUrl } from "@/lib/image-utils";
 import {
 	parsePlaygroundMessageMetadata,
@@ -1062,42 +1062,15 @@ export const ChatUI = ({
 	onSelectSkill,
 	onRemoveSkill,
 }: ChatUIProps) => {
-	// OpenAI gpt-image-2 uses pixel dimensions and supports a quality dropdown
-	const isGptImage =
-		selectedModel.toLowerCase().includes("gpt-image") ||
-		selectedModel.toLowerCase().includes("openai/gpt-image");
-
-	// Check if the model uses WIDTHxHEIGHT format (Alibaba, ZAI, or OpenAI gpt-image)
-	const usesPixelDimensions =
-		isGptImage ||
-		selectedModel.toLowerCase().includes("alibaba") ||
-		selectedModel.toLowerCase().includes("qwen-image") ||
-		selectedModel.toLowerCase().includes("zai") ||
-		selectedModel.toLowerCase().includes("cogview");
-
-	// Seedream/ByteDance models only support 2K and 4K
-	const isSeedream =
-		selectedModel.toLowerCase().includes("seedream") ||
-		selectedModel.toLowerCase().includes("bytedance/seedream");
-
-	// Gemini 3.1 Flash Image supports 0.5K, 1K (default), 2K, 4K
-	const isGemini31FlashImage = selectedModel
-		.toLowerCase()
-		.includes("gemini-3.1-flash-image");
-
-	const isGemini31FlashLiteImage = selectedModel
-		.toLowerCase()
-		.includes("gemini-3.1-flash-lite-image");
-
-	const availableSizes = isSeedream
-		? (["2K", "4K"] as const)
-		: isGemini31FlashLiteImage
-			? (["1K"] as const)
-			: isGemini31FlashImage
-				? (["0.5K", "1K", "2K", "4K"] as const)
-				: (["1K", "2K", "4K"] as const);
-
-	const qualityOptions = ["auto", "low", "medium", "high"] as const;
+	// Which size/quality controls a model exposes lives in getModelImageConfig,
+	// shared with the image playground so both surfaces offer the same options.
+	const {
+		isGptImage,
+		usesPixelDimensions,
+		availableSizes,
+		supportsQuality,
+		availableQualities: qualityOptions,
+	} = getModelImageConfig(selectedModel);
 
 	const [activeGroup, setActiveGroup] = useState<HeroSuggestionGroup>("Create");
 	const [randomizedHeroSuggestionGroups, setRandomizedHeroSuggestionGroups] =
@@ -1965,6 +1938,23 @@ export const ChatUI = ({
 											))}
 										</SelectContent>
 									</Select>
+									{supportsQuality && (
+										<Select
+											value={imageQuality}
+											onValueChange={setImageQuality}
+										>
+											<SelectTrigger size="sm" className="min-w-[100px]">
+												<SelectValue placeholder="Quality" />
+											</SelectTrigger>
+											<SelectContent>
+												{qualityOptions.map((q) => (
+													<SelectItem key={q} value={q}>
+														{q.charAt(0).toUpperCase() + q.slice(1)}
+													</SelectItem>
+												))}
+											</SelectContent>
+										</Select>
+									)}
 								</>
 							)}
 							{supportsImageGen && usesPixelDimensions && isGptImage && (

--- a/apps/playground/src/components/playground/image-page-client.tsx
+++ b/apps/playground/src/components/playground/image-page-client.tsx
@@ -551,6 +551,7 @@ export default function ImagePageClient({
 							aspect_ratio: imageAspectRatio,
 						}),
 						...(imageSize !== "1K" && { image_size: imageSize }),
+						...(includeQuality && { image_quality: imageQuality }),
 						n: imageCount,
 					};
 

--- a/apps/playground/src/lib/image-gen.spec.ts
+++ b/apps/playground/src/lib/image-gen.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { getModelImageConfig } from "@/lib/image-gen";
+
+describe("getModelImageConfig", () => {
+	it("offers only the tiers xAI's Grok Imagine 2.0 accepts", () => {
+		for (const model of [
+			"grok-imagine-image-2-0",
+			"xai/grok-imagine-image-2-0",
+		]) {
+			const config = getModelImageConfig(model);
+
+			expect(config.usesPixelDimensions).toBe(false);
+			expect(config.availableSizes).toEqual(["1K", "2K"]);
+			expect(config.defaultSize).toBe("1K");
+			expect(config.supportsQuality).toBe(true);
+			expect(config.availableQualities).toEqual(["low", "medium"]);
+			// xAI serves medium for a request that omits quality, so the playground
+			// default produces the same image and price as a bare API call.
+			expect(config.defaultQuality).toBe("medium");
+		}
+	});
+
+	it("keeps the quality control off for the older Grok Imagine models", () => {
+		// Grok Imagine 1.0 and the quality/pro variant accept no resolution or
+		// quality knob upstream — both are billed at a single flat rate.
+		for (const model of ["xai/grok-imagine-image", "grok-imagine-image-pro"]) {
+			const config = getModelImageConfig(model);
+
+			expect(config.supportsQuality).toBe(false);
+			expect(config.availableQualities).toEqual([]);
+		}
+	});
+
+	it("leaves the gpt-image quality options unchanged", () => {
+		const config = getModelImageConfig("openai/gpt-image-2");
+
+		expect(config.usesPixelDimensions).toBe(true);
+		expect(config.supportsQuality).toBe(true);
+		expect(config.availableQualities).toEqual([
+			"auto",
+			"low",
+			"medium",
+			"high",
+		]);
+		expect(config.defaultQuality).toBe("low");
+	});
+});

--- a/apps/playground/src/lib/image-gen.ts
+++ b/apps/playground/src/lib/image-gen.ts
@@ -94,11 +94,16 @@ export function getModelImageConfig(model: string) {
 		"gemini-3.1-flash-lite-image",
 	);
 
+	// Grok Imagine Image 2.0 is the only xAI image model with resolution and
+	// quality knobs; it serves 1k or 2k at low or medium quality and rejects
+	// anything else, and each combination is priced separately.
+	const isGrokImagine20 = lower.includes("grok-imagine-image-2-0");
+
 	const availableSizes = isGptImage
 		? GPT_IMAGE_SIZES
 		: isReve
 			? (["2K"] as const)
-			: isSeedreamPro
+			: isSeedreamPro || isGrokImagine20
 				? (["1K", "2K"] as const)
 				: isSeedream
 					? (["2K", "4K"] as const)
@@ -116,11 +121,19 @@ export function getModelImageConfig(model: string) {
 				? "2K"
 				: "1K";
 
-	const supportsQuality = isGptImage;
+	const supportsQuality = isGptImage || isGrokImagine20;
 	const availableQualities = isGptImage
 		? (["auto", "low", "medium", "high"] as const)
-		: ([] as readonly string[]);
-	const defaultQuality: string | undefined = isGptImage ? "low" : undefined;
+		: isGrokImagine20
+			? (["low", "medium"] as const)
+			: ([] as readonly string[]);
+	// Grok Imagine 2.0 defaults to the same tier xAI serves for a bare request,
+	// so the playground and a plain API call produce the same image and price.
+	const defaultQuality: string | undefined = isGptImage
+		? "low"
+		: isGrokImagine20
+			? "medium"
+			: undefined;
 
 	const maxInputImages = getMaxInputImages(lower);
 

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -553,6 +553,88 @@ describe("prepareRequestBody - OpenAI image generation", () => {
 	});
 });
 
+describe("prepareRequestBody - xAI image generation", () => {
+	async function prepareXaiImageRequest(imageConfig: {
+		aspect_ratio?: string;
+		image_size?: string;
+		image_quality?: string;
+		n?: number;
+	}) {
+		return (await prepareRequestBody(
+			"xai",
+			"grok-imagine-image-2-0",
+			null,
+			"grok-imagine-image-2.0",
+			[{ role: "user", content: "Generate a cinematic landscape" }],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+			false,
+			20,
+			null,
+			undefined,
+			imageConfig,
+			undefined,
+			true,
+		)) as any;
+	}
+
+	test("should forward quality and resolution", async () => {
+		const requestBody = await prepareXaiImageRequest({
+			image_quality: "low",
+			image_size: "2k",
+			n: 2,
+		});
+
+		expect(requestBody).toMatchObject({
+			model: "grok-imagine-image-2.0",
+			prompt: "Generate a cinematic landscape",
+			quality: "low",
+			resolution: "2k",
+			n: 2,
+		});
+	});
+
+	// xAI's `resolution` enum only accepts the lowercase tier names, so pixel
+	// dimensions and casing variants are normalized rather than passed through.
+	test.each([
+		["1K", "1k"],
+		["2K", "2k"],
+		["1024x1024", "1k"],
+		["1536x1024", "1k"],
+		["2048x2048", "2k"],
+		["3840x2160", "2k"],
+	])("should map image_size %s to resolution %s", async (size, resolution) => {
+		const requestBody = await prepareXaiImageRequest({ image_size: size });
+
+		expect(requestBody.resolution).toBe(resolution);
+	});
+
+	test("should omit resolution for sizes that name no xAI tier", async () => {
+		const requestBody = await prepareXaiImageRequest({ image_size: "auto" });
+
+		expect(requestBody.resolution).toBeUndefined();
+	});
+
+	test("should drop the unified auto quality", async () => {
+		const requestBody = await prepareXaiImageRequest({
+			image_quality: "auto",
+			image_size: "1k",
+		});
+
+		expect(requestBody.quality).toBeUndefined();
+		expect(requestBody.resolution).toBe("1k");
+	});
+});
+
 describe("prepareRequestBody - OpenAI prompt caching", () => {
 	test("should forward prompt cache controls to OpenAI chat completions", async () => {
 		const requestBody = (await prepareOpenAITextRequest({

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -744,6 +744,44 @@ function mapGoogleImageSize(imageSize: string): string {
 }
 
 /**
+ * Maps the unified `image_config.image_size` to xAI's `resolution` enum, which
+ * only accepts the lowercase tier names `1k` and `2k` and 422s on anything else
+ * (including `1K` and pixel-dimension strings). Callers pass sizes in whichever
+ * shape their other providers use, so a tier is resolved from the longest pixel
+ * edge when dimensions are given. Returns undefined when the size names no
+ * xAI tier, so the request omits `resolution` and gets xAI's 1k default rather
+ * than a hard rejection.
+ */
+export function mapXaiImageResolution(imageSize: string): string | undefined {
+	const normalized = imageSize.trim().toLowerCase();
+	if (normalized === "1k" || normalized === "2k") {
+		return normalized;
+	}
+
+	const dimensions = normalized.match(/^(\d+)\s*[x*]\s*(\d+)$/);
+	if (dimensions) {
+		const longestEdge = Math.max(Number(dimensions[1]), Number(dimensions[2]));
+		return longestEdge > 1536 ? "2k" : "1k";
+	}
+
+	return undefined;
+}
+
+/**
+ * xAI's image models accept `quality` as a strict enum and 422 on anything
+ * outside it, so the unified `auto` (meaning "let the provider decide") is
+ * dropped rather than forwarded.
+ */
+export function mapXaiImageQuality(imageQuality: string): string | undefined {
+	const normalized = imageQuality.trim().toLowerCase();
+	return normalized === "low" ||
+		normalized === "medium" ||
+		normalized === "high"
+		? normalized
+		: undefined;
+}
+
+/**
  * Recursively sanitizes tool input schemas for AWS Bedrock Converse.
  * Bedrock is stricter than Anthropic's direct API and rejects several JSON Schema
  * keywords that appear in OpenAI-style tool definitions from external agents.
@@ -1432,6 +1470,12 @@ export async function prepareRequestBody(
 
 		// xAI Grok Imagine uses OpenAI-compatible image generation format
 		// When images are present, use the edits format
+		const xaiQuality = image_config?.image_quality
+			? mapXaiImageQuality(image_config.image_quality)
+			: undefined;
+		const xaiResolution = image_config?.image_size
+			? mapXaiImageResolution(image_config.image_size)
+			: undefined;
 		const xaiImageRequest: any = {
 			model: usedExternalId,
 			prompt,
@@ -1439,6 +1483,8 @@ export async function prepareRequestBody(
 			...(image_config?.aspect_ratio && {
 				aspect_ratio: image_config.aspect_ratio,
 			}),
+			...(xaiQuality && { quality: xaiQuality }),
+			...(xaiResolution && { resolution: xaiResolution }),
 			...(image_config?.n && { n: image_config.n }),
 		};
 

--- a/packages/models/src/models/xai.ts
+++ b/packages/models/src/models/xai.ts
@@ -707,14 +707,14 @@ export const xaiModels = [
 				externalId: "grok-4.3",
 				inputPrice: "1.25e-6",
 				outputPrice: "2.5e-6",
-				cachedInputPrice: "0.3125e-6",
+				cachedInputPrice: "0.2e-6",
 				pricingTiers: [
 					{
 						name: "Up to 200K",
 						upToTokens: 200000,
 						inputPrice: "1.25e-6",
 						outputPrice: "2.5e-6",
-						cachedInputPrice: "0.3125e-6",
+						cachedInputPrice: "0.2e-6",
 					},
 					{
 						name: "Over 200K",
@@ -856,6 +856,43 @@ export const xaiModels = [
 		],
 	},
 	{
+		id: "grok-imagine-image-2-0",
+		name: "Grok Imagine Image 2.0",
+		description:
+			"xAI's second-generation image model for text-to-image generation and reference-image editing, with low and medium quality modes at 1k or 2k resolution.",
+		family: "xai",
+		output: ["image"],
+		releasedAt: new Date("2026-08-08"),
+		providers: [
+			{
+				test: "skip",
+				providerId: "xai",
+				contentFilterPrice: 0.05,
+				externalId: "grok-imagine-image-2.0",
+				inputPrice: "0",
+				outputPrice: "0",
+				// Billed per generated image at a rate that varies with both the
+				// requested quality and resolution, so the tier keys are
+				// "<quality>/<resolution>". xAI serves medium quality at 1k when the
+				// request omits either knob, which is what "default" covers.
+				perImagePrice: {
+					"low/1k": "0.04",
+					"low/2k": "0.06",
+					"medium/1k": "0.06",
+					"medium/2k": "0.08",
+					default: "0.06",
+				},
+				contextSize: 2000,
+				maxOutput: 4096,
+				streaming: false,
+				vision: true,
+				tools: false,
+				jsonOutput: false,
+				imageGenerations: true,
+			},
+		],
+	},
+	{
 		id: "grok-imagine-video-1-5",
 		name: "Grok Imagine Video 1.5",
 		description:
@@ -943,8 +980,24 @@ export const xaiModels = [
 				contentFilterPrice: 0.05,
 				externalId: "grok-4.5",
 				inputPrice: "2.0e-6",
-				cachedInputPrice: "0.5e-6",
+				cachedInputPrice: "0.3e-6",
 				outputPrice: "6.0e-6",
+				pricingTiers: [
+					{
+						name: "Up to 200K",
+						upToTokens: 200000,
+						inputPrice: "2.0e-6",
+						outputPrice: "6.0e-6",
+						cachedInputPrice: "0.3e-6",
+					},
+					{
+						name: "Over 200K",
+						upToTokens: Infinity,
+						inputPrice: "4.0e-6",
+						outputPrice: "12.0e-6",
+						cachedInputPrice: "0.6e-6",
+					},
+				],
 				requestPrice: "0",
 				contextSize: 500_000,
 				maxOutput: undefined,
@@ -954,6 +1007,62 @@ export const xaiModels = [
 				reasoningEfforts: ["low", "medium", "high"],
 				tools: true,
 				jsonOutput: true,
+				supportedParameters: [
+					"temperature",
+					"max_tokens",
+					"top_p",
+					"response_format",
+					"tools",
+					"tool_choice",
+					"reasoning_effort",
+				],
+			},
+		],
+	},
+	{
+		id: "grok-4-6",
+		name: "Grok 4.6",
+		description:
+			"xAI's flagship reasoning model with frontier coding, knowledge work, and STEM performance, a 500K context window, vision, and tool support.",
+		family: "xai",
+		releasedAt: new Date("2026-08-06"),
+		providers: [
+			{
+				providerId: "xai",
+				contentFilterPrice: 0.05,
+				externalId: "grok-4.6",
+				inputPrice: "2.0e-6",
+				cachedInputPrice: "0.5e-6",
+				outputPrice: "6.0e-6",
+				pricingTiers: [
+					{
+						name: "Up to 200K",
+						upToTokens: 200000,
+						inputPrice: "2.0e-6",
+						outputPrice: "6.0e-6",
+						cachedInputPrice: "0.5e-6",
+					},
+					{
+						name: "Over 200K",
+						upToTokens: Infinity,
+						inputPrice: "4.0e-6",
+						outputPrice: "12.0e-6",
+						cachedInputPrice: "1.0e-6",
+					},
+				],
+				requestPrice: "0",
+				contextSize: 500_000,
+				maxOutput: undefined,
+				streaming: true,
+				vision: true,
+				reasoning: true,
+				// Reasons on every request: xAI rejects both `none` and `max`, so the
+				// tier list stops at xhigh and never offers a way to turn it off.
+				reasoningEfforts: ["minimal", "low", "medium", "high", "xhigh"],
+				tools: true,
+				jsonOutput: true,
+				// `stop`, `frequency_penalty` and `presence_penalty` all 400 with
+				// "does not support parameter", so they stay undeclared.
 				supportedParameters: [
 					"temperature",
 					"max_tokens",


### PR DESCRIPTION
Adds `xai/grok-4-6` and `xai/grok-imagine-image-2-0` to the catalogue.

Every price here was checked against the cost xAI reports back in `usage.cost_in_usd_ticks`, and that check turned up three billing bugs in the existing xAI family — see below.

## The two new models

**`grok-4-6`** — 500K context, vision, tools, JSON output, reasoning. Verified live: `minimal`/`low`/`medium`/`high`/`xhigh` are accepted, `none` and `max` are rejected, and `stop`/`frequency_penalty`/`presence_penalty` all 400 with "does not support parameter", so they stay undeclared. Priced $2/M in, $0.50/M cached, $6/M out, doubling above the 200K long-context threshold.

**`grok-imagine-image-2-0`** — text-to-image and reference-image editing. Its flat per-image rate varies with **both** quality (`low`/`medium`) and resolution (`1k`/`2k`), so `perImagePrice` keys on `"<quality>/<resolution>"`:

| | 1k | 2k |
|---|---|---|
| low | $0.04 | $0.06 |
| medium | $0.06 | $0.08 |

The gateway did not forward either knob before, so it could only ever reach xAI's medium/1k default. It now maps `image_config.image_quality` → `quality` and `image_config.image_size` → `resolution`, normalising pixel dimensions onto the tier names (xAI 422s on `1K`, `1024x1024` and anything outside the enum) and dropping the unified `auto` quality rather than forwarding a value xAI rejects. Billing resolves the tier through the same mappers, so a dropped knob bills at the tier xAI actually served.

The playground exposes this: `getModelImageConfig` now offers 1K/2K and a Low/Medium quality selector for this model, defaulting to medium so the playground and a bare API call produce the same image and price. Both playground surfaces now read that config instead of each re-deriving it from substring checks, and the chat surface forwards the quality choice it was already collecting.

## Billing bugs this surfaced

**Reasoning tokens were never billed for any xAI model.** xAI is the exception among OpenAI-compatible providers: its `completion_tokens` *excludes* reasoning (`total_tokens = prompt + completion + reasoning`), and the count appears only under `completion_tokens_details.reasoning_tokens`. Neither the streaming nor the non-streaming parser read that nested field — both look for a top-level `usage.reasoning_tokens` — so every reasoning request was billed for its handful of visible output tokens and nothing else. One measured request billed $0.00014 against xAI's $0.00097. The fix is scoped to `xai` precisely because every other provider folds reasoning into `completion_tokens`, where reading it again would bill the same tokens twice.

**Two stale cached-input prices.** `grok-4-5` charged $0.50/M instead of $0.30/M and was missing its over-200K long-context tier; `grok-4-3` charged $0.3125/M instead of $0.20/M (its Bedrock and Azure mappings already had the right figure).

After these fixes the gateway's computed cost matches xAI's own to the cent for `grok-4-6`, `grok-4-5`, `grok-4-3`, `grok-build-0-1` and all five image tiers.

## Not fixed here

An audit of every xAI mapping against the provider's `/v1/models` prices found one more discrepancy, left alone because it is a headline repricing of shipped models rather than a correctness fix, and worth deciding separately: **`grok-4-20-beta-0309-reasoning` and `-non-reasoning` are priced $2/$6 per M while xAI now charges $1.25/$2.50** — i.e. we overbill them. (`grok-code-fast-1` is also stale, but it is already deactivated, so no live traffic is affected.)

## Verification

- Scoped e2e for both models: 106 tests pass, including streaming, all five reasoning efforts, tool calls, streaming tool calls, JSON, JSON streaming, image output and Responses-API tool calls.
- Live billing check against a locally running gateway: all four quality/resolution combinations plus the no-knobs default bill exactly what xAI charged.
- New unit tests cover the tier grid, the request-body mapping, the nested reasoning-token extraction on both parsers, and the playground config.
- `responses multi-turn` fails for the image model, as it does today for the existing `grok-imagine-image` — the test asks the model to reply with text, which an image-output model cannot do. It never runs by default; both mappings are `test: "skip"` and only ran because `TEST_MODELS` overrides that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for xAI’s Grok 4.6 reasoning model and Grok Imagine Image 2.0.
  - Added image quality and resolution options for supported xAI image models, including 1K and 2K output.
  - Added tiered pricing for newer xAI text and image models.

- **Bug Fixes**
  - Improved xAI token usage tracking, including reasoning and cached tokens.
  - Image requests now consistently forward supported quality and resolution settings.
  - Unsupported or invalid image options are safely omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->