### PR TITLE
feat: add usage columns and window to admin orgs

### DIFF
--- a/apps/api/src/routes/admin-orgs-usage-window.spec.ts
+++ b/apps/api/src/routes/admin-orgs-usage-window.spec.ts
@@ -234,4 +234,40 @@ describe("admin — organizations list usage window", () => {
 		);
 		expect(res.status).toBe(400);
 	});
+
+	// `Date.parse` would roll these over to a real day rather than reject them.
+	test.each(["2026-02-30", "2026-04-31", "2026-1-1"])(
+		"rejects the impossible date %s",
+		async (day) => {
+			const res = await app.request(
+				`/admin/organizations?limit=50&from=${day}&to=2026-12-01`,
+				{ headers: { Cookie: cookie } },
+			);
+			expect(res.status).toBe(400);
+		},
+	);
+
+	test("rejects a half-open window instead of silently widening it", async () => {
+		const fromOnly = await app.request(
+			"/admin/organizations?limit=50&from=2026-01-01",
+			{ headers: { Cookie: cookie } },
+		);
+		expect(fromOnly.status).toBe(400);
+
+		const toOnly = await app.request(
+			"/admin/organizations?limit=50&to=2026-01-31",
+			{ headers: { Cookie: cookie } },
+		);
+		expect(toOnly.status).toBe(400);
+	});
+
+	test("still treats an entirely absent window as all time", async () => {
+		const res = await app.request("/admin/organizations?limit=50", {
+			headers: { Cookie: cookie },
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as OrgListResponse;
+		const old = body.organizations.find((o) => o.id === OLD_ORG_ID);
+		expect(old!.totalRequests).toBe(1);
+	});
 });

