### PR TITLE
fix(responses): keep explicit prompt cache breakpoints on output_text

### DIFF
--- a/apps/gateway/src/responses/responses.spec.ts
+++ b/apps/gateway/src/responses/responses.spec.ts
@@ -267,6 +267,50 @@ describe("convertResponsesInputToMessages", () => {
 		expect(result[1]!.content).toBe("Hi there");
 	});
 
+	it("keeps an explicit prompt cache breakpoint on a replayed output_text part", () => {
+		// Only a marker that survives request validation can reach the provider,
+		// so this goes through the schema the route parses with. The sibling
+		// `text` part is the control: both carry the same marker.
+		const req = responsesRequestSchema.parse({
+			model: "gpt-5.6-sol",
+			prompt_cache_options: { mode: "explicit" },
+			input: [
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "output_text",
+							text: "prior answer",
+							prompt_cache_breakpoint: { mode: "explicit" },
+						},
+					],
+				},
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "text",
+							text: "prior answer",
+							prompt_cache_breakpoint: { mode: "explicit" },
+						},
+					],
+				},
+			],
+		});
+
+		const messages = convertResponsesInputToMessages(req.input);
+		const expected = [
+			{
+				type: "text",
+				text: "prior answer",
+				prompt_cache_breakpoint: { mode: "explicit" },
+			},
+		];
+
+		expect(messages[0]!.content).toEqual(expected);
+		expect(messages[1]!.content).toEqual(expected);
+	});
+
 	it("converts function_call items to assistant tool_calls", () => {
 		const input = [
 			{ role: "user" as const, content: "What's the weather?" },

--- a/apps/gateway/src/responses/schemas.ts
+++ b/apps/gateway/src/responses/schemas.ts
@@ -44,6 +44,7 @@ const messageItemSchema = z.object({
 					z.object({
 						type: z.literal("output_text"),
 						text: z.string(),
+						prompt_cache_breakpoint: promptCacheBreakpointSchema,
 					}),
 					z.object({
 						type: z.literal("text"),


### PR DESCRIPTION
## Summary

`/v1/responses` silently drops an explicit prompt cache breakpoint when it is
marked on an assistant `output_text` content part.

`messageItemSchema` in `apps/gateway/src/responses/schemas.ts` declares
`prompt_cache_breakpoint` on five of the six content-part variants —
`input_text`, `input_image`, `input_file`, `text`, `image_url` — but not on
`output_text`. Zod objects strip undeclared keys, so the marker is already gone
at `responses.ts:166` (`responsesRequestSchema.safeParse`), before anything
downstream can see it. No error, no warning.

The consumer already handles that exact part type. `convertContent` in
`apps/gateway/src/responses/tools/convert-responses-to-chat.ts` carries the
marker for `input_text | output_text | text`:

```ts
const breakpoint =
	item.prompt_cache_breakpoint !== undefined
		? { prompt_cache_breakpoint: item.prompt_cache_breakpoint }
		: undefined;
if (
	item.type === "input_text" ||
	item.type === "output_text" ||
	item.type === "text"
) {
	return { type: "text", text: item.text, ...breakpoint };
}
```

so the `output_text` half of that branch has never been reachable. Both the
schema entries and this branch landed in the same commit (e6a63d1b, #2979) —
the reader got `output_text`, the schema did not.

The gateway itself emits that shape in the other direction:
`transformContentForResponsesApi` (`packages/actions/src/prepare-request-body.ts:976-978`)
returns `{ type: "output_text", text, ...breakpoint }` for assistant turns when
converting a chat-completions request for the Responses upstream.

**Why it costs money.** With `prompt_cache_options: { mode: "explicit" }` only
marked parts are cached — `apps/gateway/src/chat/schemas/completions.ts:276`:
*"'explicit' caches only content parts marked with prompt_cache_breakpoint"*.
The natural place to mark is the end of the replayed history, which is an
assistant `output_text` item. That breakpoint disappears, so the prefix is not
cached and is billed in full. The same marker on the sibling `text` part
survives, so today the behaviour depends on which of two equivalent spellings
the client happened to use.

## Fix

One line: declare `prompt_cache_breakpoint` on the `output_text` variant, with
the same `promptCacheBreakpointSchema` as its five siblings.

## Behaviour change, stated up front

The field is optional and additive: nothing that was accepted becomes rejected
(the key was stripped, not rejected), and nothing that was rejected becomes
accepted.

Downstream, `prepare-request-body.ts:1844-1848` still strips the marker unless
the resolved pair is `openai` **and** the model supports explicit prompt caching
**and** the project has provider cache control enabled. For every other route
the upstream body is byte-identical.

The one real effect: on OpenAI GPT-5.6+, a breakpoint the caller marked on an
assistant turn now actually reaches OpenAI and triggers a cache write, **billed
at the 1.25x premium** — exactly what the comment at
`prepare-request-body.ts:1841-1843` warns about for the markers that already
work. That is what the caller asked for, and what the five sibling variants
already do, but it is a cost-visible change and it belongs in front of you
rather than in a footnote.

## Tests

One case added to the existing `describe("convertResponsesInputToMessages")`
block in `apps/gateway/src/responses/responses.spec.ts`. It parses through
`responsesRequestSchema` first: a test that called the converter with a
hand-built object would pass on `main` and prove nothing, because the converter
is not the broken part. The sibling `text` part is asserted in the same case as
a control, so the test also pins the behaviour that must not regress.

## Verification

**red — new test, `schemas.ts` reverted to `main`** (must fail without the fix)

```
$ vitest run apps/gateway/src/responses/ --no-file-parallelism

 FAIL  apps/gateway/src/responses/responses.spec.ts > convertResponsesInputToMessages >
       keeps an explicit prompt cache breakpoint on a replayed output_text part
AssertionError: expected [ { type: 'text', …(1) } ] to deeply equal [ { type: 'text', …(2) } ]

- Expected
+ Received

  [
    {
-     "prompt_cache_breakpoint": {
-       "mode": "explicit",
-     },
      "text": "prior answer",
      "type": "text",
    },
  ]

 Test Files  1 failed | 2 passed (3)
      Tests  1 failed | 108 passed (109)
```

**green — with the one-line fix**

```
$ vitest run apps/gateway/src/responses/ --no-file-parallelism

 ✓ apps/gateway/src/responses/openresponses-compliance.spec.ts (24 tests)
 ✓ apps/gateway/src/responses/response-state.spec.ts (11 tests)
 ✓ apps/gateway/src/responses/responses.spec.ts (74 tests)

 Test Files  3 passed (3)
      Tests  109 passed (109)
```

Both runs use the repo's own `vitest.config.mts` and its pinned vitest 4.1.8.

**typecheck** — `tsc --noEmit -p apps/gateway/tsconfig.json` → exit 0.

**lint** — `eslint apps/gateway/src/responses/schemas.ts apps/gateway/src/responses/responses.spec.ts` → exit 0.

**format** — `prettier --check` flags both files on this machine, but it flags them
identically on unmodified `main`: it is a CRLF checkout artifact (295 and 2311
CRs, whole-file), and prettier's output is byte-identical to the files once line
endings are ignored. The committed blobs contain zero CR.

## What I did not verify

- No Docker here, so `pnpm test:unit` end to end, the e2e suite and a full
  `turbo run build` were not run. Only the specs under
  `apps/gateway/src/responses/` were executed; `responsesRequestSchema` has no
  importers outside `responses.ts` and those specs.
- I have not observed OpenAI honouring a breakpoint on an `output_text` item
  against the live API. The evidence that this shape is the intended one is
  internal: the gateway emits it itself (`prepare-request-body.ts:976-978`) and
  the Responses reader was written to accept it (`convert-responses-to-chat.ts`).
  If assistant-side breakpoints are deliberately unsupported upstream, then the
  dead `output_text` branch in the reader is the thing to delete instead, and I
  am happy to send that PR in place of this one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional prompt-cache breakpoints in output text content.
  * Breakpoint settings are preserved when replayed content is converted into chat messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->