### PR TITLE
fix(admin): dedupe organizations list rows

### DIFF
--- a/apps/api/src/routes/admin-orgs-dedupe.spec.ts
+++ b/apps/api/src/routes/admin-orgs-dedupe.spec.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db, tables } from "@llmgateway/db";
+
+const MULTI_OWNER_ORG_ID = "dedupe-multi-owner-org";
+const FIRST_OWNER_ID = "dedupe-owner-first";
+const SECOND_OWNER_ID = "dedupe-owner-second";
+const FIRST_OWNER_EMAIL = "dedupe-owner-first@example.com";
+const SECOND_OWNER_EMAIL = "dedupe-owner-second@example.com";
+
+interface OrgListResponse {
+	organizations: {
+		id: string;
+		ownerUserId: string | null;
+		ownerEmail: string | null;
+	}[];
+	total: number;
+}
+
+describe("admin — organizations list deduplication", () => {
+	let cookie: string;
+
+	beforeEach(async () => {
+		process.env.ADMIN_EMAILS = "admin@example.com";
+		cookie = await createTestUser();
+
+		await db.insert(tables.organization).values({
+			id: MULTI_OWNER_ORG_ID,
+			name: "Dedupe Multi Owner Org",
+			billingEmail: "dedupe-multi-owner@example.com",
+		});
+
+		await db.insert(tables.user).values([
+			{
+				id: FIRST_OWNER_ID,
+				name: "First Owner",
+				email: FIRST_OWNER_EMAIL,
+				emailVerified: true,
+			},
+			{
+				id: SECOND_OWNER_ID,
+				name: "Second Owner",
+				email: SECOND_OWNER_EMAIL,
+				emailVerified: true,
+			},
+		]);
+
+		await db.insert(tables.userOrganization).values([
+			{
+				id: "dedupe-membership-first",
+				userId: FIRST_OWNER_ID,
+				organizationId: MULTI_OWNER_ORG_ID,
+				role: "owner",
+				createdAt: new Date("2026-01-01T00:00:00.000Z"),
+			},
+			{
+				id: "dedupe-membership-second",
+				userId: SECOND_OWNER_ID,
+				organizationId: MULTI_OWNER_ORG_ID,
+				role: "owner",
+				createdAt: new Date("2026-02-01T00:00:00.000Z"),
+			},
+		]);
+	});
+
+	afterEach(async () => {
+		await deleteAll();
+	});
+
+	test("lists an org with several owners once, keyed to the first owner", async () => {
+		const res = await app.request("/admin/organizations?limit=50", {
+			headers: { Cookie: cookie },
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as OrgListResponse;
+
+		const rows = body.organizations.filter((o) => o.id === MULTI_OWNER_ORG_ID);
+		expect(rows).toHaveLength(1);
+		expect(rows[0].ownerUserId).toBe(FIRST_OWNER_ID);
+		expect(rows[0].ownerEmail).toBe(FIRST_OWNER_EMAIL);
+		expect(body.organizations).toHaveLength(body.total);
+	});
+
+	test("lists it once when searching by any owner's email", async () => {
+		for (const email of [FIRST_OWNER_EMAIL, SECOND_OWNER_EMAIL]) {
+			const res = await app.request(
+				`/admin/organizations?limit=50&search=${encodeURIComponent(email)}`,
+				{ headers: { Cookie: cookie } },
+			);
+			expect(res.status).toBe(200);
+			const body = (await res.json()) as OrgListResponse;
+
+			expect(body.organizations).toHaveLength(1);
+			expect(body.total).toBe(1);
+			expect(body.organizations[0].id).toBe(MULTI_OWNER_ORG_ID);
+		}
+	});
+});

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -141,6 +141,44 @@ function buildOrganizationSearchFilter(search: string | undefined) {
 	);
 }
 
+/**
+ * One owner row per organization, for joining onto organization listings.
+ * An organization can have several members with the `owner` role, so joining
+ * the membership rows directly would emit the organization once per owner.
+ * Ranks by membership age so the founding owner wins, keyed by user id to stay
+ * deterministic when two memberships share a timestamp.
+ */
+function buildOrganizationOwnerSubquery() {
+	const ranked = db
+		.select({
+			organizationId: tables.userOrganization.organizationId,
+			userId: tables.user.id,
+			userName: tables.user.name,
+			userEmail: tables.user.email,
+			userUsername: tables.user.username,
+			rowNumber:
+				sql<number>`ROW_NUMBER() OVER (PARTITION BY ${tables.userOrganization.organizationId} ORDER BY ${tables.userOrganization.createdAt} ASC, ${tables.user.id} ASC)`.as(
+					"owner_row_number",
+				),
+		})
+		.from(tables.userOrganization)
+		.innerJoin(tables.user, eq(tables.userOrganization.userId, tables.user.id))
+		.where(eq(tables.userOrganization.role, "owner"))
+		.as("owner_ranked");
+
+	return db
+		.select({
+			organizationId: ranked.organizationId,
+			userId: ranked.userId,
+			userName: ranked.userName,
+			userEmail: ranked.userEmail,
+			userUsername: ranked.userUsername,
+		})
+		.from(ranked)
+		.where(eq(ranked.rowNumber, 1))
+		.as("owner_sub");
+}
+
 export const admin = new OpenAPIHono<ServerTypes>();
 
 admin.use("/*", adminMiddleware);
@@ -2618,17 +2656,7 @@ admin.openapi(getOrganizations, async (c) => {
 		.as("total_spent");
 
 	// Subquery for owner user per org
-	const ownerSub = db
-		.select({
-			organizationId: tables.userOrganization.organizationId,
-			userId: tables.user.id,
-			userName: tables.user.name,
-			userEmail: tables.user.email,
-		})
-		.from(tables.userOrganization)
-		.innerJoin(tables.user, eq(tables.userOrganization.userId, tables.user.id))
-		.where(eq(tables.userOrganization.role, "owner"))
-		.as("owner_sub");
+	const ownerSub = buildOrganizationOwnerSubquery();
 
 	const sortColumnMap = {
 		name: tables.organization.name,
@@ -12891,18 +12919,7 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 		.groupBy(tables.paymentFailure.organizationId)
 		.as("last_payment_failure_sub");
 
-	const ownerSub = db
-		.select({
-			organizationId: tables.userOrganization.organizationId,
-			userId: tables.user.id,
-			userName: tables.user.name,
-			userEmail: tables.user.email,
-			userUsername: tables.user.username,
-		})
-		.from(tables.userOrganization)
-		.innerJoin(tables.user, eq(tables.userOrganization.userId, tables.user.id))
-		.where(eq(tables.userOrganization.role, "owner"))
-		.as("owner_sub");
+	const ownerSub = buildOrganizationOwnerSubquery();
 
 	// All-time provider cost per org: every project, every cycle, no status or
 	// billing-cycle window. Unlike `realCostSub` (current cycle only) this never
@@ -15211,17 +15228,7 @@ admin.openapi(getChatPlansSubscribers, async (c) => {
 		.groupBy(tables.paymentFailure.organizationId)
 		.as("last_payment_failure_sub");
 
-	const ownerSub = db
-		.select({
-			organizationId: tables.userOrganization.organizationId,
-			userId: tables.user.id,
-			userName: tables.user.name,
-			userEmail: tables.user.email,
-		})
-		.from(tables.userOrganization)
-		.innerJoin(tables.user, eq(tables.userOrganization.userId, tables.user.id))
-		.where(eq(tables.userOrganization.role, "owner"))
-		.as("owner_sub");
+	const ownerSub = buildOrganizationOwnerSubquery();
 
 	// All-time provider cost per org: every project, every cycle, no status or
 	// billing-cycle window. Scoped to chat orgs so the aggregation doesn't scan


### PR DESCRIPTION
## Problem

Organizations could appear twice (or more) in the admin organizations list — both unfiltered and when searching by an email address. The listing left-joins an owner subquery that returns **one row per `owner` membership**, so any organization with more than one owner member is emitted once per owner. The `total` count is computed from `organization` alone, so the page also showed more rows than it claimed.

## Fix

`buildOrganizationOwnerSubquery()` ranks owner memberships per organization with `ROW_NUMBER()` (oldest membership first, tie-broken by user id) and keeps only the first, so the join contributes exactly one row per organization. The DevPass and Chat subscriber lists used the same duplicated join and now share the helper.

Search behaviour is unchanged: the email filter already used `EXISTS`, so it never duplicated on its own — it just surfaced the same multi-owner organization.

## Verification

New spec `admin-orgs-dedupe.spec.ts` seeds an org with two owners and asserts a single row unfiltered and when searching by either owner's email; it fails without the fix. Ran alongside the existing admin org specs (36 tests), plus `pnpm format` and `pnpm build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)