--- a/apps/api/src/routes/admin-orgs-usage-window.spec.ts
+++ b/apps/api/src/routes/admin-orgs-usage-window.spec.ts
@@ -1,0 +1,237 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { app } from "@/index.js";
+import {
+	aggregateLogsForTesting,
+	createTestUser,
+	deleteAll,
+} from "@/testing.js";
+
+import { db, tables } from "@llmgateway/db";
+
+const RECENT_ORG_ID = "usage-window-recent-org";
+const RECENT_PROJECT_ID = "usage-window-recent-project";
+const RECENT_KEY_ID = "usage-window-recent-key";
+const OLD_ORG_ID = "usage-window-old-org";
+const OLD_PROJECT_ID = "usage-window-old-project";
+const OLD_KEY_ID = "usage-window-old-key";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function daysAgo(days: number) {
+	const offset = days * DAY_MS;
+	return new Date(Date.now() - offset);
+}
+
+function toDay(date: Date) {
+	return date.toISOString().split("T")[0];
+}
+
+function makeLog(o: {
+	id: string;
+	projectId: string;
+	organizationId: string;
+	apiKeyId: string;
+	createdAt: Date;
+	cost: number;
+	totalTokens: string;
+}) {
+	return {
+		id: o.id,
+		requestId: o.id,
+		createdAt: o.createdAt,
+		updatedAt: o.createdAt,
+		organizationId: o.organizationId,
+		projectId: o.projectId,
+		apiKeyId: o.apiKeyId,
+		duration: 100,
+		requestedModel: "gpt-4",
+		requestedProvider: "openai",
+		usedModel: "gpt-4",
+		usedProvider: "openai",
+		responseSize: 100,
+		promptTokens: "10",
+		completionTokens: "10",
+		totalTokens: o.totalTokens,
+		messages: JSON.stringify([{ role: "user", content: "hi" }]),
+		mode: "hybrid" as const,
+		usedMode: "credits" as const,
+		cost: o.cost,
+	};
+}
+
+interface OrgListResponse {
+	organizations: {
+		id: string;
+		totalSpent?: string;
+		totalRequests?: number;
+		totalTokens?: number;
+	}[];
+}
+
+describe("admin — organizations list usage window", () => {
+	let cookie: string;
+
+	beforeEach(async () => {
+		process.env.ADMIN_EMAILS = "admin@example.com";
+		cookie = await createTestUser();
+
+		await db.insert(tables.organization).values([
+			{
+				id: RECENT_ORG_ID,
+				name: "Usage Window Recent Org",
+				billingEmail: "usage-window-recent@example.com",
+			},
+			{
+				id: OLD_ORG_ID,
+				name: "Usage Window Old Org",
+				billingEmail: "usage-window-old@example.com",
+			},
+		]);
+
+		await db.insert(tables.project).values([
+			{
+				id: RECENT_PROJECT_ID,
+				name: "Usage Window Recent Project",
+				organizationId: RECENT_ORG_ID,
+			},
+			{
+				id: OLD_PROJECT_ID,
+				name: "Usage Window Old Project",
+				organizationId: OLD_ORG_ID,
+			},
+		]);
+
+		await db.insert(tables.apiKey).values([
+			{
+				id: RECENT_KEY_ID,
+				token: "usage-window-recent-token",
+				projectId: RECENT_PROJECT_ID,
+				description: "Recent Key",
+				createdBy: "test-user-id",
+			},
+			{
+				id: OLD_KEY_ID,
+				token: "usage-window-old-token",
+				projectId: OLD_PROJECT_ID,
+				description: "Old Key",
+				createdBy: "test-user-id",
+			},
+		]);
+
+		await db.insert(tables.log).values([
+			// Recent org: 2 requests, 300 tokens, $3 — inside a 90-day window.
+			makeLog({
+				id: "usage-window-recent-1",
+				projectId: RECENT_PROJECT_ID,
+				organizationId: RECENT_ORG_ID,
+				apiKeyId: RECENT_KEY_ID,
+				createdAt: daysAgo(2),
+				cost: 1,
+				totalTokens: "100",
+			}),
+			makeLog({
+				id: "usage-window-recent-2",
+				projectId: RECENT_PROJECT_ID,
+				organizationId: RECENT_ORG_ID,
+				apiKeyId: RECENT_KEY_ID,
+				createdAt: daysAgo(3),
+				cost: 2,
+				totalTokens: "200",
+			}),
+			// Old org: 1 request, 9000 tokens, $50 — outside a 90-day window, so it
+			// only shows up for all time.
+			makeLog({
+				id: "usage-window-old-1",
+				projectId: OLD_PROJECT_ID,
+				organizationId: OLD_ORG_ID,
+				apiKeyId: OLD_KEY_ID,
+				createdAt: daysAgo(200),
+				cost: 50,
+				totalTokens: "9000",
+			}),
+		]);
+
+		await aggregateLogsForTesting();
+	});
+
+	afterEach(async () => {
+		await deleteAll();
+	});
+
+	test("returns all-time request and token totals when no window is given", async () => {
+		const res = await app.request("/admin/organizations?limit=50", {
+			headers: { Cookie: cookie },
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as OrgListResponse;
+
+		const recent = body.organizations.find((o) => o.id === RECENT_ORG_ID);
+		expect(recent).toBeDefined();
+		expect(recent!.totalRequests).toBe(2);
+		expect(recent!.totalTokens).toBe(300);
+		expect(parseFloat(recent!.totalSpent ?? "0")).toBeCloseTo(3, 3);
+
+		const old = body.organizations.find((o) => o.id === OLD_ORG_ID);
+		expect(old).toBeDefined();
+		expect(old!.totalRequests).toBe(1);
+		expect(old!.totalTokens).toBe(9000);
+		expect(parseFloat(old!.totalSpent ?? "0")).toBeCloseTo(50, 3);
+	});
+
+	test("scopes spend, requests, and tokens to the from/to window", async () => {
+		const res = await app.request(
+			`/admin/organizations?limit=50&from=${toDay(daysAgo(89))}&to=${toDay(daysAgo(0))}`,
+			{ headers: { Cookie: cookie } },
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as OrgListResponse;
+
+		const recent = body.organizations.find((o) => o.id === RECENT_ORG_ID);
+		expect(recent!.totalRequests).toBe(2);
+		expect(recent!.totalTokens).toBe(300);
+		expect(parseFloat(recent!.totalSpent ?? "0")).toBeCloseTo(3, 3);
+
+		// The org is still listed — only its usage aggregates fall to zero.
+		const old = body.organizations.find((o) => o.id === OLD_ORG_ID);
+		expect(old).toBeDefined();
+		expect(old!.totalRequests).toBe(0);
+		expect(old!.totalTokens).toBe(0);
+		expect(parseFloat(old!.totalSpent ?? "0")).toBeCloseTo(0, 3);
+	});
+
+	test("sorts by request count and token count", async () => {
+		const byRequests = (await (
+			await app.request(
+				"/admin/organizations?limit=50&sortBy=totalRequests&sortOrder=desc",
+				{ headers: { Cookie: cookie } },
+			)
+		).json()) as OrgListResponse;
+		expect(byRequests.organizations[0]?.id).toBe(RECENT_ORG_ID);
+
+		const byTokens = (await (
+			await app.request(
+				"/admin/organizations?limit=50&sortBy=totalTokens&sortOrder=desc",
+				{ headers: { Cookie: cookie } },
+			)
+		).json()) as OrgListResponse;
+		expect(byTokens.organizations[0]?.id).toBe(OLD_ORG_ID);
+
+		// Within the recent window the old org has no tokens, so the ordering flips.
+		const byTokensWindowed = (await (
+			await app.request(
+				`/admin/organizations?limit=50&sortBy=totalTokens&sortOrder=desc&from=${toDay(daysAgo(89))}&to=${toDay(daysAgo(0))}`,
+				{ headers: { Cookie: cookie } },
+			)
+		).json()) as OrgListResponse;
+		expect(byTokensWindowed.organizations[0]?.id).toBe(RECENT_ORG_ID);
+	});
+
+	test("rejects a malformed from/to window", async () => {
+		const res = await app.request(
+			"/admin/organizations?limit=50&from=not-a-date&to=2026-01-01",
+			{ headers: { Cookie: cookie } },
+		);
+		expect(res.status).toBe(400);
+	});
+});

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -392,6 +392,8 @@ const organizationSchema = z.object({
 	totalSpent: z.string().optional(),
 	totalCreditsSpent: z.string().optional(),
 	totalApiKeysSpent: z.string().optional(),
+	totalRequests: z.number().optional(),
+	totalTokens: z.number().optional(),
 	createdAt: z.string(),
 	status: z.string().nullable(),
 	referralBonusEnabled: z.boolean().optional(),
@@ -648,6 +650,8 @@ const sortBySchema = z.enum([
 	"status",
 	"totalCreditsAllTime",
 	"totalSpent",
+	"totalRequests",
+	"totalTokens",
 ]);
 
 const sortOrderSchema = z.enum(["asc", "desc"]);
@@ -662,6 +666,10 @@ const getOrganizations = createRoute({
 			search: z.string().optional(),
 			sortBy: sortBySchema.default("createdAt").optional(),
 			sortOrder: sortOrderSchema.default("desc").optional(),
+			// Usage window (YYYY-MM-DD) for the spend/request/token columns.
+			// Omitting both means all time.
+			from: z.string().optional(),
+			to: z.string().optional(),
 		}),
 	},
 	responses: {
@@ -2499,6 +2507,23 @@ admin.openapi(getOrganizations, async (c) => {
 	const sortBy = query.sortBy ?? "createdAt";
 	const sortOrder = query.sortOrder ?? "desc";
 
+	// Usage window for the spend/request/token aggregates. Both dates must be
+	// present to narrow the window; otherwise the aggregates cover all time.
+	let usageStartDate: Date | undefined;
+	let usageEndDate: Date | undefined;
+	if (query.from && query.to) {
+		if (
+			Number.isNaN(Date.parse(query.from + "T00:00:00Z")) ||
+			Number.isNaN(Date.parse(query.to + "T00:00:00Z"))
+		) {
+			throw new HTTPException(400, {
+				message: "Invalid from/to date (expected YYYY-MM-DD)",
+			});
+		}
+		usageStartDate = new Date(query.from + "T00:00:00.000Z");
+		usageEndDate = new Date(query.to + "T23:59:59.999Z");
+	}
+
 	const whereClause = buildOrganizationSearchFilter(search);
 
 	const [countResult] = await db
@@ -2531,7 +2556,8 @@ admin.openapi(getOrganizations, async (c) => {
 		.groupBy(tables.transaction.organizationId)
 		.as("all_time_credits");
 
-	// Subquery for total spent (usage cost) per org
+	// Subquery for usage totals (cost, requests, tokens) per org, scoped to the
+	// selected window.
 	const totalSpentSub = db
 		.select({
 			organizationId: tables.project.organizationId,
@@ -2547,11 +2573,29 @@ admin.openapi(getOrganizations, async (c) => {
 				sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.apiKeysCost} AS NUMERIC)), 0)`.as(
 					"api_keys_spent",
 				),
+			requestsTotal:
+				sql<string>`COALESCE(SUM(${projectHourlyStats.requestCount}), 0)`.as(
+					"total_requests",
+				),
+			tokensTotal:
+				sql<string>`COALESCE(SUM(CAST(${projectHourlyStats.totalTokens} AS NUMERIC)), 0)`.as(
+					"total_tokens",
+				),
 		})
 		.from(projectHourlyStats)
 		.innerJoin(
 			tables.project,
 			eq(projectHourlyStats.projectId, tables.project.id),
+		)
+		.where(
+			and(
+				usageStartDate
+					? gte(projectHourlyStats.hourTimestamp, usageStartDate)
+					: undefined,
+				usageEndDate
+					? lte(projectHourlyStats.hourTimestamp, usageEndDate)
+					: undefined,
+			),
 		)
 		.groupBy(tables.project.organizationId)
 		.as("total_spent");
@@ -2579,6 +2623,8 @@ admin.openapi(getOrganizations, async (c) => {
 		status: tables.organization.status,
 		totalCreditsAllTime: sql`COALESCE(CAST(${allTimeCredits.total} AS NUMERIC), 0)`,
 		totalSpent: sql`COALESCE(CAST(${totalSpentSub.total} AS NUMERIC), 0)`,
+		totalRequests: sql`COALESCE(CAST(${totalSpentSub.requestsTotal} AS NUMERIC), 0)`,
+		totalTokens: sql`COALESCE(CAST(${totalSpentSub.tokensTotal} AS NUMERIC), 0)`,
 	} as const;
 
 	const sortColumn = sortColumnMap[sortBy];
@@ -2614,6 +2660,13 @@ admin.openapi(getOrganizations, async (c) => {
 				sql<string>`COALESCE(${totalSpentSub.apiKeysTotal}, '0')`.as(
 					"totalApiKeysSpent",
 				),
+			totalRequests:
+				sql<string>`COALESCE(${totalSpentSub.requestsTotal}, '0')`.as(
+					"totalRequests",
+				),
+			totalTokens: sql<string>`COALESCE(${totalSpentSub.tokensTotal}, '0')`.as(
+				"totalTokens",
+			),
 			ownerUserId: ownerSub.userId,
 			ownerName: ownerSub.userName,
 			ownerEmail: ownerSub.userEmail,
@@ -2651,6 +2704,8 @@ admin.openapi(getOrganizations, async (c) => {
 			totalSpent: String(org.totalSpent ?? "0"),
 			totalCreditsSpent: String(org.totalCreditsSpent ?? "0"),
 			totalApiKeysSpent: String(org.totalApiKeysSpent ?? "0"),
+			totalRequests: Number(org.totalRequests ?? 0),
+			totalTokens: Number(org.totalTokens ?? 0),
 			createdAt: org.createdAt.toISOString(),
 			status: org.status,
 			ownerUserId: org.ownerUserId ?? null,

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -2499,6 +2499,24 @@ function aggregateBreakdownRows<T extends GlobalStatsRowMetrics>(
 	);
 }
 
+// `Date.parse` rolls impossible days over instead of rejecting them
+// ("2026-02-30" becomes March 2), so round-trip the parsed date and refuse
+// anything that did not survive unchanged.
+function parseUsageWindowDay(value: string, boundary: "from" | "to"): Date {
+	const parsed = /^\d{4}-\d{2}-\d{2}$/.test(value)
+		? new Date(value + "T00:00:00.000Z")
+		: new Date(Number.NaN);
+	if (
+		Number.isNaN(parsed.getTime()) ||
+		parsed.toISOString().slice(0, 10) !== value
+	) {
+		throw new HTTPException(400, {
+			message: `Invalid ${boundary} date (expected YYYY-MM-DD)`,
+		});
+	}
+	return parsed;
+}
+
 admin.openapi(getOrganizations, async (c) => {
 	const query = c.req.valid("query");
 	const limit = query.limit ?? 50;
@@ -2507,21 +2525,20 @@ admin.openapi(getOrganizations, async (c) => {
 	const sortBy = query.sortBy ?? "createdAt";
 	const sortOrder = query.sortOrder ?? "desc";
 
-	// Usage window for the spend/request/token aggregates. Both dates must be
-	// present to narrow the window; otherwise the aggregates cover all time.
+	// Usage window for the spend/request/token aggregates. Omitting both dates
+	// means all time; supplying only one is rejected rather than silently
+	// widening back to all time.
 	let usageStartDate: Date | undefined;
 	let usageEndDate: Date | undefined;
+	if (Boolean(query.from) !== Boolean(query.to)) {
+		throw new HTTPException(400, {
+			message: "Both from and to are required to narrow the usage window",
+		});
+	}
 	if (query.from && query.to) {
-		if (
-			Number.isNaN(Date.parse(query.from + "T00:00:00Z")) ||
-			Number.isNaN(Date.parse(query.to + "T00:00:00Z"))
-		) {
-			throw new HTTPException(400, {
-				message: "Invalid from/to date (expected YYYY-MM-DD)",
-			});
-		}
-		usageStartDate = new Date(query.from + "T00:00:00.000Z");
-		usageEndDate = new Date(query.to + "T23:59:59.999Z");
+		usageStartDate = parseUsageWindowDay(query.from, "from");
+		usageEndDate = parseUsageWindowDay(query.to, "to");
+		usageEndDate.setUTCHours(23, 59, 59, 999);
 	}
 
 	const whereClause = buildOrganizationSearchFilter(search);

--- a/ee/admin/src/app/organizations/page.tsx
+++ b/ee/admin/src/app/organizations/page.tsx
@@ -11,6 +11,7 @@ import { redirect } from "next/navigation";
 
 import { BlockOrgButton } from "@/components/block-org-button";
 import { BulkBlockOrgsButton } from "@/components/bulk-block-orgs-button";
+import { DateRangePicker } from "@/components/date-range-picker";
 import { OrgStatusToggleButton } from "@/components/org-status-toggle-button";
 import { PlanTermBadge } from "@/components/plan-term-badge";
 import { Badge } from "@/components/ui/badge";
@@ -29,6 +30,7 @@ import {
 	previewBulkBlockOrganizations,
 	setOrganizationStatus,
 } from "@/lib/admin-organizations";
+import { resolveDateRangeFromSearchParams } from "@/lib/date-range";
 import { getOrgDeletionBlockedReason } from "@/lib/org-deletion";
 import { requireSession } from "@/lib/require-session";
 import { createServerApiClient } from "@/lib/server-api";
@@ -45,8 +47,49 @@ type SortBy =
 	| "createdAt"
 	| "status"
 	| "totalCreditsAllTime"
-	| "totalSpent";
+	| "totalSpent"
+	| "totalRequests"
+	| "totalTokens";
 type SortOrder = "asc" | "desc";
+
+// The date-range picker writes `range` (relative preset) or `from`/`to`
+// (custom span) into the URL, so every link on this page has to carry them
+// along or navigating would silently reset the window to all time.
+interface DateRangeParams {
+	range?: string;
+	from?: string;
+	to?: string;
+}
+
+function buildOrganizationsHref({
+	page,
+	sortBy,
+	sortOrder,
+	search,
+	dateRange,
+}: {
+	page: number;
+	sortBy: SortBy;
+	sortOrder: SortOrder;
+	search: string;
+	dateRange: DateRangeParams;
+}) {
+	const params = new URLSearchParams();
+	params.set("page", String(page));
+	params.set("sortBy", sortBy);
+	params.set("sortOrder", sortOrder);
+	if (search) {
+		params.set("search", search);
+	}
+	if (dateRange.range) {
+		params.set("range", dateRange.range);
+	}
+	if (dateRange.from && dateRange.to) {
+		params.set("from", dateRange.from);
+		params.set("to", dateRange.to);
+	}
+	return `/organizations?${params.toString()}`;
+}
 
 function SortableHeader({
 	label,
@@ -54,18 +97,25 @@ function SortableHeader({
 	currentSortBy,
 	currentSortOrder,
 	search,
+	dateRange,
 }: {
 	label: string;
 	sortKey: SortBy;
 	currentSortBy: SortBy;
 	currentSortOrder: SortOrder;
 	search: string;
+	dateRange: DateRangeParams;
 }) {
 	const isActive = currentSortBy === sortKey;
 	const nextOrder = isActive && currentSortOrder === "asc" ? "desc" : "asc";
 
-	const searchParam = search ? `&search=${encodeURIComponent(search)}` : "";
-	const href = `/organizations?page=1&sortBy=${sortKey}&sortOrder=${nextOrder}${searchParam}`;
+	const href = buildOrganizationsHref({
+		page: 1,
+		sortBy: sortKey,
+		sortOrder: nextOrder,
+		search,
+		dateRange,
+	});
 
 	return (
 		<Link
@@ -95,12 +145,25 @@ const currencyFormatter = new Intl.NumberFormat("en-US", {
 	maximumFractionDigits: 2,
 });
 
+const numberFormatter = new Intl.NumberFormat("en-US");
+
+const compactNumberFormatter = new Intl.NumberFormat("en-US", {
+	notation: "compact",
+	maximumFractionDigits: 1,
+});
+
 function formatDate(dateString: string) {
 	return new Date(dateString).toLocaleDateString("en-US", {
 		year: "numeric",
 		month: "short",
 		day: "numeric",
 	});
+}
+
+// The resolved range is a bare YYYY-MM-DD day, which `new Date()` reads as UTC
+// midnight and would render as the previous day in western timezones.
+function formatDay(day: string) {
+	return formatDate(day + "T00:00:00");
 }
 
 function getPlanBadgeVariant(plan: string) {
@@ -155,6 +218,9 @@ export default async function OrganizationsPage({
 		search?: string;
 		sortBy?: string;
 		sortOrder?: string;
+		range?: string;
+		from?: string;
+		to?: string;
 	}>;
 }) {
 	await requireSession();
@@ -167,9 +233,20 @@ export default async function OrganizationsPage({
 	const limit = 25;
 	const offset = (page - 1) * limit;
 
+	// `from`/`to` stay undefined for "All time", which lets the API aggregate
+	// over the full history instead of a concrete span.
+	const { from, to } = resolveDateRangeFromSearchParams(params ?? {});
+	const dateRange: DateRangeParams = {
+		range: params?.range,
+		from: params?.from,
+		to: params?.to,
+	};
+	const usageWindowLabel =
+		from && to ? `${formatDay(from)} – ${formatDay(to)}` : "all time";
+
 	const $api = await createServerApiClient();
 	const { data } = await $api.GET("/admin/organizations", {
-		params: { query: { limit, offset, search, sortBy, sortOrder } },
+		params: { query: { limit, offset, search, sortBy, sortOrder, from, to } },
 	});
 
 	if (!data) {
@@ -181,13 +258,21 @@ export default async function OrganizationsPage({
 	async function handleSearch(formData: FormData) {
 		"use server";
 		const searchValue = formData.get("search") as string;
-		const sortByValue = formData.get("sortBy") as string;
-		const sortOrderValue = formData.get("sortOrder") as string;
-		const searchParam = searchValue
-			? `&search=${encodeURIComponent(searchValue)}`
-			: "";
-		const sortParam = `&sortBy=${sortByValue}&sortOrder=${sortOrderValue}`;
-		redirect(`/organizations?page=1${searchParam}${sortParam}`);
+		const sortByValue = formData.get("sortBy") as SortBy;
+		const sortOrderValue = formData.get("sortOrder") as SortOrder;
+		redirect(
+			buildOrganizationsHref({
+				page: 1,
+				sortBy: sortByValue,
+				sortOrder: sortOrderValue,
+				search: searchValue,
+				dateRange: {
+					range: (formData.get("range") as string) || undefined,
+					from: (formData.get("from") as string) || undefined,
+					to: (formData.get("to") as string) || undefined,
+				},
+			}),
+		);
 	}
 
 	async function handleToggleOrgStatus(
@@ -228,27 +313,36 @@ export default async function OrganizationsPage({
 						{data.total} organizations found • Total credits:{" "}
 						{currencyFormatter.format(parseFloat(data.totalCredits))}
 					</p>
+					<p className="mt-1 text-xs text-muted-foreground">
+						Spend, requests, and tokens cover {usageWindowLabel}.
+					</p>
 				</div>
-				<form
-					action={handleSearch}
-					className="flex w-full items-center gap-2 sm:w-auto"
-				>
-					<input type="hidden" name="sortBy" value={sortBy} />
-					<input type="hidden" name="sortOrder" value={sortOrder} />
-					<div className="relative flex-1 sm:flex-initial">
-						<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-						<input
-							type="text"
-							name="search"
-							placeholder="Search by name, email, member email, or ID..."
-							defaultValue={search}
-							className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring sm:w-64"
-						/>
-					</div>
-					<Button type="submit" size="sm">
-						Search
-					</Button>
-				</form>
+				<div className="flex w-full flex-col items-stretch gap-2 sm:w-auto sm:flex-row sm:items-center">
+					<DateRangePicker />
+					<form
+						action={handleSearch}
+						className="flex w-full items-center gap-2 sm:w-auto"
+					>
+						<input type="hidden" name="sortBy" value={sortBy} />
+						<input type="hidden" name="sortOrder" value={sortOrder} />
+						<input type="hidden" name="range" value={dateRange.range ?? ""} />
+						<input type="hidden" name="from" value={dateRange.from ?? ""} />
+						<input type="hidden" name="to" value={dateRange.to ?? ""} />
+						<div className="relative flex-1 sm:flex-initial">
+							<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+							<input
+								type="text"
+								name="search"
+								placeholder="Search by name, email, member email, or ID..."
+								defaultValue={search}
+								className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring sm:w-64"
+							/>
+						</div>
+						<Button type="submit" size="sm">
+							Search
+						</Button>
+					</form>
+				</div>
 			</header>
 
 			{search.trim().length >= MIN_BULK_BLOCK_SEARCH_LENGTH && (
@@ -277,6 +371,7 @@ export default async function OrganizationsPage({
 									currentSortBy={sortBy}
 									currentSortOrder={sortOrder}
 									search={search}
+									dateRange={dateRange}
 								/>
 							</TableHead>
 							<TableHead>
@@ -286,6 +381,7 @@ export default async function OrganizationsPage({
 									currentSortBy={sortBy}
 									currentSortOrder={sortOrder}
 									search={search}
+									dateRange={dateRange}
 								/>
 							</TableHead>
 							<TableHead>Kind</TableHead>
@@ -296,6 +392,7 @@ export default async function OrganizationsPage({
 									currentSortBy={sortBy}
 									currentSortOrder={sortOrder}
 									search={search}
+									dateRange={dateRange}
 								/>
 							</TableHead>
 							<TableHead>
@@ -305,6 +402,7 @@ export default async function OrganizationsPage({
 									currentSortBy={sortBy}
 									currentSortOrder={sortOrder}
 									search={search}
+									dateRange={dateRange}
 								/>
 							</TableHead>
 							<TableHead>
@@ -314,6 +412,7 @@ export default async function OrganizationsPage({
 									currentSortBy={sortBy}
 									currentSortOrder={sortOrder}
 									search={search}
+									dateRange={dateRange}
 								/>
 							</TableHead>
 							<TableHead>
@@ -323,6 +422,7 @@ export default async function OrganizationsPage({
 									currentSortBy={sortBy}
 									currentSortOrder={sortOrder}
 									search={search}
+									dateRange={dateRange}
 								/>
 							</TableHead>
 							<TableHead>
@@ -332,6 +432,27 @@ export default async function OrganizationsPage({
 									currentSortBy={sortBy}
 									currentSortOrder={sortOrder}
 									search={search}
+									dateRange={dateRange}
+								/>
+							</TableHead>
+							<TableHead>
+								<SortableHeader
+									label="Requests"
+									sortKey="totalRequests"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									search={search}
+									dateRange={dateRange}
+								/>
+							</TableHead>
+							<TableHead>
+								<SortableHeader
+									label="Tokens"
+									sortKey="totalTokens"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									search={search}
+									dateRange={dateRange}
 								/>
 							</TableHead>
 							<TableHead>
@@ -341,6 +462,7 @@ export default async function OrganizationsPage({
 									currentSortBy={sortBy}
 									currentSortOrder={sortOrder}
 									search={search}
+									dateRange={dateRange}
 								/>
 							</TableHead>
 							<TableHead>
@@ -350,6 +472,7 @@ export default async function OrganizationsPage({
 									currentSortBy={sortBy}
 									currentSortOrder={sortOrder}
 									search={search}
+									dateRange={dateRange}
 								/>
 							</TableHead>
 							<TableHead>Actions</TableHead>
@@ -359,7 +482,7 @@ export default async function OrganizationsPage({
 						{data.organizations.length === 0 ? (
 							<TableRow>
 								<TableCell
-									colSpan={11}
+									colSpan={13}
 									className="h-24 text-center text-muted-foreground"
 								>
 									No organizations found
@@ -435,6 +558,15 @@ export default async function OrganizationsPage({
 											</p>
 										)}
 									</TableCell>
+									<TableCell className="tabular-nums text-muted-foreground">
+										{numberFormatter.format(org.totalRequests ?? 0)}
+									</TableCell>
+									<TableCell
+										className="tabular-nums text-muted-foreground"
+										title={numberFormatter.format(org.totalTokens ?? 0)}
+									>
+										{compactNumberFormatter.format(org.totalTokens ?? 0)}
+									</TableCell>
 									<TableCell className="text-muted-foreground">
 										{formatDate(org.createdAt)}
 									</TableCell>
@@ -488,7 +620,13 @@ export default async function OrganizationsPage({
 					<div className="flex items-center gap-2">
 						<Button variant="outline" size="sm" asChild disabled={page <= 1}>
 							<Link
-								href={`/organizations?page=${page - 1}${search ? `&search=${encodeURIComponent(search)}` : ""}&sortBy=${sortBy}&sortOrder=${sortOrder}`}
+								href={buildOrganizationsHref({
+									page: page - 1,
+									sortBy,
+									sortOrder,
+									search,
+									dateRange,
+								})}
 								className={page <= 1 ? "pointer-events-none opacity-50" : ""}
 							>
 								<ChevronLeft className="h-4 w-4" />
@@ -505,7 +643,13 @@ export default async function OrganizationsPage({
 							disabled={page >= totalPages}
 						>
 							<Link
-								href={`/organizations?page=${page + 1}${search ? `&search=${encodeURIComponent(search)}` : ""}&sortBy=${sortBy}&sortOrder=${sortOrder}`}
+								href={buildOrganizationsHref({
+									page: page + 1,
+									sortBy,
+									sortOrder,
+									search,
+									dateRange,
+								})}
 								className={
 									page >= totalPages ? "pointer-events-none opacity-50" : ""
 								}


### PR DESCRIPTION
## Summary

The admin organizations list could only be sorted by spend, and every usage figure was an all-time aggregate. There was no way to ask "who sent the most requests last quarter" — the highest-volume organizations by request count or token count were invisible, and spend could not be scoped to a time window.

This adds **Requests** and **Tokens** as sortable columns next to Total Spent, and puts the existing admin date-range picker on the page so all three can be scoped to a window. The default stays all time.

## Changes

**API — `GET /admin/organizations`**

- The per-org usage subquery over `project_hourly_stats` now also sums `requestCount` and `totalTokens`, returned as `totalRequests` / `totalTokens`.
- `sortBy` accepts `totalRequests` and `totalTokens`, sorting on those same aggregates.
- New optional `from`/`to` (`YYYY-MM-DD`) filter the subquery on `hourTimestamp`. Omitting both keeps all-time behavior.
- The window is applied to the **usage subquery only**, not the outer query. Organizations with no traffic in the window still appear with zeros instead of dropping out of the list, and the `total` / `totalCredits` header figures stay stable as the window changes.

**Admin UI — `ee/admin/src/app/organizations/page.tsx`**

- Reuses the existing `DateRangePicker` — the same component already on the dashboard, DevPass, and Chat Plans pages — rather than introducing a second date control.
- Tokens render compact (`721M`) with the exact count in the `title` attribute; requests render in full.
- A caption under the heading names the active window, so a filtered table is never mistaken for all-time data.
- `buildOrganizationsHref` centralizes URL construction. Without it, the sort headers, pagination, and search form each rebuilt the query string by hand and would have silently dropped the window on click.

## Screenshots

Captured locally against seeded data.

**Before → after** (light)

<img width="900" alt="Organizations list before: no date picker, no Requests or Tokens columns" src="https://raw.githubusercontent.com/theopenco/llmgateway/88bd95e4574829fa62363125d2ccbf62c2b6bb0a/before-light.png" />

<img width="900" alt="Organizations list after: date picker in the header, Requests and Tokens columns, sorted by Requests" src="https://raw.githubusercontent.com/theopenco/llmgateway/88bd95e4574829fa62363125d2ccbf62c2b6bb0a/after-light.png" />

<details>
<summary>Dark theme, picker open, and a windowed view</summary>

Before (dark):

<img width="900" alt="Organizations list before, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/88bd95e4574829fa62363125d2ccbf62c2b6bb0a/before-dark.png" />

After (dark):

<img width="900" alt="Organizations list after, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/88bd95e4574829fa62363125d2ccbf62c2b6bb0a/after-dark.png" />

Picker open, showing the shared presets:

<img width="900" alt="Date range picker open over the organizations list" src="https://raw.githubusercontent.com/theopenco/llmgateway/88bd95e4574829fa62363125d2ccbf62c2b6bb0a/picker-dark.png" />

Scoped to "This week" — the same top organization drops from 394,659 requests / 721M tokens / $10,003.25 all-time to 37,879 / 70.4M / $974.09, and the ranking reshuffles:

<img width="900" alt="Organizations list scoped to this week, showing reduced totals and a reshuffled ranking" src="https://raw.githubusercontent.com/theopenco/llmgateway/88bd95e4574829fa62363125d2ccbf62c2b6bb0a/window-thisweek.png" />

</details>

## Verification

- New spec `admin-orgs-usage-window.spec.ts` — 9 tests, all passing. Covers all-time totals, window scoping (an organization whose only traffic is 200 days old reports zeros in a 90-day window but stays listed), sorting by requests and by tokens including the ranking flip once a window is applied, and rejection of malformed, impossible, and half-open windows.
- Re-ran `admin-metrics-mode-split.spec.ts` and `admin-bulk-block.spec.ts`, which exercise this endpoint — both green.
- `pnpm format` clean; `turbo run build --filter=api --filter=admin` passes.
- Drove the page locally end-to-end in light and dark to confirm the window reaches the query and the sorting applies within it.

## Notes for reviewers

- Date boundaries are validated as exact calendar days. `Date.parse` rolls impossible days over rather than rejecting them (`2026-02-30` becomes March 2), so each boundary is round-tripped and refused if it did not survive unchanged. Supplying only one of `from`/`to` returns 400 rather than silently falling back to all-time.
- `totalCreditsAllTime` is deliberately **not** windowed — the column is labelled "All Time Credits" and is transaction-derived rather than usage-derived.
- Unrelated and pre-existing: `pnpm build` fails at `ui#build` in a sandbox, where prerendering OpenGraph images fetches `localhost:4002` with no API running. Confirmed identical on a clean tree; `apps/ui` is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rZMQwmexcn7dkfeo3tDg6