### PR TITLE
feat(ui): add local-time toggle to datetime stats

### DIFF
--- a/apps/code/src/app/dashboard/(main)/billing/BillingClient.tsx
+++ b/apps/code/src/app/dashboard/(main)/billing/BillingClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { format, formatDistanceToNowStrict } from "date-fns";
+import { formatDistanceToNowStrict } from "date-fns";
 import { Info, Loader2 } from "lucide-react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
@@ -28,6 +28,8 @@ import { useAppConfig } from "@/lib/config";
 import { useApi } from "@/lib/fetch-client";
 import { useStripe } from "@/lib/stripe";
 import { cn } from "@/lib/utils";
+
+import { Time, TimeZoneToggle } from "@llmgateway/shared/components";
 
 import type { TierChangeTiming } from "@/app/dashboard/components/ActivePlanChangeTier";
 import type { PlanTier } from "@/app/dashboard/types";
@@ -332,22 +334,31 @@ export default function BillingClient({
 					return d;
 				})()
 			: null;
-	const renewWhen = renewAt ? format(renewAt, "MMM d, yyyy") : null;
+	const renewWhen = renewAt ? (
+		<Time date={renewAt} format="MMM d, yyyy" />
+	) : null;
 
-	const renewalHint = !renewAt
-		? "—"
-		: cancelled
-			? `Ends ${renewWhen}`
-			: `Renews ${renewWhen} (in ${formatDistanceToNowStrict(renewAt)})`;
+	const renewalHint = !renewAt ? (
+		"—"
+	) : cancelled ? (
+		<>Ends {renewWhen}</>
+	) : (
+		<>
+			Renews {renewWhen} (in {formatDistanceToNowStrict(renewAt)})
+		</>
+	);
 
 	// A scheduled tier change keeps the current tier active until renewal, then
 	// switches. Surface both the pending tier and the date it applies.
 	const pendingChangeNotice =
