### PR TITLE
fix(api-keys): show why a spend limit is rejected

### DIFF
--- a/apps/api/src/routes/keys-api.spec.ts
+++ b/apps/api/src/routes/keys-api.spec.ts
@@ -18,6 +18,35 @@ function getActivePeriodStartedAt() {
 	return new Date(Date.now() - ONE_HOUR_MS);
 }
 
+/** A second, developer-role member of the test org plus a key they created. */
+async function seedOtherMemberKey(budget: {
+	usageLimit?: string;
+	periodUsageLimit?: string;
+	periodUsageDurationValue?: number;
+	periodUsageDurationUnit?: "hour" | "day" | "week" | "month";
+}) {
+	await db.insert(tables.user).values({
+		id: "other-user-id",
+		name: "Other Developer",
+		email: "other-developer@example.com",
+		emailVerified: true,
+	});
+	await db.insert(tables.userOrganization).values({
+		id: "other-user-org-id",
+		userId: "other-user-id",
+		organizationId: "test-org-id",
+		role: "developer",
+		...budget,
+	});
+	await db.insert(tables.apiKey).values({
+		id: "other-api-key-id",
+		token: "other-api-key-token",
+		projectId: "test-project-id",
+		description: "Other Developer Key",
+		createdBy: "other-user-id",
+	});
+}
+
 describe("keys route", () => {
 	let token: string;
 
@@ -557,6 +586,53 @@ describe("keys route", () => {
 		expect(res.status).toBe(400);
 		const json = await res.json();
 		expect(json.message).toMatch(/organization limit of \$10\.00/);
+	});
+
+	test("PATCH /keys/api/limit/{id} blames the key owner's budget", async () => {
+		await seedOtherMemberKey({ usageLimit: "10" });
+
+		const res = await app.request("/keys/api/limit/other-api-key-id", {
+			method: "PATCH",
+			headers: {
+				"Content-Type": "application/json",
+				Cookie: token,
+			},
+			body: JSON.stringify({ usageLimit: "50" }),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(json.message).toMatch(/the key owner's limit of \$10\.00/);
+		expect(json.message).toMatch(/Team page/);
+	});
+
+	test("GET /keys/api returns each key owner's effective budget", async () => {
+		await seedOtherMemberKey({});
+		await db
+			.update(tables.organization)
+			.set({
+				defaultDeveloperPeriodUsageLimit: "500",
+				defaultDeveloperPeriodUsageDurationValue: 1,
+				defaultDeveloperPeriodUsageDurationUnit: "month",
+			})
+			.where(eq(tables.organization.id, "test-org-id"));
+
+		const res = await app.request("/keys/api?projectId=test-project-id", {
+			headers: { Cookie: token },
+		});
+
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		const otherKey = json.apiKeys.find(
+			(key: { id: string }) => key.id === "other-api-key-id",
+		);
+		// The developer inherits the org-wide default developer budget.
+		expect(otherKey.ownerBudget).toEqual({
+			usageLimit: null,
+			periodUsageLimit: "500",
+			periodUsageDurationValue: 1,
+			periodUsageDurationUnit: "month",
+		});
 	});
 
 	test("PATCH /keys/api/limit/{id} updates and resets period usage", async () => {

--- a/apps/api/src/routes/keys-api.ts
+++ b/apps/api/src/routes/keys-api.ts
@@ -28,6 +28,7 @@ import {
 	validateApiKeyLimitsWithinMemberBudget,
 	type ApiKeyPeriodDurationUnit,
 	type InferSelectModel,
+	type MemberBudgetOwner,
 } from "@llmgateway/db";
 import { maskToken } from "@llmgateway/shared/mask-token";
 
@@ -375,6 +376,13 @@ const createApiKeySchema = z
 		...createApiKeyPeriodConfigFieldsSchema,
 	})
 	.superRefine(validateApiKeyPeriodConfig);
+
+const memberBudgetConstraintsSchema = z.object({
+	usageLimit: z.string().nullable(),
+	periodUsageLimit: z.string().nullable(),
+	periodUsageDurationValue: z.number().int().nullable(),
+	periodUsageDurationUnit: apiKeyPeriodDurationUnitSchema.nullable(),
+});
 
 // Schema for listing API keys
 const listApiKeysQuerySchema = z.object({
@@ -808,6 +816,7 @@ function assertApiKeyLimitsWithinMemberBudget(
 	membership: MemberBudgetColumns | null | undefined,
 	organization: OrgDeveloperDefaultColumns,
 	keyLimits: ApiKeyLimitConfig,
+	owner: MemberBudgetOwner = "self",
 ): void {
 	if (!membership) {
 		return;
@@ -842,11 +851,106 @@ function assertApiKeyLimitsWithinMemberBudget(
 			periodUsageDurationUnit: keyLimits.periodUsageDurationUnit,
 		},
 		budget,
+		owner,
 	);
 
 	if (error) {
 		throw new HTTPException(400, { message: error });
 	}
+}
+
+/**
+ * Effective member budget of each key's creator, keyed by API key id. The limits
+ * editor is shown to owners/admins for keys they did not create, so it has to
+ * validate against the creator's budget rather than the viewer's own — otherwise
+ * the dialog accepts a value the PATCH route then rejects.
+ */
+async function resolveApiKeyOwnerBudgets(
+	apiKeys: Pick<ApiKeyRecord, "id" | "projectId" | "createdBy">[],
+	userOrgs: {
+		organization?:
+			| (OrgDeveloperDefaultColumns & {
+					id: string;
+					projects: { id: string }[];
+			  })
+			| null;
+	}[],
+): Promise<Map<string, ApiKeyLimitConfig>> {
+	const budgets = new Map<string, ApiKeyLimitConfig>();
+
+	if (!apiKeys.length) {
+		return budgets;
+	}
+
+	const orgByProjectId = new Map<
+		string,
+		OrgDeveloperDefaultColumns & { id: string }
+	>();
+	for (const userOrg of userOrgs) {
+		const organization = userOrg.organization;
+		if (!organization) {
+			continue;
+		}
+		for (const project of organization.projects) {
+			orgByProjectId.set(project.id, organization);
+		}
+	}
+
+	const memberships = await db.query.userOrganization.findMany({
+		where: {
+			userId: { in: [...new Set(apiKeys.map((key) => key.createdBy))] },
+			organizationId: {
+				in: [...new Set([...orgByProjectId.values()].map((org) => org.id))],
+			},
+		},
+		columns: {
+			userId: true,
+			organizationId: true,
+			role: true,
+			maxApiKeys: true,
+			usageLimit: true,
+			periodUsageLimit: true,
+			periodUsageDurationValue: true,
+			periodUsageDurationUnit: true,
+		},
+	});
+	const membershipByMember = new Map(
+		memberships.map((membership) => [
+			`${membership.userId}:${membership.organizationId}`,
+			membership,
+		]),
+	);
+
+	for (const key of apiKeys) {
+		const organization = orgByProjectId.get(key.projectId);
+		const membership = organization
+			? membershipByMember.get(`${key.createdBy}:${organization.id}`)
+			: undefined;
+		if (!organization || !membership) {
+			continue;
+		}
+
+		const budget = resolveEffectiveMemberBudget(
+			membership.role as "owner" | "admin" | "developer",
+			{
+				maxApiKeys: membership.maxApiKeys,
+				usageLimit: membership.usageLimit,
+				periodUsageLimit: membership.periodUsageLimit,
+				periodUsageDurationValue: membership.periodUsageDurationValue,
+				periodUsageDurationUnit: membership.periodUsageDurationUnit,
+			},
+			organization,
+		);
+
+		budgets.set(key.id, {
+			usageLimit: budget.usageLimit,
+			periodUsageLimit: budget.periodUsageLimit,
+			periodUsageDurationValue: budget.periodUsageDurationValue,
+			periodUsageDurationUnit: budget.periodUsageDurationUnit,
+		});
+	}
+
+	return budgets;
 }
 
 export async function createApiKeyForProject(
@@ -1067,6 +1171,11 @@ const list = createRoute({
 								apiKeySchema.omit({ token: true }).extend({
 									// Only return a masked version of the token
 									maskedToken: z.string(),
+									// The effective member budget of whoever created the key, so
+									// the limits editor validates against the cap that actually
+									// applies — not the viewer's own. Null when the creator is no
+									// longer a member of the organization.
+									ownerBudget: memberBudgetConstraintsSchema.nullable(),
 								}),
 							)
 							.openapi({}),
@@ -1224,11 +1333,14 @@ keysApi.openapi(list, async (c) => {
 		}
 	}
 
+	const ownerBudgets = await resolveApiKeyOwnerBudgets(apiKeys, userOrgs);
+
 	return c.json({
 		apiKeys: apiKeys.map((key) => ({
 			...serializeApiKey(key),
 			maskedToken: maskToken(key.token),
 			token: undefined,
+			ownerBudget: ownerBudgets.get(key.id) ?? null,
 		})),
 		planLimits: projectId
 			? {
@@ -1977,6 +2089,7 @@ keysApi.openapi(updateUsageLimit, async (c) => {
 			ownerMembership,
 			ownerOrg,
 			nextLimitConfig,
+			apiKey.createdBy === user.id ? "self" : "other",
 		);
 	}
 

--- a/apps/ui/src/components/api-keys/api-key-limit-fields.tsx
+++ b/apps/ui/src/components/api-keys/api-key-limit-fields.tsx
@@ -14,7 +14,10 @@ import { Switch } from "@/lib/components/switch";
 import { validateApiKeyLimitsWithinMemberBudget } from "@llmgateway/shared";
 
 import type { ApiKey } from "@/lib/types";
-import type { ApiKeyLimitConstraints } from "@llmgateway/shared";
+import type {
+	ApiKeyLimitConstraints,
+	MemberBudgetOwner,
+} from "@llmgateway/shared";
 
 export type MemberBudgetConstraint = ApiKeyLimitConstraints;
 
@@ -161,11 +164,16 @@ export function buildApiKeyLimitPayload(value: ApiKeyLimitFormValue): {
 export function validateApiKeyLimitPayloadWithinMemberBudget(
 	payload: ApiKeyLimitPayload,
 	memberBudget: MemberBudgetConstraint | null | undefined,
+	budgetOwner: MemberBudgetOwner = "self",
 ): string | null {
 	if (!memberBudget || !hasMemberBudgetCaps(memberBudget)) {
 		return null;
 	}
-	return validateApiKeyLimitsWithinMemberBudget(payload, memberBudget);
+	return validateApiKeyLimitsWithinMemberBudget(
+		payload,
+		memberBudget,
+		budgetOwner,
+	);
 }
 
 export function formatCurrencyAmount(value: string): string {
@@ -252,9 +260,19 @@ interface ApiKeyLimitFieldsProps {
 	onChange: (value: ApiKeyLimitFormValue) => void;
 	value: ApiKeyLimitFormValue;
 	memberBudget?: MemberBudgetConstraint | null;
+	budgetOwner?: MemberBudgetOwner;
+	ownerName?: string | null;
 }
 
-function MemberBudgetNotice({ budget }: { budget: MemberBudgetConstraint }) {
+function MemberBudgetNotice({
+	budget,
+	budgetOwner,
+	ownerName,
+}: {
+	budget: MemberBudgetConstraint;
+	budgetOwner: MemberBudgetOwner;
+	ownerName?: string | null;
+}) {
 	const parts: string[] = [];
 	if (budget.usageLimit !== null) {
 		parts.push(`${formatCurrencyAmount(budget.usageLimit)} total`);
@@ -276,6 +294,17 @@ function MemberBudgetNotice({ budget }: { budget: MemberBudgetConstraint }) {
 		return null;
 	}
 
+	if (budgetOwner === "other") {
+		return (
+			<div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
+				{ownerName ?? "The member who created this key"} is limited to{" "}
+				<span className="font-medium">{parts.join(" and ")}</span>. This
+				key&apos;s limits must be at or below that — raise their limit on the
+				Team page first.
+			</div>
+		);
+	}
+
 	return (
 		<div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
 			Your organization limits you to{" "}
@@ -290,6 +319,8 @@ export function ApiKeyLimitFields({
 	onChange,
 	value,
 	memberBudget,
+	budgetOwner = "self",
+	ownerName,
 }: ApiKeyLimitFieldsProps) {
 	const updateValue = <K extends keyof ApiKeyLimitFormValue>(
 		key: K,
@@ -304,7 +335,11 @@ export function ApiKeyLimitFields({
 	return (
 		<div className="space-y-4">
 			{memberBudget && hasMemberBudgetCaps(memberBudget) && (
-				<MemberBudgetNotice budget={memberBudget} />
+				<MemberBudgetNotice
+					budget={memberBudget}
+					budgetOwner={budgetOwner}
+					ownerName={ownerName}
+				/>
 			)}
 			<div className="rounded-md border p-4 space-y-3">
 				<div className="flex items-center gap-2">

--- a/apps/ui/src/components/api-keys/api-key-limits-dialog.tsx
+++ b/apps/ui/src/components/api-keys/api-key-limits-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 
-import { useMyMemberBudget } from "@/hooks/useTeam";
+import { useUser } from "@/hooks/useUser";
 import { Button } from "@/lib/components/button";
 import {
 	Dialog,
@@ -30,20 +30,22 @@ interface ApiKeyLimitsDialogProps {
 	apiKey: ApiKey;
 	children: React.ReactNode;
 	onSubmit: (payload: ApiKeyLimitPayload) => Promise<void> | void;
-	organizationId: string;
 }
 
 export function ApiKeyLimitsDialog({
 	apiKey,
 	children,
 	onSubmit,
-	organizationId,
 }: ApiKeyLimitsDialogProps) {
 	const [open, setOpen] = useState(false);
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [value, setValue] = useState(() => createApiKeyLimitFormValue(apiKey));
-	const { data: memberBudgetData } = useMyMemberBudget(organizationId);
-	const memberBudget = memberBudgetData?.budget ?? null;
+	const { user } = useUser();
+	// Owners/admins edit keys they did not create, so the cap that applies is the
+	// key creator's member budget, not the viewer's own.
+	const memberBudget = apiKey.ownerBudget ?? null;
+	const budgetOwner = apiKey.createdBy === user?.id ? "self" : "other";
+	const ownerName = apiKey.creator?.name ?? apiKey.creator?.email ?? null;
 
 	useEffect(() => {
 		if (!open) {
@@ -74,6 +76,7 @@ export function ApiKeyLimitsDialog({
 						const budgetError = validateApiKeyLimitPayloadWithinMemberBudget(
 							payload,
 							memberBudget,
+							budgetOwner,
 						);
 						if (budgetError) {
 							toast({ title: budgetError, variant: "destructive" });
@@ -104,6 +107,8 @@ export function ApiKeyLimitsDialog({
 							value={value}
 							onChange={setValue}
 							memberBudget={memberBudget}
+							budgetOwner={budgetOwner}
+							ownerName={ownerName}
 						/>
 					</div>
 					<DialogFooter className="pt-8">

--- a/apps/ui/src/components/api-keys/api-keys-list.tsx
+++ b/apps/ui/src/components/api-keys/api-keys-list.tsx
@@ -16,6 +16,7 @@ import { usePathname } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
 import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
+import { getApiErrorMessage } from "@/lib/api-error";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -343,9 +344,10 @@ export function ApiKeysList({
 				title: "API Key Reactivated",
 				description: "The API key is active again with a new expiration.",
 			});
-		} catch {
+		} catch (error) {
 			toast({
 				title: "Failed to reactivate API key.",
+				description: getApiErrorMessage(error, "Please try again."),
 				variant: "destructive",
 			});
 		}
@@ -371,9 +373,10 @@ export function ApiKeysList({
 			});
 
 			return data.apiKey.token;
-		} catch {
+		} catch (error) {
 			toast({
 				title: "Failed to roll API key.",
+				description: getApiErrorMessage(error, "Please try again."),
 				variant: "destructive",
 			});
 			return undefined;
@@ -402,9 +405,10 @@ export function ApiKeysList({
 				title: "API Key Renamed",
 				description: "The API key has been renamed.",
 			});
-		} catch {
+		} catch (error) {
 			toast({
 				title: "Failed to rename API key.",
+				description: getApiErrorMessage(error, "Please try again."),
 				variant: "destructive",
 			});
 		}
@@ -442,6 +446,7 @@ export function ApiKeysList({
 		} catch (error) {
 			toast({
 				title: "Failed to update API key limits.",
+				description: getApiErrorMessage(error, "Please try again."),
 				variant: "destructive",
 			});
 			throw error;

--- a/apps/ui/src/components/api-keys/api-keys-list.tsx
+++ b/apps/ui/src/components/api-keys/api-keys-list.tsx
@@ -147,6 +147,7 @@ export function ApiKeysList({
 					apiKeys: initialData.map((key) => ({
 						...key,
 						maskedToken: key.maskedToken,
+						ownerBudget: key.ownerBudget ?? null,
 					})),
 					userRole: "owner" as const,
 				},
@@ -703,7 +704,6 @@ export function ApiKeysList({
 									<TableCell>
 										<ApiKeyLimitsDialog
 											apiKey={key}
-											organizationId={orgId ?? ""}
 											onSubmit={(payload) =>
 												updateKeyUsageLimit(key.id, payload)
 											}
@@ -985,7 +985,6 @@ export function ApiKeysList({
 								<div>
 									<ApiKeyLimitsDialog
 										apiKey={key}
-										organizationId={orgId ?? ""}
 										onSubmit={(payload) => updateKeyUsageLimit(key.id, payload)}
 									>
 										<Button

--- a/apps/ui/src/components/api-keys/create-api-key-dialog.tsx
+++ b/apps/ui/src/components/api-keys/create-api-key-dialog.tsx
@@ -4,6 +4,7 @@ import { usePostHog } from "posthog-js/react";
 import { useState } from "react";
 
 import { useMyMemberBudget } from "@/hooks/useTeam";
+import { getApiErrorMessage } from "@/lib/api-error";
 import { Button } from "@/lib/components/button";
 import {
 	Dialog,
@@ -122,9 +123,10 @@ export function CreateApiKeyDialog({
 
 			setApiKey(createdKey.token);
 			setStep("created");
-		} catch {
+		} catch (error) {
 			toast({
 				title: "Failed to create API key.",
+				description: getApiErrorMessage(error, "Please try again."),
 				variant: "destructive",
 			});
 		}

--- a/apps/ui/src/components/sso/sso-client.tsx
+++ b/apps/ui/src/components/sso/sso-client.tsx
@@ -14,6 +14,7 @@ import { useState } from "react";
 
 import { ProjectMultiSelect } from "@/components/projects/project-multi-select";
 import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
+import { getApiErrorMessage } from "@/lib/api-error";
 import { Alert, AlertDescription } from "@/lib/components/alert";
 import {
 	AlertDialog,
@@ -134,24 +135,6 @@ function splitDomains(domain: string): string[] {
 
 function formatDomains(domain: string): string {
 	return splitDomains(domain).join(", ");
-}
-
-// openapi-fetch rejects with the parsed error body ({ message }), not an Error
-// instance — surface the server's message (e.g. the 409 duplicate-domain
-// conflict) instead of a generic fallback.
-function errorMessage(error: unknown, fallback: string): string {
-	if (error instanceof Error && error.message) {
-		return error.message;
-	}
-	if (
-		error &&
-		typeof error === "object" &&
-		"message" in error &&
-		typeof (error as { message?: unknown }).message === "string"
-	) {
-		return (error as { message: string }).message;
-	}
-	return fallback;
 }
 
 function ReadOnlyField({ label, value }: { label: string; value: string }) {
@@ -504,7 +487,10 @@ export function SsoClient() {
 			setGoogleEdit(null);
 		} catch (error) {
 			toast({
-				title: errorMessage(error, "Failed to save Google Workspace auto-join"),
+				title: getApiErrorMessage(
+					error,
+					"Failed to save Google Workspace auto-join",
+				),
 				variant: "destructive",
 			});
 		}

--- a/apps/ui/src/lib/api-error.ts
+++ b/apps/ui/src/lib/api-error.ts
@@ -1,0 +1,17 @@
+// openapi-react-query rethrows openapi-fetch's parsed error body ({ message }),
+// not an Error instance, so an `error instanceof Error` check alone silently
+// drops every message the API sends and leaves the user with a generic toast.
+export function getApiErrorMessage(error: unknown, fallback: string): string {
+	if (error instanceof Error && error.message) {
+		return error.message;
+	}
+	if (
+		error &&
+		typeof error === "object" &&
+		"message" in error &&
+		typeof (error as { message?: unknown }).message === "string"
+	) {
+		return (error as { message: string }).message;
+	}
+	return fallback;
+}

--- a/apps/ui/src/lib/types.ts
+++ b/apps/ui/src/lib/types.ts
@@ -5,6 +5,7 @@ import type {
 	SerializedApiKey,
 	SerializedApiKeyIamRule,
 } from "@llmgateway/db";
+import type { ApiKeyLimitConstraints } from "@llmgateway/shared";
 
 // `role` is the authenticated user's role in the org, populated by GET /orgs so
 // the dashboard can gate org-level UI for project-scoped "developer" members.
@@ -18,4 +19,8 @@ export type ApiKey = Omit<SerializedApiKey, "token"> & {
 	currentPeriodResetAt: string | null;
 	maskedToken: string;
 	iamRules?: Omit<SerializedApiKeyIamRule, "apiKeyId">[];
+	creator?: { id: string; name: string | null; email: string } | null;
+	// Effective member budget of the key's creator, returned by GET /keys/api so
+	// the limits editor validates against the cap that actually applies.
+	ownerBudget?: ApiKeyLimitConstraints | null;
 };

--- a/packages/db/src/member-budget.ts
+++ b/packages/db/src/member-budget.ts
@@ -3,6 +3,7 @@ import type { ApiKeyPeriodDurationUnit } from "./api-key-period-limit.js";
 export {
 	validateApiKeyLimitsWithinMemberBudget,
 	type ApiKeyLimitConstraints,
+	type MemberBudgetOwner,
 } from "@llmgateway/shared";
 
 /**

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -208,6 +208,7 @@ export {
 	SSO_TEAM_DEFAULT_DEVELOPER_BUDGET,
 	type ApiKeyLimitConstraints,
 	type ApiKeyPeriodDurationUnitValue,
+	type MemberBudgetOwner,
 	type MemberBudgetShape,
 } from "./member-budget-limits.js";
 

--- a/packages/shared/src/member-budget-limits.spec.ts
+++ b/packages/shared/src/member-budget-limits.spec.ts
@@ -126,6 +126,16 @@ describe("validateApiKeyLimitsWithinMemberBudget", () => {
 		).toBeNull();
 	});
 
+	it("names the key owner's limit when validating someone else's key", () => {
+		const message = validateApiKeyLimitsWithinMemberBudget(
+			{ ...NO_LIMITS, usageLimit: "150" },
+			{ ...NO_LIMITS, usageLimit: "100" },
+			"other",
+		);
+		expect(message).toMatch(/the key owner's limit of \$100\.00/);
+		expect(message).toMatch(/Team page/);
+	});
+
 	it("requires a recurring key limit when the member has one", () => {
 		expect(
 			validateApiKeyLimitsWithinMemberBudget(NO_LIMITS, {

--- a/packages/shared/src/member-budget-limits.ts
+++ b/packages/shared/src/member-budget-limits.ts
@@ -62,6 +62,22 @@ function periodWindowHours(
 	return value * PERIOD_UNIT_HOURS[unit];
 }
 
+/** Whose budget the key is being checked against — the caller's, or another member's. */
+export type MemberBudgetOwner = "self" | "other";
+
+/** How to name the enforced budget, and how to say where it can be raised. */
+function budgetOwnerCopy(owner: MemberBudgetOwner): {
+	hint: string;
+	label: string;
+} {
+	return owner === "other"
+		? {
+				label: "the key owner's limit",
+				hint: " Raise their limit on the Team page first.",
+			}
+		: { label: "your organization limit", hint: "" };
+}
+
 /**
  * Validate that a proposed API-key limit stays at or below the member's
  * effective budget (their own caps, or the org-wide default developer caps that
@@ -72,17 +88,24 @@ function periodWindowHours(
  * set a matching-or-lower cap. Recurring caps are compared by normalized hourly
  * spend rate, so a key with a shorter window can't out-spend a longer member
  * window. Pass the member's *effective* budget (post org-default resolution).
+ *
+ * `owner` only changes the wording: an owner/admin editing someone else's key is
+ * blocked by that member's budget, not their own, so the message has to name it
+ * and point at the Team page where it can be raised.
  */
 export function validateApiKeyLimitsWithinMemberBudget(
 	keyLimits: ApiKeyLimitConstraints,
 	memberBudget: ApiKeyLimitConstraints,
+	owner: MemberBudgetOwner = "self",
 ): string | null {
+	const { label, hint } = budgetOwnerCopy(owner);
+
 	if (memberBudget.usageLimit !== null) {
 		if (keyLimits.usageLimit === null) {
-			return `Set an all-time usage limit at or below your organization limit of ${formatBudgetUsd(memberBudget.usageLimit)}.`;
+			return `Set an all-time usage limit at or below ${label} of ${formatBudgetUsd(memberBudget.usageLimit)}.${hint}`;
 		}
 		if (Number(keyLimits.usageLimit) > Number(memberBudget.usageLimit)) {
-			return `All-time usage limit must be at or below your organization limit of ${formatBudgetUsd(memberBudget.usageLimit)}.`;
+			return `All-time usage limit must be at or below ${label} of ${formatBudgetUsd(memberBudget.usageLimit)}.${hint}`;
 		}
 	}
 
@@ -100,7 +123,7 @@ export function validateApiKeyLimitsWithinMemberBudget(
 			keyLimits.periodUsageDurationValue === null ||
 			keyLimits.periodUsageDurationUnit === null
 		) {
-			return `Set a recurring usage limit at or below your organization limit of ${formatBudgetUsd(memberBudget.periodUsageLimit)} per ${memberWindow}.`;
+			return `Set a recurring usage limit at or below ${label} of ${formatBudgetUsd(memberBudget.periodUsageLimit)} per ${memberWindow}.${hint}`;
 		}
 		const memberWindowHours = periodWindowHours(
 			memberBudget.periodUsageDurationValue,
@@ -121,7 +144,7 @@ export function validateApiKeyLimitsWithinMemberBudget(
 			keyWindowHours,
 		);
 		if (keyScaled.greaterThan(memberScaled)) {
-			return `Recurring usage limit can't exceed your organization limit of ${formatBudgetUsd(memberBudget.periodUsageLimit)} per ${memberWindow}.`;
+			return `Recurring usage limit can't exceed ${label} of ${formatBudgetUsd(memberBudget.periodUsageLimit)} per ${memberWindow}.${hint}`;
 		}
 	}
 


### PR DESCRIPTION
An owner/admin editing another member's API key on the **API Keys** page could
not raise or remove its spend limit. The save failed with a generic
`Failed to update API key limits`, and the actual reason was only visible in
devtools — a 400 blaming "your organization limit", which is not the admin's
limit at all.

Two independent defects:

**1. The dialog validated against the wrong budget.** It checked the new values
against the **viewer's** member budget (`GET /orgs/{id}/members/me`), while
`PATCH /keys/api/limit/{id}` enforces the **key creator's** effective budget
(their own caps, or the org-wide default developer caps SSO-provisioned members
inherit). An admin normally has no caps, so the dialog showed no notice,
accepted anything, and let the server reject it with wording that pointed at
the wrong person and offered no way forward.

**2. The server's message never reached the UI.** The toast handlers discarded
the thrown error and showed a fixed title. `openapi-react-query` rethrows
`openapi-fetch`'s parsed error body rather than an `Error` instance, so the
usual `error instanceof Error` check drops the message as well — which is why
the reason was reachable only through devtools.

Changes:

- `GET /keys/api` returns each key's creator's effective member budget as
  `ownerBudget`, so the editor can validate against the cap that actually applies.
- The limits dialog uses that budget, renders a notice naming the key owner, and
  blocks the save client-side with the same message the API would return.
- The API error names the key owner's limit and points at the Team page (where
  raising the member's budget is the actual fix) instead of saying "your
  organization limit".
- `getApiErrorMessage` (lifted out of `sso-client`, which already carried a local
  copy) now feeds the create / rename / roll / reactivate / limit toasts, so a
  server message is shown instead of being swallowed.

Enforcement is unchanged: a key still cannot exceed its owner's member budget —
the gateway applies that cap at request time regardless. This only makes the
constraint visible and actionable before the request is sent.

Not included: ~20 other call sites in `apps/ui` still use the
`error instanceof Error ? error.message : fallback` idiom and therefore still
swallow API messages. They now have a shared helper to adopt; sweeping them is
left to a follow-up rather than bundled into a support fix.

### Before

Editing a capped developer's key: no notice, and saving fails with an unhelpful toast.

<img width="1440" alt="Before, light: limits dialog with no budget notice" src="https://raw.githubusercontent.com/theopenco/llmgateway/5e4fb588610810d2bb40bc6e65783e045c4e4199/before-light.png" />
<img width="1440" alt="Before, light: Failed to update API key limits toast with no reason" src="https://raw.githubusercontent.com/theopenco/llmgateway/5e4fb588610810d2bb40bc6e65783e045c4e4199/before-light-error.png" />
<img width="1440" alt="Before, dark: limits dialog with no budget notice" src="https://raw.githubusercontent.com/theopenco/llmgateway/5e4fb588610810d2bb40bc6e65783e045c4e4199/before-dark.png" />

### After

The cap is stated up front, and an over-budget value is rejected with the reason and the fix.

<img width="1440" alt="After, light: dialog showing the key owner's budget" src="https://raw.githubusercontent.com/theopenco/llmgateway/5e4fb588610810d2bb40bc6e65783e045c4e4199/after-light.png" />
<img width="1440" alt="After, light: actionable over-budget error" src="https://raw.githubusercontent.com/theopenco/llmgateway/5e4fb588610810d2bb40bc6e65783e045c4e4199/after-light-error.png" />
<img width="1440" alt="After, dark: dialog showing the key owner's budget" src="https://raw.githubusercontent.com/theopenco/llmgateway/5e4fb588610810d2bb40bc6e65783e045c4e4199/after-dark.png" />

A server-side rejection the client cannot pre-empt (member budget lowered behind
the open dialog) now shows the API's message instead of a bare failure:

<img width="1440" alt="After: toast showing the server's error message as the description" src="https://raw.githubusercontent.com/theopenco/llmgateway/7a60c722eef59ca149d5e46474f095d652452a54/after-server-error.png" />

### Verification

- `pnpm test:unit` against an isolated per-worktree stack; new specs cover the
  `ownerBudget` payload and the owner-named 400. One pre-existing unrelated
  failure (`apps/gateway/src/onboarding-sponsorship.spec.ts`) reproduces without
  this change — it logs an extra row because a real provider key in the local
  `.env` makes the request reach the provider.
- `pnpm build`, `pnpm format`.
- Manually against locally seeded data: over-budget save blocked client-side with
  the new message; within-budget save persists; a server-only rejection surfaces
  the API's message in the toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
