### PR TITLE
feat(devpass): show full billing history

### DIFF
--- a/apps/api/src/routes/dev-plans.spec.ts
+++ b/apps/api/src/routes/dev-plans.spec.ts
@@ -1219,3 +1219,122 @@ describe("dev plan status billing history", () => {
 		expect(await getStatus()).toMatchObject({ hasBillingHistory: true });
 	});
 });
+
+describe("dev plan billing history list", () => {
+	let token: string;
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		token = await createTestUser();
+
+		await db.insert(tables.organization).values({
+			id: ORG_ID,
+			name: "Personal Org",
+			billingEmail: "admin@example.com",
+			kind: "devpass",
+			devPlan: "none",
+		});
+		await db.insert(tables.userOrganization).values({
+			userId: "test-user-id",
+			organizationId: ORG_ID,
+			role: "owner",
+		});
+	});
+
+	afterEach(async () => {
+		await db.delete(tables.transaction);
+		await deleteAll();
+	});
+
+	async function getInvoices() {
+		const res = await app.request("/dev-plans/invoices", {
+			headers: { Cookie: token },
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			invoices: {
+				id: string;
+				type: string;
+				amount: string | null;
+				creditAmount: string | null;
+			}[];
+		};
+		return body.invoices;
+	}
+
+	it("lists refunds and plan lifecycle rows alongside the charges", async () => {
+		await db.insert(tables.transaction).values([
+			{
+				id: "tx-start",
+				organizationId: ORG_ID,
+				type: "dev_plan_start",
+				amount: "29",
+				creditAmount: "87",
+				status: "completed",
+				createdAt: new Date("2026-07-15T00:00:00Z"),
+			},
+			{
+				id: "tx-cancel",
+				organizationId: ORG_ID,
+				type: "dev_plan_cancel",
+				status: "completed",
+				createdAt: new Date("2026-07-31T00:00:00Z"),
+			},
+			{
+				id: "tx-refund",
+				organizationId: ORG_ID,
+				type: "credit_refund",
+				amount: "29",
+				creditAmount: "0",
+				status: "completed",
+				relatedTransactionId: "tx-start",
+				createdAt: new Date("2026-08-12T00:00:00Z"),
+			},
+			{
+				id: "tx-end",
+				organizationId: ORG_ID,
+				type: "dev_plan_end",
+				status: "completed",
+				createdAt: new Date("2026-08-12T00:01:00Z"),
+			},
+		]);
+
+		const invoices = await getInvoices();
+
+		expect(invoices.map((i) => i.id)).toEqual([
+			"tx-end",
+			"tx-refund",
+			"tx-cancel",
+			"tx-start",
+		]);
+		expect(invoices[1]).toMatchObject({
+			type: "credit_refund",
+			amount: "29",
+		});
+	});
+
+	it("still hides negative top-up reversal rows", async () => {
+		await db.insert(tables.transaction).values([
+			{
+				id: "tx-topup",
+				organizationId: ORG_ID,
+				type: "credit_topup",
+				amount: "26.25",
+				creditAmount: "25",
+				status: "completed",
+				createdAt: new Date("2026-08-02T00:00:00Z"),
+			},
+			{
+				id: "tx-topup-reversal",
+				organizationId: ORG_ID,
+				type: "credit_topup",
+				amount: "-26.25",
+				creditAmount: "-25",
+				status: "completed",
+				createdAt: new Date("2026-08-03T00:00:00Z"),
+			},
+		]);
+
+		expect((await getInvoices()).map((i) => i.id)).toEqual(["tx-topup"]);
+	});
+});

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -78,13 +78,38 @@ export const devPlans = new OpenAPIHono<ServerTypes>();
 // lease this old cannot still have an upgrade charge in flight.
 const STALE_TIER_CHANGE_CLAIM_MS = 15 * 60 * 1000;
 
-// Transaction types that surface as invoices on the DevPass billing page.
+// Plan charges that prove the org was (or still is) a paying DevPass
+// subscriber, used to keep the billing page reachable after a plan ends.
 const DEV_PLAN_INVOICE_TYPES = [
 	"dev_plan_start",
 	"dev_plan_renewal",
 	"dev_plan_upgrade",
 	"dev_plan_reset_pass",
 ] as const;
