### PR TITLE
fix(admin): stabilize sorted list pagination

### DIFF
--- a/apps/api/src/routes/admin-orgs-sort-stability.spec.ts
+++ b/apps/api/src/routes/admin-orgs-sort-stability.spec.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db, tables } from "@llmgateway/db";
+
+// Enough rows that Postgres picks a different top-N sort per LIMIT/OFFSET, which
+// is what makes an untied ORDER BY hand back overlapping pages.
+const ORG_COUNT = 3000;
+const PAGE_SIZE = 25;
+
+interface OrgListResponse {
+	organizations: { id: string }[];
+	total: number;
+}
+
+async function collectPages(cookie: string, sortBy: string, pages: number) {
+	const ids: string[] = [];
+	for (let page = 0; page < pages; page++) {
+		const res = await app.request(
+			`/admin/organizations?limit=${PAGE_SIZE}&offset=${page * PAGE_SIZE}&sortBy=${sortBy}&sortOrder=asc`,
+			{ headers: { Cookie: cookie } },
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as OrgListResponse;
+		ids.push(...body.organizations.map((o) => o.id));
+	}
+	return ids;
+}
+
+describe("admin — organizations list sort stability", () => {
+	let cookie: string;
+
+	beforeEach(async () => {
+		process.env.ADMIN_EMAILS = "admin@example.com";
+		cookie = await createTestUser();
+
+		// No usage rows, so every org ties at 0 requests and 0 tokens.
+		await db.insert(tables.organization).values(
+			Array.from({ length: ORG_COUNT }, (_, i) => ({
+				id: `sort-stability-org-${String(i).padStart(4, "0")}`,
+				name: `Sort Stability Org ${i}`,
+				billingEmail: `sort-stability-${i}@example.com`,
+			})),
+		);
+	});
+
+	afterEach(async () => {
+		await deleteAll();
+	});
+
+	test.each(["totalTokens", "totalRequests"])(
+		"pages through tied %s totals without repeating or dropping rows",
+		async (sortBy) => {
+			const ids = await collectPages(cookie, sortBy, 3);
+			expect(ids).toHaveLength(3 * PAGE_SIZE);
+			expect(new Set(ids).size).toBe(ids.length);
+		},
+	);
+
+	test("returns the same page twice for a tied sort", async () => {
+		const first = await collectPages(cookie, "totalTokens", 2);
+		const second = await collectPages(cookie, "totalTokens", 2);
+		expect(second).toEqual(first);
+	});
+});

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -2727,7 +2727,10 @@ admin.openapi(getOrganizations, async (c) => {
 		)
 		.leftJoin(ownerSub, eq(tables.organization.id, ownerSub.organizationId))
 		.where(whereClause)
-		.orderBy(orderFn(sortColumn))
+		// Ties (every org with no usage shares 0 requests/tokens) would otherwise
+		// come back in an arbitrary order that differs per LIMIT/OFFSET plan, so
+		// paging repeats some rows and skips others.
+		.orderBy(orderFn(sortColumn), asc(tables.organization.id))
 		.limit(limit)
 		.offset(offset);
 
@@ -5183,7 +5186,7 @@ admin.openapi(getProviderStats, async (c) => {
 					modelCountSub,
 					eq(tables.provider.id, modelCountSub.providerId),
 				)
-				.orderBy(orderFn(sortColumn)),
+				.orderBy(orderFn(sortColumn), asc(tables.provider.id)),
 		]);
 
 		const totalTokensAgg = Number(totalsResult?.totalTokens ?? 0);
@@ -5249,7 +5252,7 @@ admin.openapi(getProviderStats, async (c) => {
 		})
 		.from(tables.provider)
 		.leftJoin(modelCountSub, eq(tables.provider.id, modelCountSub.providerId))
-		.orderBy(orderFn(sortColumn));
+		.orderBy(orderFn(sortColumn), asc(tables.provider.id));
 
 	return c.json({
 		providers: rows.map((r) => ({
@@ -5571,7 +5574,7 @@ admin.openapi(getModelStats, async (c) => {
 				)
 				.leftJoin(pricingSub, eq(tables.model.id, pricingSub.modelId))
 				.where(whereClause)
-				.orderBy(orderFn(sortColumn))
+				.orderBy(orderFn(sortColumn), asc(tables.model.id))
 				.limit(limit)
 				.offset(offset),
 		]);
@@ -5702,7 +5705,7 @@ admin.openapi(getModelStats, async (c) => {
 		.leftJoin(providerCountSub, eq(tables.model.id, providerCountSub.modelId))
 		.leftJoin(pricingSub, eq(tables.model.id, pricingSub.modelId))
 		.where(whereClause)
-		.orderBy(orderFn(sortColumn))
+		.orderBy(orderFn(sortColumn), asc(tables.model.id))
 		.limit(limit)
 		.offset(offset);
 
@@ -10095,7 +10098,7 @@ admin.openapi(getModelProviderMappings, async (c) => {
 				eq(tables.modelProviderMapping.id, statsJoin.mappingId),
 			)
 			.where(whereClause)
-			.orderBy(orderFn(sortColumn))
+			.orderBy(orderFn(sortColumn), asc(tables.modelProviderMapping.id))
 			.limit(limit)
 			.offset(offset),
 	]);
@@ -10831,7 +10834,7 @@ admin.openapi(getContactSubmissions, async (c) => {
 			})
 			.from(t)
 			.where(where)
-			.orderBy(orderFn(sortColumn))
+			.orderBy(orderFn(sortColumn), asc(t.id))
 			.limit(limit)
 			.offset(offset),
 		db
@@ -11898,7 +11901,7 @@ admin.openapi(getProviderListingRequests, async (c) => {
 			})
 			.from(t)
 			.where(where)
-			.orderBy(orderFn(sortColumn))
+			.orderBy(orderFn(sortColumn), asc(t.id))
 			.limit(limit)
 			.offset(offset),
 		db
@@ -13273,7 +13276,7 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 
 	const rows = await baseSelect
 		.where(whereClause)
-		.orderBy(orderFn(sortColumn))
+		.orderBy(orderFn(sortColumn), asc(tables.organization.id))
 		.limit(limit)
 		.offset(offset);
 
@@ -15499,7 +15502,7 @@ admin.openapi(getChatPlansSubscribers, async (c) => {
 
 	const rows = await baseSelect
 		.where(whereClause)
-		.orderBy(orderFn(sortColumn))
+		.orderBy(orderFn(sortColumn), asc(tables.organization.id))
 		.limit(limit)
 		.offset(offset);
 


### PR DESCRIPTION
## Problem

Sorting the admin organizations list by **Requests** or **Tokens** looked like it only sorted the current page: paging through the results showed the same organization more than once and never showed others.

The sorting is server-side (`ORDER BY` on the aggregate), but it was ordered *only* by the selected column. Requests and tokens are the worst case for that — every organization with no usage in the window ties at `0`. Postgres is free to return tied rows in any order, and it picks a different top-N sort per `LIMIT`/`OFFSET`, so page 2 is not a continuation of page 1. The result is duplicated and missing rows, which reads as "the sort isn't real".

## Fix

Add the row id as a final `ORDER BY` tiebreaker so the total order is deterministic and pages compose. Applied to every sorted admin list with the same pattern, not just organizations: providers, models, model/provider mappings, contact submissions, provider listing requests, and the DevPass/Chat subscriber lists.

## Verification

New spec `admin-orgs-sort-stability.spec.ts` seeds 3000 organizations that all tie at zero requests and tokens, then pages through the list. It fails on `main` (a duplicate row appears on page 2) and passes with the fix; it also asserts the same query returns the same page twice.

`pnpm format`, `pnpm build`, and all 178 admin API specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when browsing paginated admin lists.
  - Items with tied sort values now appear in a stable, predictable order.
  - Repeated page loads return the same results, preventing duplicate or missing entries across pages.
- **Tests**
  - Added coverage for stable pagination across organization and administrative listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->