### PR TITLE
feat(anthropic): support server-side tool search

### DIFF
--- a/apps/docs/content/features/anthropic-endpoint.mdx
+++ b/apps/docs/content/features/anthropic-endpoint.mdx
@@ -198,6 +198,39 @@ Anthropic's server-side web search tool works on this endpoint. Pass it as usual
 
 Replaying the assistant turn verbatim on the next request is supported: the `server_tool_use` and `web_search_tool_result` blocks are accepted and dropped, since the provider re-runs the search rather than reusing the previous results.
 
+### Tool Search
+
+Anthropic's server-side [tool search](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool) works on this endpoint. Pass a `tool_search_tool_*` tool alongside your catalog and mark the tools that should load on demand with `defer_loading: true`:
+
+```json
+{
+	"model": "claude-sonnet-4-6",
+	"max_tokens": 1024,
+	"messages": [{ "role": "user", "content": "What is the weather in Paris?" }],
+	"tools": [
+		{
+			"type": "tool_search_tool_regex_20251119",
+			"name": "tool_search_tool_regex"
+		},
+		{
+			"name": "get_weather",
+			"description": "Get the weather at a specific location",
+			"input_schema": { "type": "object" },
+			"defer_loading": true
+		}
+	]
+}
+```
+
+Deferred tools stay out of the rendered tools section, so adding one does not invalidate an existing prompt cache. The response carries the `server_tool_use` and `tool_search_tool_result` blocks; replay them verbatim on the next request and Anthropic keeps expanding the `tool_reference` entries they carry, so Claude reuses a discovered tool instead of searching again. `tool_reference` blocks returned from your own client-side search inside a `tool_result` are forwarded unchanged too.
+
+<Callout type="warning">
+	This is an Anthropic-only feature. If routing lands on a non-Anthropic
+	provider, the tool search tool is dropped and every tool is sent eagerly — the
+	request still works, it just loses the cache and token savings. Pin the
+	provider (`anthropic/claude-sonnet-4-6`) when those savings matter.
+</Callout>
+
 ### Gateway Response Cache
 
 If [gateway caching](/features/caching/gateway-caching) is enabled on the project, a byte-identical request is replayed from cache instead of being sent upstream. Because the replayed body is identical (same `id`, same `usage`), the `x-llmgateway-cache: HIT` response header is the marker to check. Send `x-no-cache: true` to bypass the cache for a single request.

--- a/apps/docs/content/features/anthropic-endpoint.mdx
+++ b/apps/docs/content/features/anthropic-endpoint.mdx
@@ -224,11 +224,14 @@ Anthropic's server-side [tool search](https://platform.claude.com/docs/en/agents
 
 Deferred tools stay out of the rendered tools section, so adding one does not invalidate an existing prompt cache. The response carries the `server_tool_use` and `tool_search_tool_result` blocks; replay them verbatim on the next request and Anthropic keeps expanding the `tool_reference` entries they carry, so Claude reuses a discovered tool instead of searching again. `tool_reference` blocks returned from your own client-side search inside a `tool_result` are forwarded unchanged too.
 
-<Callout type="warning">
-	This is an Anthropic-only feature. If routing lands on a non-Anthropic
-	provider, the tool search tool is dropped and every tool is sent eagerly — the
-	request still works, it just loses the cache and token savings. Pin the
-	provider (`anthropic/claude-sonnet-4-6`) when those savings matter.
+Send every tool definition on every request, including the deferred ones — Anthropic needs them server-side to run the search. At least one tool must stay non-deferred (normally the tool search tool itself), and a tool cannot carry both `defer_loading: true` and `cache_control`.
+
+**Where it works.** Tool search reaches the provider on the Anthropic API and on Anthropic models served through Google Cloud, and it needs a Claude 4.5-generation model or newer — older Claude models reject it upstream. On every other provider, including Anthropic models on AWS Bedrock, the tool search tool and `defer_loading` are dropped and all tools are sent eagerly. The request still succeeds, it just loses the cache and token savings, so pin the provider (`anthropic/claude-sonnet-4-6`) when those savings matter.
+
+<Callout type="info">
+	Bedrock is a transport limitation rather than a missing capability: Anthropic
+	exposes server-side tool search there only through the InvokeModel API, and
+	the gateway routes Bedrock through the Converse API.
 </Callout>
 
 ### Gateway Response Cache

--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -12,6 +12,10 @@ import {
 } from "@/lib/error-response.js";
 import { extractAnthropicSessionId } from "@/lib/session-id.js";
 
+import {
+	isToolSearchBlock,
+	TOOL_SEARCH_TOOL_TYPE_PREFIX,
+} from "@llmgateway/actions";
 import { logger, toError } from "@llmgateway/logger";
 
 import { logAnthropicClientError } from "./client-error-log.js";
@@ -23,6 +27,7 @@ import { buildAnthropicErrorEvent } from "./streaming-error-translation.js";
 import { mapAnthropicThinkingToReasoning } from "./thinking-to-reasoning.js";
 
 import type { ServerTypes } from "@/vars.js";
+import type { AnthropicNativeBlock } from "@llmgateway/models";
 
 // Most of the request schema is built from unions (content blocks, tool
 // variants), and a union issue's own message is a useless "Invalid input" —
@@ -168,6 +173,15 @@ const anthropicMessageSchema = z.object({
 						.union([z.array(z.unknown()), z.record(z.unknown())])
 						.optional(),
 				}),
+				// Server-side tool search results. Unlike the web-search blocks
+				// above these ARE forwarded: Anthropic expands the tool_reference
+				// entries they carry throughout the history, which is what lets
+				// Claude reuse a discovered tool without searching again.
+				z.object({
+					type: z.literal("tool_search_tool_result"),
+					tool_use_id: z.string(),
+					content: z.record(z.unknown()).optional(),
+				}),
 			]),
 		),
 	]),
@@ -208,6 +222,15 @@ const anthropicCustomToolSchema = z.object({
 			ttl: z.enum(["5m", "1h"]).optional(),
 		})
 		.nullish(),
+	defer_loading: z.boolean().optional(),
+});
+
+// Anthropic's server-side tool search tool. Matched by prefix so the undated
+// aliases and any future dated version keep working. `name` is optional
+// because several Anthropic SDKs omit it.
+const anthropicToolSearchToolSchema = z.object({
+	type: z.string().regex(/^tool_search_tool/),
+	name: z.string().optional(),
 });
 
 // Anthropic server-side tools (e.g. web_search_20250305, code_execution_*).
