### PR TITLE
feat(models): add glm-5.3 on zai

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -2018,6 +2018,34 @@ describe("prepareRequestBody - Z.ai thinking", () => {
 		});
 		expect(requestBody.thinking).toBeUndefined();
 	});
+
+	// glm-5.3 cannot disable thinking (its zai mapping declares
+	// reasoningEfforts without "none"): thinking stays enabled and the effort
+	// tier is forwarded via the native reasoning_effort field.
+
+	test("glm-5.3 enables thinking and forwards the effort tier", async () => {
+		const requestBody = await prepare({
+			model: "glm-5.3",
+			reasoningEffort: "max",
+		});
+		expect(requestBody.thinking).toEqual({ type: "enabled" });
+		expect(requestBody.reasoning_effort).toBe("max");
+	});
+
+	test("glm-5.3 keeps thinking enabled when no effort is requested", async () => {
+		const requestBody = await prepare({ model: "glm-5.3" });
+		expect(requestBody.thinking).toEqual({ type: "enabled" });
+		expect(requestBody.reasoning_effort).toBeUndefined();
+	});
+
+	test("glm-5.3 collapses none onto the provider default instead of disabling", async () => {
+		const requestBody = await prepare({
+			model: "glm-5.3",
+			reasoningEffort: "none",
+		});
+		expect(requestBody.thinking).toEqual({ type: "enabled" });
+		expect(requestBody.reasoning_effort).toBeUndefined();
+	});
 });
 
 describe("prepareRequestBody - reasoning_effort max", () => {

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -2529,7 +2529,26 @@ export async function prepareRequestBody(
 			// response_format leave the provider default rather than disabling —
 			// unless the caller explicitly asked for "none".
 			if (supportsReasoning) {
-				if (reasoning_effort === "none") {
+				// glm-5.3 dropped support for disabling thinking: sending
+				// thinking.type "disabled" fails the request, and effort is
+				// selected via the native `reasoning_effort` field (low/high/max,
+				// default max). A zai mapping whose declared reasoningEfforts
+				// exclude "none" is such an always-on model: keep thinking
+				// enabled, forward the effort tier as-is, and collapse disable
+				// requests (none/minimal) onto the provider default.
+				const declaredEfforts = providerMappingForOptions?.reasoningEfforts;
+				const alwaysThinks =
+					declaredEfforts !== undefined && !declaredEfforts.includes("none");
+				if (alwaysThinks) {
+					requestBody.thinking = { type: "enabled" };
+					if (
+						reasoning_effort !== undefined &&
+						reasoning_effort !== "none" &&
+						reasoning_effort !== "minimal"
+					) {
+						requestBody.reasoning_effort = reasoning_effort;
+					}
+				} else if (reasoning_effort === "none") {
 					requestBody.thinking = { type: "disabled" };
 				} else {
 					const wantsThinking =

--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -12,17 +12,6 @@ export const zaiModels = [
 			{
 				providerId: "zai",
 				externalId: "glm-5.3",
-				// On release day glm-5.3 ships on the GLM Coding Plan and ZCode
-				// only: every request to the OpenAI-compatible /api/paas/v4
-				// endpoint the gateway uses answers 403 code 1220 ("You do not
-				// have permission to access glm-5.3"), so the mapping cannot be
-				// exercised end-to-end and must stay out of provider selection
-				// until z.ai opens it on the standard API.
-				stability: "unstable",
-				test: "skip",
-				// z.ai has not published a GLM-5.3 rate card yet (release day);
-				// priced at GLM-5.2's card, which shares the same base model.
-				// Re-verify against the published card before marking stable.
 				inputPrice: "1.4e-6",
 				cachedInputPrice: "0.26e-6",
 				outputPrice: "4.4e-6",

--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -12,8 +12,17 @@ export const zaiModels = [
 			{
 				providerId: "zai",
 				externalId: "glm-5.3",
+				// On release day glm-5.3 ships on the GLM Coding Plan and ZCode
+				// only: every request to the OpenAI-compatible /api/paas/v4
+				// endpoint the gateway uses answers 403 code 1220 ("You do not
+				// have permission to access glm-5.3"), so the mapping cannot be
+				// exercised end-to-end and must stay out of provider selection
+				// until z.ai opens it on the standard API.
+				stability: "unstable",
+				test: "skip",
 				// z.ai has not published a GLM-5.3 rate card yet (release day);
 				// priced at GLM-5.2's card, which shares the same base model.
+				// Re-verify against the published card before marking stable.
 				inputPrice: "1.4e-6",
 				cachedInputPrice: "0.26e-6",
 				outputPrice: "4.4e-6",
@@ -23,8 +32,10 @@ export const zaiModels = [
 				streaming: true,
 				reasoning: true,
 				// glm-5.3 dropped support for disabling thinking, so no "none"
-				// tier: the API accepts only low/high/max (default max) and fails
-				// requests that send thinking.type "disabled".
+				// tier: a request that omits thinking or sends thinking.type
+				// "disabled" is rejected with code 1210, "This model always
+				// engages in thinking and cannot be disabled; please use low,
+				// high, or max".
 				reasoningEfforts: ["low", "high", "max"],
 				vision: false,
 				tools: true,

--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -2,6 +2,39 @@ import type { ModelDefinition } from "@/models.js";
 
 export const zaiModels = [
 	{
+		id: "glm-5.3",
+		name: "GLM-5.3",
+		description:
+			"Zhipu GLM-5.3 flagship coding model, post-trained on the GLM-5.2 base with stronger agentic coding and emergent cybersecurity capabilities and a 1M context window.",
+		family: "zai",
+		releasedAt: new Date("2026-08-14"),
+		providers: [
+			{
+				providerId: "zai",
+				externalId: "glm-5.3",
+				// z.ai has not published a GLM-5.3 rate card yet (release day);
+				// priced at GLM-5.2's card, which shares the same base model.
+				inputPrice: "1.4e-6",
+				cachedInputPrice: "0.26e-6",
+				outputPrice: "4.4e-6",
+				requestPrice: "0",
+				contextSize: 1000000,
+				maxOutput: 128000,
+				streaming: true,
+				reasoning: true,
+				// glm-5.3 dropped support for disabling thinking, so no "none"
+				// tier: the API accepts only low/high/max (default max) and fails
+				// requests that send thinking.type "disabled".
+				reasoningEfforts: ["low", "high", "max"],
+				vision: false,
+				tools: true,
+				webSearch: true,
+				webSearchPrice: "0.01",
+				jsonOutput: true,
+			},
+		],
+	},
+	{
 		id: "glm-5.2",
 		name: "GLM-5.2",
 		description:


### PR DESCRIPTION
Add Zhipu GLM-5.3 (released 2026-08-14) to the zai family: 1M context,
128K max output, reasoning efforts low/high/max. GLM-5.3 no longer
supports disabling thinking, so the zai request path now keeps thinking
enabled and forwards the native reasoning_effort field for zai mappings
whose declared efforts exclude "none", collapsing disable requests onto
the provider default.

## Verification

Everything below was probed live against `api.z.ai/api/paas/v4`.

| Field | Result |
| --- | --- |
| `inputPrice` / `cachedInputPrice` / `outputPrice` | $1.4 / $0.26 / $4.4 per 1M — matches z.ai's published rate card, now listing GLM-5.3 |
| `reasoningEfforts: ["low","high","max"]` | exact — `none`, `minimal`, `medium` and `xhigh` all return `[1210] This model always engages in thinking and cannot be disabled; please use low, high, or max`. Tiers visibly scale: low 19, high 41, max 126 reasoning tokens on the same prompt |
| thinking cannot be disabled | `thinking: {type:"disabled"}` → 1210; `{type:"enabled"}` → 200 |
| `contextSize: 1000000` | a ~210K-token prompt is accepted, so the ceiling is well past 200K; 1M matches the vendor doc and the shared GLM-5.2 base |
| `maxOutput: 128000` | the deployment accepts up to 131072 (`限制数值范围[1,131072]` above that); kept at 128000 to match the vendor's "128K" and the sibling glm-5.2 zai mapping |
| `tools: true` | `auto`, `required`, `none` and named function all 200 — no `supportedToolChoices` narrowing needed |
| `jsonOutput: true`, no `jsonOutputSchema` | `json_object` returns `{"city":"Paris"}`; `json_schema` is accepted but not enforced (returned plain text), so schema mode stays undeclared |
| `vision: false` | image content 400s: `messages.content.type is invalid, allowed values: ['text']` |
| `webSearch: true` | the `web_search` tool returns grounded, current results |

Billing: `completion_tokens` already includes reasoning (70 total / 64 reasoning
on one call), and z.ai reports it only nested under `completion_tokens_details`,
which the default extraction branch does not read — so `reasoningTokens` stays
null and output is billed once on `completion_tokens`. No
`completionIncludesReasoning` entry needed.

Only one zai mapping declares `reasoningEfforts` without `"none"` (this one), so
the new always-thinks branch in `prepare-request-body.ts` changes no existing
mapping's behaviour; glm-5.2 keeps `["none","high","max"]` and the old path.

## Tests

- `pnpm exec vitest run packages/actions/src/prepare-request-body.spec.ts packages/models` — 432 passed
- `TEST_MODELS="zai/glm-5.3" FULL_MODE=true pnpm test:e2e` — all 18 glm-5.3 cases
  pass: basic, streaming, tool calls (+ streaming, + results), reasoning (+
  streaming, + tool calls), reasoning effort low/high/max, JSON output (+
  streaming), and the four Responses API cases. `responses tool calls stateless`
  failed on the first pass with z.ai's `1302 Rate limit reached for requests`
  under concurrent load and passes on a rerun of that file.
- `pnpm build` — passes

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L1BksrSxL1e972RtWnZm7v


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for GLM-5.3 reasoning effort levels when sending requests to Z.ai.
  - Reasoning remains enabled by default for GLM-5.3, including when using the `none` or `minimal` effort options.

- **Bug Fixes**
  - Improved handling of Z.ai models with always-on reasoning behavior.
  - Enabled GLM-5.3 for regular capability and pricing validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->