### PR TITLE
perf(gateway): raise upstream DNS cache TTL

### DIFF
--- a/apps/gateway/src/lib/upstream-dispatcher.ts
+++ b/apps/gateway/src/lib/upstream-dispatcher.ts
@@ -27,7 +27,11 @@ let agent: Agent | null = null;
 export function installUpstreamDispatcher(): Dispatcher {
 	const keepAliveTimeoutMs = envInt("UPSTREAM_KEEPALIVE_TIMEOUT_MS", 60_000);
 	const connectTimeoutMs = envInt("UPSTREAM_CONNECT_TIMEOUT_MS", 10_000);
-	const dnsCacheTtlMs = envInt("UPSTREAM_DNS_CACHE_TTL_MS", 30_000);
+	// Provider API hostnames resolve to CDN/anycast addresses that are stable
+	// over minutes, and a connect failure on a stale address is retried by the
+	// provider-fallback logic — so a long TTL is safe, while a short one expires
+	// between requests on a quiet pod and puts resolution back on the TTFT path.
+	const dnsCacheTtlMs = envInt("UPSTREAM_DNS_CACHE_TTL_MS", 300_000);
 
 	agent = new Agent({
 		keepAliveTimeout: keepAliveTimeoutMs,

--- a/infra/helm/llmgateway/templates/configmap.yaml
+++ b/infra/helm/llmgateway/templates/configmap.yaml
@@ -102,6 +102,12 @@ data:
   {{- if .maxStreamingBufferMb }}
   MAX_STREAMING_BUFFER_MB: {{ .maxStreamingBufferMb | quote }}
   {{- end }}
+  {{- if .upstreamDnsCacheTtlMs }}
+  UPSTREAM_DNS_CACHE_TTL_MS: {{ .upstreamDnsCacheTtlMs | quote }}
+  {{- end }}
+  {{- if .upstreamKeepaliveTimeoutMs }}
+  UPSTREAM_KEEPALIVE_TIMEOUT_MS: {{ .upstreamKeepaliveTimeoutMs | quote }}
+  {{- end }}
   {{- end }}
 
   # API config

--- a/infra/helm/llmgateway/values.yaml
+++ b/infra/helm/llmgateway/values.yaml
@@ -141,6 +141,10 @@ gateway:
     healthCheckSkipDatabase: ""
     healthCheckTimeoutMs: 15000
     maxStreamingBufferMb: 50
+    # Upstream dispatcher tuning for the gateway→provider hop. Both default in
+    # code (300s DNS cache, 60s keep-alive); set here only to override.
+    upstreamDnsCacheTtlMs: ""
+    upstreamKeepaliveTimeoutMs: ""
   # Hard deadline for pod shutdown; caps every in-process drain above. Defaults
   # to 120s, or realtime.config.maxSessionSeconds + 120 when realtime.enabled.
   # Set explicitly only to override that.


### PR DESCRIPTION
## Problem

The [computesdk AI-gateway benchmark](https://github.com/computesdk/benchmarks/actions/runs/31716766465) (2026-08-13) dropped LLM Gateway from #1 (90.84, Aug 7) to #4 (88.80). The regression is entirely in cold-start probes: 3 of 10 stalled at 1.1–1.3s inside the gateway→provider hop while the remaining probes ran ~620ms, with edge DNS/TCP/TLS all under 10ms.

A stall of that size is not a handshake. TCP+TLS to a provider's anycast edge is two round trips — measured at ~10ms against `api.anthropic.com` from a nearby vantage, and tens of ms at worst. 1.1s is a DNS retransmit: in-cluster an uncached lookup goes through `ndots:5` search expansion, where a single dropped UDP packet stalls for seconds.

The dispatcher already caches DNS, but at a 30s TTL the entry expires between requests on a quiet pod, so an idle pod pays resolution again on its next request — exactly the cold-start case the probes measure.

## Approach

- Default `UPSTREAM_DNS_CACHE_TTL_MS` 30s → 300s. Provider hostnames resolve to CDN/anycast addresses that are stable over minutes, and a connect failure on a stale address is already retried by provider fallback, so a long TTL is safe while a short one only puts DNS back on the TTFT path.
- Plumb `upstreamDnsCacheTtlMs` and `upstreamKeepaliveTimeoutMs` through the Helm chart. Neither was settable without a code edit before; both stay unset in `values.yaml` so the code defaults apply, following the existing `terminationGracePeriodSeconds` pattern.

This is the reduced form of #3595. That PR paired the TTL bump with a prewarm pinger that HEAD-pings provider origins to hold a pooled connection open. Measured against undici 8.9.0 with the same Agent config, every `HEAD` to both configured origins is answered `Connection: close`, so the ping opens a connection and has it torn down immediately — it cannot keep anything pooled:

```
HEAD https://api.openai.com/               421  connection=close       6 connects / 3 req   pooled=NO
GET  https://api.openai.com/               421  connection=keep-alive  2 connects / 3 req   pooled=NO
HEAD https://api.openai.com/v1/models      401  connection=close       3 connects / 3 req   pooled=NO
GET  https://api.openai.com/v1/models      401  connection=keep-alive  2 connects / 3 req   pooled=NO
HEAD https://api.anthropic.com/            404  connection=close       3 connects / 3 req   pooled=NO
GET  https://api.anthropic.com/            404  connection=keep-alive  1 connect  / 3 req   pooled=YES
HEAD https://api.anthropic.com/v1/messages 405  connection=close       3 connects / 3 req   pooled=NO
GET  https://api.anthropic.com/v1/messages 405  connection=keep-alive  1 connect  / 3 req   pooled=YES
```

It is the method, not the path. Since the stall being chased is DNS rather than connection setup, the TTL change is the part that addresses it; a corrected pinger (`GET`, and preserving the configured path, which `new URL(x).origin` currently strips) can be revisited separately if connection setup turns out to matter.

## Verification

- `pnpm vitest run apps/gateway/src/lib/upstream-dispatcher.spec.ts` — 3/3 passing
- `helm template` with `gateway.config.upstreamDnsCacheTtlMs=600000` emits the var; with defaults it emits nothing
- `pnpm build` — 17/17 tasks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable upstream DNS cache TTL and keep-alive timeout settings for gateway deployments.
  * Deployment configuration can now override the default upstream connection behavior.

* **Improvements**
  * Increased the default upstream DNS cache duration from 30 seconds to 300 seconds.
  * DNS caching remains disabled when explicitly configured with a zero-second TTL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->