### PR TITLE
docs(reasoning): preserve reasoning across calls

### DIFF
--- a/apps/docs/content/features/reasoning.mdx
+++ b/apps/docs/content/features/reasoning.mdx
@@ -285,6 +285,147 @@ data: {
 }
 ```
 
+## Preserving Reasoning Across Calls
+
+Agents work over many turns: the model reasons, calls a tool, and the tool result arrives in the next request. Reasoning models are trained to continue from the reasoning they produced on earlier turns, so dropping it mid-task degrades tool-calling and multi-turn performance.
+
+LLMGateway preserves reasoning the same way OpenAI's Responses API does. The model returns an opaque **encrypted reasoning** payload, and you send it back unchanged along with the rest of the conversation on the next call. The payload is issued and verified by the provider — the gateway passes it through without inspecting or rewriting it.
+
+<Callout type="info">
+	Encrypted reasoning is produced by models served over OpenAI's Responses API
+	(OpenAI and Azure OpenAI reasoning models). Other reasoning models return
+	summary text only, and there is nothing to replay — asking for encrypted
+	reasoning is ignored rather than rejected, so the same client code works
+	against every model. Gemini thought signatures are handled automatically: the
+	gateway re-attaches them to replayed tool calls.
+</Callout>
+
+### Responses API
+
+Ask for the payloads with `include: ["reasoning.encrypted_content"]`, and send `store: false` if you want the turn to stay stateless:
+
+```bash
+curl -X POST "https://api.llmgateway.io/v1/responses" \
+  -H "Authorization: Bearer $LLM_GATEWAY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-5.4-nano",
+    "input": [{ "role": "user", "content": "What is the weather in Paris? Use the tool." }],
+    "tools": [
+      {
+        "type": "function",
+        "name": "get_weather",
+        "parameters": {
+          "type": "object",
+          "properties": { "city": { "type": "string" } },
+          "required": ["city"]
+        }
+      }
+    ],
+    "store": false,
+    "include": ["reasoning.encrypted_content"],
+    "reasoning": { "effort": "high" }
+  }'
+```
+
+Reasoning items in `output` then carry `encrypted_content`:
+
+```json
+{
+	"type": "reasoning",
+	"id": "rs_057d93d1ba22357e01...",
+	"summary": [],
+	"encrypted_content": "gAAAAABqfkEO3uEFtXeGSNE9..."
+}
+```
+
+On the next turn, replay the previous `output` items unchanged — reasoning items included — followed by your tool results:
+
+```json
+{
+	"model": "gpt-5.4-nano",
+	"input": [
+		{
+			"role": "user",
+			"content": "What is the weather in Paris? Use the tool."
+		},
+		{
+			"type": "reasoning",
+			"id": "rs_057d93d1ba22357e01...",
+			"summary": [],
+			"encrypted_content": "gAAAAABqfkEO3uEFtXeGSNE9..."
+		},
+		{
+			"type": "function_call",
+			"call_id": "call_923JIrDbCvIHnGqfvDbPeaLh",
+			"name": "get_weather",
+			"arguments": "{\"city\":\"Paris\"}"
+		},
+		{
+			"type": "function_call_output",
+			"call_id": "call_923JIrDbCvIHnGqfvDbPeaLh",
+			"output": "18C sunny"
+		}
+	],
+	"store": false,
+	"include": ["reasoning.encrypted_content"],
+	"reasoning": { "effort": "high" }
+}
+```
+
+Without the `include` value, reasoning items come back without `encrypted_content` and there is nothing to replay. When streaming, the payload arrives on the reasoning item's `response.output_item.done` event.
+
+#### Stateful Alternative
+
+If you would rather not carry the payloads yourself, leave `store` at its default (`true`) and chain turns with `previous_response_id`. The gateway keeps the stored response — encrypted reasoning included — for [30 days](/features/data-retention#retention-periods) and replays the reasoning for you, so `include` is not needed on that path.
+
+### Chat Completions
+
+The Chat Completions format has no reasoning items, so the gateway carries the same payloads on the assistant message as `reasoning_details`:
+
+```json
+{
+	"role": "assistant",
+	"content": null,
+	"tool_calls": [
+		{
+			"id": "call_923JIrDbCvIHnGqfvDbPeaLh",
+			"type": "function",
+			"function": { "name": "get_weather", "arguments": "{\"city\":\"Paris\"}" }
+		}
+	],
+	"reasoning_details": [
+		{
+			"type": "reasoning.encrypted",
+			"data": "gAAAAABqfkEO3uEFtXeGSNE9...",
+			"id": "rs_057d93d1ba22357e01...",
+			"format": "openai-responses-v1",
+			"index": 0
+		}
+	]
+}
+```
+
+To preserve the reasoning, append the assistant message back into `messages` exactly as you received it (with `reasoning_details` intact) before the matching `tool` result. No opt-in parameter is required — the field is always present when the model produced one. When streaming, the entries arrive as a `delta.reasoning_details` chunk.
+
+Replaying is safe across models: entries a provider cannot consume are stripped before the upstream request, so the same conversation history can be sent to any model.
+
+### Error Handling
+
+Payloads are verified by the provider that issued them. A modified, truncated, or foreign payload is rejected upstream and the error is forwarded unchanged:
+
+```json
+{
+	"error": {
+		"message": "The encrypted content for item rs_057d93d1ba22357e01... could not be verified. Reason: Encrypted content could not be decrypted or parsed.",
+		"type": "invalid_request_error",
+		"code": "invalid_encrypted_content"
+	}
+}
+```
+
+Only replay payloads against the model and provider that produced them.
+
 ## Usage Tracking
 
 ### Response Payload


### PR DESCRIPTION
## Problem

Encrypted reasoning replay has been supported for a while, but it was undocumented — a user asking how to preserve an agent's reasoning across tool-calling turns had nothing to point at. Reasoning models are trained to continue from earlier turns' reasoning, so dropping it mid-task degrades multi-turn/tool-calling performance.

## Change

New "Preserving Reasoning Across Calls" section in `features/reasoning.mdx` covering:

- **Responses API** — `include: ["reasoning.encrypted_content"]` with `store: false`, and how to replay the previous `output` items (reasoning item included) alongside `function_call_output` on the next turn.
- **Stateful alternative** — `previous_response_id` chaining, where the gateway keeps the encrypted payload in stored responses and replays it for you (no `include` needed).
- **Chat Completions** — the same payloads carried on the assistant message as `reasoning_details` (`type: "reasoning.encrypted"`, `format: "openai-responses-v1"`), replayed by echoing the assistant message back verbatim; streamed as `delta.reasoning_details`.
- **Error handling** — the upstream `invalid_encrypted_content` 400, and the rule that payloads only replay against the model/provider that issued them.

## Verification

Behaviour was compared against OpenAI's Responses API directly, then against a local gateway with the same requests:

| Behaviour | OpenAI | Gateway |
| --- | --- | --- |
| `include: ["reasoning.encrypted_content"]` returns `encrypted_content` on reasoning items | ✅ | ✅ |
| Omitting `include` omits the payload (non-streaming and streaming) | ✅ | ✅ |
| Replaying reasoning + `function_call` + `function_call_output` continues the turn | ✅ | ✅ |
| `store` defaults to on; `include` works independently of `store` | ✅ | ✅ |
| Tampered payload → 400 `invalid_encrypted_content` | ✅ | ✅ (forwarded verbatim) |
| Streaming emits the payload on the reasoning `response.output_item.done` | ✅ | ✅ |

Chat Completions was checked separately: replaying `reasoning_details` raises prompt tokens over the same request without it (the payload does reach the provider), and the entries are stripped when the conversation is replayed to a provider that cannot consume them. Models with no encrypted reasoning ignore `include` instead of erroring.

Docs build passes (`turbo run build --filter=docs`, cleared `.source`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)