+
+// Transaction types that surface in the DevPass billing history: everything a
+// devpass personal org can carry — the plan lifecycle, Reset Passes, PAYG
+// overflow top-ups and the refunds/credit grants booked against them. The
+// remaining types (Pro subscriptions, chat plans, end-user wallets) never
+// occur on a devpass org.
+const DEV_PLAN_HISTORY_TYPES = [
+	"dev_plan_start",
+	"dev_plan_renewal",
+	"dev_plan_upgrade",
+	"dev_plan_downgrade",
+	"dev_plan_cancel",
+	"dev_plan_resume",
+	"dev_plan_end",
+	"dev_plan_reset_pass",
+	"dev_plan_reset_pass_reward",
+	"dev_plan_reset_pass_gift",
+	"credit_topup",
+	"credit_refund",
+	"credit_gift",
+	"credit_manual_payment",
+] as const;
+
+type DevPlanHistoryType = (typeof DEV_PLAN_HISTORY_TYPES)[number];
 
 // A failed release is swallowed: the lease then simply expires via the
 // staleness window instead of blocking upgrades until renewal.
@@ -2387,8 +2412,9 @@ devPlans.openapi(updateBillingDetails, async (c) => {
 	});
 });
 
-// List past DevPass invoices (plan start, renewals and upgrades) with the
-// amount charged and the virtual credits granted for each billing event.
+// List the full DevPass billing history — charges (plan start, renewals,
+// upgrades, Reset Passes, PAYG top-ups), refunds and the plan lifecycle events
+// in between — with the amount charged and the virtual credits granted.
 const getInvoices = createRoute({
 	method: "get",
 	path: "/invoices",
@@ -2401,14 +2427,7 @@ const getInvoices = createRoute({
 						invoices: z.array(
 							z.object({
 								id: z.string(),
-								type: z.enum([
-									"dev_plan_start",
-									"dev_plan_renewal",
-									"dev_plan_upgrade",
-									"dev_plan_reset_pass",
-									// PAYG overflow credits purchases (manual and auto-reload).
-									"credit_topup",
-								]),
+								type: z.enum(DEV_PLAN_HISTORY_TYPES),
 								date: z.string(),
 								amount: z.string().nullable(),
 								creditAmount: z.string().nullable(),
@@ -2477,22 +2496,17 @@ devPlans.openapi(getInvoices, async (c) => {
 	const invoices = transactions
 		.filter(
 			(t) =>
-				(DEV_PLAN_INVOICE_TYPES as readonly string[]).includes(t.type) ||
-				// PAYG overflow top-ups (manual + auto-reload) are DevPass charges
-				// too. Positive amounts only: reversal rows are bookkeeping, not a
-				// billing event the user should see.
-				(t.type === "credit_topup" &&
-					t.amount !== null &&
-					parseFloat(t.amount) > 0),
+				(DEV_PLAN_HISTORY_TYPES as readonly string[]).includes(t.type) &&
+				// Negative `credit_topup` rows are reversal bookkeeping for a refund
+				// that already has its own row; showing both double-counts the money.
+				!(
+					t.type === "credit_topup" &&
+					(t.amount === null || parseFloat(t.amount) <= 0)
+				),
 		)
 		.map((t) => ({
 			id: t.id,
-			type: t.type as
-				| "dev_plan_start"
-				| "dev_plan_renewal"
-				| "dev_plan_upgrade"
-				| "dev_plan_reset_pass"
-				| "credit_topup",
+			type: t.type as DevPlanHistoryType,
 			date: t.createdAt.toISOString(),
 			amount: t.amount,
 			creditAmount: t.creditAmount,

--- a/apps/code/src/app/dashboard/components/DevPassInvoices.tsx
+++ b/apps/code/src/app/dashboard/components/DevPassInvoices.tsx
@@ -40,14 +40,22 @@ const PAGE_SIZE = 10;
 type Invoice =
 	paths["/dev-plans/invoices"]["get"]["responses"]["200"]["content"]["application/json"]["invoices"][number];
 
-// A DevPass invoice is downloadable when it is a completed, positive charge
-// (mirrors isInvoiceableTransaction on the API).
+// A DevPass billing event has a downloadable document when it is completed with
+// a positive amount (mirrors isInvoiceableTransaction on the API): a charge
+// yields an invoice, a refund a credit note. Lifecycle rows (cancel, end,
+// resume) carry no amount and have nothing to document.
 function isInvoiceable(invoice: Invoice): boolean {
 	return (
 		invoice.status === "completed" &&
 		invoice.amount !== null &&
 		Number(invoice.amount) > 0
 	);
+}
+
+// Refunds store the returned amount as a positive `amount` (see stripe.ts);
+// they render as a negative line in the history and as a credit note PDF.
+function isRefund(type: Invoice["type"]): boolean {
+	return type === "credit_refund";
 }
 
 // Invisible stand-in that reserves the exact footprint of an action button so
@@ -71,6 +79,9 @@ function InvoiceDownloadButton({ invoice }: { invoice: Invoice }) {
 	const fetchClient = useFetchClient();
 	const [loading, setLoading] = useState(false);
 
+	const refund = isRefund(invoice.type);
+	const label = refund ? "Credit note" : "Invoice";
+
 	async function handleDownload() {
 		setLoading(true);
 		try {
@@ -83,19 +94,21 @@ function InvoiceDownloadButton({ invoice }: { invoice: Invoice }) {
 			);
 
 			if (!response.ok || !data) {
-				throw new Error("Failed to download invoice");
+				throw new Error("Failed to download document");
 			}
 
 			const url = URL.createObjectURL(data as unknown as Blob);
 			const link = document.createElement("a");
 			link.href = url;
-			link.download = `invoice-${invoice.id}.pdf`;
+			link.download = `${refund ? "credit-note" : "invoice"}-${invoice.id}.pdf`;
 			document.body.appendChild(link);
 			link.click();
 			link.remove();
 			URL.revokeObjectURL(url);
 		} catch {
-			toast.error("Could not download invoice. Please try again later.");
+			toast.error(
+				`Could not download ${label.toLowerCase()}. Please try again later.`,
+			);
 		} finally {
 			setLoading(false);
 		}
@@ -113,7 +126,7 @@ function InvoiceDownloadButton({ invoice }: { invoice: Invoice }) {
 			) : (
 				<Download className="h-4 w-4" />
 			)}
-			<span className="sr-only sm:not-sr-only">Invoice</span>
+			<span className="sr-only sm:not-sr-only">{label}</span>
 		</Button>
 	);
 }
@@ -283,8 +296,17 @@ const TYPE_LABELS: Record<Invoice["type"], string> = {
 	dev_plan_start: "Plan started",
 	dev_plan_renewal: "Renewal",
 	dev_plan_upgrade: "Upgrade",
+	dev_plan_downgrade: "Downgrade",
+	dev_plan_cancel: "Plan cancelled",
+	dev_plan_resume: "Plan resumed",
+	dev_plan_end: "Plan ended",
 	dev_plan_reset_pass: "Reset Pass",
+	dev_plan_reset_pass_reward: "Reset Pass reward",
+	dev_plan_reset_pass_gift: "Reset Pass gift",
 	credit_topup: "Credits top-up",
+	credit_refund: "Refund",
+	credit_gift: "Credits gift",
+	credit_manual_payment: "Credits added",
 };
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {
@@ -306,6 +328,15 @@ function formatAmount(amount: string | null, currency: string): string {
 	return `${value.toFixed(2)} ${currency}`;
 }
 
+// Refunds move money back to the customer, so the history shows the amount as
+// negative. The stored `amount` stays positive (it feeds the credit note).
+function amountCell(invoice: Invoice): string {
+	const formatted = formatAmount(invoice.amount, invoice.currency);
+	return isRefund(invoice.type) && invoice.amount !== null
+		? `-${formatted}`
+		: formatted;
+}
+
 function formatCredits(creditAmount: string | null): string {
 	if (creditAmount === null) {
 		return "—";
@@ -314,7 +345,8 @@ function formatCredits(creditAmount: string | null): string {
 	if (!Number.isFinite(value)) {
 		return "—";
 	}
-	return `$${value.toFixed(2)}`;
+	const formatted = `$${Math.abs(value).toFixed(2)}`;
+	return value < 0 ? `-${formatted}` : formatted;
 }
 
 export default function DevPassInvoices() {
@@ -333,19 +365,19 @@ export default function DevPassInvoices() {
 
 	return (
 		<div>
-			<h2 className="mb-1 font-semibold">Invoices</h2>
+			<h2 className="mb-1 font-semibold">Billing history</h2>
 			<p className="mb-4 text-sm text-muted-foreground">
-				A record of every DevPass charge, including the amount debited and the
-				usage credits granted for that billing period.
+				A record of every DevPass billing event — charges, refunds and plan
+				changes — with the amount debited and the usage credits granted.
 			</p>
 
 			<div className="overflow-hidden rounded-xl border sm:grid sm:grid-cols-[1fr_1fr_auto_auto_auto]">
 				<div className="hidden grid-cols-subgrid gap-4 border-b bg-muted/40 px-5 py-3 text-xs font-medium text-muted-foreground sm:col-span-5 sm:grid">
 					<div>Date</div>
 					<div>Description</div>
-					<div className="text-right">Amount debited</div>
-					<div className="text-right">Credits granted</div>
-					<div className="text-right">Invoice</div>
+					<div className="text-right">Amount</div>
+					<div className="text-right">Credits</div>
+					<div className="text-right">Document</div>
 				</div>
 
 				{pageInvoices.map((invoice) => (
@@ -373,7 +405,7 @@ export default function DevPassInvoices() {
 							<span className="text-xs text-muted-foreground sm:hidden">
 								Amount{" "}
 							</span>
-							{formatAmount(invoice.amount, invoice.currency)}
+							{amountCell(invoice)}
 						</div>
 						<div className="text-right text-sm tabular-nums text-muted-foreground sm:text-right">
 							<span className="text-xs sm:hidden">Credits </span>


### PR DESCRIPTION
## Problem

The DevPass billing page only listed plan charges, Reset Passes and PAYG
top-ups. A refund recorded against one of those purchases has its own
`credit_refund` transaction, but that type was filtered out of
`GET /dev-plans/invoices` — so the money left the account with no trace on
the page the customer looks at. The same applied to the plan lifecycle rows
(cancel, resume, end) that sit between the charges.

## Change

- The endpoint now returns every transaction type a devpass org can carry:
  the plan lifecycle, Reset Passes (including reward/gift grants), PAYG
  top-ups, refunds and credit grants. Negative `credit_topup` rows stay
  hidden — they are reversal bookkeeping for a refund that already has its
  own row, so showing both would double-count the money.
- The section is now "Billing history" rather than "Invoices", since it is
  no longer only charges. Refunds render as a negative amount and offer the
  credit-note PDF (the download endpoint already generated one; nothing
  linked to it). Lifecycle rows show em dashes and no document.
- `hasBillingHistory` on `/dev-plans/status` keeps using the narrow
  purchase-type set — it answers "was this org ever a paying subscriber",
  which a cancel row or a gift must not satisfy.

## Screenshots

Local seeded data, dashboard billing page.

| | Before | After |
| --- | --- | --- |
| Light | <img width="496" alt="Invoices list, light theme, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/e3741121c57561fb865046a0ced154b68bc1881b/before-light.png" /> | <img width="496" alt="Billing history list showing a refund, light theme, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/e3741121c57561fb865046a0ced154b68bc1881b/after-light.png" /> |
| Dark | <img width="496" alt="Invoices list, dark theme, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/e3741121c57561fb865046a0ced154b68bc1881b/before-dark.png" /> | <img width="496" alt="Billing history list showing a refund, dark theme, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/e3741121c57561fb865046a0ced154b68bc1881b/after-dark.png" /> |

## Verification

- New specs in `apps/api/src/routes/dev-plans.spec.ts` cover the refund and
  lifecycle rows appearing in order, and the reversal row staying hidden.
- `pnpm format`, `pnpm build`, and the `dev-plans` + `dev-plans-payg` unit
  specs pass (47 tests).
- Walked the page locally against a seeded DevPass org carrying a refund.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
