### PR TITLE
fix: sum money columns in double precision

### DIFF
--- a/apps/api/src/lib/mode-split.ts
+++ b/apps/api/src/lib/mode-split.ts
@@ -25,12 +25,14 @@ export function modeSplitFields(table: {
 			sql<number>`COALESCE(SUM(${table.apiKeysRequestCount}), 0)`.as(
 				"apiKeysRequestCount",
 			),
-		creditsCost: sql<number>`COALESCE(SUM(${table.creditsCost}), 0)`.as(
-			"creditsCost",
-		),
-		apiKeysCost: sql<number>`COALESCE(SUM(${table.apiKeysCost}), 0)`.as(
-			"apiKeysCost",
-		),
+		creditsCost:
+			sql<number>`COALESCE(SUM(cast(${table.creditsCost} as double precision)), 0)`.as(
+				"creditsCost",
+			),
+		apiKeysCost:
+			sql<number>`COALESCE(SUM(cast(${table.apiKeysCost} as double precision)), 0)`.as(
+				"apiKeysCost",
+			),
 	};
 }
 

--- a/apps/api/src/lib/usage-report.ts
+++ b/apps/api/src/lib/usage-report.ts
@@ -181,15 +181,15 @@ export async function getUsageReport(
 			sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyModelStats.reasoningTokens} AS NUMERIC)), 0)`.as(
 				"reasoningTokens",
 			),
-		cost: sql<number>`COALESCE(SUM(${apiKeyHourlyModelStats.cost}), 0)`.as(
+		cost: sql<number>`COALESCE(SUM(cast(${apiKeyHourlyModelStats.cost} as double precision)), 0)`.as(
 			"cost",
 		),
 		inputCost:
-			sql<number>`COALESCE(SUM(${apiKeyHourlyModelStats.inputCost}), 0)`.as(
+			sql<number>`COALESCE(SUM(cast(${apiKeyHourlyModelStats.inputCost} as double precision)), 0)`.as(
 				"inputCost",
 			),
 		outputCost:
-			sql<number>`COALESCE(SUM(${apiKeyHourlyModelStats.outputCost}), 0)`.as(
+			sql<number>`COALESCE(SUM(cast(${apiKeyHourlyModelStats.outputCost} as double precision)), 0)`.as(
 				"outputCost",
 			),
 		...modeSplitFields(apiKeyHourlyModelStats),

--- a/apps/api/src/lib/user-usage-breakdown.ts
+++ b/apps/api/src/lib/user-usage-breakdown.ts
@@ -82,7 +82,9 @@ export async function getUserUsageBreakdown(options: {
 				sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyStats.totalTokens} AS NUMERIC)), 0)`.as(
 					"totalTokens",
 				),
-			cost: sql<number>`COALESCE(SUM(${apiKeyHourlyStats.cost}), 0)`.as("cost"),
+			cost: sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.cost} as double precision)), 0)`.as(
+				"cost",
+			),
 			...modeSplitFields(apiKeyHourlyStats),
 		})
 		.from(apiKeyHourlyStats)

--- a/apps/api/src/routes/activity.ts
+++ b/apps/api/src/routes/activity.ts
@@ -370,23 +370,23 @@ activity.openapi(getActivity, async (c) => {
 					sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyStats.totalTokens} AS NUMERIC)), 0)`.as(
 						"totalTokens",
 					),
-				cost: sql<number>`COALESCE(SUM(${apiKeyHourlyStats.cost}), 0)`.as(
+				cost: sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.cost} as double precision)), 0)`.as(
 					"cost",
 				),
 				inputCost:
-					sql<number>`COALESCE(SUM(${apiKeyHourlyStats.inputCost}), 0)`.as(
+					sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.inputCost} as double precision)), 0)`.as(
 						"inputCost",
 					),
 				outputCost:
-					sql<number>`COALESCE(SUM(${apiKeyHourlyStats.outputCost}), 0)`.as(
+					sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.outputCost} as double precision)), 0)`.as(
 						"outputCost",
 					),
 				requestCost:
-					sql<number>`COALESCE(SUM(${apiKeyHourlyStats.requestCost}), 0)`.as(
+					sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.requestCost} as double precision)), 0)`.as(
 						"requestCost",
 					),
 				dataStorageCost:
-					sql<number>`COALESCE(SUM(${apiKeyHourlyStats.dataStorageCost}), 0)`.as(
+					sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.dataStorageCost} as double precision)), 0)`.as(
 						"dataStorageCost",
 					),
 				errorCount:
@@ -398,27 +398,27 @@ activity.openapi(getActivity, async (c) => {
 						"cacheCount",
 					),
 				discountSavings:
-					sql<number>`COALESCE(SUM(${apiKeyHourlyStats.discountSavings}), 0)`.as(
+					sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.discountSavings} as double precision)), 0)`.as(
 						"discountSavings",
 					),
 				imageInputCost:
-					sql<number>`COALESCE(SUM(${apiKeyHourlyStats.imageInputCost}), 0)`.as(
+					sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.imageInputCost} as double precision)), 0)`.as(
 						"imageInputCost",
 					),
 				audioInputCost:
-					sql<number>`COALESCE(SUM(${apiKeyHourlyStats.audioInputCost}), 0)`.as(
+					sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.audioInputCost} as double precision)), 0)`.as(
 						"audioInputCost",
 					),
 				audioOutputCost:
-					sql<number>`COALESCE(SUM(${apiKeyHourlyStats.audioOutputCost}), 0)`.as(
+					sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.audioOutputCost} as double precision)), 0)`.as(
 						"audioOutputCost",
 					),
 				imageOutputCost:
-					sql<number>`COALESCE(SUM(${apiKeyHourlyStats.imageOutputCost}), 0)`.as(
+					sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.imageOutputCost} as double precision)), 0)`.as(
 						"imageOutputCost",
 					),
 				videoOutputCost:
-					sql<number>`COALESCE(SUM(${apiKeyHourlyStats.videoOutputCost}), 0)`.as(
+					sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.videoOutputCost} as double precision)), 0)`.as(
 						"videoOutputCost",
 					),
 				cachedTokens:
@@ -430,11 +430,11 @@ activity.openapi(getActivity, async (c) => {
 						"cacheWriteTokens",
 					),
 				cachedInputCost:
-					sql<number>`COALESCE(SUM(${apiKeyHourlyStats.cachedInputCost}), 0)`.as(
+					sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.cachedInputCost} as double precision)), 0)`.as(
 						"cachedInputCost",
 					),
 				cacheWriteInputCost:
-					sql<number>`COALESCE(SUM(${apiKeyHourlyStats.cacheWriteInputCost}), 0)`.as(
+					sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.cacheWriteInputCost} as double precision)), 0)`.as(
 						"cacheWriteInputCost",
 					),
 				creditsRequestCount:
@@ -446,19 +446,19 @@ activity.openapi(getActivity, async (c) => {
 						"apiKeysRequestCount",
 					),
 				creditsCost:
-					sql<number>`COALESCE(SUM(${apiKeyHourlyStats.creditsCost}), 0)`.as(
+					sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.creditsCost} as double precision)), 0)`.as(
 						"creditsCost",
 					),
 				apiKeysCost:
-					sql<number>`COALESCE(SUM(${apiKeyHourlyStats.apiKeysCost}), 0)`.as(
+					sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.apiKeysCost} as double precision)), 0)`.as(
 						"apiKeysCost",
 					),
 				creditsDataStorageCost:
-					sql<number>`COALESCE(SUM(${apiKeyHourlyStats.creditsDataStorageCost}), 0)`.as(
+					sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.creditsDataStorageCost} as double precision)), 0)`.as(
 						"creditsDataStorageCost",
 					),
 				apiKeysDataStorageCost:
-					sql<number>`COALESCE(SUM(${apiKeyHourlyStats.apiKeysDataStorageCost}), 0)`.as(
+					sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.apiKeysDataStorageCost} as double precision)), 0)`.as(
 						"apiKeysDataStorageCost",
 					),
 			})
@@ -501,7 +501,7 @@ activity.openapi(getActivity, async (c) => {
 					sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyModelStats.totalTokens} AS NUMERIC)), 0)`.as(
 						"totalTokens",
 					),
-				cost: sql<number>`COALESCE(SUM(${apiKeyHourlyModelStats.cost}), 0)`.as(
+				cost: sql<number>`COALESCE(SUM(cast(${apiKeyHourlyModelStats.cost} as double precision)), 0)`.as(
 					"cost",
 				),
 				...modeSplitFields(apiKeyHourlyModelStats),
@@ -576,7 +576,7 @@ activity.openapi(getActivity, async (c) => {
 						sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyStats.totalTokens} AS NUMERIC)), 0)`.as(
 							"totalTokens",
 						),
-					cost: sql<number>`COALESCE(SUM(${apiKeyHourlyStats.cost}), 0)`.as(
+					cost: sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.cost} as double precision)), 0)`.as(
 						"cost",
 					),
 					...modeSplitFields(apiKeyHourlyStats),
