### PR TITLE
chore(models): pin together V4 Pro to 0813

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -322,7 +322,7 @@ export const deepseekModels = [
 			},
 			{
 				providerId: "together-ai",
-				externalId: "deepseek-ai/DeepSeek-V4-Pro",
+				externalId: "deepseek-ai/DeepSeek-V4-Pro-0813",
 				inputPrice: "1.74e-6",
 				cachedInputPrice: "0.2e-6",
 				outputPrice: "3.48e-6",


### PR DESCRIPTION
Together AI is deprecating the undated `deepseek-ai/DeepSeek-V4-Pro` serverless endpoint on **2026-08-27** and points users at the dated `deepseek-ai/DeepSeek-V4-Pro-0813` snapshot instead.

Rather than adding a new root model for the snapshot, the existing `together-ai` mapping on `deepseek-v4-pro` is repointed at the dated id — same shape as the Flash mapping, which already serves `deepseek-ai/DeepSeek-V4-Flash-0731` under the undated `deepseek-v4-flash` model. Other providers on this model are untouched: their upstream ids are their own, and the DeepInfra deployment already serves the newer weights behind the undated id.

Pricing is unchanged — Together lists the 0813 snapshot at the same $1.74 / $0.20 cached / $3.48 per 1M as the current endpoint, so no price fields move.

**Merge timing:** as of today the 0813 endpoint is not live yet — Together's model page says "coming soon" and a direct completion request returns `model_not_available`. Hold this until the endpoint is serving (before the 27th), otherwise the `together-ai` mapping 400s; only pinned `together-ai/deepseek-v4-pro` requests are affected, everything else falls back. Once it is live, re-run the scoped e2e (`TEST_MODELS="together-ai/deepseek-v4-pro" pnpm test:e2e`) — dated snapshots have changed capability behaviour before, so the reasoning-effort and tool-choice metadata should be re-checked against the current mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the DeepSeek V4 Pro model identifier to the current provider-supported version for improved model availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->