### PR TITLE
fix(responses): support Codex tool registry

### DIFF
--- a/apps/gateway/src/responses/responses.spec.ts
+++ b/apps/gateway/src/responses/responses.spec.ts
@@ -256,8 +256,12 @@ describe("convertResponsesInputToMessages", () => {
 
 	it("passes through regular messages", () => {
 		const input = [
-			{ role: "user" as const, content: "Hello" },
-			{ role: "assistant" as const, content: "Hi there" },
+			{ type: "message" as const, role: "user" as const, content: "Hello" },
+			{
+				type: "message" as const,
+				role: "assistant" as const,
+				content: "Hi there",
+			},
 		];
 		const result = convertResponsesInputToMessages(input);
 		expect(result).toHaveLength(2);
@@ -269,7 +273,11 @@ describe("convertResponsesInputToMessages", () => {
 
 	it("converts function_call items to assistant tool_calls", () => {
 		const input = [
-			{ role: "user" as const, content: "What's the weather?" },
+			{
+				type: "message" as const,
+				role: "user" as const,
+				content: "What's the weather?",
+			},
 			{
 				type: "function_call" as const,
 				call_id: "call_123",
@@ -362,6 +370,7 @@ describe("convertResponsesInputToMessages", () => {
 	it("converts input_text content type to text", () => {
 		const input = [
 			{
+				type: "message" as const,
 				role: "user" as const,
 				content: [{ type: "input_text" as const, text: "Hello" }],
 			},
@@ -372,8 +381,12 @@ describe("convertResponsesInputToMessages", () => {
 
 	it("maps developer role to system", () => {
 		const input = [
-			{ role: "developer" as const, content: "You are helpful" },
-			{ role: "user" as const, content: "Hello" },
+			{
+				type: "message" as const,
+				role: "developer" as const,
+				content: "You are helpful",
+			},
+			{ type: "message" as const, role: "user" as const, content: "Hello" },
 		];
 		const result = convertResponsesInputToMessages(input);
 		expect(result[0]!.role).toBe("system");

--- a/apps/gateway/src/responses/responses.ts
+++ b/apps/gateway/src/responses/responses.ts
@@ -24,7 +24,11 @@ import {
 import { shortid } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
 
-import { compactRequestSchema, responsesRequestSchema } from "./schemas.js";
+import {
+	compactRequestSchema,
+	formatValidationError,
+	responsesRequestSchema,
+} from "./schemas.js";
 import { convertChatResponseToCompaction } from "./tools/convert-chat-to-compaction.js";
 import {
 	convertChatResponseToResponses,
@@ -46,6 +50,7 @@ import {
 	getStoredResponse,
 	resolveItemReferences,
 } from "./tools/response-state.js";
+import { extractAdditionalTools } from "./tools/tool-registry.js";
 
 import type { ServerTypes } from "@/vars.js";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
@@ -168,7 +173,7 @@ responses.post("/", async (c) => {
 		return c.json(
 			{
 				error: {
-					message: `Invalid request: ${validation.error.errors.map((e) => `${e.path.join(".")}: ${e.message}`).join(", ")}`,
+					message: `Invalid request: ${formatValidationError(validation.error)}`,
 					type: "invalid_request_error",
 					code: "invalid_request",
 				},
@@ -242,6 +247,16 @@ responses.post("/", async (c) => {
 	// in a prior response that a stateful client references instead of resending)
 	// back to their concrete stored items before conversion.
 	inputItems = await resolveItemReferences(inputItems, projectId);
+
+	// Clients using the Responses tool registry (Codex 0.144+) declare their
+	// tools as an `additional_tools` input item instead of the top-level `tools`
+	// array. Lift them out before the input becomes chat messages.
+	const additionalTools = extractAdditionalTools(inputItems);
+	inputItems = additionalTools.items;
+	const toolRegistry = additionalTools.registry;
+	if (additionalTools.tools.length > 0) {
+		req.tools = [...(req.tools ?? []), ...additionalTools.tools];
+	}
 
 	// Convert Responses API input to chat completions messages
 	const messages = convertResponsesInputToMessages(
@@ -358,7 +373,7 @@ responses.post("/", async (c) => {
 	// Generate log ID with resp_ prefix — this is both the log entry's primary key
 	// and the Responses API response ID
 	const logId = `resp_${shortid(24)}`;
-	const state = createStreamingState(req.model, logId, req);
+	const state = createStreamingState(req.model, logId, req, toolRegistry);
 
 	// Make internal request to the existing chat completions endpoint
 	const internalHeaders: Record<string, string> = {
@@ -591,6 +606,7 @@ responses.post("/", async (c) => {
 		req.model,
 		logId,
 		req,
+		toolRegistry,
 	);
 
 	// Store for previous_response_id (unless store: false). Storage always
@@ -662,7 +678,7 @@ responses.post("/compact", async (c) => {
 		return c.json(
 			{
 				error: {
-					message: `Invalid request: ${validation.error.errors.map((e) => `${e.path.join(".")}: ${e.message}`).join(", ")}`,
+					message: `Invalid request: ${formatValidationError(validation.error)}`,
 					type: "invalid_request_error",
 					code: "invalid_request",
 				},

--- a/apps/gateway/src/responses/schemas.ts
+++ b/apps/gateway/src/responses/schemas.ts
@@ -1,5 +1,36 @@
 import { z } from "@hono/zod-openapi";
 
+/**
+ * Flatten a Zod error into `path: message` pairs a client can act on.
+ *
+ * Union failures report a single issue at the union's own path ("Invalid
+ * input"), burying the reason in `unionErrors`. That is useless on a schema
+ * whose `input` is a union of unions: a request rejected for one bad item in a
+ * 200-item array reports only "input: Invalid input". Each union is expanded to
+ * the branch that got furthest into the value, which is the branch the client
+ * meant.
+ */
+function expandIssues(issues: z.ZodIssue[]): z.ZodIssue[] {
+	return issues.flatMap((issue) => {
+		if (issue.code !== z.ZodIssueCode.invalid_union) {
+			return [issue];
+		}
+		const nested = issue.unionErrors.flatMap((error) =>
+			expandIssues(error.issues),
+		);
+		const deepest = Math.max(0, ...nested.map((i) => i.path.length));
+		return nested.filter((i) => i.path.length === deepest);
+	});
+}
+
+export function formatValidationError(error: z.ZodError): string {
+	const seen = new Set<string>();
+	for (const issue of expandIssues(error.issues)) {
+		seen.add(`${issue.path.join(".")}: ${issue.message}`);
+	}
+	return [...seen].slice(0, 5).join(", ");
+}
+
 // OpenAI explicit prompt cache breakpoint marker (GPT-5.6 and later).
 const promptCacheBreakpointSchema = z
 	.object({
@@ -32,7 +63,7 @@ const responseInputContentSchema = z.union([
 ]);
 
 const messageItemSchema = z.object({
-	type: z.literal("message").optional(),
+	type: z.literal("message"),
 	role: z.enum(["user", "assistant", "system", "developer"]),
 	phase: z.enum(["commentary", "final_answer"]).optional(),
 	content: z
@@ -79,31 +110,136 @@ const messageItemSchema = z.object({
 		.optional(),
 });
 
-const functionCallItemSchema = z.object({
-	type: z.literal("function_call"),
-	call_id: z.string(),
-	name: z.string(),
-	arguments: z.string(),
-});
-
-const functionCallOutputItemSchema = z.object({
-	type: z.literal("function_call_output"),
-	id: z.string().optional(),
-	call_id: z.string(),
-	output: z.union([z.string(), z.array(responseInputContentSchema)]),
-	status: z.enum(["in_progress", "completed", "incomplete"]).optional(),
-});
-
-// Clients replaying reasoning items statelessly (Codex sends the whole prior
-// output back as `input`) serialize their absent optional fields as explicit
-// nulls, so every field here must accept null as well as being omitted —
-// rejecting them 400s a client on reasoning the gateway itself just emitted.
-// Nulls are normalized to undefined so downstream conversion stays unchanged.
+// Clients replaying items statelessly (Codex sends the whole prior output back
+// as `input`) serialize their absent optional fields as explicit nulls, so
+// fields here must accept null as well as being omitted — rejecting them 400s a
+// client on items the gateway itself just emitted. Nulls are normalized to
+// undefined so downstream conversion stays unchanged.
 const nullishToUndefined = <T extends z.ZodTypeAny>(schema: T) =>
 	schema
 		.nullable()
 		.optional()
 		.transform((val) => (val === null ? undefined : val));
+
+const itemStatusSchema = nullishToUndefined(
+	z.enum(["in_progress", "completed", "incomplete"]),
+);
+
+const functionCallItemSchema = z.object({
+	type: z.literal("function_call"),
+	id: nullishToUndefined(z.string()),
+	call_id: z.string(),
+	name: z.string(),
+	// Tool registries group tools under a namespace; the call names the tool
+	// within it. The gateway flattens namespaces into unique chat-completions
+	// tool names and restores this field on the way back out.
+	namespace: nullishToUndefined(z.string()),
+	arguments: z.string(),
+	status: itemStatusSchema,
+});
+
+const functionCallOutputItemSchema = z.object({
+	type: z.literal("function_call_output"),
+	id: nullishToUndefined(z.string()),
+	call_id: z.string(),
+	output: z.union([z.string(), z.array(responseInputContentSchema)]),
+	status: itemStatusSchema,
+});
+
+// Freeform ("custom") tool calls carry a raw text payload in `input` instead of
+// JSON `arguments`, so the model can emit e.g. a patch or a script without
+// JSON-escaping it.
+const customToolCallItemSchema = z.object({
+	type: z.literal("custom_tool_call"),
+	id: nullishToUndefined(z.string()),
+	call_id: z.string(),
+	name: z.string(),
+	namespace: nullishToUndefined(z.string()),
+	input: z.string(),
+	status: itemStatusSchema,
+});
+
+const customToolCallOutputItemSchema = z.object({
+	type: z.literal("custom_tool_call_output"),
+	id: nullishToUndefined(z.string()),
+	call_id: z.string(),
+	output: z.union([z.string(), z.array(responseInputContentSchema)]),
+	status: itemStatusSchema,
+});
+
+// A tool declared inside an `additional_tools` item. Namespaces nest, so this
+// is recursive; `custom` tools are freeform (no JSON schema).
+export type ToolTreeNode =
+	| {
+			type: "namespace";
+			name: string;
+			description?: string;
+			tools: ToolTreeNode[];
+	  }
+	| {
+			type: "function";
+			name: string;
+			description?: string;
+			parameters?: Record<string, unknown>;
+			strict?: boolean;
+	  }
+	| { type: "custom"; name: string; description?: string };
+
+const toolTreeNodeSchema: z.ZodType<ToolTreeNode, z.ZodTypeDef, unknown> =
+	z.lazy(() =>
+		z.discriminatedUnion("type", [
+			z.object({
+				type: z.literal("namespace"),
+				name: z.string(),
+				description: nullishToUndefined(z.string()),
+				tools: z.array(toolTreeNodeSchema),
+			}),
+			z.object({
+				type: z.literal("function"),
+				name: z.string(),
+				description: nullishToUndefined(z.string()),
+				parameters: nullishToUndefined(z.record(z.any())),
+				strict: nullishToUndefined(z.boolean()),
+			}),
+			z.object({
+				type: z.literal("custom"),
+				name: z.string(),
+				description: nullishToUndefined(z.string()),
+			}),
+		]),
+	);
+
+// Codex 0.144+ declares its tools here instead of in the top-level `tools`
+// array. The gateway flattens the tree into `tools` before conversion.
+const additionalToolsItemSchema = z.object({
+	type: z.literal("additional_tools"),
+	id: nullishToUndefined(z.string()),
+	role: nullishToUndefined(
+		z.enum(["user", "assistant", "system", "developer"]),
+	),
+	tools: z.array(toolTreeNodeSchema),
+});
+
+// Item types that record client-side or provider-built-in activity the gateway
+// cannot replay through provider routing (it never offers these tools). They
+// are accepted so a client replaying its own transcript is not rejected, and
+// dropped during conversion to chat messages.
+export const UNREPLAYABLE_ITEM_TYPES = [
+	"agent_message",
+	"local_shell_call",
+	"local_shell_call_output",
+	"web_search_call",
+	"image_generation_call",
+	"tool_search_call",
+	"tool_search_output",
+	"compaction",
+	"compaction_trigger",
+	"context_compaction",
+] as const;
+
+const unreplayableItemSchema = z
+	.object({ type: z.enum(UNREPLAYABLE_ITEM_TYPES) })
+	.passthrough();
 
 const reasoningItemSchema = z.object({
 	type: z.literal("reasoning"),
@@ -111,9 +247,7 @@ const reasoningItemSchema = z.object({
 	summary: nullishToUndefined(z.array(z.record(z.any()))),
 	content: nullishToUndefined(z.array(z.record(z.any()))),
 	encrypted_content: nullishToUndefined(z.string()),
-	status: nullishToUndefined(
-		z.enum(["in_progress", "completed", "incomplete"]),
-	),
+	status: itemStatusSchema,
 });
 
 // Reference to an item produced by a previous (stored) response. Stateful
@@ -126,13 +260,30 @@ const itemReferenceItemSchema = z.object({
 	id: z.string(),
 });
 
-const inputItemSchema = z.union([
-	messageItemSchema,
-	reasoningItemSchema,
-	functionCallItemSchema,
-	functionCallOutputItemSchema,
-	itemReferenceItemSchema,
-]);
+// `type` is optional on message items in the Responses API, so default it
+// before discriminating. A discriminated union is what makes a bad item report
+// itself: a plain z.union collapses every branch failure into a single
+// "input: Invalid input" that names neither the index nor the offending type.
+const inputItemSchema = z.preprocess(
+	(value) =>
+		value &&
+		typeof value === "object" &&
+		!Array.isArray(value) &&
+		(value as Record<string, unknown>).type === undefined
+			? { ...(value as Record<string, unknown>), type: "message" }
+			: value,
+	z.discriminatedUnion("type", [
+		messageItemSchema,
+		reasoningItemSchema,
+		functionCallItemSchema,
+		functionCallOutputItemSchema,
+		customToolCallItemSchema,
+		customToolCallOutputItemSchema,
+		additionalToolsItemSchema,
+		itemReferenceItemSchema,
+		unreplayableItemSchema,
+	]),
+);
 
 export const responsesRequestSchema = z.object({
 	model: z.string().openapi({

--- a/apps/gateway/src/responses/tool-registry.spec.ts
+++ b/apps/gateway/src/responses/tool-registry.spec.ts
@@ -1,0 +1,404 @@
+import { describe, it, expect } from "vitest";
+
+import { formatValidationError, responsesRequestSchema } from "./schemas.js";
+import { convertChatResponseToResponses } from "./tools/convert-chat-to-responses.js";
+import { convertResponsesInputToMessages } from "./tools/convert-responses-to-chat.js";
+import {
+	buildFinalOutputItems,
+	createCompletionEvents,
+	createStreamingState,
+	processStreamChunk,
+} from "./tools/convert-streaming-to-responses.js";
+import { extractAdditionalTools } from "./tools/tool-registry.js";
+
+// The tool tree Codex 0.144+ sends as its first input item: a default
+// `functions` namespace holding a freeform tool plus a regular one, and a
+// second namespace whose members must stay addressable.
+const ADDITIONAL_TOOLS_ITEM = {
+	type: "additional_tools",
+	role: "developer",
+	tools: [
+		{
+			type: "namespace",
+			name: "functions",
+			description: "",
+			tools: [
+				{ type: "custom", name: "exec", description: "Run JavaScript" },
+				{
+					type: "function",
+					name: "wait",
+					description: "Wait",
+					parameters: {
+						type: "object",
+						properties: { ms: { type: "number" } },
+					},
+				},
+			],
+		},
+		{
+			type: "namespace",
+			name: "collaboration",
+			tools: [{ type: "function", name: "spawn_agent" }],
+		},
+	],
+};
+
+const CODEX_REQUEST = {
+	model: "gpt-4o-mini",
+	input: [
+		ADDITIONAL_TOOLS_ITEM,
+		{ role: "user", content: [{ type: "input_text", text: "Test" }] },
+	],
+};
+
+describe("additional_tools input item", () => {
+	it("accepts the request Codex 0.144+ sends", () => {
+		const result = responsesRequestSchema.safeParse(CODEX_REQUEST);
+		expect(result.success).toBe(true);
+	});
+
+	it("names an unknown item type instead of collapsing to Invalid input", () => {
+		const result = responsesRequestSchema.safeParse({
+			model: "gpt-4o-mini",
+			input: [
+				{ role: "user", content: "hi" },
+				{ type: "totally_new_item_type", foo: 1 },
+			],
+		});
+		expect(result.success).toBe(false);
+		const message = formatValidationError(result.error!);
+		expect(message).toContain("input.1.type");
+		expect(message).not.toBe("input: Invalid input");
+	});
+
+	it("still reports the offending field on a malformed known item", () => {
+		const result = responsesRequestSchema.safeParse({
+			model: "gpt-4o-mini",
+			input: [{ type: "function_call", call_id: "c1", name: "f" }],
+		});
+		expect(result.success).toBe(false);
+		expect(formatValidationError(result.error!)).toContain("input.0.arguments");
+	});
+
+	it("flattens the tool tree into function tools and removes the item", () => {
+		const parsed = responsesRequestSchema.parse(CODEX_REQUEST);
+		const { items, tools, registry } = extractAdditionalTools(
+			parsed.input as unknown[],
+		);
+
+		expect(items).toHaveLength(1);
+		expect(tools.map((t) => t.name)).toEqual([
+			"exec",
+			"wait",
+			"collaboration__spawn_agent",
+		]);
+		expect(registry.customNames.has("exec")).toBe(true);
+		expect(registry.namespaces.get("collaboration__spawn_agent")).toBe(
+			"collaboration",
+		);
+
+		// A freeform tool has no schema, so it is offered as a function taking the
+		// raw payload as a single string argument.
+		expect(tools[0]!.parameters).toEqual({
+			type: "object",
+			properties: {
+				input: {
+					type: "string",
+					description:
+						"The raw text payload for this tool. Not JSON — pass the content verbatim.",
+				},
+			},
+			required: ["input"],
+			additionalProperties: false,
+		});
+		expect(tools[1]!.parameters).toEqual({
+			type: "object",
+			properties: { ms: { type: "number" } },
+		});
+	});
+
+	it("keeps the newest declaration when a chained turn redeclares tools", () => {
+		const { tools } = extractAdditionalTools([
+			{
+				type: "additional_tools",
+				tools: [{ type: "function", name: "wait", description: "old" }],
+			},
+			{
+				type: "additional_tools",
+				tools: [{ type: "function", name: "wait", description: "new" }],
+			},
+		]);
+		expect(tools).toHaveLength(1);
+		expect(tools[0]!.description).toBe("new");
+	});
+});
+
+describe("freeform tool call round trip", () => {
+	const registry = extractAdditionalTools([ADDITIONAL_TOOLS_ITEM]).registry;
+
+	it("re-emits a custom tool call with its raw payload", () => {
+		const result = convertChatResponseToResponses(
+			{
+				choices: [
+					{
+						message: {
+							role: "assistant",
+							content: null,
+							tool_calls: [
+								{
+									id: "call_1",
+									type: "function",
+									function: {
+										name: "exec",
+										arguments: JSON.stringify({ input: 'text("hi")' }),
+									},
+								},
+							],
+						},
+						finish_reason: "tool_calls",
+					},
+				],
+			},
+			"gpt-4o-mini",
+			"resp_1",
+			undefined,
+			registry,
+		);
+
+		expect(result.output[0]).toMatchObject({
+			type: "custom_tool_call",
+			call_id: "call_1",
+			name: "exec",
+			input: 'text("hi")',
+		});
+		expect(result.output[0]).not.toHaveProperty("namespace");
+	});
+
+	it("restores the namespace of a namespaced function call", () => {
+		const result = convertChatResponseToResponses(
+			{
+				choices: [
+					{
+						message: {
+							role: "assistant",
+							content: null,
+							tool_calls: [
+								{
+									id: "call_2",
+									type: "function",
+									function: {
+										name: "collaboration__spawn_agent",
+										arguments: "{}",
+									},
+								},
+							],
+						},
+						finish_reason: "tool_calls",
+					},
+				],
+			},
+			"gpt-4o-mini",
+			"resp_2",
+			undefined,
+			registry,
+		);
+
+		expect(result.output[0]).toMatchObject({
+			type: "function_call",
+			name: "spawn_agent",
+			namespace: "collaboration",
+			arguments: "{}",
+		});
+	});
+
+	it("passes a payload through verbatim when it is not the expected JSON", () => {
+		const result = convertChatResponseToResponses(
+			{
+				choices: [
+					{
+						message: {
+							role: "assistant",
+							content: null,
+							tool_calls: [
+								{
+									id: "call_3",
+									type: "function",
+									function: { name: "exec", arguments: "raw payload" },
+								},
+							],
+						},
+						finish_reason: "tool_calls",
+					},
+				],
+			},
+			"gpt-4o-mini",
+			"resp_3",
+			undefined,
+			registry,
+		);
+
+		expect(result.output[0]).toMatchObject({ input: "raw payload" });
+	});
+
+	it("converts replayed custom tool calls and outputs back to chat messages", () => {
+		const input = responsesRequestSchema.parse({
+			model: "gpt-4o-mini",
+			input: [
+				{ role: "user", content: "go" },
+				{
+					type: "custom_tool_call",
+					call_id: "call_1",
+					name: "exec",
+					input: 'text("hi")',
+				},
+				{
+					type: "custom_tool_call_output",
+					call_id: "call_1",
+					output: "hi",
+				},
+				{
+					type: "function_call",
+					call_id: "call_2",
+					name: "spawn_agent",
+					namespace: "collaboration",
+					arguments: "{}",
+				},
+				{ type: "function_call_output", call_id: "call_2", output: "spawned" },
+			],
+		}).input;
+
+		const messages = convertResponsesInputToMessages(input);
+
+		expect(messages).toHaveLength(5);
+		expect(messages[1]).toMatchObject({
+			role: "assistant",
+			tool_calls: [
+				{
+					id: "call_1",
+					function: { name: "exec", arguments: '{"input":"text(\\"hi\\")"}' },
+				},
+			],
+		});
+		expect(messages[2]).toMatchObject({
+			role: "tool",
+			tool_call_id: "call_1",
+			content: "hi",
+		});
+		expect(messages[3]!.tool_calls?.[0]!.function.name).toBe(
+			"collaboration__spawn_agent",
+		);
+		expect(messages[4]).toMatchObject({ role: "tool", content: "spawned" });
+	});
+
+	it("skips items describing activity the gateway cannot replay", () => {
+		const input = responsesRequestSchema.parse({
+			model: "gpt-4o-mini",
+			input: [
+				ADDITIONAL_TOOLS_ITEM,
+				{ type: "web_search_call", id: "ws_1", status: "completed" },
+				{ role: "user", content: "hi" },
+			],
+		}).input;
+
+		const messages = convertResponsesInputToMessages(input);
+		expect(messages).toEqual([{ role: "user", content: "hi" }]);
+	});
+});
+
+describe("freeform tool call streaming", () => {
+	const registry = extractAdditionalTools([ADDITIONAL_TOOLS_ITEM]).registry;
+
+	function streamExecCall() {
+		const state = createStreamingState(
+			"gpt-4o-mini",
+			"resp_1",
+			undefined,
+			registry,
+		);
+		const events = [
+			...processStreamChunk(
+				{
+					choices: [
+						{
+							index: 0,
+							delta: {
+								tool_calls: [
+									{
+										index: 0,
+										id: "call_1",
+										type: "function",
+										function: { name: "exec", arguments: "" },
+									},
+								],
+							},
+						},
+					],
+				},
+				state,
+			),
+			...processStreamChunk(
+				{
+					choices: [
+						{
+							index: 0,
+							delta: {
+								tool_calls: [
+									{
+										index: 0,
+										function: { arguments: '{"input":"text(1)"}' },
+									},
+								],
+							},
+						},
+					],
+				},
+				state,
+			),
+		];
+		return { state, events: [...events, ...createCompletionEvents(state)] };
+	}
+
+	it("announces and closes the item as a custom_tool_call", () => {
+		const { events } = streamExecCall();
+		const parsed = events.map((e) => JSON.parse(e.data));
+
+		const added = parsed.find((e) => e.type === "response.output_item.added");
+		expect(added.item).toMatchObject({
+			type: "custom_tool_call",
+			name: "exec",
+			input: "",
+		});
+
+		const done = parsed.find(
+			(e) => e.type === "response.output_item.done" && e.item.call_id,
+		);
+		expect(done.item).toMatchObject({
+			type: "custom_tool_call",
+			name: "exec",
+			input: "text(1)",
+		});
+	});
+
+	it("emits the payload as custom_tool_call_input events, not argument deltas", () => {
+		const { events } = streamExecCall();
+		const types = events.map((e) => JSON.parse(e.data).type);
+
+		expect(types).not.toContain("response.function_call_arguments.delta");
+		expect(types).toContain("response.custom_tool_call_input.delta");
+		expect(types).toContain("response.custom_tool_call_input.done");
+
+		const inputDone = events
+			.map((e) => JSON.parse(e.data))
+			.find((e) => e.type === "response.custom_tool_call_input.done");
+		expect(inputDone.input).toBe("text(1)");
+	});
+
+	it("stores the unwrapped payload in the final output", () => {
+		const { state } = streamExecCall();
+		expect(buildFinalOutputItems(state)[0]).toMatchObject({
+			type: "custom_tool_call",
+			name: "exec",
+			input: "text(1)",
+		});
+	});
+});

--- a/apps/gateway/src/responses/tools/convert-chat-to-responses.ts
+++ b/apps/gateway/src/responses/tools/convert-chat-to-responses.ts
@@ -1,5 +1,9 @@
 import { shortid } from "@llmgateway/db";
 
+import { toResponsesToolCallItem } from "./tool-registry.js";
+
+import type { ToolRegistry } from "./tool-registry.js";
+
 interface ChatCompletionsResponse {
 	id?: string;
 	object?: string;
@@ -297,6 +301,7 @@ export function convertChatResponseToResponses(
 	requestedModel: string,
 	responseId?: string,
 	request?: ResponsesEchoRequest,
+	toolRegistry?: ToolRegistry,
 ): ResponsesApiResponse {
 	const choice = chatResponse.choices?.[0];
 	const message = choice?.message;
@@ -420,14 +425,15 @@ export function convertChatResponseToResponses(
 
 	toolCalls.forEach((toolCall, callIndex) => {
 		emitMessagesUpTo(callIndex);
-		output.push({
-			type: "function_call",
-			id: `fc_${shortid(24)}`,
-			call_id: toolCall.id,
-			name: toolCall.function.name,
-			arguments: toolCall.function.arguments,
-			status: "completed",
-		});
+		output.push(
+			toResponsesToolCallItem(toolRegistry, {
+				id: `fc_${shortid(24)}`,
+				callId: toolCall.id,
+				name: toolCall.function.name,
+				arguments: toolCall.function.arguments,
+				status: "completed",
+			}) as ResponsesApiOutput,
+		);
 	});
 	emitMessagesUpTo(Number.MAX_SAFE_INTEGER);
 

--- a/apps/gateway/src/responses/tools/convert-responses-to-chat.ts
+++ b/apps/gateway/src/responses/tools/convert-responses-to-chat.ts
@@ -1,4 +1,28 @@
+import { UNREPLAYABLE_ITEM_TYPES } from "@/responses/schemas.js";
+
+import { flattenToolName } from "./tool-registry.js";
+
 import type { ResponsesRequest } from "@/responses/schemas.js";
+
+// Unreplayable items, plus tool declarations already lifted into `tools`. They
+// have no chat completions equivalent, so they are skipped rather than turned
+// into stray messages.
+const SKIPPED_ITEM_TYPES = new Set<string>([
+	...UNREPLAYABLE_ITEM_TYPES,
+	"additional_tools",
+]);
+
+function isToolCallItem(item: unknown): item is {
+	type: "function_call" | "custom_tool_call";
+	call_id: string;
+	name: string;
+	namespace?: string;
+	arguments?: string;
+	input?: string;
+} {
+	const type = (item as { type?: unknown } | null)?.type;
+	return type === "function_call" || type === "custom_tool_call";
+}
 
 interface ChatMessage {
 	role: "system" | "user" | "assistant" | "tool";
@@ -117,20 +141,26 @@ export function convertResponsesInputToMessages(
 		// result, which strict providers (deepseek family, bytedance, etc.)
 		// reject with "assistant message with tool_calls must be followed by
 		// tool messages".
-		if ("type" in item && item.type === "function_call") {
+		if (isToolCallItem(item)) {
 			const toolCalls: ChatMessage["tool_calls"] = [];
 
 			while (i < input.length) {
 				const current = input[i]!;
-				if (!("type" in current) || current.type !== "function_call") {
+				if (!isToolCallItem(current)) {
 					break;
 				}
 				toolCalls.push({
 					id: current.call_id,
 					type: "function",
 					function: {
-						name: current.name,
-						arguments: current.arguments,
+						name: flattenToolName(current.name, current.namespace),
+						// A freeform call carries its raw payload in `input`; the
+						// provider was offered the tool as a function taking that
+						// payload as a single string argument.
+						arguments:
+							current.type === "custom_tool_call"
+								? JSON.stringify({ input: current.input ?? "" })
+								: (current.arguments ?? ""),
 					},
 				});
 				i++;
@@ -182,13 +212,22 @@ export function convertResponsesInputToMessages(
 			continue;
 		}
 
-		// function_call_output items -> tool messages
-		if ("type" in item && item.type === "function_call_output") {
+		// function_call_output / custom_tool_call_output items -> tool messages
+		if (
+			"type" in item &&
+			(item.type === "function_call_output" ||
+				item.type === "custom_tool_call_output")
+		) {
 			messages.push({
 				role: "tool",
 				content: serializeFunctionCallOutput(item.output),
 				tool_call_id: item.call_id,
 			});
+			i++;
+			continue;
+		}
+
+		if ("type" in item && SKIPPED_ITEM_TYPES.has(item.type as string)) {
 			i++;
 			continue;
 		}

--- a/apps/gateway/src/responses/tools/convert-streaming-to-responses.ts
+++ b/apps/gateway/src/responses/tools/convert-streaming-to-responses.ts
@@ -6,8 +6,10 @@ import {
 	resolveReasoningContext,
 	stripEncryptedReasoningContent,
 } from "./convert-chat-to-responses.js";
+import { toResponsesToolCallItem } from "./tool-registry.js";
 
 import type { ResponsesEchoRequest } from "./convert-chat-to-responses.js";
+import type { ToolRegistry } from "./tool-registry.js";
 
 // One assistant message output item in the stream. Providers may emit several
 // per turn (e.g. a commentary message before tool calls and a final_answer
@@ -63,6 +65,7 @@ interface StreamingState {
 		}
 	>;
 	request?: ResponsesEchoRequest;
+	toolRegistry?: ToolRegistry;
 	servedServiceTier?: string;
 	// Effective reasoning context the provider applied, surfaced by the
 	// streaming translator on the terminal chunk.
@@ -97,6 +100,7 @@ export function createStreamingState(
 	model: string,
 	responseId?: string,
 	request?: ResponsesEchoRequest,
+	toolRegistry?: ToolRegistry,
 ): StreamingState {
 	return {
 		responseId: responseId ?? `resp_${shortid(24)}`,
@@ -113,6 +117,7 @@ export function createStreamingState(
 		sequenceNumber: 0,
 		toolCalls: new Map(),
 		request,
+		toolRegistry,
 		usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
 	};
 }
@@ -430,27 +435,31 @@ export function processStreamChunk(
 					emitEvent(state, "response.output_item.added", {
 						type: "response.output_item.added",
 						output_index: tcOutputIndex,
-						item: {
-							type: "function_call",
+						item: toResponsesToolCallItem(state.toolRegistry, {
 							id: fcId,
-							call_id: callId,
+							callId,
 							name,
 							arguments: "",
 							status: "in_progress",
-						},
+						}),
 					}),
 				);
 			} else {
 				if (tc.function?.arguments) {
 					existing.arguments += tc.function.arguments;
-					events.push(
-						emitEvent(state, "response.function_call_arguments.delta", {
-							type: "response.function_call_arguments.delta",
-							item_id: existing.id,
-							output_index: existing.outputIndex,
-							delta: tc.function.arguments,
-						}),
-					);
+					// A freeform tool's payload is the `input` field inside these JSON
+					// arguments, so it cannot be unwrapped incrementally; the whole
+					// payload is emitted as one delta when the call closes.
+					if (!state.toolRegistry?.customNames.has(existing.name)) {
+						events.push(
+							emitEvent(state, "response.function_call_arguments.delta", {
+								type: "response.function_call_arguments.delta",
+								item_id: existing.id,
+								output_index: existing.outputIndex,
+								delta: tc.function.arguments,
+							}),
+						);
+					}
 				}
 			}
 		}
@@ -674,14 +683,13 @@ export function buildFinalOutputItems(
 	for (const tc of state.toolCalls.values()) {
 		indexed.push({
 			index: tc.outputIndex,
-			item: {
-				type: "function_call",
+			item: toResponsesToolCallItem(state.toolRegistry, {
 				id: tc.id,
-				call_id: tc.callId,
+				callId: tc.callId,
 				name: tc.name,
 				arguments: tc.arguments,
 				status: "completed",
-			},
+			}),
 		});
 	}
 
@@ -791,20 +799,39 @@ export function createCompletionEvents(
 		);
 	}
 
-	// Emit output_item.done for each function_call
+	// Emit output_item.done for each tool call
 	for (const tc of state.toolCalls.values()) {
+		const item = toResponsesToolCallItem(state.toolRegistry, {
+			id: tc.id,
+			callId: tc.callId,
+			name: tc.name,
+			arguments: tc.arguments,
+			status: "completed",
+		});
+		if (item.type === "custom_tool_call") {
+			const input = item.input as string;
+			events.push(
+				emitEvent(state, "response.custom_tool_call_input.delta", {
+					type: "response.custom_tool_call_input.delta",
+					item_id: tc.id,
+					output_index: tc.outputIndex,
+					delta: input,
+				}),
+			);
+			events.push(
+				emitEvent(state, "response.custom_tool_call_input.done", {
+					type: "response.custom_tool_call_input.done",
+					item_id: tc.id,
+					output_index: tc.outputIndex,
+					input,
+				}),
+			);
+		}
 		events.push(
 			emitEvent(state, "response.output_item.done", {
 				type: "response.output_item.done",
 				output_index: tc.outputIndex,
-				item: {
-					type: "function_call",
-					id: tc.id,
-					call_id: tc.callId,
-					name: tc.name,
-					arguments: tc.arguments,
-					status: "completed",
-				},
+				item,
 			}),
 		);
 	}

--- a/apps/gateway/src/responses/tools/tool-registry.ts
+++ b/apps/gateway/src/responses/tools/tool-registry.ts
@@ -1,0 +1,221 @@
+import type { ToolTreeNode } from "@/responses/schemas.js";
+
+/**
+ * Codex 0.144+ (and any other client using the Responses tool registry) stops
+ * sending a top-level `tools` array. Tools arrive as an `additional_tools`
+ * input item holding a tree of namespaces, plain `function` tools and freeform
+ * `custom` tools, and calls come back naming a tool plus the namespace it lives
+ * in.
+ *
+ * Chat completions has neither namespaces nor freeform tools, so this module
+ * defines the round trip:
+ *
+ * - namespaces are flattened into unique tool names (`<namespace>__<tool>`),
+ * - `custom` tools are declared as a function taking a single `input` string,
+ * - tool calls are mapped back to their original name/namespace, and calls to
+ *   a `custom` tool are re-emitted as `custom_tool_call` items carrying the raw
+ *   `input` payload.
+ *
+ * Without the reverse mapping a client would receive a call for a tool it never
+ * registered under that name, or a JSON-wrapped payload for a tool it expects
+ * raw text from.
+ */
+
+// The implicit namespace of an ungrouped tool. Its members keep bare names, so
+// registries that only use this namespace round-trip unchanged.
+const DEFAULT_NAMESPACE = "functions";
+
+export interface ToolRegistry {
+	/** Flat tool name -> namespace it was declared in. */
+	namespaces: Map<string, string>;
+	/** Flat names of tools declared as freeform `custom` tools. */
+	customNames: Set<string>;
+}
+
+export function createToolRegistry(): ToolRegistry {
+	return { namespaces: new Map(), customNames: new Set() };
+}
+
+/** Join a tool name and its namespace into a unique chat-completions name. */
+export function flattenToolName(name: string, namespace?: string): string {
+	return !namespace || namespace === DEFAULT_NAMESPACE
+		? name
+		: `${namespace}__${name}`;
+}
+
+/** Inverse of {@link flattenToolName}, resolved against what was declared. */
+export function unflattenToolName(
+	flatName: string,
+	registry: ToolRegistry | undefined,
+): { name: string; namespace?: string } {
+	const namespace = registry?.namespaces.get(flatName);
+	if (!namespace) {
+		return { name: flatName };
+	}
+	return { name: flatName.slice(namespace.length + 2), namespace };
+}
+
+/**
+ * Freeform tools have no JSON schema. Providers are only offered function
+ * tools, so a `custom` tool is declared as one taking the raw payload as its
+ * single string argument; {@link toResponsesToolCallItem} unwraps it again.
+ */
+function freeformParameters(): Record<string, unknown> {
+	return {
+		type: "object",
+		properties: {
+			input: {
+				type: "string",
+				description:
+					"The raw text payload for this tool. Not JSON — pass the content verbatim.",
+			},
+		},
+		required: ["input"],
+		additionalProperties: false,
+	};
+}
+
+function flattenNode(
+	node: ToolTreeNode,
+	namespace: string | undefined,
+	tools: Record<string, unknown>[],
+	registry: ToolRegistry,
+): void {
+	if (node.type === "namespace") {
+		const nested =
+			!namespace || namespace === DEFAULT_NAMESPACE
+				? node.name
+				: `${namespace}__${node.name}`;
+		for (const child of node.tools) {
+			flattenNode(child, nested, tools, registry);
+		}
+		return;
+	}
+
+	const flatName = flattenToolName(node.name, namespace);
+	if (namespace && namespace !== DEFAULT_NAMESPACE) {
+		registry.namespaces.set(flatName, namespace);
+	}
+	// A redeclaration replaces the earlier one, so the freeform flag must be
+	// cleared rather than only ever set.
+	registry.customNames.delete(flatName);
+
+	if (node.type === "custom") {
+		registry.customNames.add(flatName);
+		tools.push({
+			type: "function",
+			name: flatName,
+			...(node.description ? { description: node.description } : {}),
+			parameters: freeformParameters(),
+		});
+		return;
+	}
+
+	tools.push({
+		type: "function",
+		name: flatName,
+		...(node.description ? { description: node.description } : {}),
+		...(node.parameters ? { parameters: node.parameters } : {}),
+		...(node.strict !== undefined ? { strict: node.strict } : {}),
+	});
+}
+
+/**
+ * Pull every `additional_tools` item out of the input and turn the tool trees
+ * it declares into top-level Responses API function tools.
+ */
+export function extractAdditionalTools(items: unknown[]): {
+	items: unknown[];
+	tools: Record<string, unknown>[];
+	registry: ToolRegistry;
+} {
+	const registry = createToolRegistry();
+	const tools: Record<string, unknown>[] = [];
+	const remaining: unknown[] = [];
+
+	for (const item of items) {
+		const candidate = item as { type?: string; tools?: ToolTreeNode[] } | null;
+		if (
+			!candidate ||
+			candidate.type !== "additional_tools" ||
+			!Array.isArray(candidate.tools)
+		) {
+			remaining.push(item);
+			continue;
+		}
+		for (const node of candidate.tools) {
+			flattenNode(node, undefined, tools, registry);
+		}
+	}
+
+	// A chained conversation replays the earlier turn's declarations alongside
+	// this turn's; the newest declaration of a name wins.
+	const deduped = new Map<string, Record<string, unknown>>();
+	for (const tool of tools) {
+		deduped.set(tool.name as string, tool);
+	}
+
+	return { items: remaining, tools: [...deduped.values()], registry };
+}
+
+/**
+ * Unwrap the raw payload a freeform tool call was given. The model is asked for
+ * `{"input": "..."}`; anything else (a partial stream, a model that emitted the
+ * payload bare) is passed through verbatim rather than dropped.
+ */
+export function unwrapFreeformInput(args: string): string {
+	try {
+		const parsed: unknown = JSON.parse(args);
+		if (
+			parsed &&
+			typeof parsed === "object" &&
+			typeof (parsed as { input?: unknown }).input === "string"
+		) {
+			return (parsed as { input: string }).input;
+		}
+	} catch {
+		// fall through
+	}
+	return args;
+}
+
+/**
+ * Build the Responses API output item for a chat completions tool call,
+ * restoring the namespace and the freeform shape the client declared.
+ */
+export function toResponsesToolCallItem(
+	registry: ToolRegistry | undefined,
+	toolCall: {
+		id: string;
+		callId: string;
+		name: string;
+		arguments: string;
+		status: "in_progress" | "completed";
+	},
+): Record<string, unknown> {
+	const { name, namespace } = unflattenToolName(toolCall.name, registry);
+	const shared = {
+		id: toolCall.id,
+		call_id: toolCall.callId,
+		name,
+		...(namespace ? { namespace } : {}),
+		status: toolCall.status,
+	};
+
+	if (registry?.customNames.has(toolCall.name)) {
+		return {
+			type: "custom_tool_call",
+			...shared,
+			input:
+				toolCall.status === "in_progress"
+					? ""
+					: unwrapFreeformInput(toolCall.arguments),
+		};
+	}
+
+	return {
+		type: "function_call",
+		...shared,
+		arguments: toolCall.status === "in_progress" ? "" : toolCall.arguments,
+	};
+}


### PR DESCRIPTION
## Problem

Codex CLI **0.144.0+** stopped sending a top-level `tools` array on `/v1/responses`. Tools now arrive as an `additional_tools` **input item** holding a tree of namespaces, plain `function` tools and freeform `custom` tools:

```json
{"type":"additional_tools","role":"developer","tools":[
  {"type":"namespace","name":"functions","tools":[
    {"type":"custom","name":"exec","description":"Run JavaScript"},
    {"type":"function","name":"wait","parameters":{}}]}]}
```

`inputItemSchema` had no branch for it, so **every Codex request failed on the first turn** with:

```
{"error":{"message":"Invalid request: input: Invalid input","type":"invalid_request_error","code":"invalid_request"}}
```

Measured version boundary: 0.143.0 sends `tools: 10` and message-only input (works); 0.144.0 / 0.144.6 / 0.145.0 / 0.146.1 / 0.147.0 all send `additional_tools`. There is no client-side escape hatch — `features.code_mode = false`, `code_mode_only = false` and `features.tool_registry` do not turn it off.

## Approach

Chat completions has neither namespaces nor freeform tools, so `tools/tool-registry.ts` defines the round trip explicitly:

- namespaces flatten into unique tool names (`<namespace>__<tool>`; the implicit `functions` namespace keeps bare names, so existing registries round-trip unchanged),
- a `custom` tool has no JSON schema, so it is offered to the provider as a function taking its raw payload as a single `input` string,
- tool calls map back to their original name/namespace on the way out, and calls to a `custom` tool are re-emitted as `custom_tool_call` items carrying the unwrapped payload.

Without the reverse mapping a client receives a call for a tool it never registered under that name, or a JSON-wrapped payload for a tool it expects raw text from — which matters for `apply_patch`, whose whole point is not being JSON-escaped.

Streaming emits `response.custom_tool_call_input.delta`/`.done` for freeform calls instead of `response.function_call_arguments.delta`. The payload lives inside the JSON arguments, so it cannot be unwrapped incrementally and is emitted as one delta when the call closes.

Also handled:

- replayed `custom_tool_call` / `custom_tool_call_output` items convert back to chat tool calls and tool messages;
- items recording activity the gateway never offers as a tool (`web_search_call`, `local_shell_call`, `agent_message`, compaction, ...) are accepted and skipped rather than rejected, so a client replaying its own transcript is not turned away.

### Error messages

The input item union is now discriminated on `type`, and union issues are expanded to the branch that got furthest into the value. A bad item now names itself:

| before | after |
| --- | --- |
| `input: Invalid input` | `input.1.type: Invalid discriminator value. Expected 'message' \| 'reasoning' \| 'function_call' \| ...` |
| `input: Invalid input` | `input.0.arguments: Required` |

That collapse is what made the original bug take a packet capture to diagnose.

## Verification

`pnpm build`, `pnpm format`, and the full `pnpm test:unit` suite (2 pre-existing environmental failures, both reproduced on the unmodified baseline). 13 new unit tests cover the flattening, the namespace round trip, freeform unwrapping, replay, and the streaming event shape.

End-to-end against a real Codex CLI 0.147.0 driving a local gateway through a capturing proxy — a full multi-turn code-mode loop (write a file, run it, report output) completed, and the wire shows the whole round trip:

```
request 3: additional_tools, message x7, custom_tool_call, custom_tool_call_output,
           reasoning, custom_tool_call, custom_tool_call_output
payload:   const a = await tools.exec_command({cmd:'pwd && rg --files ...
events:    response.custom_tool_call_input.delta/.done, no function_call_arguments.delta
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for additional tools, including namespaced and custom tools.
  - Preserved tool names, inputs, outputs, and metadata across Responses API and chat conversions.
  - Added streaming support for custom tool calls and their complete input payloads.

- **Bug Fixes**
  - Improved validation errors with clearer, more actionable field paths and messages.
  - Improved handling of replayed, unsupported, and malformed response items.
  - Prevented duplicate tool definitions from producing inconsistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->