### PR TITLE
feat(models): add ByteDance Seed 2.1 Turbo

### DIFF
--- a/packages/models/src/models/bytedance.ts
+++ b/packages/models/src/models/bytedance.ts
@@ -106,6 +106,41 @@ export const bytedanceModels = [
 		],
 	},
 	{
+		id: "seed-2-1-turbo",
+		name: "Seed 2.1 Turbo",
+		description:
+			"ByteDance Seed 2.1 Turbo multimodal model built for coding and long-horizon agent workflows with a 256K context window",
+		family: "bytedance",
+		releasedAt: new Date("2026-08-10"),
+		providers: [
+			{
+				providerId: "nanogpt",
+				externalId: "bytedance-seed/seed-2-1-turbo",
+				inputPrice: "0.5e-6",
+				outputPrice: "2.5e-6",
+				requestPrice: "0",
+				contextSize: 262144,
+				maxOutput: 262144,
+				streaming: true,
+				reasoning: true,
+				reasoningEfforts: [
+					"none",
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max",
+				],
+				// The upstream NanoGPT routes for this model reject image parts even
+				// though Seed 2.1 Turbo itself is multimodal.
+				vision: false,
+				tools: true,
+				jsonOutput: true,
+			},
+		],
+	},
+	{
 		id: "seedream-4-0",
 		name: "Seedream 4.0",
 		description:


### PR DESCRIPTION
Adds ByteDance **Seed 2.1 Turbo**, a multimodal model aimed at coding and long-horizon agent workflows, to the catalogue.

## Mapping

Served through NanoGPT (`bytedance-seed/seed-2-1-turbo`):

- 262K context, 262K max output
- $0.50/M input, $2.50/M output — confirmed against the upstream per-request cost accounting, not just the published rate card
- streaming, tools, `tool_choice: required`, and `response_format: json_schema` all verified live
- reasoning with the full effort ladder (`none` … `max`); every tier was probed and accepted, and `none` genuinely disables thinking
- `vision: false` — the model itself is multimodal, but the upstream routes behind this mapping reject image parts, so the flag matches what the deployment actually serves

## Deliberate omission

The first-party ModelArk deployment (`dola-seed-2-1-turbo-260628`) is listed on the ByteDance provider but returns `ModelNotOpen` for our account: the model needs to be activated in the Ark console before it can serve traffic. Other `dola-*` models on the same account do work, so this is a per-model activation, not a key problem. The mapping is intentionally left out until activation happens — adding it now would route requests to a deployment that hard-fails.

## Verification

- `TEST_MODELS="nanogpt/seed-2-1-turbo" FULL_MODE=true pnpm test:e2e` — all gateway e2e tests pass for the new mapping
- `pnpm build`, `pnpm format`, and the `@llmgateway/models` catalogue specs all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)