### PR TITLE
feat(gateway): refine coding agent attribution

### DIFF
--- a/apps/gateway/src/chat/tools/detect-coding-agent.spec.ts
+++ b/apps/gateway/src/chat/tools/detect-coding-agent.spec.ts
@@ -30,6 +30,11 @@ describe("detectCodingAgentFromUserAgent", () => {
 				"codex_vscode/0.147.0-alpha.6.5 (Ubuntu 24.4.0; x86_64) unknown (VS Code; 26.803.41515)",
 			),
 		).toBe("codex");
+		expect(
+			detectCodingAgentFromUserAgent(
+				"codex_exec/0.66.0 (Ubuntu 24.4.0; x86_64)",
+			),
+		).toBe("codex");
 	});
 
 	it("detects OpenCode", () => {
@@ -165,6 +170,30 @@ describe("detectCodingAgentFromUserAgent", () => {
 		expect(detectCodingAgentFromUserAgent("droid/1.2.3")).toBe("factory-droid");
 	});
 
+	it("detects MiMo Code", () => {
+		expect(detectCodingAgentFromUserAgent("mimocode")).toBe("mimo-code");
+		expect(detectCodingAgentFromUserAgent("mimocode/1.4.0")).toBe("mimo-code");
+		expect(detectCodingAgentFromUserAgent("mimo-code/2.0")).toBe("mimo-code");
+	});
+
+	it("detects Traycer", () => {
+		expect(detectCodingAgentFromUserAgent("traycer-agents/1.9.0")).toBe(
+			"traycer",
+		);
+		expect(detectCodingAgentFromUserAgent("Traycer/2.0 (vscode)")).toBe(
+			"traycer",
+		);
+	});
+
+	it("detects Foundry Toolkit", () => {
+		expect(detectCodingAgentFromUserAgent("windows-ai-studio/0.15.2")).toBe(
+			"foundry-toolkit",
+		);
+		expect(detectCodingAgentFromUserAgent("foundry-toolkit/1.0.0")).toBe(
+			"foundry-toolkit",
+		);
+	});
+
 	it("detects Hermes Agent", () => {
 		expect(detectCodingAgentFromUserAgent("hermes-agent/0.5.0")).toBe(
 			"hermes-agent",
@@ -213,6 +242,18 @@ describe("detectCodingAgentFromUserAgent", () => {
 			detectCodingAgentFromUserAgent(
 				"langchainjs-openai/1.0.0 ((node/v24.16.0; linux; x64))",
 			),
+		).toBeUndefined();
+		expect(
+			detectCodingAgentFromUserAgent("spring-ai-openai/1.0.0"),
+		).toBeUndefined();
+		expect(
+			detectCodingAgentFromUserAgent("tauri-plugin-http/2.4.0"),
+		).toBeUndefined();
+		expect(
+			detectCodingAgentFromUserAgent("Go-http-client/2.0"),
+		).toBeUndefined();
+		expect(
+			detectCodingAgentFromUserAgent("RikkaHub-Android/1.8.0"),
 		).toBeUndefined();
 	});
 });

--- a/apps/gateway/src/chat/tools/detect-coding-agent.spec.ts
+++ b/apps/gateway/src/chat/tools/detect-coding-agent.spec.ts
@@ -230,10 +230,18 @@ describe("detectCodingAgentFromUserAgent", () => {
 				"ai/6.0.168 ai-sdk/provider-utils/4.0.23 runtime/node.js/26",
 			),
 		).toBeUndefined();
+		// Every OpenAI SDK variant, not just the async one: the SDK is only ever
+		// attributed via an explicit x-source, never via its User-Agent.
+		expect(
+			detectCodingAgentFromUserAgent("OpenAI/Python 2.32.0"),
+		).toBeUndefined();
 		expect(
 			detectCodingAgentFromUserAgent("AsyncOpenAI/Python 2.32.0"),
 		).toBeUndefined();
 		expect(detectCodingAgentFromUserAgent("OpenAI/JS 6.47.0")).toBeUndefined();
+		expect(
+			detectCodingAgentFromUserAgent("Anthropic/Python 0.75.0"),
+		).toBeUndefined();
 		expect(detectCodingAgentFromUserAgent("litellm/1.90.1")).toBeUndefined();
 		expect(
 			detectCodingAgentFromUserAgent("cli-proxy-openai-compat"),

--- a/apps/ui/src/components/apps/app-metadata.ts
+++ b/apps/ui/src/components/apps/app-metadata.ts
@@ -124,6 +124,20 @@ export const APP_METADATA: Record<string, AppMetadata> = {
 		category: "coding",
 		Icon: MimoCodeIcon,
 	},
+	traycer: {
+		displayName: "Traycer",
+		url: "https://traycer.ai",
+		description:
+			"Plan-first coding layer for VS Code. Drafts the plan, then hands it to your agent of choice.",
+		category: "coding",
+	},
+	"foundry-toolkit": {
+		displayName: "Foundry Toolkit",
+		url: "https://code.visualstudio.com/docs/intelligentapps/overview",
+		description:
+			"Microsoft's VS Code extension for building and evaluating agents. Compares models side by side.",
+		category: "coding",
+	},
 	zed: {
 		displayName: "Zed",
 		url: "https://zed.dev",

--- a/packages/shared/src/coding-agents.spec.ts
+++ b/packages/shared/src/coding-agents.spec.ts
@@ -35,6 +35,11 @@ describe("isRecognizedCodingAgent", () => {
 		expect(isRecognizedCodingAgent("kimi-code")).toBe(true);
 		expect(isRecognizedCodingAgent("qwen-code")).toBe(true);
 		expect(isRecognizedCodingAgent("factory-droid")).toBe(true);
+		expect(isRecognizedCodingAgent("mimo-code")).toBe(true);
+		expect(isRecognizedCodingAgent("mimocode")).toBe(true);
+		expect(isRecognizedCodingAgent("traycer")).toBe(true);
+		expect(isRecognizedCodingAgent("foundry-toolkit")).toBe(true);
+		expect(isRecognizedCodingAgent("windows-ai-studio")).toBe(true);
 	});
 
 	it("recognizes *claw forks via pattern", () => {
@@ -67,6 +72,11 @@ describe("normalizeSourceToAgentId", () => {
 		expect(normalizeSourceToAgentId("qwencode")).toBe("qwen-code");
 		expect(normalizeSourceToAgentId("droid")).toBe("factory-droid");
 		expect(normalizeSourceToAgentId("pi-coding-agent")).toBe("pi-agent");
+		expect(normalizeSourceToAgentId("mimocode")).toBe("mimo-code");
+		expect(normalizeSourceToAgentId("traycer-agents")).toBe("traycer");
+		expect(normalizeSourceToAgentId("windows-ai-studio")).toBe(
+			"foundry-toolkit",
+		);
 	});
 
 	it("returns the same value for canonical IDs", () => {

--- a/packages/shared/src/coding-agents.spec.ts
+++ b/packages/shared/src/coding-agents.spec.ts
@@ -40,6 +40,9 @@ describe("isRecognizedCodingAgent", () => {
 		expect(isRecognizedCodingAgent("traycer")).toBe(true);
 		expect(isRecognizedCodingAgent("foundry-toolkit")).toBe(true);
 		expect(isRecognizedCodingAgent("windows-ai-studio")).toBe(true);
+		// Detection never infers this one from a User-Agent, but callers that opt
+		// in explicitly are still recognized.
+		expect(isRecognizedCodingAgent("openai-sdk")).toBe(true);
 	});
 
 	it("recognizes *claw forks via pattern", () => {

--- a/packages/shared/src/coding-agents.ts
+++ b/packages/shared/src/coding-agents.ts
@@ -216,7 +216,12 @@ export const CODING_AGENTS: CodingAgentDefinition[] = [
 		id: "openai-sdk",
 		label: "OpenAI SDK",
 		xSourceValues: ["openai-sdk"],
-		userAgentPatterns: [/^OpenAI\/Python/i, /^Is\/JS/i],
+		// Explicit x-source only. The SDK's own User-Agent ("OpenAI/Python 2.x",
+		// "AsyncOpenAI/Python 2.x", "OpenAI/JS 6.x") says nothing about what is
+		// driving it, so matching on it would attribute every plain API script as
+		// a coding agent — and did so asymmetrically, since the sync Python client
+		// matched while the async one and the JS client did not.
+		userAgentPatterns: [],
 	},
 ];
 

--- a/packages/shared/src/coding-agents.ts
+++ b/packages/shared/src/coding-agents.ts
@@ -31,6 +31,8 @@ export const CODING_AGENTS: CodingAgentDefinition[] = [
 			/^codex_cli_rs\//i,
 			/^codex[-_]tui\//i,
 			/^codex[-_]vscode\//i,
+			// Headless `codex exec` runs identify as "codex_exec/<version> …".
+			/^codex[-_]exec/i,
 			/^codex\//i,
 		],
 	},
@@ -188,6 +190,27 @@ export const CODING_AGENTS: CodingAgentDefinition[] = [
 			/^droid\//i,
 			/\bfactory[-_]droid\b/i,
 		],
+	},
+	{
+		id: "mimo-code",
+		label: "MiMo Code",
+		xSourceValues: ["mimo-code", "mimocode"],
+		// The CLI sends a bare "mimocode" product token with no separator.
+		userAgentPatterns: [/^mimo[-_]?code/i, /\bmimo[-_]code\b/i],
+	},
+	{
+		id: "traycer",
+		label: "Traycer",
+		xSourceValues: ["traycer", "traycer-agents"],
+		userAgentPatterns: [/^traycer[-_]agents\b/i, /^traycer\//i, /\btraycer\b/i],
+	},
+	{
+		id: "foundry-toolkit",
+		label: "Foundry Toolkit",
+		// Microsoft's VS Code extension, formerly "AI Toolkit"/"Windows AI Studio";
+		// the marketplace id (and its User-Agent) still says windows-ai-studio.
+		xSourceValues: ["foundry-toolkit", "ai-toolkit", "windows-ai-studio"],
+		userAgentPatterns: [/^windows[-_]ai[-_]studio/i, /^foundry[-_]toolkit/i],
 	},
 	{
 		id: "openai-sdk",


### PR DESCRIPTION
## Problem

Another pass over the top user agents hitting the gateway, after #3568. Four more identifiable developer tools are still landing in the unattributed bucket because the User-Agent they send matches no pattern in `CODING_AGENTS` — so their traffic is missing from the Agents/Apps dashboards and fails the `isRecognizedCodingAgent` gate on DevPass coding plans.

The same pass surfaced the opposite problem: the `openai-sdk` entry matched on the OpenAI SDK's own User-Agent, which attributes plain API scripts as a coding agent.

## Changes

### Newly attributed

| Agent | Observed User-Agent | Notes |
| --- | --- | --- |
| MiMo Code | `mimocode` | Xiaomi's coding CLI — already has an integration guide, an icon, and an `APP_METADATA` entry (`mimo-code`); it was just never wired into detection |
| Traycer | `traycer-agents` | Plan-first coding extension for VS Code and its forks |
| Foundry Toolkit | `windows-ai-studio` | Microsoft's VS Code extension for building/evaluating agents, formerly "AI Toolkit"/"Windows AI Studio" — the marketplace id and UA still say `windows-ai-studio` |

Extra pattern on an existing definition:

- **Codex** — headless `codex exec` runs identify as `codex_exec/<version> …`, which none of the existing patterns matched (`^codex\/` needs the slash immediately after `codex`).

Dashboard metadata (`APP_METADATA`) added for Traycer and Foundry Toolkit so the Apps page shows a name and description instead of the raw source id. MiMo Code already had one.

### No longer attributed

`openai-sdk` carried `userAgentPatterns: [/^OpenAI\/Python/i, /^Is\/JS/i]`. That was wrong in three ways:

- The SDK's User-Agent says nothing about what is driving it, so any plain Python script was recorded as a coding agent.
- It was asymmetric — `OpenAI/Python` matched, `AsyncOpenAI/Python` did not, so the same application split across two buckets depending on whether it used the async client.
- `/^Is\/JS/i` matched nothing at all; the JS client sends `OpenAI/JS`.

The entry now has no UA patterns: the OpenAI SDK is attributed only when a caller opts in with `x-source: openai-sdk`, exactly like every other generic SDK. The spec already asserted `AsyncOpenAI/Python` and `OpenAI/JS` stay unattributed — `OpenAI/Python` now joins them, and a test pins that the explicit `x-source` escape hatch still resolves.

This only changes attribution today: the DevPass source gate is behind `DEVPASS_ENFORCE_SOURCE_RESTRICTION`, which defaults to off. If we ever turn it on, raw-SDK callers would need to send `x-source: openai-sdk` — which is already true for the async and JS clients.

### Left alone

Everything else in the traffic sample stays unattributed on purpose — generic SDKs and runtimes (AI SDK, OpenAI/Anthropic SDKs, LangChain, litellm, spring-ai, Go/Bun/Deno/node/python HTTP clients), proxies (`cli-proxy-openai-compat`), desktop/mobile chat clients (`tauri-plugin-http`, `RikkaHub-Android`) and a handful of unidentifiable low-volume names. Several of those are added to the existing "leaves generic SDKs and proxies unattributed" test so a future broad pattern cannot quietly start attributing them.

## Notes

- Adding an entry also widens the `x-source` allowlist that gates DevPass coding plans. Deliberate for MiMo Code and Traycer. Foundry Toolkit is the judgement call in this set: it is a genuine VS Code developer extension rather than a raw SDK, but its traffic is model evaluation rather than code editing — happy to drop that one entry if we'd rather keep the gate strictly agentic.

## Verification

`pnpm format`, `pnpm build`, and the unit specs for `packages/shared` plus the gateway UA detector all pass (36 tests), with new cases asserting on the exact User-Agent product tokens observed in traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)