### PR TITLE
feat(admin): all-time range on global stats

### DIFF
--- a/ee/admin/src/app/global-stats/client.tsx
+++ b/ee/admin/src/app/global-stats/client.tsx
@@ -259,22 +259,13 @@ export function GlobalStatsClient() {
 	const pathname = usePathname();
 	const searchParams = useSearchParams();
 
-	const { from, to } = resolveGlobalStatsRange(searchParams);
+	const { allTime, from, to } = resolveGlobalStatsRange(searchParams);
 	const usageMode = useUsageMode();
 	const orgKind = useOrgKind();
 	const groupBy = parseGroupBy(searchParams.get("groupBy"));
 	const chartMetric = parseMetric(searchParams.get("metric"));
 	const modelView = parseModelView(searchParams.get("modelView"));
 	const showTimeseriesBreakdown = parseBreakdown(searchParams.get("breakdown"));
-
-	const rangeLabel = useMemo(() => {
-		const fromDate = parseISO(from);
-		const toDate = parseISO(to);
-		if (Number.isNaN(fromDate.getTime()) || Number.isNaN(toDate.getTime())) {
-			return "selected range";
-		}
-		return `${format(fromDate, "MMM d, yyyy")} – ${format(toDate, "MMM d, yyyy")}`;
-	}, [from, to]);
 
 	const updateParam = useCallback(
 		(key: string, value: string) => {
@@ -290,7 +281,7 @@ export function GlobalStatsClient() {
 	// The range picker and the mode/kind selectors write to the URL directly, so
 	// reset pagination during render when any of them changes (each also
 	// re-sorts the breakdown).
-	const viewKey = `${from}|${to}|${usageMode}|${orgKind}`;
+	const viewKey = `${allTime ? "all" : `${from}|${to}`}|${usageMode}|${orgKind}`;
 	const [lastViewKey, setLastViewKey] = useState(viewKey);
 	if (viewKey !== lastViewKey) {
 		setLastViewKey(viewKey);
@@ -326,15 +317,37 @@ export function GlobalStatsClient() {
 	// mode/kind are applied server-side (both are part of the aggregation key),
 	// so every metric below is already narrowed to the selected slice and the
 	// filters take part in the query key.
+	// All time carries no bounds: the API derives the span from the first and
+	// last recorded day, so it is requested as `range=all` instead of from/to.
 	const { data, isLoading, isError } = $api.useQuery(
 		"get",
 		"/admin/global-stats",
 		{
 			params: {
-				query: { from, to, groupBy, modelView, mode: usageMode, kind: orgKind },
+				query: {
+					...(allTime ? { range: "all" as const } : { from, to }),
+					groupBy,
+					modelView,
+					mode: usageMode,
+					kind: orgKind,
+				},
 			},
 		},
 	);
+
+	const rangeLabel = useMemo(() => {
+		const start = from ?? data?.start;
+		const end = to ?? data?.end;
+		if (!start || !end) {
+			return "all time";
+		}
+		const startDate = parseISO(start);
+		const endDate = parseISO(end);
+		if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) {
+			return allTime ? "all time" : "selected range";
+		}
+		return `${format(startDate, "MMM d, yyyy")} – ${format(endDate, "MMM d, yyyy")}`;
+	}, [allTime, from, to, data?.start, data?.end]);
 
 	const totals = data?.totals;
 	const timeseries = useMemo(() => data?.timeseries ?? [], [data?.timeseries]);

--- a/ee/admin/src/components/global-stats-range-picker.tsx
+++ b/ee/admin/src/components/global-stats-range-picker.tsx
@@ -33,6 +33,10 @@ interface DatePreset {
 
 export const DEFAULT_GLOBAL_STATS_PRESET = "last_7_days";
 
+// All time has no client-side date range: the API derives the span from the
+// first/last recorded day, so it travels as `range=all` instead of from/to.
+export const ALL_TIME_PRESET = "all_time";
+
 function buildPresets(today: Date): DatePreset[] {
 	return [
 		{
@@ -89,14 +93,20 @@ function buildPresets(today: Date): DatePreset[] {
 	];
 }
 
-export function resolveGlobalStatsRange(searchParams: URLSearchParams): {
-	from: string;
-	to: string;
-} {
+export type ResolvedGlobalStatsRange =
+	| { allTime: true; from: undefined; to: undefined }
+	| { allTime: false; from: string; to: string };
+
+export function resolveGlobalStatsRange(
+	searchParams: URLSearchParams,
+): ResolvedGlobalStatsRange {
+	if (searchParams.get("range") === "all") {
+		return { allTime: true, from: undefined, to: undefined };
+	}
 	const fromParam = searchParams.get("from");
 	const toParam = searchParams.get("to");
 	if (fromParam && toParam) {
-		return { from: fromParam, to: toParam };
+		return { allTime: false, from: fromParam, to: toParam };
 	}
 	const today = new Date();
 	const presets = buildPresets(today);
@@ -104,6 +114,7 @@ export function resolveGlobalStatsRange(searchParams: URLSearchParams): {
 		presets.find((p) => p.value === DEFAULT_GLOBAL_STATS_PRESET) ?? presets[0];
 	const range = preset.getRange();
 	return {
+		allTime: false,
 		from: format(range.from, "yyyy-MM-dd"),
 		to: format(range.to, "yyyy-MM-dd"),
 	};
@@ -120,11 +131,30 @@ export function GlobalStatsRangePicker() {
 	const today = useMemo(() => new Date(), []);
 	const presets = useMemo(() => buildPresets(today), [today]);
 
-	const { from, to } = resolveGlobalStatsRange(searchParams);
-	const fromDate = useMemo(() => new Date(`${from}T00:00:00`), [from]);
-	const toDate = useMemo(() => new Date(`${to}T00:00:00`), [to]);
+	const { allTime, from, to } = resolveGlobalStatsRange(searchParams);
+	// All time has no explicit bounds, so the calendar still opens on the
+	// default preset's window rather than an empty selection.
+	const fallbackRange = useMemo(
+		() =>
+			(
+				presets.find((p) => p.value === DEFAULT_GLOBAL_STATS_PRESET) ??
+				presets[0]
+			).getRange(),
+		[presets],
+	);
+	const fromDate = useMemo(
+		() => (from ? new Date(`${from}T00:00:00`) : fallbackRange.from),
+		[from, fallbackRange],
+	);
+	const toDate = useMemo(
+		() => (to ? new Date(`${to}T00:00:00`) : fallbackRange.to),
+		[to, fallbackRange],
+	);
 
 	const activePreset = useMemo(() => {
+		if (allTime) {
+			return ALL_TIME_PRESET;
+		}
 		for (const preset of presets) {
 			const r = preset.getRange();
 			if (
@@ -135,7 +165,7 @@ export function GlobalStatsRangePicker() {
 			}
 		}
 		return "custom";
-	}, [presets, from, to]);
+	}, [allTime, presets, from, to]);
 
 	const updateRange = (newFrom: Date, newTo: Date) => {
 		const params = new URLSearchParams(searchParams.toString());
@@ -148,6 +178,15 @@ export function GlobalStatsRangePicker() {
 	const handlePresetSelect = (preset: DatePreset) => {
 		const r = preset.getRange();
 		updateRange(r.from, r.to);
+		setOpen(false);
+	};
+
+	const handleAllTimeSelect = () => {
+		const params = new URLSearchParams(searchParams.toString());
+		params.delete("from");
+		params.delete("to");
+		params.set("range", "all");
+		router.replace(`${pathname}?${params.toString()}`, { scroll: false });
 		setOpen(false);
 	};
 
@@ -165,12 +204,15 @@ export function GlobalStatsRangePicker() {
 	};
 
 	const triggerLabel = useMemo(() => {
+		if (allTime) {
+			return "All time";
+		}
 		const preset = presets.find((p) => p.value === activePreset);
 		if (preset) {
 			return preset.label;
 		}
 		return `${format(fromDate, "MMM d, yyyy")} – ${format(toDate, "MMM d, yyyy")}`;
-	}, [activePreset, presets, fromDate, toDate]);
+	}, [allTime, activePreset, presets, fromDate, toDate]);
 
 	return (
 		<Popover
@@ -208,6 +250,16 @@ export function GlobalStatsRangePicker() {
 								{preset.label}
 							</button>
 						))}
+						<button
+							type="button"
+							onClick={handleAllTimeSelect}
+							className={cn(
+								"w-full px-3 py-2 text-left text-sm transition-colors hover:bg-accent",
+								activePreset === ALL_TIME_PRESET && "bg-accent/50",
+							)}
+						>
+							All time
+						</button>
 						<div className="my-1 border-t border-border/60" />
 						<button
 							type="button"


### PR DESCRIPTION
The global stats date selector topped out at "Last year", so there was no way to see cross-organization totals over the full recorded history — even though `GET /admin/global-stats` has supported `range=all` all along (it derives the span from the first and last recorded day).

## Approach

- Adds an **All time** preset to `GlobalStatsRangePicker`. It has no client-side date range, so instead of writing `from`/`to` it sets `range=all` and clears the two date params.
- `resolveGlobalStatsRange` now returns an `allTime` flag alongside the bounds, and the page sends `range=all` instead of `from`/`to` when it is set.
- The range label ("All 10 models across …") falls back to the `start`/`end` the API reports for the derived span, so the card shows the real history window rather than a guess.

Bounded windows keep their 731-day cap; only all-time spans the full history, which is existing server-side behaviour.

## Screenshots

Local stack with seeded/synthetic aggregation rows spanning ~14 months.

### Date selector — before / after

| Before | After |
| --- | --- |
| <img width="720" alt="Date selector without All time, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/5eaf027e2be7b27dc49600be86890b34a8820550/before-dropdown-light.png" /> | <img width="720" alt="Date selector with All time, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/5eaf027e2be7b27dc49600be86890b34a8820550/after-dropdown-light.png" /> |
| <img width="720" alt="Date selector without All time, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/5eaf027e2be7b27dc49600be86890b34a8820550/before-dropdown-dark.png" /> | <img width="720" alt="Date selector with All time, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/5eaf027e2be7b27dc49600be86890b34a8820550/after-dropdown-dark.png" /> |

### All time selected

<img width="1440" alt="Global stats with All time selected, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/5eaf027e2be7b27dc49600be86890b34a8820550/after-alltime-light.png" />

<img width="1440" alt="Global stats with All time selected, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/5eaf027e2be7b27dc49600be86890b34a8820550/after-alltime-dark.png" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)