### PR TITLE
feat(admin): show refunds in DevPass history

### DIFF
--- a/apps/api/src/routes/admin-devpass-detail-history.spec.ts
+++ b/apps/api/src/routes/admin-devpass-detail-history.spec.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db, tables } from "@llmgateway/db";
+
+const ORG_ID = "admin-devpass-history-org";
+const originalAdminEmails = process.env.ADMIN_EMAILS;
+
+interface DetailTransaction {
+	id: string;
+	type: string;
+	amount: string | null;
+	relatedTransactionId: string | null;
+	refundable: boolean;
+	refundIneligibleReason: string | null;
+	refundedAmount: string;
+}
+
+describe("admin devpass subscriber billing history", () => {
+	let cookie: string;
+
+	beforeEach(async () => {
+		process.env.ADMIN_EMAILS = "admin@example.com";
+		cookie = await createTestUser();
+
+		await db.insert(tables.organization).values({
+			id: ORG_ID,
+			name: "History Org",
+			billingEmail: "history@example.com",
+			kind: "devpass",
+			devPlan: "lite",
+		});
+		await db.insert(tables.userOrganization).values({
+			userId: "test-user-id",
+			organizationId: ORG_ID,
+			role: "owner",
+		});
+		await db.insert(tables.transaction).values([
+			{
+				id: "history-tx-start",
+				organizationId: ORG_ID,
+				type: "dev_plan_start",
+				amount: "29",
+				creditAmount: "87",
+				status: "completed",
+				stripeInvoiceId: "inv_history_start",
+				createdAt: new Date("2026-07-15T07:21:15Z"),
+			},
+			{
+				id: "history-tx-cancel",
+				organizationId: ORG_ID,
+				type: "dev_plan_cancel",
+				status: "completed",
+				createdAt: new Date("2026-07-31T07:47:19Z"),
+			},
+			{
+				id: "history-tx-refund",
+				organizationId: ORG_ID,
+				type: "credit_refund",
+				amount: "29",
+				creditAmount: "0",
+				status: "completed",
+				relatedTransactionId: "history-tx-start",
+				createdAt: new Date("2026-08-12T21:06:22Z"),
+			},
+			{
+				id: "history-tx-gift",
+				organizationId: ORG_ID,
+				type: "credit_gift",
+				amount: null,
+				creditAmount: "10",
+				status: "completed",
+				createdAt: new Date("2026-08-12T21:07:00Z"),
+			},
+		]);
+	});
+
+	afterEach(async () => {
+		if (originalAdminEmails === undefined) {
+			delete process.env.ADMIN_EMAILS;
+		} else {
+			process.env.ADMIN_EMAILS = originalAdminEmails;
+		}
+		await db.delete(tables.transaction);
+		await deleteAll();
+	});
+
+	async function getTransactions(): Promise<DetailTransaction[]> {
+		const res = await app.request(`/admin/devpass/${ORG_ID}`, {
+			headers: { Cookie: cookie },
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { transactions: DetailTransaction[] };
+		return body.transactions;
+	}
+
+	it("lists the refund and credit-grant rows, not just the charges", async () => {
+		const transactions = await getTransactions();
+
+		expect(transactions.map((t) => t.id)).toEqual([
+			"history-tx-gift",
+			"history-tx-refund",
+			"history-tx-cancel",
+			"history-tx-start",
+		]);
+
+		const refund = transactions.find((t) => t.id === "history-tx-refund")!;
+		expect(refund.amount).toBe("29");
+		expect(refund.relatedTransactionId).toBe("history-tx-start");
+	});
+
+	it("offers no refund action on the refund row itself", async () => {
+		const refund = (await getTransactions()).find(
+			(t) => t.id === "history-tx-refund",
+		)!;
+
+		expect(refund.refundable).toBe(false);
+		expect(refund.refundIneligibleReason).toBe("unsupported_type");
+	});
+
+	it("still reports the refunded total on the original payment", async () => {
+		const start = (await getTransactions()).find(
+			(t) => t.id === "history-tx-start",
+		)!;
+
+		expect(start.refundedAmount).toBe("29.00");
+		expect(start.refundable).toBe(false);
+		expect(start.refundIneligibleReason).toBe("fully_refunded");
+	});
+});

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -12338,6 +12338,9 @@ const devpassTransactionSchema = z.object({
 	currency: z.string(),
 	status: z.string(),
 	description: z.string().nullable(),
+	// The payment a refund reverses, so the two rows can be tied together in
+	// the panel. Null on everything else.
+	relatedTransactionId: z.string().nullable(),
 	// Whether an admin can refund this payment, and how much of it is left.
 	// `refundIneligibleReason` is null when `refundable` is true.
 	refundable: z.boolean(),
@@ -14491,6 +14494,7 @@ admin.openapi(getDevpassSubscriber, async (c) => {
 			currency: tables.transaction.currency,
 			status: tables.transaction.status,
 			description: tables.transaction.description,
+			relatedTransactionId: tables.transaction.relatedTransactionId,
 			stripePaymentIntentId: tables.transaction.stripePaymentIntentId,
 			stripeInvoiceId: tables.transaction.stripeInvoiceId,
 		})
@@ -14508,8 +14512,16 @@ admin.openapi(getDevpassSubscriber, async (c) => {
 					"dev_plan_renewal",
 					"dev_plan_reset_pass",
 					"dev_plan_reset_pass_gift",
+					"dev_plan_reset_pass_reward",
 					// PAYG overflow top-ups are DevPass billing events too.
 					"credit_topup",
+					// Money and credits going back out. Without `credit_refund` a
+					// refunded payment reads as a charge that was never reversed —
+					// the refund exists only as a badge on the original row — and
+					// gifted or manually paid credits appear from nowhere.
+					"credit_refund",
+					"credit_gift",
+					"credit_manual_payment",
 					// Legacy types — pre dev_plan_* rename, still in DB for older
 					// dev plan subscribers; without these their history reads as empty.
 					"subscription_start",
@@ -14571,6 +14583,7 @@ admin.openapi(getDevpassSubscriber, async (c) => {
 				currency: t.currency,
 				status: t.status,
 				description: t.description ?? null,
+				relatedTransactionId: t.relatedTransactionId ?? null,
 				refundable: refundability.refundable,
 				refundIneligibleReason: refundability.reason,
 				refundedAmount: refundability.refundedAmount,

--- a/ee/admin/src/app/devpass/[orgId]/page.tsx
+++ b/ee/admin/src/app/devpass/[orgId]/page.tsx
@@ -68,10 +68,20 @@ function formatDateTime(dateString: string) {
 	});
 }
 
+// Money going back to the customer. Stored with a positive `amount` (see
+// stripe.ts), so the panel renders it negative to keep the column readable as
+// a ledger.
+function isRefundType(type: string) {
+	return type === "credit_refund";
+}
+
 function formatTransactionType(type: string) {
 	// On a DevPass org, credit_topup rows are PAYG overflow purchases.
 	if (type === "credit_topup") {
 		return "PAYG Top-up";
+	}
+	if (isRefundType(type)) {
+		return "Refund";
 	}
 	return type.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
 }
@@ -79,7 +89,7 @@ function formatTransactionType(type: string) {
 function getTransactionTypeBadgeVariant(
 	type: string,
 ): "default" | "secondary" | "outline" | "destructive" {
-	if (type.includes("cancel") || type.includes("end")) {
+	if (isRefundType(type) || type.includes("cancel") || type.includes("end")) {
 		return "destructive";
 	}
 	if (
@@ -513,7 +523,7 @@ export default async function DevpassDetailPage({
 				<TabsList className="w-full justify-start overflow-x-auto sm:w-auto">
 					<TabsTrigger value="transactions">
 						<Receipt className="mr-1.5 h-4 w-4" />
-						Subscription history ({data.transactions.length})
+						Billing history ({data.transactions.length})
 					</TabsTrigger>
 					<TabsTrigger value="payment-failures">
 						<CreditCard className="mr-1.5 h-4 w-4" />
@@ -543,7 +553,7 @@ export default async function DevpassDetailPage({
 											colSpan={8}
 											className="h-24 text-center text-muted-foreground"
 										>
-											No subscription events recorded
+											No billing events recorded
 										</TableCell>
 									</TableRow>
 								) : (
@@ -560,9 +570,19 @@ export default async function DevpassDetailPage({
 													{formatTransactionType(t.type)}
 												</Badge>
 											</TableCell>
-											<TableCell className="tabular-nums">
+											<TableCell
+												className={cn(
+													"tabular-nums",
+													isRefundType(t.type) &&
+														"text-rose-600 dark:text-rose-400",
+												)}
+											>
 												{t.amount
-													? currencyFormatter.format(parseFloat(t.amount))
+													? currencyFormatter.format(
+															isRefundType(t.type)
+																? -parseFloat(t.amount)
+																: parseFloat(t.amount),
+														)
 													: "—"}
 											</TableCell>
 											<TableCell className="tabular-nums">
@@ -583,8 +603,14 @@ export default async function DevpassDetailPage({
 													{t.status}
 												</Badge>
 											</TableCell>
-											<TableCell className="max-w-[300px] truncate text-muted-foreground">
-												{t.description ?? "—"}
+											<TableCell className="max-w-[300px] text-muted-foreground">
+												<div className="truncate">{t.description ?? "—"}</div>
+												{isRefundType(t.type) && t.relatedTransactionId && (
+													<div className="mt-1 flex items-center gap-1 text-xs">
+														<span>reverses</span>
+														<CopyableId id={t.relatedTransactionId} />
+													</div>
+												)}
 											</TableCell>
 											<TableCell className="text-right">
 												<div className="flex items-center justify-end gap-2">


### PR DESCRIPTION
## Problem

The DevPass subscriber panel in the admin dashboard filtered its transaction
list down to plan lifecycle rows, Reset Passes and PAYG top-ups. A refund is
its own `credit_refund` transaction, so it never appeared: the only hint was a
small "refunded $X" badge on the original payment, with no date, no id, no
reason and no way to see a partial refund history. Gifted credits
(`credit_gift`), manually recorded off-Stripe payments (`credit_manual_payment`)
and survey-reward Reset Passes were invisible for the same reason.

## Change

- Include `credit_refund`, `credit_gift`, `credit_manual_payment` and
  `dev_plan_reset_pass_reward` in the subscriber detail query, and return
  `relatedTransactionId` so a refund can be tied to the payment it reverses.
- Render refund rows as a negative amount in red, badged `Refund`, with a
  `reverses <transaction id>` line under the description. The row itself
  offers no refund action — `computeAdminRefundability` reports
  `unsupported_type` for it, which the dialog already renders as no control
  at all.
- Rename the tab to "Billing history"; it stopped being only subscription
  events when top-ups were added, and now clearly is not.

The existing "refunded $X" badge on the original payment is unchanged, so a
partially refunded payment still shows both the remaining refundable amount
and every refund row that produced it.

## Screenshots

Local seeded data, admin DevPass subscriber page.

| | Before | After |
| --- | --- | --- |
| Light | <img width="900" alt="Subscription history tab without the refund row, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/196233b2ecfd1fe2cc6a0e1bf352ec17ec9d60f1/admin-before-light.png" /> | <img width="900" alt="Billing history tab showing the refund row, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/196233b2ecfd1fe2cc6a0e1bf352ec17ec9d60f1/admin-after-light.png" /> |
| Dark | <img width="900" alt="Subscription history tab without the refund row, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/196233b2ecfd1fe2cc6a0e1bf352ec17ec9d60f1/admin-before-dark.png" /> | <img width="900" alt="Billing history tab showing the refund row, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/196233b2ecfd1fe2cc6a0e1bf352ec17ec9d60f1/admin-after-dark.png" /> |

## Verification

- New spec `apps/api/src/routes/admin-devpass-detail-history.spec.ts`: the
  refund and credit-grant rows are listed in order, the refund carries its
  `relatedTransactionId`, it is not itself refundable, and the original
  payment still reports the refunded total.
- `pnpm format`, `pnpm build`, and the admin DevPass specs pass.
- Walked the page locally against a seeded DevPass org carrying a refund.

Related: #3582 does the same for the customer-facing DevPass billing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin DevPass billing history now displays refunds, gifts, manual payments, reset-pass rewards, and PAYG top-ups.
  * Refund transactions show their associated original payment and clearly identify reversed charges.
* **Improvements**
  * Refund amounts are displayed as negative values with distinct destructive styling.
  * Billing tabs and empty states now use clearer billing terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->