### PR TITLE
feat: default admin orgs list to this week

### DIFF
--- a/ee/admin/src/app/organizations/page.tsx
+++ b/ee/admin/src/app/organizations/page.tsx
@@ -30,7 +30,10 @@ import {
 	previewBulkBlockOrganizations,
 	setOrganizationStatus,
 } from "@/lib/admin-organizations";
-import { resolveDateRangeFromSearchParams } from "@/lib/date-range";
+import {
+	ORGANIZATIONS_DEFAULT_RANGE,
+	resolveDateRangeFromSearchParams,
+} from "@/lib/date-range";
 import { getOrgDeletionBlockedReason } from "@/lib/org-deletion";
 import { requireSession } from "@/lib/require-session";
 import { createServerApiClient } from "@/lib/server-api";
@@ -233,9 +236,13 @@ export default async function OrganizationsPage({
 	const limit = 25;
 	const offset = (page - 1) * limit;
 
-	// `from`/`to` stay undefined for "All time", which lets the API aggregate
-	// over the full history instead of a concrete span.
-	const { from, to } = resolveDateRangeFromSearchParams(params ?? {});
+	// An empty URL resolves to the page default rather than all time. `from`/`to`
+	// stay undefined only when "All time" is picked explicitly, which lets the
+	// API aggregate over the full history instead of a concrete span.
+	const { from, to } = resolveDateRangeFromSearchParams(
+		params ?? {},
+		ORGANIZATIONS_DEFAULT_RANGE,
+	);
 	const dateRange: DateRangeParams = {
 		range: params?.range,
 		from: params?.from,
@@ -318,7 +325,7 @@ export default async function OrganizationsPage({
 					</p>
 				</div>
 				<div className="flex w-full flex-col items-stretch gap-2 sm:w-auto sm:flex-row sm:items-center">
-					<DateRangePicker />
+					<DateRangePicker defaultRange={ORGANIZATIONS_DEFAULT_RANGE} />
 					<form
 						action={handleSearch}
 						className="flex w-full items-center gap-2 sm:w-auto"

--- a/ee/admin/src/components/date-range-picker.tsx
+++ b/ee/admin/src/components/date-range-picker.tsx
@@ -12,6 +12,7 @@ import {
 	PopoverTrigger,
 } from "@/components/ui/popover";
 import {
+	ALL_TIME_RANGE,
 	RELATIVE_RANGE_PRESETS,
 	findRelativeRangePreset,
 	resolveDateRange,
@@ -33,12 +34,18 @@ const MONTH_NAMES = [
 	"Dec",
 ];
 
-export function getDateRangeFromParams(searchParams: URLSearchParams) {
-	const resolved = resolveDateRange({
-		range: searchParams.get("range") ?? undefined,
-		from: searchParams.get("from") ?? undefined,
-		to: searchParams.get("to") ?? undefined,
-	});
+export function getDateRangeFromParams(
+	searchParams: URLSearchParams,
+	defaultRange?: string,
+) {
+	const resolved = resolveDateRange(
+		{
+			range: searchParams.get("range") ?? undefined,
+			from: searchParams.get("from") ?? undefined,
+			to: searchParams.get("to") ?? undefined,
+		},
+		defaultRange,
+	);
 
 	if (resolved.from && resolved.to) {
 		return {
@@ -187,7 +194,7 @@ function MonthRangePicker({ from, to, onSelect }: MonthRangePickerProps) {
 	);
 }
 
-export function DateRangePicker() {
+export function DateRangePicker({ defaultRange }: { defaultRange?: string }) {
 	const router = useRouter();
 	const pathname = usePathname();
 	const searchParams = useSearchParams();
@@ -195,7 +202,10 @@ export function DateRangePicker() {
 	const [search, setSearch] = useState("");
 	const [showCalendar, setShowCalendar] = useState(false);
 
-	const { from, to, isAllTime } = getDateRangeFromParams(searchParams);
+	const { from, to, isAllTime } = getDateRangeFromParams(
+		searchParams,
+		defaultRange,
+	);
 	const today = useMemo(() => new Date(), []);
 
 	const presets = useMemo(
@@ -205,7 +215,7 @@ export function DateRangePicker() {
 				label: p.getLabel(today),
 				value: p.value,
 			})),
-			{ label: "All time", value: "all_time" },
+			{ label: "All time", value: ALL_TIME_RANGE },
 		],
 		[today],
 	);
@@ -215,8 +225,18 @@ export function DateRangePicker() {
 		if (findRelativeRangePreset(rangeParam)) {
 			return rangeParam as string;
 		}
-		return isAllTime ? "all_time" : "custom";
-	}, [searchParams, isAllTime]);
+		if (rangeParam === ALL_TIME_RANGE) {
+			return ALL_TIME_RANGE;
+		}
+		// An empty URL means the page's own default is in force, so highlight
+		// that preset rather than the one the empty URL would otherwise imply.
+		const hasCustomSpan =
+			Boolean(searchParams.get("from")) && Boolean(searchParams.get("to"));
+		if (!hasCustomSpan && findRelativeRangePreset(defaultRange)) {
+			return defaultRange as string;
+		}
+		return isAllTime ? ALL_TIME_RANGE : "custom";
+	}, [searchParams, isAllTime, defaultRange]);
 
 	const filteredPresets = useMemo(
 		() =>
@@ -236,11 +256,18 @@ export function DateRangePicker() {
 		router.push(`${pathname}?${params.toString()}`);
 	};
 
-	const clearDateRange = () => {
+	const selectAllTime = () => {
 		const params = new URLSearchParams(searchParams.toString());
-		params.delete("range");
 		params.delete("from");
 		params.delete("to");
+		// On a page with its own default, an empty URL means that default, so
+		// "all time" has to be written out to override it. Pages without a
+		// default keep the shorter URL, which resolves to all time either way.
+		if (defaultRange) {
+			params.set("range", ALL_TIME_RANGE);
+		} else {
+			params.delete("range");
+		}
 		const qs = params.toString();
 		router.push(qs ? `${pathname}?${qs}` : pathname);
 	};
@@ -250,10 +277,10 @@ export function DateRangePicker() {
 			setShowCalendar(true);
 			return;
 		}
-		// "All time" leaves the URL without range/from/to so the API uses its
-		// native all-time aggregate path instead of a concrete 2020→today range.
-		if (value === "all_time") {
-			clearDateRange();
+		// "All time" keeps range/from/to off the URL so the API uses its native
+		// all-time aggregate path instead of a concrete 2020→today range.
+		if (value === ALL_TIME_RANGE) {
+			selectAllTime();
 			setOpen(false);
 			return;
 		}

--- a/ee/admin/src/lib/date-range.spec.ts
+++ b/ee/admin/src/lib/date-range.spec.ts
@@ -1,0 +1,68 @@
+import { format, startOfWeek, subDays } from "date-fns";
+import { describe, expect, test } from "vitest";
+
+import {
+	ALL_TIME_RANGE,
+	ORGANIZATIONS_DEFAULT_RANGE,
+	resolveDateRange,
+} from "./date-range";
+
+const day = (date: Date) => format(date, "yyyy-MM-dd");
+
+describe("resolveDateRange", () => {
+	test("treats an empty query as all time when no default is given", () => {
+		expect(resolveDateRange({})).toEqual({});
+	});
+
+	test("falls back to the page default when the query is empty", () => {
+		const resolved = resolveDateRange({}, ORGANIZATIONS_DEFAULT_RANGE);
+		const today = new Date();
+		expect(resolved).toEqual({
+			from: day(startOfWeek(today, { weekStartsOn: 1 })),
+			to: day(today),
+		});
+	});
+
+	test("lets an explicit all_time override the default", () => {
+		expect(
+			resolveDateRange({ range: ALL_TIME_RANGE }, ORGANIZATIONS_DEFAULT_RANGE),
+		).toEqual({});
+	});
+
+	test("lets an explicit preset override the default", () => {
+		const resolved = resolveDateRange(
+			{ range: "last_90_days" },
+			ORGANIZATIONS_DEFAULT_RANGE,
+		);
+		const today = new Date();
+		expect(resolved).toEqual({
+			from: day(subDays(today, 89)),
+			to: day(today),
+		});
+	});
+
+	test("lets a custom span override the default", () => {
+		expect(
+			resolveDateRange(
+				{ from: "2026-01-01", to: "2026-01-31" },
+				ORGANIZATIONS_DEFAULT_RANGE,
+			),
+		).toEqual({ from: "2026-01-01", to: "2026-01-31" });
+	});
+
+	test("ignores a half-open custom span and uses the default", () => {
+		const resolved = resolveDateRange(
+			{ from: "2026-01-01" },
+			ORGANIZATIONS_DEFAULT_RANGE,
+		);
+		const today = new Date();
+		expect(resolved).toEqual({
+			from: day(startOfWeek(today, { weekStartsOn: 1 })),
+			to: day(today),
+		});
+	});
+
+	test("falls back to all time when the default is not a known preset", () => {
+		expect(resolveDateRange({}, "not_a_preset")).toEqual({});
+	});
+});

--- a/ee/admin/src/lib/date-range.ts
+++ b/ee/admin/src/lib/date-range.ts
@@ -144,11 +144,27 @@ export interface DateRangeSearchParams {
 	to?: string;
 }
 
+// "All time" as an explicit choice rather than the absence of one. A page that
+// sets `defaultRange` needs this to tell "the user picked all time" apart from
+// "the user picked nothing yet", which would otherwise both be an empty URL.
+export const ALL_TIME_RANGE = "all_time";
+
+// The organizations list aggregates every project-hour row an organization has
+// ever produced, so it opens on a recent window rather than all time — the
+// hour_timestamp index turns the scan into a range read, and admins land on
+// current activity instead of lifetime totals. "All time" is still one click
+// away in the picker.
+export const ORGANIZATIONS_DEFAULT_RANGE = "this_week";
+
 // Resolves the URL query state into concrete `from`/`to` date strings for API
 // calls. A valid `range` preset wins and is resolved against today; `from`/`to`
-// are honored only as a custom span; neither means "all time" (both undefined
-// so the API uses its native all-time path).
-export function resolveDateRange(params: DateRangeSearchParams): {
+// are honored only as a custom span; then the page's own `defaultRange`, if it
+// set one. Nothing left means all time (both undefined, so the API uses its
+// native all-time path).
+export function resolveDateRange(
+	params: DateRangeSearchParams,
+	defaultRange?: string,
+): {
 	from?: string;
 	to?: string;
 } {
@@ -160,18 +176,33 @@ export function resolveDateRange(params: DateRangeSearchParams): {
 			to: format(to, "yyyy-MM-dd"),
 		};
 	}
+	if (params.range === ALL_TIME_RANGE) {
+		return {};
+	}
 	if (params.from && params.to) {
 		return { from: params.from, to: params.to };
+	}
+	const fallback = findRelativeRangePreset(defaultRange);
+	if (fallback) {
+		const { from, to } = fallback.getRange(new Date());
+		return {
+			from: format(from, "yyyy-MM-dd"),
+			to: format(to, "yyyy-MM-dd"),
+		};
 	}
 	return {};
 }
 
 export function resolveDateRangeFromSearchParams(
 	params: Record<string, string | string[] | undefined>,
+	defaultRange?: string,
 ): { from?: string; to?: string } {
-	return resolveDateRange({
-		range: typeof params.range === "string" ? params.range : undefined,
-		from: typeof params.from === "string" ? params.from : undefined,
-		to: typeof params.to === "string" ? params.to : undefined,
-	});
+	return resolveDateRange(
+		{
+			range: typeof params.range === "string" ? params.range : undefined,
+			from: typeof params.from === "string" ? params.from : undefined,
+			to: typeof params.to === "string" ? params.to : undefined,
+		},
+		defaultRange,
+	);
 }


### PR DESCRIPTION
Follow-up to #3579, which added the Requests/Tokens columns and the date-range picker to the admin organizations list.

## Problem

That page opened on **all time**, so every load aggregated every `project_hourly_stats` row an organization had ever produced — an unbounded full scan that grows with the table forever. It is also rarely the question being asked: lifetime totals are dominated by whoever has been around longest, which buries current activity.

## Change

Default the page to **this week**. `project_hourly_stats` has a dedicated `project_hourly_stats_hour_timestamp_idx`, so a windowed query becomes a range read over recent rows instead of a full scan, and admins land on who is active now.

"All time" is still one click away in the picker — nothing is lost, it is just no longer what you pay for on every page load.

### The one subtlety

Previously "All time" was encoded as the *absence* of `range`/`from`/`to`. Once the page has its own default, an empty URL means "use the default", so clearing the params would have silently reselected this week — making "All time" unreachable.

So "All time" is now written out as `range=all_time`. `resolveDateRange` treats it as an explicit choice that beats the default, and `DateRangePicker` gained an optional `defaultRange`. Pages that pass nothing keep the shorter URL and behave exactly as before.

## Blast radius

`DateRangePicker` is shared. The dashboard, DevPass, and Chat Plans pages pass no `defaultRange`, so for them `resolveDateRange` short-circuits identically to the old code path and "All time" still clears the params. Only the organizations list opts in.

## Screenshots

<img width="900" alt="Organizations list on a bare URL, now defaulting to This week" src="https://raw.githubusercontent.com/theopenco/llmgateway/12a556dc3efe136b9e0e21483dd02b377e1e73e3/default-light.png" />

Bare `/organizations` now opens on This week, with the caption naming the window.

<details>
<summary>Explicit "All time" still reachable, plus dark theme</summary>

`?range=all_time` — the caption reads "all time" and lifetime totals come back:

<img width="900" alt="Organizations list with range=all_time showing lifetime totals" src="https://raw.githubusercontent.com/theopenco/llmgateway/12a556dc3efe136b9e0e21483dd02b377e1e73e3/alltime-dark.png" />

Default, dark:

<img width="900" alt="Organizations list defaulting to This week, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/12a556dc3efe136b9e0e21483dd02b377e1e73e3/default-dark.png" />

All time, light:

<img width="900" alt="Organizations list with range=all_time, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/12a556dc3efe136b9e0e21483dd02b377e1e73e3/alltime-light.png" />

</details>

## Verification

New `ee/admin/src/lib/date-range.spec.ts` (7 tests) covers the resolution order: empty query with no default is all time; empty query with a default resolves to it; an explicit preset, an explicit `all_time`, and a custom span each beat the default; a half-open span falls back to the default; an unknown default degrades to all time.

Driven in a browser to confirm the round trip, since the failure mode here is a URL/label mismatch rather than a bad number:

| step | URL | picker label |
| --- | --- | --- |
| load bare page | `/organizations` | This week |
| pick "All time" | `/organizations?range=all_time` | All time |
| then sort by Tokens | `/organizations?page=1&sortBy=totalTokens&sortOrder=asc&range=all_time` | All time |

The default applies without a redirect, so it costs no extra round trip. `pnpm format` clean; `turbo run build --filter=admin` passes; re-ran `admin-orgs-usage-window.spec.ts` (9 tests) — unchanged and green, since the API is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rZMQwmexcn7dkfeo3tDg6

---
_Generated by [Claude Code](https://claude.ai/code/session_018rZMQwmexcn7dkfeo3tDg6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Organizations page now defaults to showing data from the current week.
  * Date-range selections remain consistent between the page and date-range picker.
  * Selecting **All time** explicitly displays the complete available history.
  * Custom date ranges and preset selections continue to override the page default.
* **Bug Fixes**
  * Improved handling of empty, partial, or unrecognized date-range parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->