### PR TITLE
feat(sql): add phantom output cost audit query

### DIFF
--- a/sql/phantom_output_cost_by_project.sql
+++ b/sql/phantom_output_cost_by_project.sql
@@ -1,0 +1,129 @@
+-- Phantom output cost audit, scoped to one account's projects.
+--
+-- Purpose:
+-- Find log rows whose billed output cost is far above what the recorded
+-- completion tokens would cost at the served service tier's output rate —
+-- "cost without tokens" rows, e.g. interrupted streams that were billed on
+-- an estimated output count that was never written back to
+-- completion_tokens.
+--
+-- Fill in before running:
+-- - the account email in the proj CTE (and the org kind if not devpass)
+-- - used_model and the per-token output rates in the tier CASE; the rates
+--   below are for openai/gpt-5.6-sol (flex $15/M, priority $60/M,
+--   standard $30/M)
+-- - the created_at lower bound
+-- - the timezone offset in created_at_local (set to the reporter's local
+--   timezone so rows line up with their screenshots/reports)
+--
+-- Performance:
+-- - proj is MATERIALIZED so resolving the project ids is the first node of
+--   the query plan; the lateral join then probes a project_id-leading log
+--   index (log_project_id_created_at_idx or log_project_id_used_model_idx)
+--   once per project instead of hash-joining against a scan of log.
+-- - Keep the created_at lower bound so the index prunes by time as well
+--   (retention pruning removes very old rows anyway).
+--
+-- Reading the results:
+-- - The 1.6x headroom keeps legitimate rows out: org discounts only lower
+--   real costs, and the long-context pricing tier tops out at 1.5x the base
+--   output rate (pricing_tier is selected so those stand out if present).
+-- - Suspect rows show large output_cost with small/zero completion_tokens,
+--   typically canceled = true or an error-ish unified_finish_reason, and
+--   estimated_cost = true.
+-- - excess_output_cost is the per-row over-billed amount; the second query
+--   totals it for a refund figure.
+
+with proj as materialized (
+	select p.id
+	from "user" u
+	join user_organization uo on uo.user_id = u.id
+	join organization o on o.id = uo.organization_id
+	join project p on p.organization_id = o.id
+	where u.email = 'customer@example.com'
+	  and o.kind = 'devpass'
+)
+select
+	l.id,
+	l.created_at,
+	l.created_at + interval '9 hours' as created_at_local,
+	l.used_service_tier,
+	l.pricing_tier,
+	l.unified_finish_reason,
+	l.canceled,
+	l.streamed,
+	l.estimated_cost,
+	l.prompt_tokens,
+	l.completion_tokens,
+	l.reasoning_tokens,
+	round(l.output_cost::numeric, 6) as output_cost,
+	round(
+		(coalesce(l.completion_tokens, '0')::numeric * l.output_rate)::numeric,
+		6
+	) as expected_output_cost,
+	round(
+		(
+			l.output_cost::numeric
+			- coalesce(l.completion_tokens, '0')::numeric * l.output_rate
+		)::numeric,
+		6
+	) as excess_output_cost
+from proj
+cross join lateral (
+	select
+		ll.*,
+		case ll.used_service_tier
+			when 'flex' then 0.000015
+			when 'priority' then 0.00006
+			else 0.00003
+		end as output_rate
+	from log ll
+	where ll.project_id = proj.id
+	  and ll.created_at >= '2026-08-01'
+	  and ll.used_model = 'openai/gpt-5.6-sol'
+	  and ll.output_cost is not null
+	  and ll.output_cost > 0
+) l
+where l.output_cost::numeric
+	> coalesce(l.completion_tokens, '0')::numeric * l.output_rate * 1.6
+order by l.created_at;
+
+-- Totals over the same phantom rows (count + refund amount).
+
+with proj as materialized (
+	select p.id
+	from "user" u
+	join user_organization uo on uo.user_id = u.id
+	join organization o on o.id = uo.organization_id
+	join project p on p.organization_id = o.id
+	where u.email = 'customer@example.com'
+	  and o.kind = 'devpass'
+)
+select
+	count(*) as phantom_rows,
+	round(
+		sum(
+			l.output_cost::numeric
+			- coalesce(l.completion_tokens, '0')::numeric * l.output_rate
+		)::numeric,
+		4
+	) as total_excess_output_cost
+from proj
+cross join lateral (
+	select
+		ll.output_cost,
+		ll.completion_tokens,
+		case ll.used_service_tier
+			when 'flex' then 0.000015
+			when 'priority' then 0.00006
+			else 0.00003
+		end as output_rate
+	from log ll
+	where ll.project_id = proj.id
+	  and ll.created_at >= '2026-08-01'
+	  and ll.used_model = 'openai/gpt-5.6-sol'
+	  and ll.output_cost is not null
+	  and ll.output_cost > 0
+) l
+where l.output_cost::numeric
+	> coalesce(l.completion_tokens, '0')::numeric * l.output_rate * 1.6;


### PR DESCRIPTION
## Problem

When investigating "output cost doesn't match output tokens" reports (e.g. an hour whose blended output rate multiplies out far above any real tier rate), the phantom rows come from streams that died before the provider sent usage: the pre-#3546 estimator billed an estimated output count that was never written back to `completion_tokens`, leaving cost with no matching tokens. #3546 fixed this going forward but did not backfill, so historical rows still carry the mismatch and each report needs an ad-hoc query.

## Approach

Adds `sql/phantom_output_cost_by_project.sql`, a reusable two-part audit:

1. Per-row detail: every log row for a given account + model where `output_cost` exceeds `completion_tokens × served-tier output rate × 1.6`, with `expected_output_cost` / `excess_output_cost` columns and the diagnostic fields (`canceled`, `estimated_cost`, `unified_finish_reason`, `pricing_tier`).
2. Totals: phantom row count and the summed excess, i.e. the refund amount.

Scalability is the point of the shape: the project-id resolution is a `MATERIALIZED` CTE so it is the first node of the plan, and the log access is a `LATERAL` join on `project_id` — verified with `EXPLAIN` that the planner runs a nested loop probing a `project_id`-leading index (`log_project_id_used_model_idx` locally) instead of scanning `log`. The `created_at` lower bound keeps `log_project_id_created_at_idx` usable too. The 1.6× headroom keeps legitimate rows out (discounts only lower costs; the long-context tier tops out at 1.5× base). Per-row `::numeric` casts avoid float4 accumulation drift in the sum.

The committed file uses placeholder values (`customer@example.com`, `openai/gpt-5.6-sol` rates as the example CASE) — fill in account email, model, rates and date bound before running.

## Verification

- Both statements run clean against the local dev database (seeded schema).
- `EXPLAIN` confirms the materialized-CTE → nested-loop → index-scan plan shape.
- `pnpm format` and full `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account-scoped audit queries to identify projects with potentially excessive billed output costs.
  * Included detailed results with calculated excess costs and an aggregated summary of suspect records.
  * Supports filtering by model, date range, output cost, and organization type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->