@@ -735,51 +735,51 @@ activity.openapi(getActivity, async (c) => {
 				sql<number>`COALESCE(SUM(CAST(${projectHourlyStats.totalTokens} AS NUMERIC)), 0)`.as(
 					"totalTokens",
 				),
-			cost: sql<number>`COALESCE(SUM(${projectHourlyStats.cost}), 0)`.as(
+			cost: sql<number>`COALESCE(SUM(cast(${projectHourlyStats.cost} as double precision)), 0)`.as(
 				"cost",
 			),
 			inputCost:
-				sql<number>`COALESCE(SUM(${projectHourlyStats.inputCost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyStats.inputCost} as double precision)), 0)`.as(
 					"inputCost",
 				),
 			outputCost:
-				sql<number>`COALESCE(SUM(${projectHourlyStats.outputCost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyStats.outputCost} as double precision)), 0)`.as(
 					"outputCost",
 				),
 			requestCost:
-				sql<number>`COALESCE(SUM(${projectHourlyStats.requestCost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyStats.requestCost} as double precision)), 0)`.as(
 					"requestCost",
 				),
 			dataStorageCost:
-				sql<number>`COALESCE(SUM(${projectHourlyStats.dataStorageCost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyStats.dataStorageCost} as double precision)), 0)`.as(
 					"dataStorageCost",
 				),
 			imageInputCost:
-				sql<number>`COALESCE(SUM(${projectHourlyStats.imageInputCost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyStats.imageInputCost} as double precision)), 0)`.as(
 					"imageInputCost",
 				),
 			audioInputCost:
-				sql<number>`COALESCE(SUM(${projectHourlyStats.audioInputCost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyStats.audioInputCost} as double precision)), 0)`.as(
 					"audioInputCost",
 				),
 			audioOutputCost:
-				sql<number>`COALESCE(SUM(${projectHourlyStats.audioOutputCost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyStats.audioOutputCost} as double precision)), 0)`.as(
 					"audioOutputCost",
 				),
 			imageOutputCost:
-				sql<number>`COALESCE(SUM(${projectHourlyStats.imageOutputCost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyStats.imageOutputCost} as double precision)), 0)`.as(
 					"imageOutputCost",
 				),
 			videoOutputCost:
-				sql<number>`COALESCE(SUM(${projectHourlyStats.videoOutputCost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyStats.videoOutputCost} as double precision)), 0)`.as(
 					"videoOutputCost",
 				),
 			cachedInputCost:
-				sql<number>`COALESCE(SUM(${projectHourlyStats.cachedInputCost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyStats.cachedInputCost} as double precision)), 0)`.as(
 					"cachedInputCost",
 				),
 			cacheWriteInputCost:
-				sql<number>`COALESCE(SUM(${projectHourlyStats.cacheWriteInputCost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyStats.cacheWriteInputCost} as double precision)), 0)`.as(
 					"cacheWriteInputCost",
 				),
 			errorCount:
@@ -791,7 +791,7 @@ activity.openapi(getActivity, async (c) => {
 					"cacheCount",
 				),
 			discountSavings:
-				sql<number>`COALESCE(SUM(${projectHourlyStats.discountSavings}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyStats.discountSavings} as double precision)), 0)`.as(
 					"discountSavings",
 				),
 			creditsRequestCount:
@@ -803,19 +803,19 @@ activity.openapi(getActivity, async (c) => {
 					"apiKeysRequestCount",
 				),
 			creditsCost:
-				sql<number>`COALESCE(SUM(${projectHourlyStats.creditsCost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyStats.creditsCost} as double precision)), 0)`.as(
 					"creditsCost",
 				),
 			apiKeysCost:
-				sql<number>`COALESCE(SUM(${projectHourlyStats.apiKeysCost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyStats.apiKeysCost} as double precision)), 0)`.as(
 					"apiKeysCost",
 				),
 			creditsDataStorageCost:
-				sql<number>`COALESCE(SUM(${projectHourlyStats.creditsDataStorageCost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyStats.creditsDataStorageCost} as double precision)), 0)`.as(
 					"creditsDataStorageCost",
 				),
 			apiKeysDataStorageCost:
-				sql<number>`COALESCE(SUM(${projectHourlyStats.apiKeysDataStorageCost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyStats.apiKeysDataStorageCost} as double precision)), 0)`.as(
 					"apiKeysDataStorageCost",
 				),
 		})
@@ -863,7 +863,7 @@ activity.openapi(getActivity, async (c) => {
 					sql<number>`COALESCE(SUM(CAST(${projectHourlyModelStats.totalTokens} AS NUMERIC)), 0)`.as(
 						"totalTokens",
 					),
-				cost: sql<number>`COALESCE(SUM(${projectHourlyModelStats.cost}), 0)`.as(
+				cost: sql<number>`COALESCE(SUM(cast(${projectHourlyModelStats.cost} as double precision)), 0)`.as(
 					"cost",
 				),
 				...modeSplitFields(projectHourlyModelStats),
@@ -929,7 +929,7 @@ activity.openapi(getActivity, async (c) => {
 					sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyStats.totalTokens} AS NUMERIC)), 0)`.as(
 						"totalTokens",
 					),
-				cost: sql<number>`COALESCE(SUM(${apiKeyHourlyStats.cost}), 0)`.as(
+				cost: sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.cost} as double precision)), 0)`.as(
 					"cost",
 				),
 				...modeSplitFields(apiKeyHourlyStats),
@@ -1201,7 +1201,7 @@ activity.openapi(getSourceActivity, async (c) => {
 				sql<number>`COALESCE(SUM(CAST(${projectHourlySourceStats.totalTokens} AS NUMERIC)), 0)`.as(
 					"totalTokens",
 				),
-			cost: sql<number>`COALESCE(SUM(${projectHourlySourceStats.cost}), 0)`.as(
+			cost: sql<number>`COALESCE(SUM(cast(${projectHourlySourceStats.cost} as double precision)), 0)`.as(
 				"cost",
 			),
 			...modeSplitFields(projectHourlySourceStats),
@@ -1220,7 +1220,11 @@ activity.openapi(getSourceActivity, async (c) => {
 			),
 		)
 		.groupBy(projectHourlySourceStats.source)
-		.orderBy(desc(sql`COALESCE(SUM(${projectHourlySourceStats.cost}), 0)`));
+		.orderBy(
+			desc(
+				sql`COALESCE(SUM(cast(${projectHourlySourceStats.cost} as double precision)), 0)`,
+			),
+		);
 
 	return c.json({
 		sources: rows.map((r) => ({

--- a/apps/api/src/routes/admin-provider-credentials.ts
+++ b/apps/api/src/routes/admin-provider-credentials.ts
@@ -642,7 +642,7 @@ adminProviderCredentials.openapi(getProviderKeySpend, async (c) => {
 		db
 			.select({
 				timestamp: bucketLabelExpr.as("bucket"),
-				cost: sql<number>`COALESCE(SUM(${tables.providerKeyHourlyStats.cost}), 0)`.as(
+				cost: sql<number>`COALESCE(SUM(cast(${tables.providerKeyHourlyStats.cost} as double precision)), 0)`.as(
 					"cost",
 				),
 				requestCount:
@@ -673,7 +673,7 @@ adminProviderCredentials.openapi(getProviderKeySpend, async (c) => {
 			.select({
 				organizationId: tables.project.organizationId,
 				organizationName: tables.organization.name,
-				cost: sql<number>`COALESCE(SUM(${tables.providerKeyHourlyStats.cost}), 0)`.as(
+				cost: sql<number>`COALESCE(SUM(cast(${tables.providerKeyHourlyStats.cost} as double precision)), 0)`.as(
 					"cost",
 				),
 				requestCount:
@@ -692,7 +692,11 @@ adminProviderCredentials.openapi(getProviderKeySpend, async (c) => {
 			)
 			.where(baseFilter)
 			.groupBy(tables.project.organizationId, tables.organization.name)
-			.orderBy(desc(sql`SUM(${tables.providerKeyHourlyStats.cost})`))
+			.orderBy(
+				desc(
+					sql`SUM(cast(${tables.providerKeyHourlyStats.cost} as double precision))`,
+				),
+			)
 			.limit(20),
 	]);
 
@@ -827,7 +831,7 @@ adminProviderCredentials.openapi(getSpendOverview, async (c) => {
 			.select({
 				timestamp: bucketLabelExpr.as("bucket"),
 				providerKeyId: tables.providerKeyHourlyStats.providerKeyId,
-				cost: sql<number>`COALESCE(SUM(${tables.providerKeyHourlyStats.cost}), 0)`.as(
+				cost: sql<number>`COALESCE(SUM(cast(${tables.providerKeyHourlyStats.cost} as double precision)), 0)`.as(
 					"cost",
 				),
 				requestCount:

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -200,16 +200,18 @@ function tokenBreakdownSums(table: {
 			sql<number>`COALESCE(SUM(CAST(${table.totalOutputTokens} AS NUMERIC)), 0)`.as(
 				"output_tokens",
 			),
-		inputCost: sql<number>`COALESCE(SUM(${table.totalInputCost}), 0)`.as(
-			"input_cost",
-		),
+		inputCost:
+			sql<number>`COALESCE(SUM(cast(${table.totalInputCost} as double precision)), 0)`.as(
+				"input_cost",
+			),
 		cachedInputCost:
-			sql<number>`COALESCE(SUM(${table.totalCachedInputCost}), 0)`.as(
+			sql<number>`COALESCE(SUM(cast(${table.totalCachedInputCost} as double precision)), 0)`.as(
 				"cached_input_cost",
 			),
-		outputCost: sql<number>`COALESCE(SUM(${table.totalOutputCost}), 0)`.as(
-			"output_cost",
-		),
+		outputCost:
+			sql<number>`COALESCE(SUM(cast(${table.totalOutputCost} as double precision)), 0)`.as(
+				"output_cost",
+			),
 	};
 }
 
@@ -252,15 +254,16 @@ function tokenBreakdownSubTotals(
 			sql<number>`COALESCE(SUM(COALESCE(${sub.outputTokens}, 0)), 0)`.as(
 				"output_tokens",
 			),
-		inputCost: sql<number>`COALESCE(SUM(COALESCE(${sub.inputCost}, 0)), 0)`.as(
-			"input_cost",
-		),
+		inputCost:
+			sql<number>`COALESCE(SUM(COALESCE(cast(${sub.inputCost} as double precision), 0)), 0)`.as(
+				"input_cost",
+			),
 		cachedInputCost:
-			sql<number>`COALESCE(SUM(COALESCE(${sub.cachedInputCost}, 0)), 0)`.as(
+			sql<number>`COALESCE(SUM(COALESCE(cast(${sub.cachedInputCost} as double precision), 0)), 0)`.as(
 				"cached_input_cost",
 			),
 		outputCost:
-			sql<number>`COALESCE(SUM(COALESCE(${sub.outputCost}, 0)), 0)`.as(
+			sql<number>`COALESCE(SUM(COALESCE(cast(${sub.outputCost} as double precision), 0)), 0)`.as(
 				"output_cost",
 			),
 	};
@@ -2755,31 +2758,32 @@ admin.openapi(getOrganizationMetrics, async (c) => {
 					sql<number>`COALESCE(SUM(CAST(${projectHourlyStats.totalTokens} AS INTEGER)), 0)`.as(
 						"totalTokens",
 					),
-				totalCost: sql<number>`COALESCE(SUM(${projectHourlyStats.cost}), 0)`.as(
-					"totalCost",
-				),
+				totalCost:
+					sql<number>`COALESCE(SUM(cast(${projectHourlyStats.cost} as double precision)), 0)`.as(
+						"totalCost",
+					),
 				inputCost:
-					sql<number>`COALESCE(SUM(${projectHourlyStats.inputCost}), 0)`.as(
+					sql<number>`COALESCE(SUM(cast(${projectHourlyStats.inputCost} as double precision)), 0)`.as(
 						"inputCost",
 					),
 				outputCost:
-					sql<number>`COALESCE(SUM(${projectHourlyStats.outputCost}), 0)`.as(
+					sql<number>`COALESCE(SUM(cast(${projectHourlyStats.outputCost} as double precision)), 0)`.as(
 						"outputCost",
 					),
 				discountSavings:
-					sql<number>`COALESCE(SUM(${projectHourlyStats.discountSavings}), 0)`.as(
+					sql<number>`COALESCE(SUM(cast(${projectHourlyStats.discountSavings} as double precision)), 0)`.as(
 						"discountSavings",
 					),
 				cachedInputCost:
-					sql<number>`COALESCE(SUM(${projectHourlyStats.cachedInputCost}), 0)`.as(
+					sql<number>`COALESCE(SUM(cast(${projectHourlyStats.cachedInputCost} as double precision)), 0)`.as(
 						"cachedInputCost",
 					),
 				cacheWriteInputCost:
-					sql<number>`COALESCE(SUM(${projectHourlyStats.cacheWriteInputCost}), 0)`.as(
+					sql<number>`COALESCE(SUM(cast(${projectHourlyStats.cacheWriteInputCost} as double precision)), 0)`.as(
 						"cacheWriteInputCost",
 					),
 				dataStorageCost:
-					sql<number>`COALESCE(SUM(${projectHourlyStats.dataStorageCost}), 0)`.as(
+					sql<number>`COALESCE(SUM(cast(${projectHourlyStats.dataStorageCost} as double precision)), 0)`.as(
 						"dataStorageCost",
 					),
 			})
@@ -2818,7 +2822,7 @@ admin.openapi(getOrganizationMetrics, async (c) => {
 				usedModel: projectHourlyModelStats.usedModel,
 				usedProvider: projectHourlyModelStats.usedProvider,
 				totalCost:
-					sql<number>`COALESCE(SUM(${projectHourlyModelStats.cost}), 0)`.as(
+					sql<number>`COALESCE(SUM(cast(${projectHourlyModelStats.cost} as double precision)), 0)`.as(
 						"totalCost",
 					),
 			})
@@ -3388,31 +3392,32 @@ admin.openapi(getProjectMetrics, async (c) => {
 				sql<number>`COALESCE(SUM(CAST(${projectHourlyStats.totalTokens} AS INTEGER)), 0)`.as(
 					"totalTokens",
 				),
-			totalCost: sql<number>`COALESCE(SUM(${projectHourlyStats.cost}), 0)`.as(
-				"totalCost",
-			),
+			totalCost:
+				sql<number>`COALESCE(SUM(cast(${projectHourlyStats.cost} as double precision)), 0)`.as(
+					"totalCost",
+				),
 			inputCost:
-				sql<number>`COALESCE(SUM(${projectHourlyStats.inputCost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyStats.inputCost} as double precision)), 0)`.as(
 					"inputCost",
 				),
 			outputCost:
-				sql<number>`COALESCE(SUM(${projectHourlyStats.outputCost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyStats.outputCost} as double precision)), 0)`.as(
 					"outputCost",
 				),
 			discountSavings:
-				sql<number>`COALESCE(SUM(${projectHourlyStats.discountSavings}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyStats.discountSavings} as double precision)), 0)`.as(
 					"discountSavings",
 				),
 			cachedInputCost:
-				sql<number>`COALESCE(SUM(${projectHourlyStats.cachedInputCost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyStats.cachedInputCost} as double precision)), 0)`.as(
 					"cachedInputCost",
 				),
 			cacheWriteInputCost:
-				sql<number>`COALESCE(SUM(${projectHourlyStats.cacheWriteInputCost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyStats.cacheWriteInputCost} as double precision)), 0)`.as(
 					"cacheWriteInputCost",
 				),
 			dataStorageCost:
-				sql<number>`COALESCE(SUM(${projectHourlyStats.dataStorageCost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyStats.dataStorageCost} as double precision)), 0)`.as(
 					"dataStorageCost",
 				),
 		})
@@ -3451,7 +3456,7 @@ admin.openapi(getProjectMetrics, async (c) => {
 			usedModel: projectHourlyModelStats.usedModel,
 			usedProvider: projectHourlyModelStats.usedProvider,
 			totalCost:
-				sql<number>`COALESCE(SUM(${projectHourlyModelStats.cost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyModelStats.cost} as double precision)), 0)`.as(
 					"totalCost",
 				),
 		})
@@ -4985,9 +4990,10 @@ admin.openapi(getProviderStats, async (c) => {
 					sql<number>`COALESCE(SUM(CAST(${mph.totalTokens} AS NUMERIC)), 0)`.as(
 						"totalTokens",
 					),
-				totalCost: sql<number>`COALESCE(SUM(${mph.totalCost}), 0)`.as(
-					"totalCost",
-				),
+				totalCost:
+					sql<number>`COALESCE(SUM(cast(${mph.totalCost} as double precision)), 0)`.as(
+						"totalCost",
+					),
 				// Only streamed requests record a time-to-first-token, so the
 				// average divides by the sample count, not the request count.
 				// Reasoning-token samples take precedence so thinking mappings
@@ -5029,7 +5035,7 @@ admin.openapi(getProviderStats, async (c) => {
 							"totalTokens",
 						),
 					totalCost:
-						sql<number>`COALESCE(SUM(COALESCE(${providerStatsSub.totalCost}, 0)), 0)`.as(
+						sql<number>`COALESCE(SUM(COALESCE(cast(${providerStatsSub.totalCost} as double precision), 0)), 0)`.as(
 							"totalCost",
 						),
 					...tokenBreakdownSubTotals(providerStatsSub),
@@ -5324,9 +5330,10 @@ admin.openapi(getModelStats, async (c) => {
 					sql<number>`COALESCE(SUM(CAST(${mh.totalTokens} AS NUMERIC)), 0)`.as(
 						"totalTokens",
 					),
-				totalCost: sql<number>`COALESCE(SUM(${mh.totalCost}), 0)`.as(
-					"totalCost",
-				),
+				totalCost:
+					sql<number>`COALESCE(SUM(cast(${mh.totalCost} as double precision)), 0)`.as(
+						"totalCost",
+					),
 				...tokenBreakdownSums(mh),
 			})
 			.from(mh)
@@ -5396,7 +5403,7 @@ admin.openapi(getModelStats, async (c) => {
 						"totalTokens",
 					),
 				totalCost:
-					sql<number>`COALESCE(SUM(COALESCE(${modelAggSub.totalCost}, 0)), 0)`.as(
+					sql<number>`COALESCE(SUM(COALESCE(cast(${modelAggSub.totalCost} as double precision), 0)), 0)`.as(
 						"totalCost",
 					),
 				...tokenBreakdownSubTotals(modelAggSub),
@@ -5826,16 +5833,18 @@ admin.openapi(getModelDetail, async (c) => {
 					sql<number>`SUM(CAST(${projectHourlyModelStats.outputTokens} AS NUMERIC))`.as(
 						"output_tokens",
 					),
-				inputCost: sql<number>`SUM(${projectHourlyModelStats.inputCost})`.as(
-					"input_cost",
-				),
+				inputCost:
+					sql<number>`SUM(cast(${projectHourlyModelStats.inputCost} as double precision))`.as(
+						"input_cost",
+					),
 				cachedInputCost:
-					sql<number>`SUM(${projectHourlyModelStats.cachedInputCost})`.as(
+					sql<number>`SUM(cast(${projectHourlyModelStats.cachedInputCost} as double precision))`.as(
 						"cached_input_cost",
 					),
-				outputCost: sql<number>`SUM(${projectHourlyModelStats.outputCost})`.as(
-					"output_cost",
-				),
+				outputCost:
+					sql<number>`SUM(cast(${projectHourlyModelStats.outputCost} as double precision))`.as(
+						"output_cost",
+					),
 			})
 			.from(projectHourlyModelStats)
 			.where(
@@ -7607,7 +7616,7 @@ admin.openapi(getProviderHistory, async (c) => {
 						"total_tokens",
 					),
 				totalCost:
-					sql<number>`SUM(${modelProviderMappingHistoryHourly.totalCost})`.as(
+					sql<number>`SUM(cast(${modelProviderMappingHistoryHourly.totalCost} as double precision))`.as(
 						"total_cost",
 					),
 				...tokenBreakdownSums(modelProviderMappingHistoryHourly),
@@ -7695,7 +7704,7 @@ admin.openapi(getProviderHistory, async (c) => {
 		db
 			.select({
 				hourTimestamp: projectHourlyModelStats.hourTimestamp,
-				cost: sql<number>`SUM(${projectHourlyModelStats.cost})`,
+				cost: sql<number>`SUM(cast(${projectHourlyModelStats.cost} as double precision))`,
 			})
 			.from(projectHourlyModelStats)
 			.where(
@@ -7765,7 +7774,9 @@ admin.openapi(getModelHistory, async (c) => {
 					sql<number>`SUM(CAST(${projectHourlyModelStats.totalTokens} AS NUMERIC))`.as(
 						"total_tokens",
 					),
-				cost: sql<number>`SUM(${projectHourlyModelStats.cost})`.as("cost"),
+				cost: sql<number>`SUM(cast(${projectHourlyModelStats.cost} as double precision))`.as(
+					"cost",
+				),
 				inputTokens:
 					sql<number>`SUM(CAST(${projectHourlyModelStats.inputTokens} AS NUMERIC))`.as(
 						"input_tokens",
@@ -7778,16 +7789,18 @@ admin.openapi(getModelHistory, async (c) => {
 					sql<number>`SUM(CAST(${projectHourlyModelStats.outputTokens} AS NUMERIC))`.as(
 						"output_tokens",
 					),
-				inputCost: sql<number>`SUM(${projectHourlyModelStats.inputCost})`.as(
-					"input_cost",
-				),
+				inputCost:
+					sql<number>`SUM(cast(${projectHourlyModelStats.inputCost} as double precision))`.as(
+						"input_cost",
+					),
 				cachedInputCost:
-					sql<number>`SUM(${projectHourlyModelStats.cachedInputCost})`.as(
+					sql<number>`SUM(cast(${projectHourlyModelStats.cachedInputCost} as double precision))`.as(
 						"cached_input_cost",
 					),
-				outputCost: sql<number>`SUM(${projectHourlyModelStats.outputCost})`.as(
-					"output_cost",
-				),
+				outputCost:
+					sql<number>`SUM(cast(${projectHourlyModelStats.outputCost} as double precision))`.as(
+						"output_cost",
+					),
 			})
 			.from(projectHourlyModelStats)
 			.where(
@@ -7867,9 +7880,10 @@ admin.openapi(getModelHistory, async (c) => {
 				totalTokens: sql<number>`SUM(${modelHistoryHourly.totalTokens})`.as(
 					"total_tokens",
 				),
-				totalCost: sql<number>`SUM(${modelHistoryHourly.totalCost})`.as(
-					"total_cost",
-				),
+				totalCost:
+					sql<number>`SUM(cast(${modelHistoryHourly.totalCost} as double precision))`.as(
+						"total_cost",
+					),
 				...tokenBreakdownSums(modelHistoryHourly),
 			})
 			.from(modelHistoryHourly)
@@ -7928,7 +7942,10 @@ admin.openapi(getModelHistory, async (c) => {
 			totalTokens: sql<number>`SUM(${modelHistory.totalTokens})`.as(
 				"total_tokens",
 			),
-			totalCost: sql<number>`SUM(${modelHistory.totalCost})`.as("total_cost"),
+			totalCost:
+				sql<number>`SUM(cast(${modelHistory.totalCost} as double precision))`.as(
+					"total_cost",
+				),
 			...tokenBreakdownSums(modelHistory),
 		})
 		.from(modelHistory)
@@ -8019,7 +8036,9 @@ admin.openapi(getMappingHistory, async (c) => {
 					sql<number>`SUM(CAST(${projectHourlyModelStats.totalTokens} AS NUMERIC))`.as(
 						"total_tokens",
 					),
-				cost: sql<number>`SUM(${projectHourlyModelStats.cost})`.as("cost"),
+				cost: sql<number>`SUM(cast(${projectHourlyModelStats.cost} as double precision))`.as(
+					"cost",
+				),
 				inputTokens:
 					sql<number>`SUM(CAST(${projectHourlyModelStats.inputTokens} AS NUMERIC))`.as(
 						"input_tokens",
@@ -8032,16 +8051,18 @@ admin.openapi(getMappingHistory, async (c) => {
 					sql<number>`SUM(CAST(${projectHourlyModelStats.outputTokens} AS NUMERIC))`.as(
 						"output_tokens",
 					),
-				inputCost: sql<number>`SUM(${projectHourlyModelStats.inputCost})`.as(
-					"input_cost",
-				),
+				inputCost:
+					sql<number>`SUM(cast(${projectHourlyModelStats.inputCost} as double precision))`.as(
+						"input_cost",
+					),
 				cachedInputCost:
-					sql<number>`SUM(${projectHourlyModelStats.cachedInputCost})`.as(
+					sql<number>`SUM(cast(${projectHourlyModelStats.cachedInputCost} as double precision))`.as(
 						"cached_input_cost",
 					),
-				outputCost: sql<number>`SUM(${projectHourlyModelStats.outputCost})`.as(
-					"output_cost",
-				),
+				outputCost:
+					sql<number>`SUM(cast(${projectHourlyModelStats.outputCost} as double precision))`.as(
+						"output_cost",
+					),
 			})
 			.from(projectHourlyModelStats)
 			.where(
@@ -8145,7 +8166,7 @@ admin.openapi(getMappingHistory, async (c) => {
 						"total_tokens",
 					),
 				totalCost:
-					sql<number>`SUM(${modelProviderMappingHistoryHourly.totalCost})`.as(
+					sql<number>`SUM(cast(${modelProviderMappingHistoryHourly.totalCost} as double precision))`.as(
 						"total_cost",
 					),
 				...tokenBreakdownSums(modelProviderMappingHistoryHourly),
@@ -8216,9 +8237,10 @@ admin.openapi(getMappingHistory, async (c) => {
 				sql<number>`SUM(${modelProviderMappingHistory.totalTokens})`.as(
 					"total_tokens",
 				),
-			totalCost: sql<number>`SUM(${modelProviderMappingHistory.totalCost})`.as(
-				"total_cost",
-			),
+			totalCost:
+				sql<number>`SUM(cast(${modelProviderMappingHistory.totalCost} as double precision))`.as(
+					"total_cost",
+				),
 			...tokenBreakdownSums(modelProviderMappingHistory),
 		})
 		.from(modelProviderMappingHistory)
@@ -8372,9 +8394,10 @@ admin.openapi(getProviderDetail, async (c) => {
 					sql<number>`COALESCE(SUM(${mph.timeToFirstReasoningTokenCount}), 0)`.as(
 						"ttfrt_count",
 					),
-				totalCost: sql<number>`COALESCE(SUM(${mph.totalCost}), 0)`.as(
-					"total_cost",
-				),
+				totalCost:
+					sql<number>`COALESCE(SUM(cast(${mph.totalCost} as double precision)), 0)`.as(
+						"total_cost",
+					),
 				...tokenBreakdownSums(mph),
 			})
 			.from(mph)
@@ -8678,9 +8701,10 @@ admin.openapi(getMappingDetail, async (c) => {
 			// samples take precedence so thinking mappings aren't measured on
 			// their (much later) first content token.
 			avgTtft: avgEffectiveTtftSql(mph).as("avg_ttft"),
-			totalCost: sql<number>`COALESCE(SUM(${mph.totalCost}), 0)`.as(
-				"total_cost",
-			),
+			totalCost:
+				sql<number>`COALESCE(SUM(cast(${mph.totalCost} as double precision)), 0)`.as(
+					"total_cost",
+				),
 			...tokenBreakdownSums(mph),
 		})
 		.from(mph)
@@ -8804,7 +8828,9 @@ admin.openapi(getGlobalCostByModel, async (c) => {
 	const rows = await db
 		.select({
 			usedModel: projectHourlyModelStats.usedModel,
-			cost: sql<number>`SUM(${projectHourlyModelStats.cost})`.as("cost"),
+			cost: sql<number>`SUM(cast(${projectHourlyModelStats.cost} as double precision))`.as(
+				"cost",
+			),
 			requestCount:
 				sql<number>`SUM(${projectHourlyModelStats.requestCount})`.as(
 					"request_count",
@@ -8825,7 +8851,9 @@ admin.openapi(getGlobalCostByModel, async (c) => {
 				: gte(projectHourlyModelStats.hourTimestamp, startDate),
 		)
 		.groupBy(projectHourlyModelStats.usedModel)
-		.orderBy(desc(sql`SUM(${projectHourlyModelStats.cost})`))
+		.orderBy(
+			desc(sql`SUM(cast(${projectHourlyModelStats.cost} as double precision))`),
+		)
 		.limit(20);
 
 	const totalCost = rows.reduce((sum, r) => sum + Number(r.cost), 0);
@@ -8921,7 +8949,9 @@ admin.openapi(getOrgCostByModel, async (c) => {
 	const rows = await db
 		.select({
 			usedModel: projectHourlyModelStats.usedModel,
-			cost: sql<number>`SUM(${projectHourlyModelStats.cost})`.as("cost"),
+			cost: sql<number>`SUM(cast(${projectHourlyModelStats.cost} as double precision))`.as(
+				"cost",
+			),
 			requestCount:
 				sql<number>`SUM(${projectHourlyModelStats.requestCount})`.as(
 					"request_count",
@@ -8940,7 +8970,9 @@ admin.openapi(getOrgCostByModel, async (c) => {
 			),
 		)
 		.groupBy(projectHourlyModelStats.usedModel)
-		.orderBy(desc(sql`SUM(${projectHourlyModelStats.cost})`))
+		.orderBy(
+			desc(sql`SUM(cast(${projectHourlyModelStats.cost} as double precision))`),
+		)
 		.limit(20);
 
 	const totalCost = rows.reduce((sum, r) => sum + Number(r.cost), 0);
@@ -9219,7 +9251,9 @@ async function buildCostByModelTimeseries({
 	const modelTotals = await db
 		.select({
 			usedModel: projectHourlyModelStats.usedModel,
-			cost: sql<number>`SUM(${projectHourlyModelStats.cost})`.as("cost"),
+			cost: sql<number>`SUM(cast(${projectHourlyModelStats.cost} as double precision))`.as(
+				"cost",
+			),
 		})
 		.from(projectHourlyModelStats)
 		.where(baseFilter)
@@ -9259,7 +9293,9 @@ async function buildCostByModelTimeseries({
 		.select({
 			bucket: bucketExpr.as("bucket"),
 			usedModel: projectHourlyModelStats.usedModel,
-			cost: sql<number>`SUM(${projectHourlyModelStats.cost})`.as("cost"),
+			cost: sql<number>`SUM(cast(${projectHourlyModelStats.cost} as double precision))`.as(
+				"cost",
+			),
 			requestCount:
 				sql<number>`SUM(${projectHourlyModelStats.requestCount})`.as(
 					"request_count",
@@ -9314,7 +9350,9 @@ async function buildCostBySourceTimeseries({
 	const sourceTotals = await db
 		.select({
 			source: projectHourlySourceStats.source,
-			cost: sql<number>`SUM(${projectHourlySourceStats.cost})`.as("cost"),
+			cost: sql<number>`SUM(cast(${projectHourlySourceStats.cost} as double precision))`.as(
+				"cost",
+			),
 		})
 		.from(projectHourlySourceStats)
 		.where(baseFilter)
@@ -9341,7 +9379,9 @@ async function buildCostBySourceTimeseries({
 		.select({
 			bucket: bucketExpr.as("bucket"),
 			source: projectHourlySourceStats.source,
-			cost: sql<number>`SUM(${projectHourlySourceStats.cost})`.as("cost"),
+			cost: sql<number>`SUM(cast(${projectHourlySourceStats.cost} as double precision))`.as(
+				"cost",
+			),
 			requestCount:
 				sql<number>`SUM(${projectHourlySourceStats.requestCount})`.as(
 					"request_count",
@@ -9558,7 +9598,9 @@ admin.openapi(getProjectModelProviderStats, async (c) => {
 			"cached_count",
 		);
 	const costExpr =
-		sql<number>`COALESCE(SUM(${projectHourlyModelStats.cost}), 0)`.as("cost");
+		sql<number>`COALESCE(SUM(cast(${projectHourlyModelStats.cost} as double precision)), 0)`.as(
+			"cost",
+		);
 	const totalTokensExpr =
 		sql<number>`COALESCE(SUM(CAST(${projectHourlyModelStats.totalTokens} AS NUMERIC)), 0)`.as(
 			"total_tokens",
@@ -9604,15 +9646,15 @@ admin.openapi(getProjectModelProviderStats, async (c) => {
 					"output_tokens",
 				),
 			inputCost:
-				sql<number>`COALESCE(SUM(${projectHourlyModelStats.inputCost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyModelStats.inputCost} as double precision)), 0)`.as(
 					"input_cost",
 				),
 			cachedInputCost:
-				sql<number>`COALESCE(SUM(${projectHourlyModelStats.cachedInputCost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyModelStats.cachedInputCost} as double precision)), 0)`.as(
 					"cached_input_cost",
 				),
 			outputCost:
-				sql<number>`COALESCE(SUM(${projectHourlyModelStats.outputCost}), 0)`.as(
+				sql<number>`COALESCE(SUM(cast(${projectHourlyModelStats.outputCost} as double precision)), 0)`.as(
 					"output_cost",
 				),
 		})
@@ -9843,7 +9885,7 @@ admin.openapi(getModelProviderMappings, async (c) => {
 						sql<number>`COALESCE(SUM(${mappingHistory.table.cachedCount}), 0)`.as(
 							"cachedCount",
 						),
-					cost: sql<number>`COALESCE(SUM(${mappingHistory.table.totalCost}), 0)`.as(
+					cost: sql<number>`COALESCE(SUM(cast(${mappingHistory.table.totalCost} as double precision)), 0)`.as(
 						"cost",
 					),
 					...tokenBreakdownSums(mappingHistory.table),
@@ -9892,7 +9934,7 @@ admin.openapi(getModelProviderMappings, async (c) => {
 							"totalTokens",
 						),
 					totalCost:
-						sql<number>`COALESCE(SUM(${mappingHistory.table.totalCost}), 0)`.as(
+						sql<number>`COALESCE(SUM(cast(${mappingHistory.table.totalCost} as double precision)), 0)`.as(
 							"totalCost",
 						),
 					...tokenBreakdownSums(mappingHistory.table),
@@ -14106,7 +14148,7 @@ admin.openapi(getDevpassUsage, async (c) => {
 				sql<number>`COALESCE(SUM(CAST(${projectHourlyModelStats.totalTokens} AS NUMERIC)), 0)`.as(
 					"total_tokens",
 				),
-			cost: sql<number>`COALESCE(SUM(${projectHourlyModelStats.cost}), 0)`.as(
+			cost: sql<number>`COALESCE(SUM(cast(${projectHourlyModelStats.cost} as double precision)), 0)`.as(
 				"cost",
 			),
 		})
@@ -14121,7 +14163,11 @@ admin.openapi(getDevpassUsage, async (c) => {
 		)
 		.where(projectModelWhere)
 		.groupBy(projectHourlyModelStats.usedModel)
-		.orderBy(desc(sql`COALESCE(SUM(${projectHourlyModelStats.cost}), 0)`))
+		.orderBy(
+			desc(
+				sql`COALESCE(SUM(cast(${projectHourlyModelStats.cost} as double precision)), 0)`,
+			),
+		)
 		.limit(limit);
 
 	const providerRows = await db
@@ -14135,7 +14181,7 @@ admin.openapi(getDevpassUsage, async (c) => {
 				sql<number>`COALESCE(SUM(CAST(${projectHourlyModelStats.totalTokens} AS NUMERIC)), 0)`.as(
 					"total_tokens",
 				),
-			cost: sql<number>`COALESCE(SUM(${projectHourlyModelStats.cost}), 0)`.as(
+			cost: sql<number>`COALESCE(SUM(cast(${projectHourlyModelStats.cost} as double precision)), 0)`.as(
 				"cost",
 			),
 		})
@@ -14150,7 +14196,11 @@ admin.openapi(getDevpassUsage, async (c) => {
 		)
 		.where(projectModelWhere)
 		.groupBy(projectHourlyModelStats.usedProvider)
-		.orderBy(desc(sql`COALESCE(SUM(${projectHourlyModelStats.cost}), 0)`))
+		.orderBy(
+			desc(
+				sql`COALESCE(SUM(cast(${projectHourlyModelStats.cost} as double precision)), 0)`,
+			),
+		)
 		.limit(limit);
 
 	// Sources: use the per-project hourly source aggregator so the breakdown
@@ -14173,7 +14223,7 @@ admin.openapi(getDevpassUsage, async (c) => {
 				sql<number>`COALESCE(SUM(CAST(${projectHourlySourceStats.totalTokens} AS NUMERIC)), 0)`.as(
 					"total_tokens",
 				),
-			cost: sql<number>`COALESCE(SUM(${projectHourlySourceStats.cost}), 0)`.as(
+			cost: sql<number>`COALESCE(SUM(cast(${projectHourlySourceStats.cost} as double precision)), 0)`.as(
 				"cost",
 			),
 		})
@@ -14188,7 +14238,11 @@ admin.openapi(getDevpassUsage, async (c) => {
 		)
 		.where(projectSourceWhere)
 		.groupBy(projectHourlySourceStats.source)
-		.orderBy(desc(sql`COALESCE(SUM(${projectHourlySourceStats.cost}), 0)`))
+		.orderBy(
+			desc(
+				sql`COALESCE(SUM(cast(${projectHourlySourceStats.cost} as double precision)), 0)`,
+			),
+		)
 		.limit(limit);
 
 	const mapRow = (r: {
@@ -15963,7 +16017,7 @@ admin.openapi(getChatPlansUsage, async (c) => {
 				sql<number>`COALESCE(SUM(CAST(${projectHourlyModelStats.totalTokens} AS NUMERIC)), 0)`.as(
 					"total_tokens",
 				),
-			cost: sql<number>`COALESCE(SUM(${projectHourlyModelStats.cost}), 0)`.as(
+			cost: sql<number>`COALESCE(SUM(cast(${projectHourlyModelStats.cost} as double precision)), 0)`.as(
 				"cost",
 			),
 		})
@@ -15978,7 +16032,11 @@ admin.openapi(getChatPlansUsage, async (c) => {
 		)
 		.where(projectModelWhere)
 		.groupBy(projectHourlyModelStats.usedModel)
-		.orderBy(desc(sql`COALESCE(SUM(${projectHourlyModelStats.cost}), 0)`))
+		.orderBy(
+			desc(
+				sql`COALESCE(SUM(cast(${projectHourlyModelStats.cost} as double precision)), 0)`,
+			),
+		)
 		.limit(limit);
 
 	const providerRows = await db
@@ -15992,7 +16050,7 @@ admin.openapi(getChatPlansUsage, async (c) => {
 				sql<number>`COALESCE(SUM(CAST(${projectHourlyModelStats.totalTokens} AS NUMERIC)), 0)`.as(
 					"total_tokens",
 				),
-			cost: sql<number>`COALESCE(SUM(${projectHourlyModelStats.cost}), 0)`.as(
+			cost: sql<number>`COALESCE(SUM(cast(${projectHourlyModelStats.cost} as double precision)), 0)`.as(
 				"cost",
 			),
 		})
@@ -16007,7 +16065,11 @@ admin.openapi(getChatPlansUsage, async (c) => {
 		)
 		.where(projectModelWhere)
 		.groupBy(projectHourlyModelStats.usedProvider)
-		.orderBy(desc(sql`COALESCE(SUM(${projectHourlyModelStats.cost}), 0)`))
+		.orderBy(
+			desc(
+				sql`COALESCE(SUM(cast(${projectHourlyModelStats.cost} as double precision)), 0)`,
+			),
+		)
 		.limit(limit);
 
 	const projectSourceWhere = and(
@@ -16027,7 +16089,7 @@ admin.openapi(getChatPlansUsage, async (c) => {
 				sql<number>`COALESCE(SUM(CAST(${projectHourlySourceStats.totalTokens} AS NUMERIC)), 0)`.as(
 					"total_tokens",
 				),
-			cost: sql<number>`COALESCE(SUM(${projectHourlySourceStats.cost}), 0)`.as(
+			cost: sql<number>`COALESCE(SUM(cast(${projectHourlySourceStats.cost} as double precision)), 0)`.as(
 				"cost",
 			),
 		})
@@ -16042,7 +16104,11 @@ admin.openapi(getChatPlansUsage, async (c) => {
 		)
 		.where(projectSourceWhere)
 		.groupBy(projectHourlySourceStats.source)
-		.orderBy(desc(sql`COALESCE(SUM(${projectHourlySourceStats.cost}), 0)`))
+		.orderBy(
+			desc(
+				sql`COALESCE(SUM(cast(${projectHourlySourceStats.cost} as double precision)), 0)`,
+			),
+		)
 		.limit(limit);
 
 	const mapRow = (r: {

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -146,7 +146,9 @@ analytics.openapi(getMembersUsage, async (c) => {
 	const usageRows = await db
 		.select({
 			apiKeyId: apiKeyHourlyStats.apiKeyId,
-			cost: sql<number>`SUM(${apiKeyHourlyStats.cost})`.as("cost"),
+			cost: sql<number>`SUM(cast(${apiKeyHourlyStats.cost} as double precision))`.as(
+				"cost",
+			),
 			totalTokens:
 				sql<number>`SUM(CAST(${apiKeyHourlyStats.totalTokens} AS NUMERIC))`.as(
 					"total_tokens",
@@ -402,7 +404,9 @@ analytics.openapi(getMemberDetail, async (c) => {
 
 	const summaryRows = await db
 		.select({
-			cost: sql<number>`COALESCE(SUM(${apiKeyHourlyStats.cost}), 0)`.as("cost"),
+			cost: sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.cost} as double precision)), 0)`.as(
+				"cost",
+			),
 			inputTokens:
 				sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyStats.inputTokens} AS NUMERIC)), 0)`.as(
 					"input_tokens",
@@ -458,7 +462,9 @@ analytics.openapi(getMemberDetail, async (c) => {
 		.select({
 			usedModel: apiKeyHourlyModelStats.usedModel,
 			usedProvider: apiKeyHourlyModelStats.usedProvider,
-			cost: sql<number>`SUM(${apiKeyHourlyModelStats.cost})`.as("cost"),
+			cost: sql<number>`SUM(cast(${apiKeyHourlyModelStats.cost} as double precision))`.as(
+				"cost",
+			),
 			requestCount: sql<number>`SUM(${apiKeyHourlyModelStats.requestCount})`.as(
 				"request_count",
 			),
@@ -480,7 +486,9 @@ analytics.openapi(getMemberDetail, async (c) => {
 			apiKeyHourlyModelStats.usedModel,
 			apiKeyHourlyModelStats.usedProvider,
 		)
-		.orderBy(desc(sql`SUM(${apiKeyHourlyModelStats.cost})`));
+		.orderBy(
+			desc(sql`SUM(cast(${apiKeyHourlyModelStats.cost} as double precision))`),
+		);
 
 	const costByModel = modelRows
 		.map((r) => ({
@@ -539,7 +547,7 @@ analytics.openapi(getMemberDetail, async (c) => {
 			).as("date"),
 			usedModel: apiKeyHourlyModelStats.usedModel,
 			usedProvider: apiKeyHourlyModelStats.usedProvider,
-			cost: sql<number>`COALESCE(SUM(${apiKeyHourlyModelStats.cost}), 0)`.as(
+			cost: sql<number>`COALESCE(SUM(cast(${apiKeyHourlyModelStats.cost} as double precision)), 0)`.as(
 				"cost",
 			),
 			requestCount:
@@ -731,7 +739,9 @@ analytics.openapi(getSelfUsage, async (c) => {
 
 	const summaryRows = await db
 		.select({
-			cost: sql<number>`COALESCE(SUM(${apiKeyHourlyStats.cost}), 0)`.as("cost"),
+			cost: sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.cost} as double precision)), 0)`.as(
+				"cost",
+			),
 			inputTokens:
 				sql<number>`COALESCE(SUM(CAST(${apiKeyHourlyStats.inputTokens} AS NUMERIC)), 0)`.as(
 					"input_tokens",
@@ -782,7 +792,9 @@ analytics.openapi(getSelfUsage, async (c) => {
 			date: bucketDate(apiKeyHourlyStats.hourTimestamp, timeZone, false).as(
 				"date",
 			),
-			cost: sql<number>`COALESCE(SUM(${apiKeyHourlyStats.cost}), 0)`.as("cost"),
+			cost: sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.cost} as double precision)), 0)`.as(
+				"cost",
+			),
 			requestCount:
 				sql<number>`COALESCE(SUM(${apiKeyHourlyStats.requestCount}), 0)`.as(
 					"request_count",
@@ -823,7 +835,9 @@ analytics.openapi(getSelfUsage, async (c) => {
 	const modelRows = await db
 		.select({
 			usedModel: apiKeyHourlyModelStats.usedModel,
-			cost: sql<number>`SUM(${apiKeyHourlyModelStats.cost})`.as("cost"),
+			cost: sql<number>`SUM(cast(${apiKeyHourlyModelStats.cost} as double precision))`.as(
+				"cost",
+			),
 			requestCount: sql<number>`SUM(${apiKeyHourlyModelStats.requestCount})`.as(
 				"request_count",
 			),
@@ -842,7 +856,9 @@ analytics.openapi(getSelfUsage, async (c) => {
 			),
 		)
 		.groupBy(apiKeyHourlyModelStats.usedModel)
-		.orderBy(desc(sql`SUM(${apiKeyHourlyModelStats.cost})`));
+		.orderBy(
+			desc(sql`SUM(cast(${apiKeyHourlyModelStats.cost} as double precision))`),
+		);
 	const topModels = modelRows.slice(0, 5).map((r) => ({
 		key: r.usedModel || "unknown",
 		cost: Number(r.cost ?? 0),
@@ -982,7 +998,7 @@ analytics.openapi(getOrgActivity, async (c) => {
 			date: bucketDate(projectHourlyStats.hourTimestamp, timeZone, false).as(
 				"date",
 			),
-			cost: sql<number>`COALESCE(SUM(${projectHourlyStats.cost}), 0)`.as(
+			cost: sql<number>`COALESCE(SUM(cast(${projectHourlyStats.cost} as double precision)), 0)`.as(
 				"cost",
 			),
 			requestCount:
@@ -1056,7 +1072,7 @@ analytics.openapi(getOrgActivity, async (c) => {
 					false,
 				).as("date"),
 				usedModel: projectHourlyModelStats.usedModel,
-				cost: sql<number>`COALESCE(SUM(${projectHourlyModelStats.cost}), 0)`.as(
+				cost: sql<number>`COALESCE(SUM(cast(${projectHourlyModelStats.cost} as double precision)), 0)`.as(
 					"cost",
 				),
 				requestCount:
@@ -1108,7 +1124,7 @@ analytics.openapi(getOrgActivity, async (c) => {
 					"date",
 				),
 				projectId: projectHourlyStats.projectId,
-				cost: sql<number>`COALESCE(SUM(${projectHourlyStats.cost}), 0)`.as(
+				cost: sql<number>`COALESCE(SUM(cast(${projectHourlyStats.cost} as double precision)), 0)`.as(
 					"cost",
 				),
 				requestCount:
@@ -1173,7 +1189,7 @@ analytics.openapi(getOrgActivity, async (c) => {
 				),
 				apiKeyId: apiKeyHourlyStats.apiKeyId,
 				description: tables.apiKey.description,
-				cost: sql<number>`COALESCE(SUM(${apiKeyHourlyStats.cost}), 0)`.as(
+				cost: sql<number>`COALESCE(SUM(cast(${apiKeyHourlyStats.cost} as double precision)), 0)`.as(
 					"cost",
 				),
 				requestCount:

--- a/apps/api/src/routes/organization.ts
+++ b/apps/api/src/routes/organization.ts
@@ -1521,7 +1521,7 @@ organization.openapi(getCreditsRunway, async (c) => {
 	// blended `cost` would overstate the burn rate for BYOK-heavy orgs.
 	const result = await db
 		.select({
-			totalCost: sql<number>`COALESCE(SUM(${projectHourlyStats.creditsCost}), 0) + COALESCE(SUM(${projectHourlyStats.apiKeysDataStorageCost}), 0)`,
+			totalCost: sql<number>`COALESCE(SUM(cast(${projectHourlyStats.creditsCost} as double precision)), 0) + COALESCE(SUM(cast(${projectHourlyStats.apiKeysDataStorageCost} as double precision)), 0)`,
 		})
 		.from(projectHourlyStats)
 		.innerJoin(

--- a/apps/api/src/routes/team.ts
+++ b/apps/api/src/routes/team.ts
@@ -26,7 +26,7 @@ import {
 	inArray,
 	isValidApiKeyPeriodDuration,
 	resolveEffectiveMemberBudget,
-	sum,
+	sql,
 	tables,
 	type OrgDefaultDeveloperBudget,
 } from "@llmgateway/db";
@@ -309,7 +309,10 @@ async function computeMemberSpend(
 				member.periodUsageDurationUnit,
 			);
 			const rows = await db
-				.select({ total: sum(tables.apiKeyHourlyStats.cost) })
+				// cost is float4; SUM(real) accumulates in float4 too, so cast first.
+				.select({
+					total: sql<string>`coalesce(sum(cast(${tables.apiKeyHourlyStats.cost} as double precision)), 0)`,
+				})
 				.from(tables.apiKeyHourlyStats)
 				.where(
 					and(

--- a/apps/api/src/testing.ts
+++ b/apps/api/src/testing.ts
@@ -150,56 +150,61 @@ function getCommonAggregationFields() {
 			sql<string>`coalesce(sum(cast(${tables.log.cacheWriteTokens} as numeric)), 0)`.as(
 				"cacheWriteTokens",
 			),
-		cost: sql<number>`coalesce(sum(${tables.log.cost}), 0)`.as("cost"),
-		inputCost: sql<number>`coalesce(sum(${tables.log.inputCost}), 0)`.as(
-			"inputCost",
+		cost: sql<number>`coalesce(sum(cast(${tables.log.cost} as double precision)), 0)`.as(
+			"cost",
 		),
-		outputCost: sql<number>`coalesce(sum(${tables.log.outputCost}), 0)`.as(
-			"outputCost",
-		),
-		requestCost: sql<number>`coalesce(sum(${tables.log.requestCost}), 0)`.as(
-			"requestCost",
-		),
+		inputCost:
+			sql<number>`coalesce(sum(cast(${tables.log.inputCost} as double precision)), 0)`.as(
+				"inputCost",
+			),
+		outputCost:
+			sql<number>`coalesce(sum(cast(${tables.log.outputCost} as double precision)), 0)`.as(
+				"outputCost",
+			),
+		requestCost:
+			sql<number>`coalesce(sum(cast(${tables.log.requestCost} as double precision)), 0)`.as(
+				"requestCost",
+			),
 		dataStorageCost:
-			sql<number>`coalesce(sum(cast(${tables.log.dataStorageCost} as real)), 0)`.as(
+			sql<number>`coalesce(sum(cast(${tables.log.dataStorageCost} as double precision)), 0)`.as(
 				"dataStorageCost",
 			),
 		discountSavings: sql<number>`coalesce(
 			sum(
 				case
 					when ${tables.log.discount} > 0 and ${tables.log.discount} < 1
-					then ${tables.log.cost} * ${tables.log.discount} / (1 - ${tables.log.discount})
+					then cast(${tables.log.cost} as double precision) * ${tables.log.discount} / (1 - ${tables.log.discount})
 					else 0
 				end
 			),
 			0
 		)`.as("discountSavings"),
 		imageInputCost:
-			sql<number>`coalesce(sum(${tables.log.imageInputCost}), 0)`.as(
+			sql<number>`coalesce(sum(cast(${tables.log.imageInputCost} as double precision)), 0)`.as(
 				"imageInputCost",
 			),
 		imageOutputCost:
-			sql<number>`coalesce(sum(${tables.log.imageOutputCost}), 0)`.as(
+			sql<number>`coalesce(sum(cast(${tables.log.imageOutputCost} as double precision)), 0)`.as(
 				"imageOutputCost",
 			),
 		audioInputCost:
-			sql<number>`coalesce(sum(${tables.log.audioInputCost}), 0)`.as(
+			sql<number>`coalesce(sum(cast(${tables.log.audioInputCost} as double precision)), 0)`.as(
 				"audioInputCost",
 			),
 		audioOutputCost:
-			sql<number>`coalesce(sum(${tables.log.audioOutputCost}), 0)`.as(
+			sql<number>`coalesce(sum(cast(${tables.log.audioOutputCost} as double precision)), 0)`.as(
 				"audioOutputCost",
 			),
 		videoOutputCost:
-			sql<number>`coalesce(sum(${tables.log.videoOutputCost}), 0)`.as(
+			sql<number>`coalesce(sum(cast(${tables.log.videoOutputCost} as double precision)), 0)`.as(
 				"videoOutputCost",
 			),
 		cachedInputCost:
-			sql<number>`coalesce(sum(${tables.log.cachedInputCost}), 0)`.as(
+			sql<number>`coalesce(sum(cast(${tables.log.cachedInputCost} as double precision)), 0)`.as(
 				"cachedInputCost",
 			),
 		cacheWriteInputCost:
-			sql<number>`coalesce(sum(${tables.log.cacheWriteInputCost}), 0)`.as(
+			sql<number>`coalesce(sum(cast(${tables.log.cacheWriteInputCost} as double precision)), 0)`.as(
 				"cacheWriteInputCost",
 			),
 		// Per-mode breakdowns
@@ -212,19 +217,19 @@ function getCommonAggregationFields() {
 				"apiKeysRequestCount",
 			),
 		creditsCost:
-			sql<number>`coalesce(sum(case when ${tables.log.usedMode} = 'credits' then ${tables.log.cost} else 0 end), 0)`.as(
+			sql<number>`coalesce(sum(case when ${tables.log.usedMode} = 'credits' then cast(${tables.log.cost} as double precision) else 0 end), 0)`.as(
 				"creditsCost",
 			),
 		apiKeysCost:
-			sql<number>`coalesce(sum(case when ${tables.log.usedMode} = 'api-keys' then ${tables.log.cost} else 0 end), 0)`.as(
+			sql<number>`coalesce(sum(case when ${tables.log.usedMode} = 'api-keys' then cast(${tables.log.cost} as double precision) else 0 end), 0)`.as(
 				"apiKeysCost",
 			),
 		creditsDataStorageCost:
-			sql<number>`coalesce(sum(case when ${tables.log.usedMode} = 'credits' then cast(${tables.log.dataStorageCost} as real) else 0 end), 0)`.as(
+			sql<number>`coalesce(sum(case when ${tables.log.usedMode} = 'credits' then cast(${tables.log.dataStorageCost} as double precision) else 0 end), 0)`.as(
 				"creditsDataStorageCost",
 			),
 		apiKeysDataStorageCost:
-			sql<number>`coalesce(sum(case when ${tables.log.usedMode} = 'api-keys' then cast(${tables.log.dataStorageCost} as real) else 0 end), 0)`.as(
+			sql<number>`coalesce(sum(case when ${tables.log.usedMode} = 'api-keys' then cast(${tables.log.dataStorageCost} as double precision) else 0 end), 0)`.as(
 				"apiKeysDataStorageCost",
 			),
 	};
@@ -462,7 +467,9 @@ export async function aggregateLogsForTesting() {
 				sql<string>`coalesce(sum(cast(${tables.log.totalTokens} as numeric)), 0)`.as(
 					"totalTokens",
 				),
-			cost: sql<number>`coalesce(sum(${tables.log.cost}), 0)`.as("cost"),
+			cost: sql<number>`coalesce(sum(cast(${tables.log.cost} as double precision)), 0)`.as(
+				"cost",
+			),
 		})
 		.from(tables.log)
 		.where(isNotNull(tables.log.providerKeyId))

--- a/apps/gateway/src/lib/cached-queries.ts
+++ b/apps/gateway/src/lib/cached-queries.ts
@@ -21,7 +21,7 @@ import {
 	isNull,
 	ne,
 	or,
-	sum,
+	sql,
 	cdb as db,
 	apiKey as apiKeyTable,
 	apiKeyHourlyStats as apiKeyHourlyStatsTable,
@@ -1240,7 +1240,10 @@ export async function getMemberPeriodSpend(
 		[apiKeyHourlyStatsTableName, apiKeyTableName, projectTableName],
 		async () =>
 			await db
-				.select({ total: sum(apiKeyHourlyStatsTable.cost) })
+				// cost is float4; SUM(real) accumulates in float4 too, so cast first.
+				.select({
+					total: sql<string>`coalesce(sum(cast(${apiKeyHourlyStatsTable.cost} as double precision)), 0)`,
+				})
 				.from(apiKeyHourlyStatsTable)
 				.where(
 					and(

--- a/apps/gateway/src/realtime/billing.ts
+++ b/apps/gateway/src/realtime/billing.ts
@@ -96,7 +96,7 @@ export async function getUnsettledRealtimeOrganizationSpend(
 		.select({
 			total: sql<
 				string | null
-			>`sum(coalesce(${log.billingCost}, ${log.cost}::numeric))`,
+			>`sum(coalesce(${log.billingCost}, ${log.cost}::float8::numeric))`,
 		})
 		.from(log)
 		.where(

--- a/apps/worker/src/services/follow-up-emails.ts
+++ b/apps/worker/src/services/follow-up-emails.ts
@@ -318,7 +318,7 @@ async function processLowUsageEmails(): Promise<void> {
 		LEFT JOIN (
 			SELECT
 				${project.organizationId} AS organization_id,
-				SUM(${projectHourlyStats.cost}) AS total_spent
+				SUM(cast(${projectHourlyStats.cost} as double precision)) AS total_spent
 			FROM ${projectHourlyStats}
 			JOIN ${project} ON ${project.id} = ${projectHourlyStats.projectId}
 			GROUP BY ${project.organizationId}
@@ -394,7 +394,7 @@ async function processNoRepurchaseEmails(): Promise<void> {
 		LEFT JOIN (
 			SELECT
 				${project.organizationId} AS organization_id,
-				SUM(${projectHourlyStats.cost}) AS total_spent
+				SUM(cast(${projectHourlyStats.cost} as double precision)) AS total_spent
 			FROM ${projectHourlyStats}
 			JOIN ${project} ON ${project.id} = ${projectHourlyStats.projectId}
 			GROUP BY ${project.organizationId}

--- a/apps/worker/src/services/stats-calculator.ts
+++ b/apps/worker/src/services/stats-calculator.ts
@@ -382,15 +382,20 @@ async function calculateModelHistoryForMinute(targetMinute: Date) {
 				sql<number>`count(${log.timeToFirstReasoningToken})::int`.as(
 					"timeToFirstReasoningTokenCount",
 				),
-			totalCost: sql<number>`coalesce(sum(${log.cost}), 0)`.as("totalCost"),
-			totalInputCost: sql<number>`coalesce(sum(${log.inputCost}), 0)`.as(
-				"totalInputCost",
-			),
-			totalOutputCost: sql<number>`coalesce(sum(${log.outputCost}), 0)`.as(
-				"totalOutputCost",
-			),
+			totalCost:
+				sql<number>`coalesce(sum(cast(${log.cost} as double precision)), 0)`.as(
+					"totalCost",
+				),
+			totalInputCost:
+				sql<number>`coalesce(sum(cast(${log.inputCost} as double precision)), 0)`.as(
+					"totalInputCost",
+				),
+			totalOutputCost:
+				sql<number>`coalesce(sum(cast(${log.outputCost} as double precision)), 0)`.as(
+					"totalOutputCost",
+				),
 			totalCachedInputCost:
-				sql<number>`coalesce(sum(${log.cachedInputCost}), 0)`.as(
+				sql<number>`coalesce(sum(cast(${log.cachedInputCost} as double precision)), 0)`.as(
 					"totalCachedInputCost",
 				),
 			// Service-tier coverage. `requestedServiceTier` holds the tier the gateway
@@ -656,15 +661,20 @@ async function calculateHistoryForMinute(targetMinute: Date) {
 				sql<number>`count(${log.timeToFirstReasoningToken})::int`.as(
 					"timeToFirstReasoningTokenCount",
 				),
-			totalCost: sql<number>`coalesce(sum(${log.cost}), 0)`.as("totalCost"),
-			totalInputCost: sql<number>`coalesce(sum(${log.inputCost}), 0)`.as(
-				"totalInputCost",
-			),
-			totalOutputCost: sql<number>`coalesce(sum(${log.outputCost}), 0)`.as(
-				"totalOutputCost",
-			),
+			totalCost:
+				sql<number>`coalesce(sum(cast(${log.cost} as double precision)), 0)`.as(
+					"totalCost",
+				),
+			totalInputCost:
+				sql<number>`coalesce(sum(cast(${log.inputCost} as double precision)), 0)`.as(
+					"totalInputCost",
+				),
+			totalOutputCost:
+				sql<number>`coalesce(sum(cast(${log.outputCost} as double precision)), 0)`.as(
+					"totalOutputCost",
+				),
 			totalCachedInputCost:
-				sql<number>`coalesce(sum(${log.cachedInputCost}), 0)`.as(
+				sql<number>`coalesce(sum(cast(${log.cachedInputCost} as double precision)), 0)`.as(
 					"totalCachedInputCost",
 				),
 			// Service-tier coverage. `requestedServiceTier` holds the tier the gateway
@@ -1118,10 +1128,10 @@ async function calculateModelHistoryForHour(targetHour: Date) {
 			totalTimeToFirstReasoningToken: sql<number>`coalesce(sum(${modelHistory.totalTimeToFirstReasoningToken}), 0)::int`,
 			timeToFirstTokenCount: sql<number>`coalesce(sum(${modelHistory.timeToFirstTokenCount}), 0)::int`,
 			timeToFirstReasoningTokenCount: sql<number>`coalesce(sum(${modelHistory.timeToFirstReasoningTokenCount}), 0)::int`,
-			totalCost: sql<number>`coalesce(sum(${modelHistory.totalCost}), 0)`,
-			totalInputCost: sql<number>`coalesce(sum(${modelHistory.totalInputCost}), 0)`,
-			totalOutputCost: sql<number>`coalesce(sum(${modelHistory.totalOutputCost}), 0)`,
-			totalCachedInputCost: sql<number>`coalesce(sum(${modelHistory.totalCachedInputCost}), 0)`,
+			totalCost: sql<number>`coalesce(sum(cast(${modelHistory.totalCost} as double precision)), 0)`,
+			totalInputCost: sql<number>`coalesce(sum(cast(${modelHistory.totalInputCost} as double precision)), 0)`,
+			totalOutputCost: sql<number>`coalesce(sum(cast(${modelHistory.totalOutputCost} as double precision)), 0)`,
+			totalCachedInputCost: sql<number>`coalesce(sum(cast(${modelHistory.totalCachedInputCost} as double precision)), 0)`,
 			serviceTierExplicitCount: sql<number>`coalesce(sum(${modelHistory.serviceTierExplicitCount}), 0)::int`,
 			serviceTierImplicitCount: sql<number>`coalesce(sum(${modelHistory.serviceTierImplicitCount}), 0)::int`,
 			serviceTierServedCount: sql<number>`coalesce(sum(${modelHistory.serviceTierServedCount}), 0)::int`,
@@ -1188,10 +1198,10 @@ async function calculateMappingHistoryForHour(targetHour: Date) {
 			totalTimeToFirstReasoningToken: sql<number>`coalesce(sum(${modelProviderMappingHistory.totalTimeToFirstReasoningToken}), 0)::int`,
 			timeToFirstTokenCount: sql<number>`coalesce(sum(${modelProviderMappingHistory.timeToFirstTokenCount}), 0)::int`,
 			timeToFirstReasoningTokenCount: sql<number>`coalesce(sum(${modelProviderMappingHistory.timeToFirstReasoningTokenCount}), 0)::int`,
-			totalCost: sql<number>`coalesce(sum(${modelProviderMappingHistory.totalCost}), 0)`,
-			totalInputCost: sql<number>`coalesce(sum(${modelProviderMappingHistory.totalInputCost}), 0)`,
-			totalOutputCost: sql<number>`coalesce(sum(${modelProviderMappingHistory.totalOutputCost}), 0)`,
-			totalCachedInputCost: sql<number>`coalesce(sum(${modelProviderMappingHistory.totalCachedInputCost}), 0)`,
+			totalCost: sql<number>`coalesce(sum(cast(${modelProviderMappingHistory.totalCost} as double precision)), 0)`,
+			totalInputCost: sql<number>`coalesce(sum(cast(${modelProviderMappingHistory.totalInputCost} as double precision)), 0)`,
+			totalOutputCost: sql<number>`coalesce(sum(cast(${modelProviderMappingHistory.totalOutputCost} as double precision)), 0)`,
+			totalCachedInputCost: sql<number>`coalesce(sum(cast(${modelProviderMappingHistory.totalCachedInputCost} as double precision)), 0)`,
 			serviceTierExplicitCount: sql<number>`coalesce(sum(${modelProviderMappingHistory.serviceTierExplicitCount}), 0)::int`,
 			serviceTierImplicitCount: sql<number>`coalesce(sum(${modelProviderMappingHistory.serviceTierImplicitCount}), 0)::int`,
 			serviceTierServedCount: sql<number>`coalesce(sum(${modelProviderMappingHistory.serviceTierServedCount}), 0)::int`,


### PR DESCRIPTION
Follow-up to #3547, which fixed only the admin global stats endpoint and the worker's shared aggregation fields. Every other place that summed a float4 money column had the same latent bug.

## The bug

Postgres' `sum(real)` returns **`real`** — the accumulation itself is single precision, about 7 significant digits. Once a running sum is large enough its ulp exceeds a cent, so the result depends on how the rows happened to be grouped, and a headline stops matching the slices underneath it. On the admin Global Stats page that showed up as a double-digit-dollar discrepancy; everywhere else the magnitudes are smaller, so it hasn't surfaced yet.

```sql
with r as (select (i % 4) as bucket, 1234.5678::real as c from generate_series(1,800) i)
select (select sum(c)::text from r),                                          -- 987650.7
       (select sum(s)::text from (select sum(c) s from r group by bucket) g),  -- 987652.7
       (select sum(c::float8::numeric)::text from r);                          -- 987654.19921875
```

## The fix

Cast each money column to `double precision` *inside* the sum, so the accumulation happens in float8. Casting the column rather than restructuring the aggregate handles all three shapes uniformly — plain sums, `CASE` branches, and nested `coalesce`:

```diff
-cost: sql<number>`coalesce(sum(${log.cost}), 0)`
+cost: sql<number>`coalesce(sum(cast(${log.cost} as double precision)), 0)`

-then ${log.cost} * ${log.discount} / (1 - ${log.discount})
+then cast(${log.cost} as double precision) * ${log.discount} / (1 - ${log.discount})
```

The result type stays a JS number (float8 and float4 both come back as numbers from `pg`), so no call site changes.

169 sums across 12 files: activity, analytics, admin, admin provider credentials, usage reports, user usage breakdown, mode split, organization, follow-up emails, the model/mapping history rollups in `stats-calculator`, and the `testing.ts` aggregation helper that mirrors them.

Three of those were `cast(... as real)`, which is **strictly worse than no cast at all** — it forces a `numeric` column down to float4 before summing. Those become `double precision`.

## Three sites that needed more than a cast

- **`team.ts`** and **`gateway/lib/cached-queries.ts`** used drizzle's `sum()` helper, which emits a bare `sum(real)`. Both are member-budget enforcement over `api_key_hourly_stats.cost`. Replaced with an explicit cast; `sql` had to be imported in both.
- **`gateway/realtime/billing.ts`** already accumulated in `numeric`, so it was never at risk — but it reached numeric via `real::numeric`, which routes through float4's **6-digit display form** (`790469.7661::real::numeric` → `790470`). Now `real::float8::numeric`, which is the exact stored value. This is the only change on a live billing path; it makes per-row values strictly more precise and does not alter aggregation semantics.

## Why double precision and not numeric

`numeric` is exact and grouping-independent, which is why the all-time cross-tenant sums in #3547 use it — but it returns a string from `pg`, so every call site would need a `::float8` and a type change. At the per-project and per-model magnitudes here, float8's 15–16 significant digits put the error around 1e-16 relative, far below any display precision. `double precision` gets the correctness with a zero-risk diff.

## Verification

- Re-ran the detector across the repo: **0 remaining** uncast money sums, and no double-casts or `as real` left behind.
- `apps/api` + `apps/worker`: **1066/1067 pass**. The one failure (`account-deletion.spec.ts`, Stripe mock call ordering) passes in isolation, is cross-suite state, and that file is not in this diff.
- `pnpm format` and `pnpm build` clean.

No behaviour change is expected on any dashboard — the sums were already approximately right at these magnitudes. This removes the failure mode before the numbers grow into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the accuracy and consistency of spend, cost, usage, and credit totals across dashboards, reports, analytics, activity views, and administrative summaries.
  - Updated cost calculations to preserve greater precision when aggregating usage across models, providers, projects, teams, and billing periods.
  - Improved ordering and ranking of cost-based results by using more precise totals.
  - Existing response formats, usage metrics, and billing behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->