@@ -238,6 +261,7 @@ const anthropicServerToolSchema = z.object({
 
 const anthropicToolSchema = z.union([
 	anthropicCustomToolSchema,
+	anthropicToolSearchToolSchema,
 	anthropicServerToolSchema,
 ]);
 
@@ -331,6 +355,7 @@ const anthropicContentBlockSchema = z.object({
 		"thinking",
 		"server_tool_use",
 		"web_search_tool_result",
+		"tool_search_tool_result",
 	]),
 	text: z.string().optional(),
 	thinking: z.string().optional(),
@@ -338,7 +363,8 @@ const anthropicContentBlockSchema = z.object({
 	name: z.string().optional(),
 	input: z.record(z.unknown()).optional(),
 	tool_use_id: z.string().optional(),
-	content: z.array(z.unknown()).optional(),
+	// An array for web search results, an object for tool search results.
+	content: z.union([z.array(z.unknown()), z.record(z.unknown())]).optional(),
 });
 
 const anthropicResponseSchema = z.object({
@@ -391,13 +417,26 @@ interface AnthropicWebSearchResult {
 
 // Response-only Anthropic content blocks. Clients replay the assistant turn
 // verbatim on the next request, so these arrive back here; none of them has an
-// OpenAI-format equivalent, so they're dropped on the request direction.
+// OpenAI-format equivalent, so they're dropped from the lowered content. The
+// tool search pair is carried separately on `anthropic_native_blocks` and
+// spliced back in for Anthropic upstreams — see collectToolSearchBlocks.
 const NON_FORWARDABLE_CONTENT_BLOCK_TYPES = new Set([
 	"thinking",
 	"redacted_thinking",
 	"server_tool_use",
 	"web_search_tool_result",
+	"tool_search_tool_result",
 ]);
+
+// The tool search pair out of an assistant turn. `server_tool_use` is matched
+// on its name because the web-search variant shares the block type and must
+// stay dropped: replaying it needs an `encrypted_content` the gateway cannot
+// reconstruct from url_citation annotations.
+function collectToolSearchBlocks(
+	content: Array<{ type: string; name?: string }>,
+): AnthropicNativeBlock[] {
+	return content.filter(isToolSearchBlock) as AnthropicNativeBlock[];
+}
 
 function generateServerToolUseId(): string {
 	return `srvtoolu_${randomUUID()}`;
@@ -669,10 +708,15 @@ anthropic.openapi(messages, async (c) => {
 				.map((block) => block.text)
 				.join("");
 
+			const toolSearchBlocks = collectToolSearchBlocks(message.content);
+
 			openaiMessages.push({
 				role: message.role,
 				content: textContent || "",
 				tool_calls: toolCalls,
+				...(toolSearchBlocks.length > 0 && {
+					anthropic_native_blocks: toolSearchBlocks,
+				}),
 			});
 			continue;
 		}
@@ -706,10 +750,28 @@ anthropic.openapi(messages, async (c) => {
 					)
 					.join("\n");
 
+				// A client-side tool search answers with `tool_reference` blocks in
+				// the tool_result content array. Stringifying them would leave
+				// Anthropic nothing to expand, so keep the originals alongside the
+				// lowered string and replay them on Anthropic upstreams.
+				const referenceBlocks = blocks.flatMap((block) =>
+					Array.isArray(block.content)
+						? block.content.filter(
+								(entry: unknown): entry is AnthropicNativeBlock =>
+									!!entry &&
+									typeof entry === "object" &&
+									(entry as { type?: unknown }).type === "tool_reference",
+							)
+						: [],
+				);
+
 				openaiMessages.push({
 					role: "tool",
 					content: combinedContent,
 					tool_call_id: toolUseId,
+					...(referenceBlocks.length > 0 && {
+						anthropic_native_blocks: referenceBlocks,
+					}),
 				});
 			}
 
@@ -752,11 +814,24 @@ anthropic.openapi(messages, async (c) => {
 			const forwardableBlocks = message.content.filter(
 				(block) => !NON_FORWARDABLE_CONTENT_BLOCK_TYPES.has(block.type),
 			);
+			const toolSearchBlocks =
+				message.role === "assistant"
+					? collectToolSearchBlocks(message.content)
+					: [];
 
 			// A turn made up entirely of dropped blocks (e.g. a `pause_turn` reply
 			// carrying only server_tool_use) would otherwise become an empty
-			// message, which providers reject.
+			// message, which providers reject. A search-only turn is the exception:
+			// its blocks still have to reach Anthropic, so it is forwarded with
+			// empty content and dropped again for providers that can't take them.
 			if (forwardableBlocks.length === 0) {
+				if (toolSearchBlocks.length > 0) {
+					openaiMessages.push({
+						role: message.role,
+						content: "",
+						anthropic_native_blocks: toolSearchBlocks,
+					});
+				}
 				continue;
 			}
 
@@ -779,6 +854,9 @@ anthropic.openapi(messages, async (c) => {
 				openaiMessages.push({
 					role: message.role,
 					content: textContent,
+					...(toolSearchBlocks.length > 0 && {
+						anthropic_native_blocks: toolSearchBlocks,
+					}),
 				});
 			} else {
 				// For multi-modal content, or text content with cache_control markers,
@@ -808,6 +886,9 @@ anthropic.openapi(messages, async (c) => {
 				openaiMessages.push({
 					role: message.role,
 					content,
+					...(toolSearchBlocks.length > 0 && {
+						anthropic_native_blocks: toolSearchBlocks,
+					}),
 				});
 			}
 		} else {
@@ -836,21 +917,37 @@ anthropic.openapi(messages, async (c) => {
 							description: tool.description,
 							parameters: tool.input_schema,
 						},
+						// Carried through to Anthropic upstreams and stripped
+						// elsewhere, where the tool is simply loaded eagerly.
+						...(tool.defer_loading === true && { defer_loading: true }),
+					};
+				}
+
+				if (tool.type.startsWith(TOOL_SEARCH_TOOL_TYPE_PREFIX)) {
+					return {
+						type: "tool_search",
+						tool_search_type: tool.type,
+						...(tool.name ? { name: tool.name } : {}),
 					};
 				}
 
 				if (tool.type.startsWith("web_search")) {
+					// The tool-search variant shares this branch's union but carries
+					// none of the web-search options, so narrow before reading them.
+					const searchTool = tool as z.infer<typeof anthropicServerToolSchema>;
 					return {
 						type: "web_search",
-						...(tool.max_uses !== undefined ? { max_uses: tool.max_uses } : {}),
-						...(tool.user_location
-							? { user_location: tool.user_location }
+						...(searchTool.max_uses !== undefined
+							? { max_uses: searchTool.max_uses }
 							: {}),
-						...(tool.allowed_domains
-							? { allowed_domains: tool.allowed_domains }
+						...(searchTool.user_location
+							? { user_location: searchTool.user_location }
 							: {}),
-						...(tool.blocked_domains
-							? { blocked_domains: tool.blocked_domains }
+						...(searchTool.allowed_domains
+							? { allowed_domains: searchTool.allowed_domains }
+							: {}),
+						...(searchTool.blocked_domains
+							? { blocked_domains: searchTool.blocked_domains }
 							: {}),
 					};
 				}
@@ -1407,6 +1504,54 @@ anthropic.openapi(messages, async (c) => {
 									}
 								}
 
+								// Handle Anthropic's server-side tool search blocks, which
+								// the inner stream forwards verbatim. Emitted complete
+								// (start + stop) like the web-search pair above, and for
+								// the same reason: they carry no incremental deltas by the
+								// time they reach here.
+								if (
+									Array.isArray(delta.anthropic_native_blocks) &&
+									delta.anthropic_native_blocks.length > 0
+								) {
+									// Anthropic streams blocks strictly sequentially, so close
+									// any open text block first — text that follows the search
+									// opens a new block after it.
+									if (currentTextBlockIndex !== null) {
+										contentBlocks[currentTextBlockIndex].stopped = true;
+										await stream.writeSSE({
+											data: JSON.stringify({
+												type: "content_block_stop",
+												index: currentTextBlockIndex,
+											}),
+											event: "content_block_stop",
+										});
+										currentTextBlockIndex = null;
+									}
+
+									for (const block of delta.anthropic_native_blocks) {
+										const blockIndex = contentBlocks.length;
+										contentBlocks.push({
+											type: block.type,
+											stopped: true,
+										});
+										await stream.writeSSE({
+											data: JSON.stringify({
+												type: "content_block_start",
+												index: blockIndex,
+												content_block: block,
+											}),
+											event: "content_block_start",
+										});
+										await stream.writeSSE({
+											data: JSON.stringify({
+												type: "content_block_stop",
+												index: blockIndex,
+											}),
+											event: "content_block_stop",
+										});
+									}
+								}
+
 								// Handle content delta
 								if (delta.content) {
 									// Find or create a text block
@@ -1654,6 +1799,16 @@ anthropic.openapi(messages, async (c) => {
 			tool_use_id: serverToolUseId,
 			content: responseWebSearchResults,
 		});
+	}
+
+	// Anthropic's server-side tool search blocks come back verbatim from the
+	// inner response. They precede the text and tool_use blocks they led to, and
+	// the client has to replay them for Anthropic to keep expanding the
+	// tool_reference entries they carry.
+	const responseToolSearchBlocks =
+		openaiResponse.choices?.[0]?.message?.anthropic_native_blocks;
+	if (Array.isArray(responseToolSearchBlocks)) {
+		content.push(...responseToolSearchBlocks);
 	}
 
 	if (openaiResponse.choices?.[0]?.message?.content) {

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -9108,6 +9108,367 @@ describe("api", () => {
 			}
 		});
 
+		// Anthropic's server-side tool search is the one server tool whose value
+		// is entirely in what it keeps OUT of the request: `defer_loading` holds
+		// the deferred definitions out of the cached prompt prefix. Both the tool
+		// and the flag have to survive the OpenAI-format round trip, and the
+		// resulting server_tool_use / tool_search_tool_result pair has to come
+		// back so the client can replay it.
+		test("forwards the tool search tool, defer_loading and the replayed pair", async () => {
+			await db.insert(tables.apiKey).values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+			await db.insert(tables.providerKey).values({
+				id: "provider-key-id",
+				token: "sk-test-key",
+				provider: "anthropic",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			});
+
+			let capturedBody: any;
+			const originalFetch = globalThis.fetch;
+			const fetchSpy = vi
+				.spyOn(globalThis, "fetch")
+				.mockImplementation(async (input, init) => {
+					const url =
+						typeof input === "string"
+							? input
+							: input instanceof URL
+								? input.toString()
+								: input.url;
+
+					if (url.includes(`${mockServerUrl}/v1/messages`)) {
+						capturedBody = JSON.parse(init?.body as string);
+						return new Response(
+							JSON.stringify({
+								id: "msg_ts",
+								type: "message",
+								role: "assistant",
+								model: "claude-sonnet-4-6",
+								content: [
+									{
+										type: "server_tool_use",
+										id: "srvtoolu_2",
+										name: "tool_search_tool_regex",
+										input: { pattern: "weather" },
+									},
+									{
+										type: "tool_search_tool_result",
+										tool_use_id: "srvtoolu_2",
+										content: {
+											type: "tool_search_tool_search_result",
+											tool_references: [
+												{ type: "tool_reference", tool_name: "get_weather" },
+											],
+										},
+									},
+									{ type: "text", text: "Found a weather tool." },
+								],
+								stop_reason: "end_turn",
+								stop_sequence: null,
+								usage: { input_tokens: 50, output_tokens: 10 },
+							}),
+							{
+								status: 200,
+								headers: { "Content-Type": "application/json" },
+							},
+						);
+					}
+
+					return await originalFetch(input as RequestInfo | URL, init);
+				});
+
+			try {
+				const res = await app.request("/v1/messages", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: "Bearer real-token",
+						"x-no-fallback": "true",
+					},
+					body: JSON.stringify({
+						model: "anthropic/claude-sonnet-4-6",
+						max_tokens: 1024,
+						messages: [
+							{ role: "user", content: "What is the weather in Paris?" },
+							{
+								role: "assistant",
+								content: [
+									{
+										type: "server_tool_use",
+										id: "srvtoolu_1",
+										name: "tool_search_tool_regex",
+										input: { pattern: "weather" },
+									},
+									{
+										type: "tool_search_tool_result",
+										tool_use_id: "srvtoolu_1",
+										content: {
+											type: "tool_search_tool_search_result",
+											tool_references: [
+												{ type: "tool_reference", tool_name: "get_weather" },
+											],
+										},
+									},
+									{ type: "text", text: "Let me check." },
+									{
+										type: "tool_use",
+										id: "toolu_1",
+										name: "get_weather",
+										input: { location: "Paris" },
+									},
+								],
+							},
+							{
+								role: "user",
+								content: [
+									{
+										type: "tool_result",
+										tool_use_id: "toolu_1",
+										content: "sunny",
+									},
+								],
+							},
+						],
+						tools: [
+							{
+								type: "tool_search_tool_regex_20251119",
+								name: "tool_search_tool_regex",
+							},
+							{
+								name: "get_weather",
+								description: "Get the weather at a specific location",
+								input_schema: {
+									type: "object",
+									properties: { location: { type: "string" } },
+									required: ["location"],
+								},
+								defer_loading: true,
+							},
+						],
+					}),
+				});
+
+				expect(res.status).toBe(200);
+
+				// The tool search tool reaches Anthropic under its own type, and the
+				// deferred tool keeps its flag — without which the whole point of
+				// the feature (a cache-stable prefix) is lost.
+				expect(capturedBody?.tools).toEqual([
+					{
+						type: "tool_search_tool_regex_20251119",
+						name: "tool_search_tool_regex",
+					},
+					{
+						name: "get_weather",
+						description: "Get the weather at a specific location",
+						input_schema: {
+							type: "object",
+							properties: { location: { type: "string" } },
+							required: ["location"],
+						},
+						defer_loading: true,
+					},
+				]);
+
+				// The replayed pair has to reach Anthropic ahead of the tool_use it
+				// led to, or Claude re-searches for a tool it already found.
+				const assistantTurn = capturedBody?.messages?.find(
+					(m: { role: string }) => m.role === "assistant",
+				);
+				expect(
+					assistantTurn?.content?.map((b: { type: string }) => b.type),
+				).toEqual([
+					"text",
+					"server_tool_use",
+					"tool_search_tool_result",
+					"tool_use",
+				]);
+
+				// And the client gets the new pair back so it can replay it next turn.
+				const json: any = await res.json();
+				expect(json.content.map((b: { type: string }) => b.type)).toEqual([
+					"server_tool_use",
+					"tool_search_tool_result",
+					"text",
+				]);
+				expect(json.content[1].content.tool_references).toEqual([
+					{ type: "tool_reference", tool_name: "get_weather" },
+				]);
+			} finally {
+				fetchSpy.mockRestore();
+			}
+		});
+
+		test("re-emits the streamed tool search pair as content blocks", async () => {
+			await db.insert(tables.apiKey).values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+			await db.insert(tables.providerKey).values({
+				id: "provider-key-id",
+				token: "sk-test-key",
+				provider: "anthropic",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			});
+
+			const sse = [
+				`event: message_start\ndata: ${JSON.stringify({
+					type: "message_start",
+					message: {
+						id: "msg_ts_stream",
+						type: "message",
+						role: "assistant",
+						model: "claude-sonnet-4-6",
+						content: [],
+						usage: { input_tokens: 50, output_tokens: 0 },
+					},
+				})}\n\n`,
+				`event: content_block_start\ndata: ${JSON.stringify({
+					type: "content_block_start",
+					index: 0,
+					content_block: {
+						type: "server_tool_use",
+						id: "srvtoolu_stream",
+						name: "tool_search_tool_regex",
+					},
+				})}\n\n`,
+				`event: content_block_delta\ndata: ${JSON.stringify({
+					type: "content_block_delta",
+					index: 0,
+					delta: {
+						type: "input_json_delta",
+						partial_json: '{"pattern":"weather"}',
+					},
+				})}\n\n`,
+				`event: content_block_stop\ndata: ${JSON.stringify({
+					type: "content_block_stop",
+					index: 0,
+				})}\n\n`,
+				`event: content_block_start\ndata: ${JSON.stringify({
+					type: "content_block_start",
+					index: 1,
+					content_block: {
+						type: "tool_search_tool_result",
+						tool_use_id: "srvtoolu_stream",
+						content: {
+							type: "tool_search_tool_search_result",
+							tool_references: [
+								{ type: "tool_reference", tool_name: "get_weather" },
+							],
+						},
+					},
+				})}\n\n`,
+				`event: content_block_start\ndata: ${JSON.stringify({
+					type: "content_block_start",
+					index: 2,
+					content_block: { type: "text", text: "" },
+				})}\n\n`,
+				`event: content_block_delta\ndata: ${JSON.stringify({
+					type: "content_block_delta",
+					index: 2,
+					delta: { type: "text_delta", text: "Found it." },
+				})}\n\n`,
+				`event: message_delta\ndata: ${JSON.stringify({
+					type: "message_delta",
+					delta: { stop_reason: "end_turn" },
+					usage: { output_tokens: 12 },
+				})}\n\n`,
+				`event: message_stop\ndata: ${JSON.stringify({
+					type: "message_stop",
+				})}\n\n`,
+			].join("");
+
+			const originalFetch = globalThis.fetch;
+			const fetchSpy = vi
+				.spyOn(globalThis, "fetch")
+				.mockImplementation(async (input, init) => {
+					const url =
+						typeof input === "string"
+							? input
+							: input instanceof URL
+								? input.toString()
+								: input.url;
+
+					if (url.includes(`${mockServerUrl}/v1/messages`)) {
+						return new Response(sse, {
+							status: 200,
+							headers: { "Content-Type": "text/event-stream" },
+						});
+					}
+
+					return await originalFetch(input as RequestInfo | URL, init);
+				});
+
+			try {
+				const res = await app.request("/v1/messages", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: "Bearer real-token",
+						"x-no-fallback": "true",
+					},
+					body: JSON.stringify({
+						model: "anthropic/claude-sonnet-4-6",
+						max_tokens: 1024,
+						stream: true,
+						messages: [
+							{ role: "user", content: "What is the weather in Paris?" },
+						],
+						tools: [
+							{
+								type: "tool_search_tool_regex_20251119",
+								name: "tool_search_tool_regex",
+							},
+						],
+					}),
+				});
+
+				expect(res.status).toBe(200);
+				const text = await res.text();
+				const starts = text
+					.split("\n")
+					.filter((line) => line.startsWith("data: "))
+					.map((line) => {
+						try {
+							return JSON.parse(line.slice(6));
+						} catch {
+							return null;
+						}
+					})
+					.filter(
+						(event) => event && event.type === "content_block_start",
+					) as any[];
+
+				const searchCall = starts.find(
+					(event) => event.content_block?.type === "server_tool_use",
+				);
+				expect(searchCall?.content_block).toMatchObject({
+					id: "srvtoolu_stream",
+					name: "tool_search_tool_regex",
+					input: { pattern: "weather" },
+				});
+
+				const searchResult = starts.find(
+					(event) => event.content_block?.type === "tool_search_tool_result",
+				);
+				expect(searchResult?.content_block?.content?.tool_references).toEqual([
+					{ type: "tool_reference", tool_name: "get_weather" },
+				]);
+			} finally {
+				fetchSpy.mockRestore();
+			}
+		});
+
 		test("still rejects a custom tool missing input_schema", async () => {
 			await db.insert(tables.apiKey).values({
 				id: "token-id",

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -306,7 +306,10 @@ import {
 	withCurrentRequestMetadataOnOpenAiResponse,
 	zeroCostsOnCachedResponseUsage,
 } from "./tools/transform-response-to-openai.js";
-import { transformStreamingToOpenai } from "./tools/transform-streaming-to-openai.js";
+import {
+	type AnthropicToolSearchState,
+	transformStreamingToOpenai,
+} from "./tools/transform-streaming-to-openai.js";
 import { validateFreeModelUsage } from "./tools/validate-free-model-usage.js";
 import { validateModelCapabilities } from "./tools/validate-model-capabilities.js";
 
@@ -1684,7 +1687,7 @@ chat.openapi(completions, async (c) => {
 	// exempt. n > 1 with streaming text-only output is fully supported.
 	if (n !== undefined && n > 1 && stream && tools) {
 		const functionToolsCount = tools.filter(
-			(t: { type: string }) => t.type !== "web_search",
+			(t: { type: string }) => t.type === "function",
 		).length;
 		if (functionToolsCount > 0) {
 			return c.json(
@@ -9094,6 +9097,9 @@ chat.openapi(completions, async (c) => {
 						? 1
 						: 0;
 				const serverToolUseIndices = new Set<number>(); // Track Anthropic server_tool_use block indices
+				// Accumulates Anthropic tool search calls until their result block
+				// arrives, so the pair can be forwarded to native clients intact.
+				const toolSearchState: AnthropicToolSearchState = new Map();
 				let sawUpstreamDoneSentinel = false;
 				let sawProviderTerminalEvent = false;
 				let sawOpenAiResponsesDoneEvent = false;
@@ -9953,6 +9959,7 @@ chat.openapi(completions, async (c) => {
 									messages,
 									serverToolUseIndices,
 									supportsReasoning,
+									toolSearchState,
 								);
 
 								// Skip null events (some providers have non-data events)
@@ -13905,6 +13912,17 @@ chat.openapi(completions, async (c) => {
 	) {
 		transformedResponse.choices[0].message.message_items =
 			parsedResponse.messageItems;
+	}
+	// Surface Anthropic's server-side tool search blocks so the /v1/messages
+	// layer can hand them back to the client, which replays them on the next
+	// turn — that is what lets Claude reuse an already discovered tool.
+	if (
+		parsedResponse.anthropicNativeBlocks &&
+		parsedResponse.anthropicNativeBlocks.length > 0 &&
+		transformedResponse.choices?.[0]?.message
+	) {
+		transformedResponse.choices[0].message.anthropic_native_blocks =
+			parsedResponse.anthropicNativeBlocks;
 	}
 	// Surface the effective reasoning context the provider applied so the
 	// Responses layer reports the served mode rather than echoing the request.

--- a/apps/gateway/src/chat/schemas/completions.ts
+++ b/apps/gateway/src/chat/schemas/completions.ts
@@ -162,6 +162,13 @@ export const completionsRequestSchema = z.object({
 					description:
 						"Separate phased assistant message items (e.g. commentary and final_answer) emitted by OpenAI Responses API models in a single turn. preceding_tool_calls records how many of the message's tool calls came before each item. Replayed upstream as individual message items in their original order; stripped for other providers.",
 				}),
+			anthropic_native_blocks: z
+				.array(z.object({ type: z.string() }).passthrough())
+				.optional()
+				.openapi({
+					description:
+						"Anthropic content blocks with no OpenAI-format equivalent. On an assistant message these are the server-side tool search blocks (`server_tool_use` + `tool_search_tool_result`), replayed ahead of the message's tool calls; on a tool message they are the `tool_result` content array, which is how a client-side tool search returns `tool_reference` blocks. Replayed on the Anthropic Messages API only and stripped for every other provider.",
+				}),
 		}),
 	),
 	temperature: z
@@ -289,6 +296,21 @@ export const completionsRequestSchema = z.object({
 						description: z.string().optional(),
 						parameters: z.record(z.any()).optional(),
 					}),
+					defer_loading: z.boolean().optional().openapi({
+						description:
+							"Anthropic only. Keeps the tool out of the rendered tools section so it never enters the cached prompt prefix, and loads it on demand once the tool search tool discovers it. Requires a `tool_search` tool in `tools`, and Anthropic rejects a request whose tools are all deferred. Stripped for every other provider, which receives the tool eagerly instead.",
+					}),
+				}),
+				z.object({
+					type: z.literal("tool_search"),
+					tool_search_type: z
+						.string()
+						.regex(/^tool_search_tool/)
+						.openapi({
+							description:
+								"Anthropic tool search tool type, e.g. `tool_search_tool_regex_20251119` or `tool_search_tool_bm25_20251119`.",
+						}),
+					name: z.string().optional(),
 				}),
 				z.object({
 					type: z.literal("web_search"),

--- a/apps/gateway/src/chat/tools/openai-content-filter.ts
+++ b/apps/gateway/src/chat/tools/openai-content-filter.ts
@@ -112,8 +112,15 @@ function buildTextSummary(message: BaseMessage): string | null {
 				continue;
 			}
 
-			if (part.type === "tool_result" && part.content.trim().length > 0) {
-				segments.push(`tool_result: ${part.content.trim()}`);
+			if (part.type === "tool_result") {
+				// The content is a block array when a client-side tool search
+				// answered with tool_reference blocks; there is no user text in
+				// those, so only the string form is worth screening.
+				const text =
+					typeof part.content === "string" ? part.content.trim() : "";
+				if (text.length > 0) {
+					segments.push(`tool_result: ${text}`);
+				}
 			}
 		}
 	}

--- a/apps/gateway/src/chat/tools/parse-provider-response.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.ts
@@ -1,3 +1,4 @@
+import { isToolSearchBlock } from "@llmgateway/actions";
 import { redisClient } from "@llmgateway/cache";
 import { shortid } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
@@ -15,7 +16,11 @@ import {
 } from "./reasoning-details.js";
 
 import type { Annotation, ImageObject } from "./types.js";
-import type { Provider, ReasoningDetail } from "@llmgateway/models";
+import type {
+	AnthropicNativeBlock,
+	Provider,
+	ReasoningDetail,
+} from "@llmgateway/models";
 
 /**
  * Parses response content and metadata from different providers
@@ -60,6 +65,7 @@ export function parseProviderResponse(
 	let audioInputTokens: number | null = null;
 	let cachedAudioInputTokens: number | null = null;
 	let toolResults = null;
+	let anthropicNativeBlocks: AnthropicNativeBlock[] | null = null;
 	let images: ImageObject[] = [];
 	const annotations: Annotation[] = [];
 	let webSearchCount = 0;
@@ -302,6 +308,16 @@ export function parseProviderResponse(
 						? promptTokens + completionTokens
 						: null;
 			}
+			// Server-side tool search leaves a server_tool_use +
+			// tool_search_tool_result pair in the content. Neither has an
+			// OpenAI-format equivalent, so surface them verbatim for the
+			// /v1/messages layer to replay — Anthropic expands the tool_reference
+			// entries they carry on every later turn.
+			const toolSearchBlocks = contentBlocks.filter(isToolSearchBlock);
+			if (toolSearchBlocks.length > 0) {
+				anthropicNativeBlocks = toolSearchBlocks;
+			}
+
 			// Extract tool calls from Anthropic format
 			toolResults =
 				json.content
@@ -1277,6 +1293,7 @@ export function parseProviderResponse(
 		audioInputTokens,
 		cachedAudioInputTokens,
 		toolResults,
+		anthropicNativeBlocks,
 		images,
 		annotations: annotations.length > 0 ? annotations : null,
 		webSearchCount: webSearchCount > 0 ? webSearchCount : null,

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -1,3 +1,4 @@
+import { TOOL_SEARCH_TOOL_TYPE_PREFIX } from "@llmgateway/actions";
 import { redisClient } from "@llmgateway/cache";
 import { shortid } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
@@ -13,7 +14,7 @@ import { buildEncryptedReasoningDetail } from "./reasoning-details.js";
 import { transformOpenaiStreaming } from "./transform-openai-streaming.js";
 
 import type { Annotation, StreamingDelta } from "./types.js";
-import type { Provider } from "@llmgateway/models";
+import type { AnthropicNativeBlock, Provider } from "@llmgateway/models";
 
 function normalizeAnthropicUsage(usage: any): any {
 	if (!usage || typeof usage !== "object") {
@@ -58,6 +59,17 @@ function normalizeAnthropicUsage(usage: any): any {
 	return normalizedUsage;
 }
 
+/**
+ * Per-stream accumulator for Anthropic's server-side tool search calls, keyed
+ * by content block index. The search input arrives as `input_json_delta`
+ * chunks, so the `server_tool_use` block can only be emitted once its
+ * `tool_search_tool_result` shows up — which is also when it is useful.
+ */
+export type AnthropicToolSearchState = Map<
+	number,
+	{ id: string; name: string; input: string }
+>;
+
 export function transformStreamingToOpenai(
 	usedProvider: Provider,
 	usedModel: string,
@@ -65,6 +77,7 @@ export function transformStreamingToOpenai(
 	messages: any[],
 	serverToolUseIndices?: Set<number>,
 	supportsReasoning = true,
+	toolSearchState?: AnthropicToolSearchState,
 ): any {
 	let transformedData = data;
 
@@ -160,6 +173,20 @@ export function transformStreamingToOpenai(
 				if (serverToolUseIndices && data.index !== undefined) {
 					serverToolUseIndices.add(data.index);
 				}
+				// Tool search calls are replayable, so hold on to this one until
+				// its result block arrives and completes the pair.
+				if (
+					toolSearchState &&
+					data.index !== undefined &&
+					typeof data.content_block.name === "string" &&
+					data.content_block.name.startsWith(TOOL_SEARCH_TOOL_TYPE_PREFIX)
+				) {
+					toolSearchState.set(data.index, {
+						id: data.content_block.id,
+						name: data.content_block.name,
+						input: "",
+					});
+				}
 				transformedData = {
 					id: data.id ?? `chatcmpl-${Date.now()}`,
 					object: "chat.completion.chunk",
@@ -222,6 +249,10 @@ export function transformStreamingToOpenai(
 					data.index !== undefined &&
 					serverToolUseIndices.has(data.index)
 				) {
+					const pendingSearch = toolSearchState?.get(data.index);
+					if (pendingSearch) {
+						pendingSearch.input += partialJson;
+					}
 					transformedData = {
 						id: data.id ?? `chatcmpl-${Date.now()}`,
 						object: "chat.completion.chunk",
@@ -293,6 +324,64 @@ export function transformStreamingToOpenai(
 							delta: {
 								role: "assistant",
 								...(annotations.length > 0 && { annotations }),
+							},
+							finish_reason: null,
+						},
+					],
+					usage: normalizeAnthropicUsage(usage),
+				};
+			} else if (
+				data.type === "content_block_start" &&
+				data.content_block?.type === "tool_search_tool_result"
+			) {
+				// The tool search pair has no OpenAI representation, so forward both
+				// blocks verbatim for the /v1/messages layer to re-emit. The result
+				// block arriving is what tells us the matching server_tool_use call
+				// is complete, so they are emitted together.
+				const resultBlock = data.content_block;
+				let searchCall: { id: string; name: string; input: string } | undefined;
+				if (toolSearchState) {
+					for (const [index, pending] of toolSearchState) {
+						if (pending.id === resultBlock.tool_use_id) {
+							searchCall = pending;
+							toolSearchState.delete(index);
+							break;
+						}
+					}
+				}
+				const nativeBlocks: AnthropicNativeBlock[] = [];
+				if (searchCall) {
+					let input: unknown = {};
+					try {
+						input = searchCall.input ? JSON.parse(searchCall.input) : {};
+					} catch {
+						// A truncated search input is not worth failing the stream over;
+						// the result block below is what carries the discovered tools.
+						input = {};
+					}
+					nativeBlocks.push({
+						type: "server_tool_use",
+						id: searchCall.id,
+						name: searchCall.name,
+						input,
+					});
+				}
+				nativeBlocks.push({
+					type: "tool_search_tool_result",
+					tool_use_id: resultBlock.tool_use_id,
+					content: resultBlock.content,
+				});
+				transformedData = {
+					id: data.id ?? `chatcmpl-${Date.now()}`,
+					object: "chat.completion.chunk",
+					created: data.created ?? Math.floor(Date.now() / 1000),
+					model: data.model ?? usedModel,
+					choices: [
+						{
+							index: 0,
+							delta: {
+								role: "assistant",
+								anthropic_native_blocks: nativeBlocks,
 							},
 							finish_reason: null,
 						},

--- a/packages/actions/src/anthropic-tool-search.spec.ts
+++ b/packages/actions/src/anthropic-tool-search.spec.ts
@@ -1,0 +1,265 @@
+import { describe, expect, test } from "vitest";
+
+import { prepareRequestBody } from "./prepare-request-body.js";
+
+import type {
+	AnthropicRequestBody,
+	BaseMessage,
+	OpenAIRequestBody,
+	OpenAIToolInput,
+	ProviderId,
+} from "@llmgateway/models";
+
+const TOOL_SEARCH_TOOL: OpenAIToolInput = {
+	type: "tool_search",
+	tool_search_type: "tool_search_tool_regex_20251119",
+	name: "tool_search_tool_regex",
+};
+
+const DEFERRED_TOOL: OpenAIToolInput = {
+	type: "function",
+	function: {
+		name: "get_weather",
+		description: "Get the weather at a specific location",
+		parameters: {
+			type: "object",
+			properties: { location: { type: "string" } },
+			required: ["location"],
+		},
+	},
+	defer_loading: true,
+};
+
+const SEARCH_CALL = {
+	type: "server_tool_use",
+	id: "srvtoolu_1",
+	name: "tool_search_tool_regex",
+	input: { pattern: "weather" },
+};
+
+const SEARCH_RESULT = {
+	type: "tool_search_tool_result",
+	tool_use_id: "srvtoolu_1",
+	content: {
+		type: "tool_search_tool_search_result",
+		tool_references: [{ type: "tool_reference", tool_name: "get_weather" }],
+	},
+};
+
+async function prepare(
+	provider: ProviderId,
+	model: string,
+	messages: BaseMessage[],
+	tools: OpenAIToolInput[],
+) {
+	return await prepareRequestBody(
+		provider,
+		model,
+		null,
+		model,
+		messages,
+		false,
+		undefined,
+		1024,
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		tools,
+	);
+}
+
+describe("anthropic tool search", () => {
+	test("forwards defer_loading and the tool search tool to Anthropic", async () => {
+		const body = (await prepare(
+			"anthropic",
+			"claude-sonnet-4-6",
+			[{ role: "user", content: "What is the weather in Paris?" }],
+			[TOOL_SEARCH_TOOL, DEFERRED_TOOL],
+		)) as AnthropicRequestBody;
+
+		expect(body.tools).toEqual([
+			{
+				type: "tool_search_tool_regex_20251119",
+				name: "tool_search_tool_regex",
+			},
+			{
+				name: "get_weather",
+				description: "Get the weather at a specific location",
+				input_schema: {
+					type: "object",
+					properties: { location: { type: "string" } },
+					required: ["location"],
+				},
+				defer_loading: true,
+			},
+		]);
+	});
+
+	test("derives the tool search tool name when the caller omits it", async () => {
+		const body = (await prepare(
+			"anthropic",
+			"claude-sonnet-4-6",
+			[{ role: "user", content: "hi" }],
+			[
+				{
+					type: "tool_search",
+					tool_search_type: "tool_search_tool_bm25_20251119",
+				},
+			],
+		)) as AnthropicRequestBody;
+
+		expect(body.tools).toEqual([
+			{
+				type: "tool_search_tool_bm25_20251119",
+				name: "tool_search_tool_bm25",
+			},
+		]);
+	});
+
+	test("drops the tool search tool and defer_loading for other providers", async () => {
+		const body = (await prepare(
+			"openai",
+			"gpt-4o-mini",
+			[{ role: "user", content: "What is the weather in Paris?" }],
+			[TOOL_SEARCH_TOOL, DEFERRED_TOOL],
+		)) as OpenAIRequestBody;
+
+		// The tool is still offered, just eagerly — degrading costs prompt cache,
+		// not correctness.
+		expect(body.tools).toEqual([
+			{
+				type: "function",
+				function: {
+					name: "get_weather",
+					description: "Get the weather at a specific location",
+					parameters: {
+						type: "object",
+						properties: { location: { type: "string" } },
+						required: ["location"],
+					},
+				},
+			},
+		]);
+	});
+
+	test("replays the tool search pair ahead of the assistant's tool calls", async () => {
+		const body = (await prepare(
+			"anthropic",
+			"claude-sonnet-4-6",
+			[
+				{ role: "user", content: "What is the weather in Paris?" },
+				{
+					role: "assistant",
+					content: "Let me look for a weather tool.",
+					tool_calls: [
+						{
+							id: "toolu_1",
+							type: "function",
+							function: {
+								name: "get_weather",
+								arguments: '{"location":"Paris"}',
+							},
+						},
+					],
+					anthropic_native_blocks: [SEARCH_CALL, SEARCH_RESULT],
+				},
+				{ role: "tool", tool_call_id: "toolu_1", content: "sunny" },
+			],
+			[TOOL_SEARCH_TOOL, DEFERRED_TOOL],
+		)) as AnthropicRequestBody;
+
+		const assistant = body.messages.find((m) => m.role === "assistant");
+		expect(assistant?.content.map((block) => block.type)).toEqual([
+			"text",
+			"server_tool_use",
+			"tool_search_tool_result",
+			"tool_use",
+		]);
+	});
+
+	test("keeps a search-only assistant turn for Anthropic", async () => {
+		const body = (await prepare(
+			"anthropic",
+			"claude-sonnet-4-6",
+			[
+				{ role: "user", content: "What is the weather in Paris?" },
+				{
+					role: "assistant",
+					content: "",
+					anthropic_native_blocks: [SEARCH_CALL, SEARCH_RESULT],
+				},
+				{ role: "user", content: "Well?" },
+			],
+			[TOOL_SEARCH_TOOL, DEFERRED_TOOL],
+		)) as AnthropicRequestBody;
+
+		const assistant = body.messages.find((m) => m.role === "assistant");
+		expect(assistant?.content.map((block) => block.type)).toEqual([
+			"server_tool_use",
+			"tool_search_tool_result",
+		]);
+	});
+
+	test("drops a search-only assistant turn for other providers", async () => {
+		const body = (await prepare(
+			"openai",
+			"gpt-4o-mini",
+			[
+				{ role: "user", content: "What is the weather in Paris?" },
+				{
+					role: "assistant",
+					content: "",
+					anthropic_native_blocks: [SEARCH_CALL, SEARCH_RESULT],
+				},
+				{ role: "user", content: "Well?" },
+			],
+			[DEFERRED_TOOL],
+		)) as OpenAIRequestBody;
+
+		// Stripping the blocks would otherwise leave an empty assistant message,
+		// which providers reject.
+		expect(body.messages.map((m) => m.role)).toEqual(["user", "user"]);
+		expect(JSON.stringify(body.messages)).not.toContain(
+			"anthropic_native_blocks",
+		);
+	});
+
+	test("replays tool_reference blocks in a tool_result verbatim", async () => {
+		const references = [{ type: "tool_reference", tool_name: "get_weather" }];
+		const body = (await prepare(
+			"anthropic",
+			"claude-sonnet-4-6",
+			[
+				{ role: "user", content: "What is the weather in Paris?" },
+				{
+					role: "assistant",
+					content: "",
+					tool_calls: [
+						{
+							id: "toolu_search",
+							type: "function",
+							function: { name: "find_tools", arguments: '{"q":"weather"}' },
+						},
+					],
+				},
+				{
+					role: "tool",
+					tool_call_id: "toolu_search",
+					content: JSON.stringify(references),
+					anthropic_native_blocks: references,
+				},
+			],
+			[DEFERRED_TOOL],
+		)) as AnthropicRequestBody;
+
+		const toolResultTurn = body.messages.at(-1);
+		expect(toolResultTurn?.content).toEqual([
+			{
+				type: "tool_result",
+				tool_use_id: "toolu_search",
+				content: references,
+			},
+		]);
+	});
+});

--- a/packages/actions/src/anthropic-tool-search.spec.ts
+++ b/packages/actions/src/anthropic-tool-search.spec.ts
@@ -96,6 +96,41 @@ describe("anthropic tool search", () => {
 		]);
 	});
 
+	// Anthropic lists tool search as available on Google Cloud, and the gateway
+	// posts a Messages body to :rawPredict there, so Vertex gets the same
+	// treatment as the direct API.
+	test("forwards the same tools on vertex-anthropic", async () => {
+		const body = (await prepare(
+			"vertex-anthropic",
+			"claude-sonnet-4-6",
+			[{ role: "user", content: "What is the weather in Paris?" }],
+			[TOOL_SEARCH_TOOL, DEFERRED_TOOL],
+		)) as AnthropicRequestBody;
+
+		expect(body.tools?.[0]).toEqual({
+			type: "tool_search_tool_regex_20251119",
+			name: "tool_search_tool_regex",
+		});
+		expect(body.tools?.[1]).toMatchObject({ defer_loading: true });
+	});
+
+	// Anthropic offers tool search on Bedrock only through InvokeModel, and the
+	// gateway drives Bedrock through Converse — so it degrades to eager loading
+	// here even though Bedrock serves the same Claude models.
+	test("strips both for aws-bedrock, which the gateway drives via Converse", async () => {
+		const body = await prepare(
+			"aws-bedrock",
+			"claude-sonnet-4-6",
+			[{ role: "user", content: "What is the weather in Paris?" }],
+			[TOOL_SEARCH_TOOL, DEFERRED_TOOL],
+		);
+
+		const serialized = JSON.stringify(body);
+		expect(serialized).not.toContain("tool_search");
+		expect(serialized).not.toContain("defer_loading");
+		expect(serialized).toContain("get_weather");
+	});
+
 	test("derives the tool search tool name when the caller omits it", async () => {
 		const body = (await prepare(
 			"anthropic",

--- a/packages/actions/src/anthropic-tool-search.ts
+++ b/packages/actions/src/anthropic-tool-search.ts
@@ -1,0 +1,109 @@
+import type {
+	AnthropicNativeBlock,
+	BaseMessage,
+	OpenAIToolInput,
+	OpenAIToolSearchToolInput,
+	ProviderId,
+} from "@llmgateway/models";
+
+/**
+ * Anthropic's server-side tool search tool types all share this prefix. Matched
+ * by prefix rather than by an exact list so a future dated version (or the
+ * undated `tool_search_tool_regex` / `tool_search_tool_bm25` aliases) keeps
+ * working without a gateway release.
+ */
+export const TOOL_SEARCH_TOOL_TYPE_PREFIX = "tool_search_tool";
+
+/**
+ * Providers that speak the Anthropic Messages API natively and therefore
+ * understand `defer_loading`, the tool search tool, and the `server_tool_use` /
+ * `tool_search_tool_result` / `tool_reference` blocks. Everything else gets
+ * these stripped: the tools are still sent, just eagerly, which costs prompt
+ * cache and tokens but never fails.
+ *
+ * AWS Bedrock is deliberately excluded — the gateway drives it through the
+ * Converse API, which does not offer server-side tool search.
+ */
+export function usesAnthropicMessagesApi(provider: ProviderId): boolean {
+	return provider === "anthropic" || provider === "vertex-anthropic";
+}
+
+export function isToolSearchTool(
+	tool: OpenAIToolInput,
+): tool is OpenAIToolSearchToolInput {
+	return tool.type === "tool_search";
+}
+
+export function isToolSearchBlock(block: unknown): boolean {
+	if (!block || typeof block !== "object") {
+		return false;
+	}
+	const { type, name } = block as { type?: unknown; name?: unknown };
+	if (type === "tool_search_tool_result") {
+		return true;
+	}
+	return (
+		type === "server_tool_use" &&
+		typeof name === "string" &&
+		name.startsWith(TOOL_SEARCH_TOOL_TYPE_PREFIX)
+	);
+}
+
+/**
+ * Renders the tool search tool in Anthropic's wire format.
+ */
+export function toAnthropicToolSearchTool(
+	tool: OpenAIToolSearchToolInput,
+): AnthropicNativeBlock {
+	return {
+		type: tool.tool_search_type,
+		name: tool.name ?? tool.tool_search_type.replace(/_\d{8}$/, ""),
+	};
+}
+
+/**
+ * Removes the Anthropic-only tool extensions for upstreams that would reject
+ * them (`defer_loading` is an unknown property, and the tool search tool has no
+ * counterpart at all).
+ */
+export function stripAnthropicToolExtensions(
+	tools: OpenAIToolInput[] | undefined,
+): OpenAIToolInput[] | undefined {
+	if (!tools) {
+		return tools;
+	}
+	return tools
+		.filter((tool) => !isToolSearchTool(tool))
+		.map((tool) => {
+			if (tool.type !== "function" || tool.defer_loading === undefined) {
+				return tool;
+			}
+			const { defer_loading: _deferLoading, ...rest } = tool;
+			return rest;
+		});
+}
+
+/**
+ * Removes the Anthropic-only content blocks carried on messages. Strict
+ * upstreams reject unknown message fields, so this has to run for every
+ * non-Anthropic provider. An assistant turn that consisted only of a tool
+ * search is left with nothing to say, so it is dropped rather than forwarded
+ * as an empty message that providers reject.
+ */
+export function stripAnthropicNativeBlocks(
+	messages: BaseMessage[],
+): BaseMessage[] {
+	return messages.flatMap((message) => {
+		if (message.anthropic_native_blocks === undefined) {
+			return [message];
+		}
+		const { anthropic_native_blocks: _dropped, ...rest } = message;
+		const isEmpty =
+			(rest.content === undefined ||
+				rest.content === null ||
+				rest.content === "" ||
+				(Array.isArray(rest.content) && rest.content.length === 0)) &&
+			(!rest.tool_calls || rest.tool_calls.length === 0);
+		return isEmpty ? [] : [rest];
+	});
+}

--- a/packages/actions/src/anthropic-tool-search.ts
+++ b/packages/actions/src/anthropic-tool-search.ts
@@ -21,8 +21,19 @@ export const TOOL_SEARCH_TOOL_TYPE_PREFIX = "tool_search_tool";
  * these stripped: the tools are still sent, just eagerly, which costs prompt
  * cache and tokens but never fails.
  *
- * AWS Bedrock is deliberately excluded — the gateway drives it through the
- * Converse API, which does not offer server-side tool search.
+ * `vertex-anthropic` qualifies because it posts an Anthropic Messages body to
+ * `:rawPredict`, and Anthropic lists tool search as available on Google Cloud.
+ *
+ * AWS Bedrock is excluded for a transport reason, not a capability one:
+ * Anthropic offers tool search there only through InvokeModel, and this gateway
+ * drives Bedrock through the Converse API (see get-provider-endpoint). Moving
+ * the Bedrock Anthropic path to InvokeModel is what would unlock it — do not
+ * "fix" this by adding aws-bedrock here while Converse is still the transport.
+ *
+ * Model support is a separate axis and is deliberately not gated here: tool
+ * search needs a Claude 4.5-generation model or newer, and an older model is
+ * rejected upstream with a 4xx rather than being silently downgraded, the same
+ * way unsupported reasoning efforts are handled.
  */
 export function usesAnthropicMessagesApi(provider: ProviderId): boolean {
 	return provider === "anthropic" || provider === "vertex-anthropic";

--- a/packages/actions/src/index.ts
+++ b/packages/actions/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./anthropic-tool-search.js";
 export * from "./transform-anthropic-messages.js";
 export * from "./parse-data-url.js";
 export * from "./parse-tool-call-arguments.js";

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -29,6 +29,13 @@ import {
 import { getApiKeyHashSecret } from "@llmgateway/shared/api-key-hash";
 import { assertSafeUserContentUrl } from "@llmgateway/shared/url-safety-node";
 
+import {
+	isToolSearchTool,
+	stripAnthropicNativeBlocks,
+	stripAnthropicToolExtensions,
+	toAnthropicToolSearchTool,
+	usesAnthropicMessagesApi,
+} from "./anthropic-tool-search.js";
 import { parseDataUrl } from "./parse-data-url.js";
 import { parseToolCallArguments } from "./parse-tool-call-arguments.js";
 import { ImageSizeLimitError, processImageUrl } from "./process-image-url.js";
@@ -1309,6 +1316,21 @@ export async function prepareRequestBody(
 	reasoning_context?: "auto" | "current_turn" | "all_turns",
 ): Promise<ProviderRequestBody | FormData> {
 	tools = normalizeToolParameters(tools);
+	// Anthropic's server-side tool search (`defer_loading` plus the tool search
+	// tool) only exists on the Anthropic Messages API. Anywhere else the tools
+	// are still sent, just without deferral, so the request degrades to ordinary
+	// eager tool loading instead of failing on an unknown property.
+	const anthropicMessagesApi = usesAnthropicMessagesApi(usedProvider);
+	if (!anthropicMessagesApi) {
+		if (tools?.some(isToolSearchTool)) {
+			logger.warn(
+				"Dropping Anthropic tool search for a non-Anthropic provider",
+				{ usedProvider, usedInternalModel, toolCount: tools.length },
+			);
+		}
+		tools = stripAnthropicToolExtensions(tools);
+		messages = stripAnthropicNativeBlocks(messages);
+	}
 	const modelDef = models.find((m) => m.id === usedInternalModel);
 	const providerMappingForOptions = getProviderMapping(
 		modelDef,
@@ -2963,7 +2985,20 @@ export async function prepareRequestBody(
 						name: tool.function.name,
 						description: tool.function.description,
 						input_schema: tool.function.parameters,
+						// Anthropic strips deferred tools from the rendered tools
+						// section before the cache key is computed, so forwarding this
+						// is what keeps a large tool catalogue out of the cached prefix.
+						...(tool.defer_loading === true && { defer_loading: true }),
 					}));
+				}
+				// The tool search tool has to come first: Anthropic rejects a request
+				// whose tools are all deferred, and it is the one tool that never is.
+				const toolSearchTools = tools.filter(isToolSearchTool);
+				if (toolSearchTools.length > 0) {
+					requestBody.tools = [
+						...toolSearchTools.map(toAnthropicToolSearchTool),
+						...((requestBody.tools as unknown[]) ?? []),
+					];
 				}
 			}
 

--- a/packages/actions/src/transform-anthropic-messages.ts
+++ b/packages/actions/src/transform-anthropic-messages.ts
@@ -253,6 +253,14 @@ export async function transformAnthropicMessages(
 			const currentCount = toolResultCount.get(m.tool_call_id) ?? 0;
 			toolResultCount.set(m.tool_call_id, currentCount + 1);
 
+			// A client-side tool search returns `tool_reference` blocks in the
+			// tool_result content array. Stringifying that array would leave
+			// Anthropic nothing to expand, so replay the original blocks verbatim.
+			const resultContent: ToolResultContent["content"] =
+				m.anthropic_native_blocks && m.anthropic_native_blocks.length > 0
+					? m.anthropic_native_blocks
+					: toolResultContent;
+
 			// If there are multiple mapped IDs, create tool_result blocks for each one
 			// This handles the case where we have duplicate tool_use but only one tool_result
 			if (mappedToolUseIds.length > 1 && currentCount === 0) {
@@ -262,7 +270,7 @@ export async function transformAnthropicMessages(
 						({
 							type: "tool_result",
 							tool_use_id: mappedId,
-							content: toolResultContent,
+							content: resultContent,
 						}) as ToolResultContent,
 				);
 			} else {
@@ -272,7 +280,7 @@ export async function transformAnthropicMessages(
 					{
 						type: "tool_result",
 						tool_use_id: toolUseId,
-						content: toolResultContent,
+						content: resultContent,
 					} as ToolResultContent,
 				];
 			}
@@ -284,9 +292,19 @@ export async function transformAnthropicMessages(
 				!(isTextContent(part) && (!part.text || part.text.trim() === "")),
 		);
 
+		// Anthropic-only blocks (the server-side tool search pair) that the client
+		// replayed from a previous assistant turn. They belong immediately before
+		// the tool_use blocks they led to, which is where Anthropic emitted them;
+		// Anthropic expands the `tool_reference` entries they carry throughout the
+		// history, so keeping them lets Claude reuse a tool it already discovered
+		// instead of searching for it again.
+		const nativeBlocks =
+			m.role === "assistant" ? (m.anthropic_native_blocks ?? []) : [];
+
 		// Ensure we have at least some content - if all content was filtered out but we have tool_calls, that's still valid
 		if (
 			filteredContent.length === 0 &&
+			nativeBlocks.length === 0 &&
 			(!m.tool_calls || m.tool_calls.length === 0)
 		) {
 			// Skip messages with no valid content
@@ -296,8 +314,23 @@ export async function transformAnthropicMessages(
 		// Map role correctly for Anthropic (no system or tool roles)
 		const anthropicRole = m.role === "assistant" ? "assistant" : "user";
 
+		let anthropicContent: AnthropicMessage["content"] = filteredContent;
+		if (nativeBlocks.length > 0) {
+			const firstToolUseIdx = filteredContent.findIndex(
+				(part) => part.type === "tool_use",
+			);
+			anthropicContent =
+				firstToolUseIdx === -1
+					? [...filteredContent, ...nativeBlocks]
+					: [
+							...filteredContent.slice(0, firstToolUseIdx),
+							...nativeBlocks,
+							...filteredContent.slice(firstToolUseIdx),
+						];
+		}
+
 		results.push({
-			content: filteredContent,
+			content: anthropicContent,
 			role: anthropicRole,
 		});
 	}

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -19,6 +19,15 @@ export const toolFunction = z.object({
 export const functionTool = z.object({
 	type: z.literal("function"),
 	function: toolFunction,
+	// Recorded as sent: it is why the tool stayed out of the cached prompt
+	// prefix on an Anthropic upstream.
+	defer_loading: z.boolean().optional(),
+});
+
+export const toolSearchTool = z.object({
+	type: z.literal("tool_search"),
+	tool_search_type: z.string(),
+	name: z.string().optional(),
 });
 
 export const webSearchTool = z.object({
@@ -35,7 +44,7 @@ export const webSearchTool = z.object({
 	max_uses: z.number().optional(),
 });
 
-export const tool = z.union([functionTool, webSearchTool]);
+export const tool = z.union([functionTool, webSearchTool, toolSearchTool]);
 
 export const toolChoice = z.union([
 	z.literal("none"),

--- a/packages/models/src/types.ts
+++ b/packages/models/src/types.ts
@@ -83,7 +83,21 @@ export interface ToolUseContent {
 export interface ToolResultContent {
 	type: "tool_result";
 	tool_use_id: string;
-	content: string;
+	// Anthropic accepts a block array here as well as a plain string; the array
+	// form is what carries `tool_reference` blocks for a client-side tool search.
+	content: string | AnthropicNativeBlock[];
+}
+
+/**
+ * Anthropic content block with no OpenAI-format equivalent — currently the
+ * server-side tool search pair (`server_tool_use` + `tool_search_tool_result`)
+ * and the `tool_reference` blocks a client-side tool search returns. Carried
+ * verbatim between the caller and the Anthropic Messages API and dropped for
+ * every other upstream.
+ */
+export interface AnthropicNativeBlock {
+	type: string;
+	[key: string]: unknown;
 }
 
 export type MessageContent =
@@ -139,6 +153,13 @@ export interface BaseMessage {
 		phase?: "commentary" | "final_answer";
 		preceding_tool_calls?: number;
 	}>;
+	// Anthropic content blocks that survive a round trip verbatim because the
+	// OpenAI format has no equivalent. On an assistant message these are the
+	// server-side tool search blocks, spliced back in ahead of the tool_use
+	// blocks; on a tool message they are the `tool_result` content array, which
+	// is how a client-side tool search returns `tool_reference` blocks. Replayed
+	// on the Anthropic Messages API only and stripped for every other upstream.
+	anthropic_native_blocks?: AnthropicNativeBlock[];
 }
 
 // Provider-specific message formats
@@ -148,7 +169,7 @@ export interface OpenAIMessage extends BaseMessage {
 
 export interface AnthropicMessage {
 	role: "user" | "assistant";
-	content: MessageContent[];
+	content: (MessageContent | AnthropicNativeBlock)[];
 }
 
 export interface GoogleMessage {
@@ -191,6 +212,12 @@ export interface OpenAIFunctionToolInput {
 		description?: string;
 		parameters?: FunctionParameter | Record<string, any>;
 	};
+	/**
+	 * Anthropic-only: keep this tool out of the rendered tools section so it
+	 * never enters the cached prompt prefix, and load it on demand when the
+	 * tool search tool discovers it. Stripped for every other upstream.
+	 */
+	defer_loading?: boolean;
 }
 
 // Web search tool input type
@@ -206,9 +233,24 @@ export interface OpenAIWebSearchToolInput {
 	max_uses?: number;
 }
 
-// Compatible type for API requests - accepts both function and web_search tools
+/**
+ * Anthropic's server-side tool search tool. It has no OpenAI equivalent, so it
+ * travels through the gateway under its own `type` and is emitted verbatim on
+ * the Anthropic Messages API and dropped everywhere else.
+ */
+export interface OpenAIToolSearchToolInput {
+	type: "tool_search";
+	/** Anthropic tool type, e.g. `tool_search_tool_regex_20251119`. */
+	tool_search_type: string;
+	name?: string;
+}
+
+// Compatible type for API requests - accepts function, web_search and
+// tool_search tools
 export type OpenAIToolInput =
-	OpenAIFunctionToolInput | OpenAIWebSearchToolInput;
+	| OpenAIFunctionToolInput
+	| OpenAIWebSearchToolInput
+	| OpenAIToolSearchToolInput;
 
 export interface AnthropicTool {
 	name: string;


### PR DESCRIPTION
## Problem

Anthropic's [tool search tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool) and the per-tool `defer_loading` flag were silently dropped by the gateway.

`/v1/messages` lowers every request into the internal OpenAI chat-completions shape, which has no slot for either. So:

- `defer_loading: true` was stripped by the tool schema (Zod strips unknown keys — no error, just gone), and the outbound Anthropic body was rebuilt from `name`/`description`/`input_schema` only.
- `tool_search_tool_regex_20251119` / `_bm25_20251119` hit the "unsupported Anthropic server tool" branch and were dropped with a warning.
- The response-side `server_tool_use` + `tool_search_tool_result` pair had no handling at all.

Net effect for a client like Claude Code: deferred tools were forwarded as ordinary eagerly-loaded tools and the search tool vanished. The request still worked, but it lost exactly what the feature exists for — the tool definitions landed in the cached prompt prefix, so adding one invalidated the prompt cache and the full tool-definition tokens were paid every turn.

## Approach

Carry the Anthropic-only bits through the internal representation and emit them on the Anthropic Messages API only.

**Request**

- `defer_loading` rides on the internal function tool (`OpenAIFunctionToolInput.defer_loading`) and is rendered onto the Anthropic tool.
- `tool_search_tool_*` becomes a new internal `tool_search` tool instead of being dropped, and is emitted **first** — Anthropic rejects a request whose tools are all deferred, and the search tool is the one that never is. Matched by prefix so the undated aliases and future dated versions keep working.
- `server_tool_use` + `tool_search_tool_result` round-trip on a new `anthropic_native_blocks` message field and are spliced back in ahead of the turn's `tool_use` blocks, which is where Anthropic emitted them. Anthropic expands the `tool_reference` entries they carry throughout the history, so keeping them lets Claude reuse a discovered tool instead of searching again. `tool_reference` blocks returned from a client-side search inside a `tool_result` are preserved the same way (they were being `JSON.stringify`'d into a string).
- Web-search `server_tool_use` blocks stay dropped as before — replaying those needs an `encrypted_content` the gateway can't reconstruct from `url_citation` annotations — so the two are distinguished by tool name.

**Response**

The pair is surfaced back to the client in both modes. Streaming accumulates the search input across `input_json_delta` chunks and emits the completed pair when the result block lands, mirroring how the web-search pair is already re-rendered.

## Where it applies

`usesAnthropicMessagesApi()` — `anthropic` and `vertex-anthropic`. Anthropic's feature matrix lists tool search as available on Google Cloud, and the gateway posts a Messages body to `:rawPredict` there, so Vertex gets the same treatment as the direct API.

**AWS Bedrock is excluded for a transport reason, not a capability one.** Anthropic exposes server-side tool search on Bedrock only through the InvokeModel API, and this gateway drives Bedrock through Converse (`/model/{id}/converse`). Switching that path to InvokeModel is what would unlock it; that is well outside this change. The code comment says so explicitly so nobody "fixes" it by adding `aws-bedrock` to the list while Converse is still the transport.

Model support is a separate axis and is deliberately **not** gated: tool search needs a Claude 4.5-generation model or newer, and an older model is rejected upstream with a 4xx rather than silently downgraded — the same way unsupported reasoning efforts are handled today.

Everywhere else both extensions are stripped and the request degrades to eager tool loading with a warn log, rather than failing on an unknown property. Routing is intentionally **not** narrowed — a surprising "no provider available" is worse than a request that still works with less caching. The docs note this and suggest pinning the provider when the savings matter.

`defer_loading` and the `tool_search` tool are also accepted on `/v1/chat/completions`, so OpenAI-format clients can reach the feature too.

## Verification

- `pnpm build`, `pnpm format`, `pnpm lint` clean.
- New: `packages/actions/src/anthropic-tool-search.spec.ts` (9 tests) covering forwarding to Anthropic and Vertex, stripping for Bedrock and other providers, the name derivation, history splice ordering, the search-only turn in both directions, and verbatim `tool_reference` replay.
- New in `apps/gateway/src/api.spec.ts`: end-to-end `/v1/messages` coverage of the forwarded tools + replayed pair + returned pair (non-streaming), and the streamed pair re-emitted as content blocks.
- `pnpm test:unit`: 4729 passed. Two failures (`admin-devpass-payg`, `onboarding-sponsorship`) reproduce identically on a clean tree with these changes stashed — pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Anthropic server-side Tool Search with deferred tool loading and tool references.
  * Preserved and replayed native Tool Search blocks in streaming and non-streaming responses.
  * Added provider-aware handling for Anthropic-specific tools and content.
* **Documentation**
  * Added usage guidance, request and response examples, replay behavior, provider support, and routing limitations.
* **Bug Fixes**
  * Improved handling of non-string tool-result content to prevent processing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->