-		showPendingChange && pendingPlanData
-			? `Your plan ${pendingIsUpgrade ? "upgrades" : "switches"} to ${pendingPlanData.name}${
-					renewWhen ? ` on ${renewWhen}` : " at your next renewal"
-				}. You keep your current allowance until then.`
-			: null;
+		showPendingChange && pendingPlanData ? (
+			<>
+				Your plan {pendingIsUpgrade ? "upgrades" : "switches"} to{" "}
+				{pendingPlanData.name}
+				{renewWhen ? <> on {renewWhen}</> : " at your next renewal"}. You keep
+				your current allowance until then.
+			</>
+		) : null;
 
 	return (
 		<div className="space-y-10">
@@ -404,51 +415,54 @@ export default function BillingClient({
 						)}
 					</div>
 
-					{cancelled ? (
-						<Button
-							variant="outline"
-							size="sm"
-							onClick={handleResume}
-							disabled={isResuming}
-						>
-							{isResuming && (
-								<Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-							)}
-							Resume subscription
-						</Button>
-					) : (
-						<AlertDialog>
-							<AlertDialogTrigger asChild>
-								<Button
-									variant="ghost"
-									size="sm"
-									disabled={isCancelling}
-									className="text-muted-foreground"
-								>
-									{isCancelling && (
-										<Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-									)}
-									Cancel subscription
-								</Button>
-							</AlertDialogTrigger>
-							<AlertDialogContent>
-								<AlertDialogHeader>
-									<AlertDialogTitle>Cancel your Dev Plan?</AlertDialogTitle>
-									<AlertDialogDescription>
-										Your plan stays active until the end of the current billing
-										period. You won&apos;t be charged again, and you can resume
-										any time before then.
-									</AlertDialogDescription>
-								</AlertDialogHeader>
-								<AlertDialogFooter>
-									<AlertDialogCancel>Keep subscription</AlertDialogCancel>
-									<AlertDialogAction onClick={handleCancel}>
+					<div className="flex items-center gap-3">
+						<TimeZoneToggle />
+						{cancelled ? (
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={handleResume}
+								disabled={isResuming}
+							>
+								{isResuming && (
+									<Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+								)}
+								Resume subscription
+							</Button>
+						) : (
+							<AlertDialog>
+								<AlertDialogTrigger asChild>
+									<Button
+										variant="ghost"
+										size="sm"
+										disabled={isCancelling}
+										className="text-muted-foreground"
+									>
+										{isCancelling && (
+											<Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+										)}
 										Cancel subscription
-									</AlertDialogAction>
-								</AlertDialogFooter>
-							</AlertDialogContent>
-						</AlertDialog>
-					)}
+									</Button>
+								</AlertDialogTrigger>
+								<AlertDialogContent>
+									<AlertDialogHeader>
+										<AlertDialogTitle>Cancel your Dev Plan?</AlertDialogTitle>
+										<AlertDialogDescription>
+											Your plan stays active until the end of the current
+											billing period. You won&apos;t be charged again, and you
+											can resume any time before then.
+										</AlertDialogDescription>
+									</AlertDialogHeader>
+									<AlertDialogFooter>
+										<AlertDialogCancel>Keep subscription</AlertDialogCancel>
+										<AlertDialogAction onClick={handleCancel}>
+											Cancel subscription
+										</AlertDialogAction>
+									</AlertDialogFooter>
+								</AlertDialogContent>
+							</AlertDialog>
+						)}
+					</div>
 				</div>
 
 				{/* Clarify DevPass vs pay-as-you-go billing */}

--- a/apps/code/src/app/dashboard/agents/[agentId]/AgentDetailClient.tsx
+++ b/apps/code/src/app/dashboard/agents/[agentId]/AgentDetailClient.tsx
@@ -30,6 +30,7 @@ import { useUser } from "@/hooks/useUser";
 import { useApi, useFetchClient } from "@/lib/fetch-client";
 
 import { buildAgentLogsCsv } from "@llmgateway/shared";
+import { Time, TimeZoneToggle } from "@llmgateway/shared/components";
 
 type ModelSortColumn =
 	| "id"
@@ -270,7 +271,7 @@ function RequestRow({ log }: { log: ApiLog }) {
 					{log.usedModel ?? log.requestedModel ?? "—"}
 				</p>
 				<p className="text-xs text-muted-foreground/70">
-					{new Date(log.createdAt).toLocaleString()}
+					<Time date={log.createdAt} format="M/d/yyyy, h:mm:ss a" />
 				</p>
 			</div>
 			<div className="flex items-center gap-3 text-xs text-muted-foreground tabular-nums">
@@ -516,6 +517,7 @@ function AgentDetailBody({
 					</div>
 				</div>
 				<div className="flex flex-wrap items-center gap-2">
+					<TimeZoneToggle />
 					<TimeRangePicker value={timeRange} onChange={updateTimeRange} />
 					<button
 						type="button"

--- a/apps/code/src/app/dashboard/components/ActivePlanChangeTier.tsx
+++ b/apps/code/src/app/dashboard/components/ActivePlanChangeTier.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { format } from "date-fns";
 import { ArrowDown, ArrowRight, ArrowUp, Loader2 } from "lucide-react";
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 
 import {
 	AlertDialog,
@@ -19,6 +18,8 @@ import { Button } from "@/components/ui/button";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { useApi } from "@/lib/fetch-client";
 import { cn, formatUsageRatio } from "@/lib/utils";
+
+import { Time, TimeZoneToggle } from "@llmgateway/shared/components";
 
 import type { PlanOption, PlanTier } from "@/app/dashboard/types";
 import type { paths } from "@/lib/api/v1";
@@ -82,7 +83,10 @@ export default function ActivePlanChangeTier({
 
 	return (
 		<div>
-			<h2 className="mb-1 font-semibold">Change plan</h2>
+			<div className="flex items-center justify-between gap-4">
+				<h2 className="mb-1 font-semibold">Change plan</h2>
+				<TimeZoneToggle />
+			</div>
 			<p className="mb-4 text-sm text-muted-foreground">
 				{cancelled
 					? "Your subscription is scheduled to cancel. Resume it first to change your plan."
@@ -331,9 +335,11 @@ function TierChangeDialog({
 	);
 }
 
-function formatRenewalDate(iso: string): string | null {
+function formatRenewalDate(iso: string): ReactNode | null {
 	const date = new Date(iso);
-	return Number.isNaN(date.getTime()) ? null : format(date, "MMM d, yyyy");
+	return Number.isNaN(date.getTime()) ? null : (
+		<Time date={date} format="MMM d, yyyy" />
+	);
 }
 
 // Shared between the timing chooser and the fallback preview copy so the
@@ -427,7 +433,7 @@ function UpgradeTimingChoice({
 				/>
 				<span className="flex flex-col gap-1">
 					<span className="text-sm font-medium">
-						At next renewal{renewalDate ? ` — ${renewalDate}` : ""}
+						At next renewal{renewalDate ? <> — {renewalDate}</> : ""}
 					</span>
 					<span className="text-xs text-muted-foreground">
 						No charge today. You keep your {currentName} allowance until{" "}

--- a/apps/code/src/app/dashboard/components/ActivityHeatmap.tsx
+++ b/apps/code/src/app/dashboard/components/ActivityHeatmap.tsx
@@ -5,6 +5,12 @@ import { useMemo } from "react";
 
 import { useApi } from "@/lib/fetch-client";
 
+import {
+	getBrowserTimeZone,
+	parseDayString,
+	useTimeZonePreference,
+} from "@llmgateway/shared";
+
 interface ActivityHeatmapProps {
 	projectId: string | null;
 }
@@ -56,6 +62,13 @@ function dateKey(d: Date): string {
 	return `${yyyy}-${mm}-${dd}`;
 }
 
+function dateKeyLocal(d: Date): string {
+	const yyyy = d.getFullYear();
+	const mm = String(d.getMonth() + 1).padStart(2, "0");
+	const dd = String(d.getDate()).padStart(2, "0");
+	return `${yyyy}-${mm}-${dd}`;
+}
+
 function formatDateLong(iso: string): string {
 	const d = new Date(iso + "T00:00:00Z");
 	return d.toLocaleDateString(undefined, {
@@ -67,7 +80,22 @@ function formatDateLong(iso: string): string {
 	});
 }
 
+function formatDateLongLocal(iso: string): string {
+	// The day key is already a local calendar day (matches the API's
+	// local-bucketed day strings) — render its literal day, not a UTC shift.
+	const d = parseDayString(iso);
+	return d.toLocaleDateString(undefined, {
+		weekday: "short",
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+	});
+}
+
 export default function ActivityHeatmap({ projectId }: ActivityHeatmapProps) {
+	const { pref } = useTimeZonePreference();
+	const local = pref === "local";
+	const timezone = local ? getBrowserTimeZone() : undefined;
 	const api = useApi();
 
 	const { data, isLoading } = api.useQuery(
@@ -76,8 +104,15 @@ export default function ActivityHeatmap({ projectId }: ActivityHeatmapProps) {
 		{
 			params: {
 				query: projectId
-					? { projectId, timeRange: "365d" as const }
-					: { timeRange: "365d" as const },
+					? {
+							projectId,
+							timeRange: "365d" as const,
+							...(timezone ? { timezone } : {}),
+						}
+					: {
+							timeRange: "365d" as const,
+							...(timezone ? { timezone } : {}),
+						},
 			},
 		},
 		{
@@ -90,14 +125,25 @@ export default function ActivityHeatmap({ projectId }: ActivityHeatmapProps) {
 	const { weeks, totalRequests, activeDays, currentStreak, max, monthMarks } =
 		useMemo(() => {
 			const today = new Date();
-			today.setUTCHours(0, 0, 0, 0);
+			if (local) {
+				today.setHours(0, 0, 0, 0);
+			} else {
+				today.setUTCHours(0, 0, 0, 0);
+			}
 
 			const start = new Date(today);
-			start.setUTCDate(start.getUTCDate() - 364);
+			if (local) {
+				start.setDate(start.getDate() - 364);
+			} else {
+				start.setUTCDate(start.getUTCDate() - 364);
+			}
 
-			const dayOfWeekStart = start.getUTCDay();
 			const gridStart = new Date(start);
-			gridStart.setUTCDate(gridStart.getUTCDate() - dayOfWeekStart);
+			if (local) {
+				gridStart.setDate(gridStart.getDate() - start.getDay());
+			} else {
+				gridStart.setUTCDate(gridStart.getUTCDate() - start.getUTCDay());
+			}
 
 			const totalDaysInGrid =
 				Math.floor(
@@ -123,12 +169,16 @@ export default function ActivityHeatmap({ projectId }: ActivityHeatmapProps) {
 				for (let d = 0; d < 7; d++) {
 					const cellDate = new Date(gridStart);
 					const offset = w * 7;
-					cellDate.setUTCDate(gridStart.getUTCDate() + offset + d);
+					if (local) {
+						cellDate.setDate(gridStart.getDate() + offset + d);
+					} else {
+						cellDate.setUTCDate(gridStart.getUTCDate() + offset + d);
+					}
 					if (cellDate < start || cellDate > today) {
 						week.push(null);
 						continue;
 					}
-					const key = dateKey(cellDate);
+					const key = local ? dateKeyLocal(cellDate) : dateKey(cellDate);
 					const c = counts.get(key) ?? 0;
 					if (c > maxCount) {
 						maxCount = c;
@@ -145,12 +195,17 @@ export default function ActivityHeatmap({ projectId }: ActivityHeatmapProps) {
 			let streak = 0;
 			const cursor = new Date(today);
 			while (cursor >= start) {
-				const c = counts.get(dateKey(cursor)) ?? 0;
+				const c =
+					counts.get(local ? dateKeyLocal(cursor) : dateKey(cursor)) ?? 0;
 				if (c === 0) {
 					break;
 				}
 				streak += 1;
-				cursor.setUTCDate(cursor.getUTCDate() - 1);
+				if (local) {
+					cursor.setDate(cursor.getDate() - 1);
+				} else {
+					cursor.setUTCDate(cursor.getUTCDate() - 1);
+				}
 			}
 
 			const seenMonths = new Set<number>();
@@ -160,9 +215,12 @@ export default function ActivityHeatmap({ projectId }: ActivityHeatmapProps) {
 				if (!firstReal) {
 					continue;
 				}
-				const d = new Date(firstReal.date + "T00:00:00Z");
-				const month = d.getUTCMonth();
-				const day = d.getUTCDate();
+				const month = local
+					? parseDayString(firstReal.date).getMonth()
+					: new Date(firstReal.date + "T00:00:00Z").getUTCMonth();
+				const day = local
+					? parseDayString(firstReal.date).getDate()
+					: new Date(firstReal.date + "T00:00:00Z").getUTCDate();
 				if (day <= 7 && !seenMonths.has(month)) {
 					seenMonths.add(month);
 					marks.push({ weekIndex: w, label: MONTH_LABELS[month] });
@@ -177,7 +235,7 @@ export default function ActivityHeatmap({ projectId }: ActivityHeatmapProps) {
 				max: maxCount,
 				monthMarks: marks,
 			};
-		}, [data]);
+		}, [data, local]);
 
 	if (!projectId) {
 		return null;
@@ -261,7 +319,9 @@ export default function ActivityHeatmap({ projectId }: ActivityHeatmapProps) {
 														</span>{" "}
 														<span className="text-background/70">
 															{cell.count === 1 ? "request" : "requests"} ·{" "}
-															{formatDateLong(cell.date)}
+															{local
+																? formatDateLongLocal(cell.date)
+																: formatDateLong(cell.date)}
 														</span>
 														<span className="absolute left-1/2 top-full -ml-1 h-2 w-2 -translate-y-1 rotate-45 bg-foreground" />
 													</div>

--- a/apps/code/src/app/dashboard/components/AgentModelUsageChart.tsx
+++ b/apps/code/src/app/dashboard/components/AgentModelUsageChart.tsx
@@ -23,6 +23,8 @@ import {
 } from "@/components/ui/select";
 import { useApi } from "@/lib/fetch-client";
 
+import { getBrowserTimeZone, useTimeZonePreference } from "@llmgateway/shared";
+
 import type { paths } from "@/lib/api/v1";
 import type { TooltipProps } from "recharts";
 
@@ -211,6 +213,8 @@ function ChartTooltipContent({
 export function AgentModelUsageChart({ projectId }: AgentModelUsageChartProps) {
 	const [range, setRange] = useState<AgentChartTimeRange>("24h");
 	const [metric, setMetric] = useState<Metric>("cost");
+	const { pref } = useTimeZonePreference();
+	const timezone = pref === "local" ? getBrowserTimeZone() : undefined;
 	const api = useApi();
 
 	const { data, isLoading, isFetching } = api.useQuery(
@@ -221,6 +225,7 @@ export function AgentModelUsageChart({ projectId }: AgentModelUsageChartProps) {
 				query: {
 					timeRange: range,
 					projectId,
+					...(timezone ? { timezone } : {}),
 				},
 			},
 		},

--- a/apps/code/src/app/dashboard/components/DevPassInvoices.tsx
+++ b/apps/code/src/app/dashboard/components/DevPassInvoices.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { format } from "date-fns";
 import {
 	ChevronLeft,
 	ChevronRight,
@@ -30,7 +29,11 @@ import {
 	isRefundFeedbackComplete,
 	type RefundReason,
 } from "@llmgateway/shared";
-import { RefundReasonFieldset } from "@llmgateway/shared/components";
+import {
+	RefundReasonFieldset,
+	Time,
+	TimeZoneToggle,
+} from "@llmgateway/shared/components";
 
 import type { paths } from "@/lib/api/v1";
 import type { ReactNode } from "react";
@@ -333,7 +336,10 @@ export default function DevPassInvoices() {
 
 	return (
 		<div>
-			<h2 className="mb-1 font-semibold">Invoices</h2>
+			<div className="flex items-center justify-between gap-4">
+				<h2 className="mb-1 font-semibold">Invoices</h2>
+				<TimeZoneToggle />
+			</div>
 			<p className="mb-4 text-sm text-muted-foreground">
 				A record of every DevPass charge, including the amount debited and the
 				usage credits granted for that billing period.
@@ -354,7 +360,7 @@ export default function DevPassInvoices() {
 						className="grid grid-cols-2 gap-x-4 gap-y-1 border-b px-5 py-4 last:border-b-0 sm:col-span-5 sm:grid-cols-subgrid sm:items-center"
 					>
 						<div className="text-sm tabular-nums">
-							{format(new Date(invoice.date), "MMM d, yyyy")}
+							<Time date={invoice.date} format="MMM d, yyyy" />
 						</div>
 						<div className="text-sm">
 							<span>{TYPE_LABELS[invoice.type]}</span>

--- a/apps/code/src/app/dashboard/components/UsageOverview.tsx
+++ b/apps/code/src/app/dashboard/components/UsageOverview.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { format, formatDistanceToNowStrict } from "date-fns";
+import { formatDistanceToNowStrict } from "date-fns";
 import { Activity, Coins, Cpu, Gem, TrendingUp } from "lucide-react";
 import { usePostHog } from "posthog-js/react";
 import { useEffect } from "react";
 
 import { useAppConfig } from "@/lib/config";
 import { useApi } from "@/lib/fetch-client";
+
+import { Time, TimeZoneToggle } from "@llmgateway/shared/components";
 
 import { AgentModelUsageChart } from "./AgentModelUsageChart";
 import AllowanceExhaustedCard from "./AllowanceExhaustedCard";
@@ -54,7 +56,7 @@ function MetricCard({
 }: {
 	label: string;
 	value: string;
-	hint?: string;
+	hint?: React.ReactNode;
 	icon: React.ComponentType<{ className?: string }>;
 }) {
 	return (
@@ -110,9 +112,13 @@ function WeeklyAllowanceMeter({
 						<span className="font-normal text-muted-foreground">spent</span>
 					</div>
 					<div className="mt-0.5 text-xs text-muted-foreground">
-						{resetsAt
-							? `Resets ${format(new Date(resetsAt), "MMM d")}`
-							: "Window starts with your first premium request"}
+						{resetsAt ? (
+							<>
+								Resets <Time date={resetsAt} format="MMM d" />
+							</>
+						) : (
+							"Window starts with your first premium request"
+						)}
 					</div>
 				</div>
 				<div
@@ -285,9 +291,13 @@ export default function UsageOverview({
 	);
 	const cycleLengthLabel = billingCycleStart ? "this cycle" : "30d";
 
-	const cycleLabel = billingCycleStart
-		? `Since ${format(new Date(billingCycleStart), "MMM d, yyyy")}`
-		: "Active";
+	const cycleLabel = billingCycleStart ? (
+		<>
+			Since <Time date={billingCycleStart} format="MMM d, yyyy" />
+		</>
+	) : (
+		"Active"
+	);
 
 	// The renewal/period-end date must come from Stripe's actual
 	// `current_period_end` (surfaced as `currentPeriodEnd`), not from
@@ -311,13 +321,19 @@ export default function UsageOverview({
 				})()
 			: null;
 
-	const cycleEndsHint = cancelledAtPeriodEnd
-		? renewAt
-			? `Cancels ${format(renewAt, "MMM d, yyyy")}`
-			: "Cancels at period end"
-		: renewAt
-			? `Renews in ${formatDistanceToNowStrict(renewAt)}`
-			: "—";
+	const cycleEndsHint = cancelledAtPeriodEnd ? (
+		renewAt ? (
+			<>
+				Cancels <Time date={renewAt} format="MMM d, yyyy" />
+			</>
+		) : (
+			"Cancels at period end"
+		)
+	) : renewAt ? (
+		`Renews in ${formatDistanceToNowStrict(renewAt)}`
+	) : (
+		"—"
+	);
 
 	return (
 		<div className="space-y-5">
@@ -338,6 +354,7 @@ export default function UsageOverview({
 						{cycleLabel} · {cycleEndsHint}
 					</p>
 				</div>
+				<TimeZoneToggle />
 			</div>
 
 			{/* Usage progress */}
@@ -448,9 +465,9 @@ export default function UsageOverview({
 							: "—"
 					}
 					hint={
-						peakDay && (peakDay.cost ?? 0) > 0
-							? format(new Date(peakDay.date), "MMM d")
-							: undefined
+						peakDay && (peakDay.cost ?? 0) > 0 ? (
+							<Time date={peakDay.date} format="MMM d" />
+						) : undefined
 					}
 					icon={TrendingUp}
 				/>

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/page.tsx
@@ -2,6 +2,8 @@ import { RecentLogs } from "@/components/activity/recent-logs";
 import { fetchModels, fetchProviders } from "@/lib/fetch-models";
 import { fetchServerData } from "@/lib/server-api";
 
+import { TimeZoneToggle } from "@llmgateway/shared/components";
+
 import type { LogsData } from "@/types/activity";
 
 export default async function ActivityPage({
@@ -95,11 +97,14 @@ export default async function ActivityPage({
 	return (
 		<div className="flex flex-col">
 			<div className="flex-1 space-y-4 p-4 pt-6 md:p-8">
-				<div>
-					<h2 className="text-3xl font-bold tracking-tight">Activity Logs</h2>
-					<p className="mt-1 text-sm text-muted-foreground">
-						Your recent API requests and system events
-					</p>
+				<div className="flex items-center justify-between gap-4">
+					<div>
+						<h2 className="text-3xl font-bold tracking-tight">Activity Logs</h2>
+						<p className="mt-1 text-sm text-muted-foreground">
+							Your recent API requests and system events
+						</p>
+					</div>
+					<TimeZoneToggle />
 				</div>
 				<RecentLogs
 					initialData={initialLogsData ?? undefined}

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/agents/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/agents/page.tsx
@@ -6,6 +6,8 @@ import { parseAgentTimeRange } from "@/lib/agent-time-ranges";
 import { DEVPASS_CARD_COLLAPSED_COOKIE } from "@/lib/cookies";
 import { fetchServerData } from "@/lib/server-api";
 
+import { TimeZoneToggle } from "@llmgateway/shared/components";
+
 import type { SourceActivityData } from "@/types/activity";
 
 export default async function AgentsPage({
@@ -41,11 +43,14 @@ export default async function AgentsPage({
 		<div className="flex flex-col">
 			<div className="flex-1 space-y-4 p-4 pt-6 md:p-8">
 				<DevPassCard defaultCollapsed={devPassCollapsed} />
-				<div>
-					<h2 className="text-3xl font-bold tracking-tight">Agents</h2>
-					<p className="text-muted-foreground">
-						Monitor your AI coding agents and their activity
-					</p>
+				<div className="flex items-center justify-between gap-4">
+					<div>
+						<h2 className="text-3xl font-bold tracking-tight">Agents</h2>
+						<p className="text-muted-foreground">
+							Monitor your AI coding agents and their activity
+						</p>
+					</div>
+					<TimeZoneToggle />
 				</div>
 				<AgentsView
 					projectId={projectId}

--- a/apps/ui/src/app/dashboard/[orgId]/org/audit-logs/audit-logs-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/audit-logs/audit-logs-client.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { format } from "date-fns";
 import { Check, Copy } from "lucide-react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useState, useEffect, useCallback } from "react";
@@ -26,6 +25,8 @@ import {
 	SelectValue,
 } from "@/lib/components/select";
 import { useFetchClient } from "@/lib/fetch-client";
+
+import { Time, TimeZoneToggle } from "@llmgateway/shared/components";
 
 import { ContactSalesCard } from "./contact-sales-card";
 
@@ -273,12 +274,15 @@ export function AuditLogsClient() {
 	return (
 		<div className="space-y-6">
 			<Card>
-				<CardHeader>
-					<CardTitle>Audit Logs</CardTitle>
-					<CardDescription>
-						View a complete history of all actions taken within your
-						organization.
-					</CardDescription>
+				<CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
+					<div>
+						<CardTitle>Audit Logs</CardTitle>
+						<CardDescription>
+							View a complete history of all actions taken within your
+							organization.
+						</CardDescription>
+					</div>
+					<TimeZoneToggle />
 				</CardHeader>
 				<CardContent>
 					{/* Filters */}
@@ -366,7 +370,7 @@ export function AuditLogsClient() {
 															{formatAction(log.action)}
 														</Badge>
 														<span className="text-xs text-muted-foreground">
-															{format(new Date(log.createdAt), "PPp")}
+															<Time date={log.createdAt} format="PPp" />
 														</span>
 													</div>
 													<div className="text-sm">
@@ -454,7 +458,7 @@ export function AuditLogsClient() {
 													className="hover:bg-muted/25 transition-colors"
 												>
 													<td className="p-4 align-middle text-sm whitespace-nowrap">
-														{format(new Date(log.createdAt), "PPp")}
+														<Time date={log.createdAt} format="PPp" />
 													</td>
 													<td className="p-4 align-middle">
 														<div className="flex flex-col">

--- a/apps/ui/src/app/dashboard/[orgId]/org/security-events/security-events-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/security-events/security-events-client.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { format } from "date-fns";
 import { AlertTriangle, ShieldAlert, ShieldCheck, Eye } from "lucide-react";
 import { useParams } from "next/navigation";
 import { useState, useEffect, useCallback } from "react";
@@ -26,6 +25,8 @@ import {
 	SelectValue,
 } from "@/lib/components/select";
 import { useFetchClient } from "@/lib/fetch-client";
+
+import { Time, TimeZoneToggle } from "@llmgateway/shared/components";
 
 import { ContactSalesCard } from "./contact-sales-card";
 
@@ -278,11 +279,14 @@ export function SecurityEventsClient() {
 
 			{/* Violations List */}
 			<Card>
-				<CardHeader>
-					<CardTitle>Security Events</CardTitle>
-					<CardDescription>
-						View all guardrail violations and security events
-					</CardDescription>
+				<CardHeader className="flex flex-row items-start justify-between gap-4 space-y-0">
+					<div>
+						<CardTitle>Security Events</CardTitle>
+						<CardDescription>
+							View all guardrail violations and security events
+						</CardDescription>
+					</div>
+					<TimeZoneToggle />
 				</CardHeader>
 				<CardContent>
 					{/* Filters */}
@@ -371,7 +375,7 @@ export function SecurityEventsClient() {
 															{violation.actionTaken}
 														</Badge>
 														<span className="text-xs text-muted-foreground">
-															{format(new Date(violation.createdAt), "PPp")}
+															<Time date={violation.createdAt} format="PPp" />
 														</span>
 													</div>
 													<div className="text-sm font-medium">
@@ -421,7 +425,7 @@ export function SecurityEventsClient() {
 													className="hover:bg-muted/25 transition-colors"
 												>
 													<td className="p-4 align-middle text-sm whitespace-nowrap">
-														{format(new Date(violation.createdAt), "PPp")}
+														<Time date={violation.createdAt} format="PPp" />
 													</td>
 													<td className="p-4 align-middle">
 														<span className="text-sm font-medium">

--- a/apps/ui/src/app/dashboard/[orgId]/org/team/team-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/team/team-client.tsx
@@ -90,6 +90,7 @@ import { getBrowserTimeZone } from "@/lib/timezone";
 import { applyUsageMode } from "@/lib/usage-mode";
 
 import { SSO_TEAM_DEFAULT_DEVELOPER_BUDGET } from "@llmgateway/shared";
+import { Time, TimeZoneToggle } from "@llmgateway/shared/components";
 
 import type { Route } from "next";
 
@@ -898,6 +899,7 @@ export function TeamClient({ initialData }: { initialData?: TeamMembersData }) {
 							</p>
 						</div>
 						<div className="flex items-center gap-2">
+							<TimeZoneToggle />
 							{showUsage && (
 								<>
 									<UsageModeSelector />
@@ -1339,10 +1341,10 @@ export function TeamClient({ initialData }: { initialData?: TeamMembersData }) {
 													)}
 												</TableCell>
 												<TableCell>
-													{format(new Date(invite.createdAt), "MMM d, yyyy")}
+													<Time date={invite.createdAt} format="MMM d, yyyy" />
 												</TableCell>
 												<TableCell>
-													{format(new Date(invite.expiresAt), "MMM d, yyyy")}
+													<Time date={invite.expiresAt} format="MMM d, yyyy" />
 												</TableCell>
 												{isAdmin && (
 													<TableCell className="text-right">

--- a/apps/ui/src/components/activity/agents-view.tsx
+++ b/apps/ui/src/components/activity/agents-view.tsx
@@ -47,6 +47,7 @@ import {
 	OpenClawIcon,
 	OpenCodeIcon,
 	SoulForgeIcon,
+	Time,
 } from "@llmgateway/shared/components";
 
 import type { paths } from "@/lib/api/v1";
@@ -352,9 +353,8 @@ function SessionCard({
 							<ChevronRight className="h-4 w-4 text-muted-foreground" />
 						)}
 						<div className="text-sm text-muted-foreground">
-							{session.startTime.toLocaleDateString()}{" "}
-							{session.startTime.toLocaleTimeString()} &ndash;{" "}
-							{session.endTime.toLocaleTimeString()}
+							<Time date={session.startTime} format="M/d/yyyy h:mm:ss a" />{" "}
+							&ndash; <Time date={session.endTime} format="h:mm:ss a" />
 						</div>
 					</div>
 					<div className="flex items-center gap-4 text-sm text-muted-foreground">

--- a/apps/ui/src/components/activity/sessions-view.tsx
+++ b/apps/ui/src/components/activity/sessions-view.tsx
@@ -26,6 +26,8 @@ import {
 } from "@/lib/components/select";
 import { useApi } from "@/lib/fetch-client";
 
+import { Time, TimeZoneToggle } from "@llmgateway/shared/components";
+
 import type { paths } from "@/lib/api/v1";
 import type { Log } from "@llmgateway/db";
 
@@ -210,9 +212,8 @@ function SessionCard({
 								{formatSourceLabel(session.source)}
 							</div>
 							<div className="text-sm text-muted-foreground">
-								{session.startTime.toLocaleDateString()}{" "}
-								{session.startTime.toLocaleTimeString()} -{" "}
-								{session.endTime.toLocaleTimeString()}
+								<Time date={session.startTime} format="M/d/yyyy h:mm:ss a" /> -{" "}
+								<Time date={session.endTime} format="h:mm:ss a" />
 							</div>
 						</div>
 					</div>
@@ -339,6 +340,7 @@ export function SessionsView({
 	return (
 		<div className="space-y-4">
 			<div className="flex flex-wrap gap-2 mb-4 sticky top-0 bg-background z-10 py-2">
+				<TimeZoneToggle />
 				<DateRangeSelect
 					onChange={(_value: string, range: DateRange) => {
 						setDateRange(range);

--- a/apps/ui/src/components/api-keys/api-keys-client.tsx
+++ b/apps/ui/src/components/api-keys/api-keys-client.tsx
@@ -16,6 +16,8 @@ import {
 import { useApi } from "@/lib/fetch-client";
 import { extractOrgAndProjectFromPath } from "@/lib/navigation-utils";
 
+import { TimeZoneToggle } from "@llmgateway/shared/components";
+
 import type { Project, ApiKey } from "@/lib/types";
 
 export function ApiKeysClient({ initialData }: { initialData: ApiKey[] }) {
@@ -85,34 +87,37 @@ export function ApiKeysClient({ initialData }: { initialData: ApiKey[] }) {
 							Create and manage API keys to authenticate requests to LLM Gateway
 						</p>
 					</div>
-					{selectedProject && (
-						<CreateApiKeyDialog
-							selectedProject={selectedProject}
-							disabled={
-								planLimits
-									? planLimits.currentCount >= planLimits.maxKeys
-									: false
-							}
-							disabledMessage={
-								planLimits
-									? `${planLimits.plan === "enterprise" ? "Enterprise" : planLimits.plan === "pro" ? "Pro" : "Free"} plan allows maximum ${planLimits.maxKeys} API keys per organization`
-									: undefined
-							}
-						>
-							<Button
+					<div className="flex items-center gap-4">
+						<TimeZoneToggle />
+						{selectedProject && (
+							<CreateApiKeyDialog
+								selectedProject={selectedProject}
 								disabled={
-									!selectedProject ||
-									(planLimits
+									planLimits
 										? planLimits.currentCount >= planLimits.maxKeys
-										: false)
+										: false
 								}
-								className="cursor-pointer flex items-center space-x-1 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed"
+								disabledMessage={
+									planLimits
+										? `${planLimits.plan === "enterprise" ? "Enterprise" : planLimits.plan === "pro" ? "Pro" : "Free"} plan allows maximum ${planLimits.maxKeys} API keys per organization`
+										: undefined
+								}
 							>
-								<Orbit className=" h-4 w-4 mt-0.5" />
-								Create API Key
-							</Button>
-						</CreateApiKeyDialog>
-					)}
+								<Button
+									disabled={
+										!selectedProject ||
+										(planLimits
+											? planLimits.currentCount >= planLimits.maxKeys
+											: false)
+									}
+									className="cursor-pointer flex items-center space-x-1 w-full md:w-auto disabled:opacity-50 disabled:cursor-not-allowed"
+								>
+									<Orbit className=" h-4 w-4 mt-0.5" />
+									Create API Key
+								</Button>
+							</CreateApiKeyDialog>
+						)}
+					</div>
 				</div>
 				<div className="space-y-4">
 					{/* Desktop Card */}

--- a/apps/ui/src/components/api-keys/api-keys-list.tsx
+++ b/apps/ui/src/components/api-keys/api-keys-list.tsx
@@ -56,6 +56,8 @@ import { toast } from "@/lib/components/use-toast";
 import { useApi } from "@/lib/fetch-client";
 import { extractOrgAndProjectFromPath } from "@/lib/navigation-utils";
 
+import { Time } from "@llmgateway/shared/components";
+
 import {
 	formatCurrentPeriodUsageSummary,
 	formatCurrencyAmount,
@@ -664,22 +666,15 @@ export function ApiKeysList({
 										<Tooltip>
 											<TooltipTrigger asChild>
 												<span className="text-muted-foreground cursor-help border-b border-dotted border-muted-foreground/50 hover:border-muted-foreground">
-													{Intl.DateTimeFormat(undefined, {
-														month: "short",
-														day: "numeric",
-														year: "numeric",
-													}).format(new Date(key.createdAt))}
+													<Time date={key.createdAt} format="MMM d, yyyy" />
 												</span>
 											</TooltipTrigger>
 											<TooltipContent>
 												<p className="max-w-xs text-xs whitespace-nowrap">
-													{Intl.DateTimeFormat(undefined, {
-														month: "short",
-														day: "numeric",
-														year: "numeric",
-														hour: "2-digit",
-														minute: "2-digit",
-													}).format(new Date(key.createdAt))}
+													<Time
+														date={key.createdAt}
+														format="MMM d, yyyy, hh:mm a"
+													/>
 												</p>
 											</TooltipContent>
 										</Tooltip>
@@ -869,13 +864,10 @@ export function ApiKeysList({
 									{renderExpiry(key)}
 									<div className="flex items-center gap-2 mt-1">
 										<span className="text-xs text-muted-foreground">
-											{Intl.DateTimeFormat(undefined, {
-												month: "short",
-												day: "numeric",
-												year: "numeric",
-												hour: "2-digit",
-												minute: "2-digit",
-											}).format(new Date(key.createdAt))}
+											<Time
+												date={key.createdAt}
+												format="MMM d, yyyy, hh:mm a"
+											/>
 										</span>
 									</div>
 								</div>

--- a/apps/ui/src/components/dashboard/transactions-client.tsx
+++ b/apps/ui/src/components/dashboard/transactions-client.tsx
@@ -20,6 +20,8 @@ import {
 } from "@/lib/components/table";
 import { useApi } from "@/lib/fetch-client";
 
+import { Time, TimeZoneToggle } from "@llmgateway/shared/components";
+
 interface TransactionsClientProps {
 	initialTransactionsData?: any;
 }
@@ -153,6 +155,7 @@ export function TransactionsClient({
 					<h2 className="text-2xl md:text-3xl font-bold tracking-tight">
 						Transactions
 					</h2>
+					<TimeZoneToggle />
 				</div>
 				<Card>
 					<CardHeader>
@@ -193,7 +196,10 @@ export function TransactionsClient({
 												<div>Amount: ${transaction.amount}</div>
 												<div>
 													Date:{" "}
-													{new Date(transaction.createdAt).toLocaleDateString()}
+													<Time
+														date={transaction.createdAt}
+														format="M/d/yyyy"
+													/>
 												</div>
 												{transaction.description && (
 													<div>Description: {transaction.description}</div>
@@ -232,7 +238,10 @@ export function TransactionsClient({
 													</Badge>
 												</TableCell>
 												<TableCell>
-													{new Date(transaction.createdAt).toLocaleDateString()}
+													<Time
+														date={transaction.createdAt}
+														format="M/d/yyyy"
+													/>
 												</TableCell>
 												<TableCell>{transaction.description ?? "—"}</TableCell>
 											</TableRow>

--- a/apps/ui/src/lib/timezone.ts
+++ b/apps/ui/src/lib/timezone.ts
@@ -1,7 +1,1 @@
-export function getBrowserTimeZone(): string {
-	try {
-		return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
-	} catch {
-		return "UTC";
-	}
-}
+export { getBrowserTimeZone } from "@llmgateway/shared";

--- a/packages/shared/src/components/index.tsx
+++ b/packages/shared/src/components/index.tsx
@@ -20,5 +20,7 @@ export * from "./provider-icons";
 export * from "./refund-reason-fieldset";
 export * from "./reorderable-list";
 export * from "./searchable-select";
-export * from "./use-countdown";
+export * from "./time";
+export * from "./time-zone-toggle";
 export * from "./ui/index";
+export * from "./use-countdown";

--- a/packages/shared/src/components/log-card.tsx
+++ b/packages/shared/src/components/log-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { format, formatDistanceToNow } from "date-fns";
+import { formatDistanceToNow } from "date-fns";
 import {
 	AlertCircle,
 	AudioWaveform,
@@ -50,6 +50,8 @@ import {
 	formatServiceTierMultiplier,
 	getServiceTier,
 } from "@llmgateway/models";
+
+import { Time } from "./time";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1193,7 +1195,7 @@ export function LogCard({
 							<div className="grid grid-cols-2 gap-2 rounded-md border p-3 text-sm">
 								<div className="text-muted-foreground">Date</div>
 								<div className="font-mono text-xs">
-									{format(new Date(log.createdAt), "dd.MM.yyyy HH:mm:ss")}
+									<Time date={log.createdAt} format="dd.MM.yyyy HH:mm:ss" />
 								</div>
 								<div className="text-muted-foreground">Request ID</div>
 								<div className="flex items-center gap-1 font-mono text-xs break-all">

--- a/packages/shared/src/components/time-zone-toggle.tsx
+++ b/packages/shared/src/components/time-zone-toggle.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useTimeZonePreference } from "@/hooks/use-time-zone-preference.js";
+
+import { Label } from "./ui/label";
+import { Switch } from "./ui/switch";
+
+export function TimeZoneToggle({ className }: { className?: string }) {
+	const { pref, setPref } = useTimeZonePreference();
+	return (
+		<label className={`flex items-center gap-2 ${className ?? ""}`}>
+			<Switch
+				checked={pref === "local"}
+				onCheckedChange={(checked: boolean) =>
+					setPref(checked ? "local" : "utc")
+				}
+			/>
+			<Label className="text-xs text-muted-foreground">Local time</Label>
+		</label>
+	);
+}

--- a/packages/shared/src/components/time.tsx
+++ b/packages/shared/src/components/time.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { useTimeZonePreference } from "@/hooks/use-time-zone-preference.js";
+import { timeToDisplay } from "@/lib/format-date.js";
+
+export function Time({
+	date,
+	format,
+	className,
+}: {
+	date: Date | string;
+	format: string;
+	className?: string;
+}) {
+	const [mounted, setMounted] = useState(false);
+	const { pref } = useTimeZonePreference();
+	useEffect(() => setMounted(true), []);
+	if (!mounted) {
+		return null; // never render a server-TZ guess
+	}
+	const value = typeof date === "string" ? date : date.toISOString();
+	return (
+		<span className={className}>{timeToDisplay(value, format, pref)}</span>
+	);
+}

--- a/packages/shared/src/hooks/use-time-zone-preference.ts
+++ b/packages/shared/src/hooks/use-time-zone-preference.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import {
+	type TimeZonePref,
+	readTimeZonePref,
+	writeTimeZonePref,
+} from "@/lib/format-date.js";
+
+const listeners = new Set<() => void>();
+let current: TimeZonePref = "utc";
+
+function emit(): void {
+	listeners.forEach((l) => l());
+}
+
+export function useTimeZonePreference(): {
+	pref: TimeZonePref;
+	setPref: (pref: TimeZonePref) => void;
+} {
+	const [pref, setPrefState] = useState<TimeZonePref>(current);
+	useEffect(() => {
+		const loaded = readTimeZonePref();
+		current = loaded;
+		setPrefState(loaded);
+		const listener = () => setPrefState(current);
+		listeners.add(listener);
+		return () => {
+			listeners.delete(listener);
+		};
+	}, []);
+
+	const setPref = useCallback((next: TimeZonePref) => {
+		current = next;
+		writeTimeZonePref(next);
+		emit();
+	}, []);
+
+	return { pref, setPref };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -128,6 +128,8 @@ export {
 
 export { useIsMobile } from "./hooks/use-mobile.js";
 
+export { useTimeZonePreference } from "./hooks/use-time-zone-preference.js";
+
 export { cn } from "./lib/utils.js";
 
 export {
@@ -136,6 +138,18 @@ export {
 } from "./video-proxy.js";
 
 export { selectLoadBalancedItem } from "./load-balance.js";
+
+export {
+	TIME_ZONE_PREF_KEY,
+	formatInTimeZone,
+	getBrowserTimeZone,
+	isDayString,
+	parseDayString,
+	readTimeZonePref,
+	timeToDisplay,
+	type TimeZonePref,
+	writeTimeZonePref,
+} from "./lib/format-date.js";
 
 export {
 	fillRandomFloats,

--- a/packages/shared/src/lib/format-date.spec.ts
+++ b/packages/shared/src/lib/format-date.spec.ts
@@ -1,0 +1,123 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+	formatInTimeZone,
+	getBrowserTimeZone,
+	isDayString,
+	parseDayString,
+	readTimeZonePref,
+	timeToDisplay,
+	writeTimeZonePref,
+} from "./format-date.js";
+
+const ORIGINAL_TZ = process.env.TZ;
+const ORIGINAL_LOCAL_STORAGE = (globalThis as Record<string, unknown>)
+	.localStorage;
+const prefStore = new Map<string, string>();
+beforeAll(() => {
+	process.env.TZ = "America/Montreal"; // UTC−4 (EDT) — known offset
+	// Node has no localStorage — stub an in-memory one for the pref round-trip.
+	(globalThis as Record<string, unknown>).localStorage = {
+		getItem: (key: string) => prefStore.get(key) ?? null,
+		setItem: (key: string, value: string) => {
+			prefStore.set(key, value);
+		},
+		removeItem: (key: string) => {
+			prefStore.delete(key);
+		},
+		clear: () => {
+			prefStore.clear();
+		},
+		key: (index: number) => Array.from(prefStore.keys())[index] ?? null,
+		get length() {
+			return prefStore.size;
+		},
+	};
+});
+afterAll(() => {
+	if (ORIGINAL_TZ) {
+		process.env.TZ = ORIGINAL_TZ;
+	}
+	if (ORIGINAL_LOCAL_STORAGE === undefined) {
+		delete (globalThis as Record<string, unknown>).localStorage;
+	} else {
+		(globalThis as Record<string, unknown>).localStorage =
+			ORIGINAL_LOCAL_STORAGE;
+	}
+});
+
+describe("parseDayString", () => {
+	it("parses YYYY-MM-DD as LOCAL midnight (not UTC)", () => {
+		const d = parseDayString("2026-08-12");
+		expect(d.getFullYear()).toBe(2026);
+		expect(d.getMonth()).toBe(7);
+		expect(d.getDate()).toBe(12);
+		expect(d.getHours()).toBe(0);
+		expect(d.getTimezoneOffset()).toBe(240); // EDT — proves it's local-anchored
+	});
+	it("rejects malformed input", () => {
+		expect(() => parseDayString("08/12/2026")).toThrow();
+		expect(() => parseDayString("")).toThrow();
+	});
+});
+
+describe("isDayString", () => {
+	it("matches YYYY-MM-DD only", () => {
+		expect(isDayString("2026-08-12")).toBe(true);
+		expect(isDayString("2026-08-12T00:00:00Z")).toBe(false);
+	});
+});
+
+describe("formatInTimeZone", () => {
+	it("renders an instant in the requested zone", () => {
+		// 2026-08-12T04:00:00Z = Aug 12 00:00 in Montreal (UTC−4)
+		const out = formatInTimeZone(
+			"2026-08-12T04:00:00.000Z",
+			"MMM d, yyyy HH:mm",
+			"America/Montreal",
+		);
+		expect(out).toBe("Aug 12, 2026 00:00");
+	});
+	it("renders in UTC", () => {
+		const out = formatInTimeZone(
+			"2026-08-12T04:00:00.000Z",
+			"MMM d, yyyy HH:mm",
+			"UTC",
+		);
+		expect(out).toBe("Aug 12, 2026 04:00");
+	});
+});
+
+describe("timeToDisplay (toggle-aware)", () => {
+	it("utc pref → UTC wall clock, day strings as UTC midnight (legacy behavior)", () => {
+		expect(timeToDisplay("2026-08-12", "MMM d, yyyy", "utc")).toBe(
+			"Aug 12, 2026",
+		);
+		expect(
+			timeToDisplay("2026-08-12T04:00:00.000Z", "MMM d, HH:mm", "utc"),
+		).toBe("Aug 12, 04:00");
+	});
+	it("local pref → browser/local wall clock, day strings as local midnight (fixes off-by-one)", () => {
+		expect(timeToDisplay("2026-08-12", "MMM d, yyyy", "local")).toBe(
+			"Aug 12, 2026",
+		);
+		expect(
+			timeToDisplay("2026-08-12T04:00:00.000Z", "MMM d, HH:mm", "local"),
+		).toBe("Aug 12, 00:00");
+	});
+});
+
+describe("readTimeZonePref / writeTimeZonePref", () => {
+	it("defaults to utc and round-trips", () => {
+		expect(readTimeZonePref()).toBe("utc");
+		writeTimeZonePref("local");
+		expect(readTimeZonePref()).toBe("local");
+		writeTimeZonePref("utc");
+	});
+});
+
+describe("getBrowserTimeZone", () => {
+	it("returns a non-empty IANA name (or UTC fallback)", () => {
+		expect(getBrowserTimeZone().length).toBeGreaterThan(0);
+	});
+});

--- a/packages/shared/src/lib/format-date.ts
+++ b/packages/shared/src/lib/format-date.ts
@@ -1,0 +1,97 @@
+import { format } from "date-fns";
+
+export const TIME_ZONE_PREF_KEY = "llmgateway:tz-pref";
+export type TimeZonePref = "utc" | "local";
+
+const DAY_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+export function isDayString(value: string): boolean {
+	return DAY_RE.test(value);
+}
+
+/** "YYYY-MM-DD" as LOCAL midnight. new Date("YYYY-MM-DD") is UTC midnight,
+ *  which renders as the previous day for UTC− users in local mode. */
+export function parseDayString(day: string): Date {
+	const m = DAY_RE.exec(day);
+	if (!m) {
+		throw new Error(`Invalid day string: ${day} (expected YYYY-MM-DD)`);
+	}
+	return new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+}
+
+export function getBrowserTimeZone(): string {
+	try {
+		return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+	} catch {
+		return "UTC";
+	}
+}
+
+/** Dependency-free format in a target timezone (date-fns v4 has no native
+ *  formatInTimeZone): read the target zone's wall-clock fields with Intl, then
+ *  build a Date whose LOCAL fields equal them — format() prints exactly those
+ *  fields, deterministically in any runtime TZ. */
+export function formatInTimeZone(
+	date: Date | string | number,
+	pattern: string,
+	timeZone: string,
+): string {
+	const d = new Date(date);
+	const parts = new Intl.DateTimeFormat("en-US", {
+		timeZone,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+		hour: "2-digit",
+		minute: "2-digit",
+		second: "2-digit",
+		hourCycle: "h23",
+	}).formatToParts(d);
+	const read = (t: string) =>
+		Number(parts.find((p) => p.type === t)?.value ?? 0);
+	return format(
+		new Date(
+			read("year"),
+			read("month") - 1,
+			read("day"),
+			read("hour"),
+			read("minute"),
+			read("second"),
+		),
+		pattern,
+	);
+}
+
+export function timeToDisplay(
+	value: string | Date,
+	pattern: string,
+	pref: TimeZonePref,
+): string {
+	if (typeof value === "string" && isDayString(value)) {
+		// A "YYYY-MM-DD" string carries no timezone: render its literal calendar
+		// day in BOTH modes (this is also the fix for the off-by-one display bug).
+		return format(parseDayString(value), pattern);
+	}
+	const d = new Date(value);
+	return pref === "utc"
+		? formatInTimeZone(d, pattern, "UTC")
+		: formatInTimeZone(d, pattern, getBrowserTimeZone());
+}
+
+export function readTimeZonePref(): TimeZonePref {
+	try {
+		return localStorage.getItem(TIME_ZONE_PREF_KEY) === "local"
+			? "local"
+			: "utc";
+	} catch {
+		return "utc"; // SSR / non-browser
+	}
+}
+
+export function writeTimeZonePref(pref: TimeZonePref): void {
+	try {
+		localStorage.setItem(TIME_ZONE_PREF_KEY, pref);
+	} catch {
+		// ignore
+	}
+}


### PR DESCRIPTION
## Feature

A **"Local time" toggle** appears next to every stats section that displays a
datetime on the dashboard and the DevPass dashboard.

- **OFF (default)** — datetimes render in UTC+0, exactly as today (day-only
  strings like invoice dates now render their literal calendar day — a display
  bug fix that also affected UTC mode).
- **ON** — datetimes render in the end-user's **browser timezone**
  (`Intl.DateTimeFormat().resolvedOptions().timeZone`). The preference is
  stored in `localStorage` (`llmgateway:tz-pref`) and applies everywhere.

## Before / After

| Theme | Before | After |
|---|---|---|
| Light | ![before-light](https://files.catbox.moe/rwd6jy.png) | ![after-light](https://files.catbox.moe/o2yua6.png) |
| Dark | ![before-dark](https://files.catbox.moe/en01kq.png) | ![after-dark](https://files.catbox.moe/eu7jas.png) |

*API Keys dashboard section: the "Local time" toggle appears next to "Create API Key" (right of the section heading). Toggle OFF (default) = UTC rendering identical to today.*

## Why

Datetimes were previously rendered server-side in UTC (and day-only strings
like invoice dates were parsed as UTC midnight), so non-UTC users saw UTC+0
times and, for day strings, the previous calendar day. This makes the local
display opt-in instead of silently changing everyone's view.

## Change (frontend-only)

- `@llmgateway/shared`: `formatInTimeZone` / `timeToDisplay` helpers,
  `useTimeZonePreference` (localStorage-backed, pub/sub-synced),
  mount-gated `<Time>` component (no hydration mismatch), and
  `<TimeZoneToggle>` built on the shared `Switch`.
- `apps/ui`: audit logs, security events, transactions, team invites, agent &
  session rows, API keys, activity log detail — toggle + `<Time>` in each
  section header.
- DevPass (`apps/code`): usage overview chips, invoices (off-by-one day fixed
  in local mode), agent detail logs, billing renew date, plan-change date,
  activity heatmap (local-day buckets when ON; API `timezone` param already
  supported server-side since 2026-07-03 — no API changes).
- Deliberately untouched: model release dates, contract/plan-term dates,
  blog/changelog publication dates (documented UTC semantics); analytics chart
  bucketing already sends browser TZ (July 2026 feature).

## Tests

- Unit: `parseDayString` (local-midnight), `formatInTimeZone` (Montreal + UTC),
  `timeToDisplay` (utc/local × ISO + day strings), pref read/write default —
  **9 tests, all pass** under pinned `TZ=America/Montreal`.
- `pnpm format` clean, `pnpm lint` clean,
  `pnpm turbo run build --filter=ui --filter=code --filter=@llmgateway/shared` passes (14/14).
- Manual: toggle OFF matches today's UTC output exactly; toggle ON with TZ
  `America/Montreal` shows local times and correct invoice days; heatmap day
  boundary flips at local midnight; no hydration warnings.
