### PR TITLE
docs(add-model): never merge a broken model

### DIFF
--- a/.agents/skills/add-model/SKILL.md
+++ b/.agents/skills/add-model/SKILL.md
@@ -223,6 +223,13 @@ also fails on `main`.
 
 `pnpm format`, `pnpm build`, conventional title, then the `pull-request` skill.
 
+Never merge — and never enable auto-merge on — a mapping that does not actually
+work: it could not serve a live request, or its scoped e2e fails with no fix
+available from our side. `stability: "unstable"` and `test: "skip"` keep CI green
+and keep the mapping out of routing, but they do not make the model work. Say
+plainly that it does not work and why, leave the PR open, and hand the merge
+decision to the user. Same for prices nobody could verify.
+
 The PR body carries the evidence:
 
 - Per mapping: external id, prices, context, max output, capabilities.


### PR DESCRIPTION
Auto-merge was enabled on a model mapping whose scoped e2e never passed — CI
went green only because the mapping was marked `test: "skip"`, which is not the
same thing as the model working.

Adds a rule to §9 of the `add-model` skill: never merge or auto-merge a mapping
that does not actually work (no live request served, or scoped e2e failing with
no fix available on our side). State plainly that it does not work and why,
leave the PR open, and hand the merge decision to the user. Same for prices
nobody could verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for handling model mappings that are not ready for production routing.
  * Clarified that mappings with missing live-request support, incomplete end-to-end validation, or unverified pricing must remain open for review.
  * Documented safe ways to exclude unfinished mappings from routing and CI until verification is complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->