### PR TITLE
chore(models): drop stale Sonnet 5 intro price note

### DIFF
--- a/packages/models/src/models/anthropic.ts
+++ b/packages/models/src/models/anthropic.ts
@@ -561,8 +561,6 @@ export const anthropicModels = [
 			{
 				providerId: "anthropic",
 				externalId: "claude-sonnet-5",
-				// Introductory pricing through 2026-08-31 (input $2, output $10 per 1M);
-				// standard rate is input $3, output $15.
 				inputPrice: "2.0e-6",
 				outputPrice: "10.0e-6",
 				cachedInputPrice: "0.2e-6",
@@ -587,8 +585,6 @@ export const anthropicModels = [
 			{
 				providerId: "aws-bedrock",
 				externalId: "anthropic.claude-sonnet-5",
-				// Introductory pricing through 2026-08-31 (input $2, output $10 per 1M);
-				// standard rate is input $3, output $15.
 				inputPrice: "2.0e-6",
 				outputPrice: "10.0e-6",
 				cachedInputPrice: "0.2e-6",
@@ -612,8 +608,6 @@ export const anthropicModels = [
 			{
 				providerId: "vertex-anthropic",
 				externalId: "claude-sonnet-5",
-				// Introductory pricing through 2026-08-31 (input $2, output $10 per 1M);
-				// standard rate is input $3, output $15.
 				inputPrice: "2.0e-6",
 				outputPrice: "10.0e-6",
 				cachedInputPrice: "0.2e-6",


### PR DESCRIPTION
The three Claude Sonnet 5 provider mappings carried a comment saying the $2/$10 per 1M input/output prices were introductory through 2026-08-31 and would revert to $3/$15 on September 1.

Anthropic has since cancelled that increase — [their pricing page](https://platform.claude.com/docs/en/docs/about-claude/pricing) now states the $2/$10 rate is the standard price and the scheduled September 1 increase will not occur. The prices in the catalogue are already correct; only the note was stale.

This matters beyond tidiness: acting on that comment on September 1 would have raised Sonnet 5 to $3/$15, which crosses the premium threshold ($5+/M input **or** $15+/M output) and would have flipped the model from standard to premium — pulling it under the DevPass weekly fair-use allowance and overbilling pay-as-you-go usage by 50%.

No behaviour change; comment-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed outdated introductory-pricing notes from Claude Sonnet 5 provider listings.
  * Pricing remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->