### PR TITLE
fix(gateway): surface trailing stream errors

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -7175,6 +7175,65 @@ describe("api", () => {
 			);
 		});
 
+		test("streaming request surfaces a trailing upstream error tail", async () => {
+			await db.insert(tables.apiKey).values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+
+			await db.insert(tables.providerKey).values({
+				id: "provider-key-id",
+				token: "sk-test-key",
+				provider: "llmgateway",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			});
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer real-token`,
+				},
+				body: JSON.stringify({
+					model: "llmgateway/custom",
+					messages: [
+						{
+							role: "user",
+							content: "TRIGGER_STREAM_TRAILING_ERROR",
+						},
+					],
+					stream: true,
+				}),
+			});
+
+			expect(res.status).toBe(200);
+
+			const streamResult = await readAll(res.body);
+
+			expect(streamResult.hasContent).toBe(true);
+			expect(streamResult.hasError).toBe(true);
+			expect(streamResult.errorEvents.length).toBeGreaterThan(0);
+			expect(streamResult.errorEvents[0].error.type).toBe("upstream_error");
+			expect(streamResult.errorEvents[0].error.code).toBe("UNAVAILABLE");
+			expect(streamResult.errorEvents[0].error.message).toContain(
+				"high demand",
+			);
+
+			const logs = await waitForLogs(1);
+			expect(logs.length).toBe(1);
+			expect(logs[0].finishReason).toBe("upstream_error");
+			expect(logs[0].unifiedFinishReason).toBe("upstream_error");
+			expect(logs[0].hasError).toBe(true);
+			expect(logs[0].errorDetails?.statusCode).toBe(503);
+			expect(logs[0].errorDetails?.statusText).toBe(
+				"Upstream Stream Terminated",
+			);
+		});
+
 		test("streaming request closes cleanly after finish reason without upstream done sentinel", async () => {
 			await db.insert(tables.apiKey).values({
 				id: "token-id",

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -254,6 +254,7 @@ import { checkOpenAIContentFilter } from "./tools/openai-content-filter.js";
 import { convertAwsEventStreamToSSE } from "./tools/parse-aws-eventstream.js";
 import { parseModelInput } from "./tools/parse-model-input.js";
 import { parseProviderResponse } from "./tools/parse-provider-response.js";
+import { parseTrailingUpstreamError } from "./tools/parse-trailing-upstream-error.js";
 import {
 	exclusionReason,
 	getProviderFilterReasons,
@@ -1011,6 +1012,17 @@ function inferStreamingErrorStatusCode(
 	}
 	if (typeof openAiCompatibleStreamError.status === "number") {
 		return openAiCompatibleStreamError.status;
+	}
+	// Google-style (google.rpc) error payloads carry the HTTP status as a
+	// numeric `code` (e.g. {"code": 503, "status": "UNAVAILABLE"}). Only trust
+	// it in the HTTP error range: other providers use numeric `code` for
+	// internal error catalogues.
+	if (
+		typeof openAiCompatibleStreamError.code === "number" &&
+		openAiCompatibleStreamError.code >= 400 &&
+		openAiCompatibleStreamError.code <= 599
+	) {
+		return openAiCompatibleStreamError.code;
 	}
 
 	const errorType =
@@ -10799,14 +10811,39 @@ chat.openapi(completions, async (c) => {
 						const responseText = hasBufferedNonWhitespace
 							? buffer.slice(0, 5000)
 							: "Stream ended before a terminal finish reason or [DONE] event";
+						// A provider can shed a stream mid-flight by writing one
+						// structured JSON error as a raw body tail (not an SSE event)
+						// before closing — the Gemini API does this when Flex-tier
+						// capacity is shed (503 UNAVAILABLE "high demand"). Surface that
+						// error instead of the generic truncation message so callers see
+						// the real, retryable cause.
+						const trailingUpstreamError = parseTrailingUpstreamError(buffer);
+						const statusCode = trailingUpstreamError
+							? inferStreamingErrorStatusCode(
+									trailingUpstreamError,
+									responseText,
+								)
+							: 502;
 						const errorMessage =
-							"Upstream stream terminated unexpectedly before completion";
+							trailingUpstreamError &&
+							typeof trailingUpstreamError.message === "string"
+								? trailingUpstreamError.message
+								: "Upstream stream terminated unexpectedly before completion";
+						const errorCode = trailingUpstreamError
+							? typeof trailingUpstreamError.code === "string"
+								? trailingUpstreamError.code
+								: typeof trailingUpstreamError.status === "string"
+									? trailingUpstreamError.status
+									: "stream_truncated"
+							: "stream_truncated";
 
 						logger.warn("[streaming] Stream ended without terminal event", {
 							provider: usedProvider,
 							model: usedInternalModel,
 							bufferLength: buffer.length,
 							fullContentLength: fullContent.length,
+							hasTrailingUpstreamError: trailingUpstreamError !== null,
+							statusCode,
 							hasToolCalls:
 								!!streamingToolCalls && streamingToolCalls.length > 0,
 							unifiedFinishReason: getUnifiedFinishReason(
@@ -10818,9 +10855,9 @@ chat.openapi(completions, async (c) => {
 						streamingError = {
 							message: errorMessage,
 							type: "upstream_error",
-							code: "stream_truncated",
+							code: errorCode,
 							details: {
-								statusCode: 502,
+								statusCode,
 								statusText: "Upstream Stream Terminated",
 								responseText,
 								timestamp: new Date().toISOString(),
@@ -10831,16 +10868,27 @@ chat.openapi(completions, async (c) => {
 						};
 						finishReason = "upstream_error";
 
+						// A stealth provider's raw error tail (and vocabulary) must not
+						// reach the client; the unredacted payload above still feeds the
+						// internal-only log columns.
+						const redactTruncationError =
+							shouldRedactProviderError(usedProvider);
 						try {
 							await writeSSEAndCache({
 								event: "error",
 								data: JSON.stringify({
 									error: {
-										message: errorMessage,
+										message: redactTruncationError
+											? redactedProviderErrorText(statusCode)
+											: errorMessage,
 										type: "upstream_error",
-										code: "stream_truncated",
+										code: redactTruncationError
+											? "stream_truncated"
+											: errorCode,
 										param: null,
-										responseText,
+										responseText: redactTruncationError
+											? redactedProviderErrorText(statusCode)
+											: responseText,
 									},
 								}),
 								id: String(eventId++),

--- a/apps/gateway/src/chat/tools/normalize-streaming-error.spec.ts
+++ b/apps/gateway/src/chat/tools/normalize-streaming-error.spec.ts
@@ -40,6 +40,64 @@ describe("normalizeStreamingError", () => {
 		expect(normalized.log.details.cause).toContain("UND_ERR_SOCKET");
 	});
 
+	it("surfaces a structured trailing upstream error on termination", () => {
+		// The Gemini API sheds Flex-tier capacity by writing a raw JSON error
+		// tail and closing the socket; the tail is still in the stream buffer.
+		const socketCloseError = new Error("other side closed") as Error & {
+			code?: string;
+		};
+		socketCloseError.name = "SocketError";
+		socketCloseError.code = "UND_ERR_SOCKET";
+		const error = new TypeError("terminated", { cause: socketCloseError });
+
+		const bufferSnapshot =
+			'\n\r\n{\n  "error": {\n    "code": 503,\n    "message": "This model is currently experiencing high demand. Spikes in demand are usually temporary. Please try again later.",\n    "status": "UNAVAILABLE"\n  }\n}\n';
+
+		const normalized = normalizeStreamingError({
+			error,
+			provider: "google-ai-studio",
+			model: "gemini-3.7-flash",
+			bufferSnapshot,
+			phase: "upstream_read",
+		});
+
+		expect(normalized.terminated).toBe(true);
+		expect(normalized.client.message).toContain("high demand");
+		expect(normalized.client.details.statusCode).toBe(503);
+		expect(normalized.client.details.statusText).toBe(
+			"Upstream Stream Terminated",
+		);
+	});
+
+	it("keeps the scrubbed payload when a trailing error is redacted", () => {
+		const socketCloseError = new Error("other side closed") as Error & {
+			code?: string;
+		};
+		socketCloseError.name = "SocketError";
+		socketCloseError.code = "UND_ERR_SOCKET";
+		const error = new TypeError("terminated", { cause: socketCloseError });
+
+		const bufferSnapshot =
+			'{"error":{"code":503,"message":"SecretVendor is currently experiencing high demand.","status":"UNAVAILABLE"}}';
+
+		const normalized = normalizeStreamingError({
+			error,
+			provider: "tundra",
+			model: "kimi-k2.6",
+			bufferSnapshot,
+			phase: "upstream_read",
+			redact: true,
+		});
+
+		// The upstream status still classifies the failure, but the vendor's
+		// message never reaches the client.
+		expect(normalized.client.details.statusCode).toBe(503);
+		expect(normalized.client.message).toBe(redactedProviderErrorText(503));
+		const clientSerialized = JSON.stringify(normalized.client);
+		expect(clientSerialized).not.toContain("SecretVendor");
+		expect(normalized.log.details.bufferSnapshot).toBe(bufferSnapshot);
+	});
+
 	it("preserves generic streaming read errors with 500 classification", () => {
 		const error = new SyntaxError("Unexpected end of JSON input");
 

--- a/apps/gateway/src/chat/tools/normalize-streaming-error.ts
+++ b/apps/gateway/src/chat/tools/normalize-streaming-error.ts
@@ -1,6 +1,7 @@
 import { redactedProviderErrorText } from "@/lib/stealth-provider-errors.js";
 
 import { extractErrorCause } from "./extract-error-cause.js";
+import { parseTrailingUpstreamError } from "./parse-trailing-upstream-error.js";
 
 interface ErrorWithCode extends Error {
 	code?: string;
@@ -180,12 +181,32 @@ export function normalizeStreamingError(
 	const errorCode = getErrorCode(error);
 
 	const terminated = isUpstreamTermination(error);
-	const statusCode = terminated ? 502 : 500;
+	// A provider that sheds a stream (e.g. the Gemini API dropping Flex-tier
+	// capacity) may write one structured JSON error as a raw body tail before
+	// closing the socket. Surface that error's message and status instead of
+	// the generic termination text so callers see the real, retryable cause.
+	const trailingUpstreamError =
+		terminated && bufferSnapshot
+			? parseTrailingUpstreamError(bufferSnapshot)
+			: null;
+	const trailingStatusCode =
+		trailingUpstreamError &&
+		typeof trailingUpstreamError.code === "number" &&
+		trailingUpstreamError.code >= 400 &&
+		trailingUpstreamError.code <= 599
+			? trailingUpstreamError.code
+			: undefined;
+	const trailingMessage =
+		trailingUpstreamError && typeof trailingUpstreamError.message === "string"
+			? trailingUpstreamError.message
+			: undefined;
+	const statusCode = terminated ? (trailingStatusCode ?? 502) : 500;
 	const statusText = terminated
 		? "Upstream Stream Terminated"
 		: "Streaming Read Error";
 	const message = terminated
-		? "Upstream stream terminated unexpectedly before completion"
+		? (trailingMessage ??
+			"Upstream stream terminated unexpectedly before completion")
 		: `Streaming error: ${rawMessage}`;
 	const responseText = cause ? `${rawMessage} | cause: ${cause}` : rawMessage;
 

--- a/apps/gateway/src/chat/tools/parse-trailing-upstream-error.spec.ts
+++ b/apps/gateway/src/chat/tools/parse-trailing-upstream-error.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { parseTrailingUpstreamError } from "./parse-trailing-upstream-error.js";
+
+describe("parseTrailingUpstreamError", () => {
+	it("parses the Gemini Flex capacity-shed tail", () => {
+		const buffer =
+			'\n\r\n{\n  "error": {\n    "code": 503,\n    "message": "This model is currently experiencing high demand. Spikes in demand are usually temporary. Please try again later.",\n    "status": "UNAVAILABLE"\n  }\n}\n';
+		const error = parseTrailingUpstreamError(buffer);
+		expect(error).not.toBeNull();
+		expect(error?.code).toBe(503);
+		expect(error?.status).toBe("UNAVAILABLE");
+		expect(error?.message).toContain("high demand");
+	});
+
+	it("skips leftover SSE framing lines before the error tail", () => {
+		const buffer =
+			'\nid: 1\n\n\r\n{\n  "error": {\n    "code": 503,\n    "message": "This model is currently experiencing high demand.",\n    "status": "UNAVAILABLE"\n  }\n}\n';
+		const error = parseTrailingUpstreamError(buffer);
+		expect(error).not.toBeNull();
+		expect(error?.code).toBe(503);
+	});
+
+	it("returns null for whitespace-only buffers", () => {
+		expect(parseTrailingUpstreamError("")).toBeNull();
+		expect(parseTrailingUpstreamError("\n\r\n  ")).toBeNull();
+	});
+
+	it("returns null for a partial SSE frame", () => {
+		expect(
+			parseTrailingUpstreamError('data: {"choices":[{"delta":{"content":"hi'),
+		).toBeNull();
+	});
+
+	it("returns null for truncated JSON", () => {
+		expect(
+			parseTrailingUpstreamError('{"error":{"code":503,"message":"high dem'),
+		).toBeNull();
+	});
+
+	it("returns null for JSON without an error member", () => {
+		expect(parseTrailingUpstreamError('{"candidates":[]}')).toBeNull();
+	});
+
+	it("returns null when error.message is missing or empty", () => {
+		expect(parseTrailingUpstreamError('{"error":{"code":503}}')).toBeNull();
+		expect(
+			parseTrailingUpstreamError('{"error":{"code":503,"message":""}}'),
+		).toBeNull();
+	});
+
+	it("returns null when error is not an object", () => {
+		expect(parseTrailingUpstreamError('{"error":"boom"}')).toBeNull();
+		expect(parseTrailingUpstreamError('{"error":[1]}')).toBeNull();
+	});
+});

--- a/apps/gateway/src/chat/tools/parse-trailing-upstream-error.ts
+++ b/apps/gateway/src/chat/tools/parse-trailing-upstream-error.ts
@@ -1,0 +1,49 @@
+/**
+ * Parse an upstream error a provider wrote as a raw (non-SSE) JSON tail before
+ * closing a streaming response. The Gemini API sheds Flex-tier capacity this
+ * way mid-stream: an HTTP 200 SSE stream ends with a bare
+ * `{"error": {"code": 503, "message": "...", "status": "UNAVAILABLE"}}` body
+ * instead of a terminal data event, so the real cause sits unparsed in the
+ * gateway's leftover stream buffer.
+ *
+ * Returns the `error` object only when everything after the buffer's last SSE
+ * event separator (blank line) is exactly one complete JSON object carrying an
+ * object `error` member with a non-empty string `message`. Partial SSE frames,
+ * truncated JSON, or any other tail shape yields null so callers fall back to
+ * the generic truncation error.
+ */
+export function parseTrailingUpstreamError(
+	buffer: string,
+): Record<string, unknown> | null {
+	// The leftover buffer may still hold trailing lines of the last consumed
+	// SSE frame (e.g. "\nid: 1\n\n") ahead of the raw error tail — everything
+	// before the final blank-line separator belongs to SSE framing, not to the
+	// provider's closing error body.
+	let tail = buffer;
+	const separators = buffer.matchAll(/\r?\n\r?\n/g);
+	for (const separator of separators) {
+		tail = buffer.slice(separator.index + separator[0].length);
+	}
+	const trimmed = tail.trim();
+	if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+		return null;
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(trimmed);
+	} catch {
+		return null;
+	}
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		return null;
+	}
+	const error = (parsed as { error?: unknown }).error;
+	if (!error || typeof error !== "object" || Array.isArray(error)) {
+		return null;
+	}
+	const message = (error as { message?: unknown }).message;
+	if (typeof message !== "string" || message.length === 0) {
+		return null;
+	}
+	return error as Record<string, unknown>;
+}

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -920,6 +920,10 @@ mockOpenAIServer.post("/v1/chat/completions", async (c) => {
 		chatMessages,
 		"TRIGGER_TRUNCATED_STREAM",
 	);
+	const shouldEndWithTrailingError = hasUserMessageTrigger(
+		chatMessages,
+		"TRIGGER_STREAM_TRAILING_ERROR",
+	);
 	const shouldFinishWithoutDone = hasUserMessageTrigger(
 		chatMessages,
 		"TRIGGER_FINISH_WITHOUT_DONE",
@@ -1125,6 +1129,16 @@ mockOpenAIServer.post("/v1/chat/completions", async (c) => {
 			}
 
 			if (shouldTruncateStream) {
+				return;
+			}
+
+			// Mimic the Gemini API shedding Flex capacity mid-stream: a raw JSON
+			// error body tail (not an SSE event), then the stream closes without a
+			// finish reason or [DONE].
+			if (shouldEndWithTrailingError) {
+				await stream.write(
+					'\r\n{\n  "error": {\n    "code": 503,\n    "message": "This model is currently experiencing high demand. Spikes in demand are usually temporary. Please try again later.",\n    "status": "UNAVAILABLE"\n  }\n}\n',
+				);
 				return;
 			}
 


### PR DESCRIPTION
## Problem

The Gemini API sheds Flex-tier capacity **mid-stream**: an HTTP 200 SSE stream stops after a few chunks and the connection closes with a raw (non-SSE) JSON error tail in the body:

```
{
  "error": {
    "code": 503,
    "message": "This model is currently experiencing high demand. Spikes in demand are usually temporary. Please try again later.",
    "status": "UNAVAILABLE"
  }
}
```

Because that tail never forms a complete SSE event, it sat unparsed in the gateway's stream buffer, and every such request surfaced as the generic:

```
Upstream stream terminated unexpectedly before completion
```

with the real cause buried inside `responseText`. On `gemini-3.7-flash` this is currently very visible: launch-week demand means Flex requests (including DevPass orgs with the Flex default tier) are shed a large fraction of the time, and Flex routes exclusively to `google-ai-studio` (Vertex rejects Flex for this model), so there is no fallback mapping to absorb it — the caller just sees the cryptic truncation error on every shed.

## Fix

- New `parseTrailingUpstreamError` helper: strictly parses the leftover stream buffer (everything after the last SSE event separator) as a single complete JSON object with an `error.message`; anything else returns null and keeps today's behavior.
- The "stream ended without terminal event" branch in `chat.ts` now surfaces the parsed error's message, status code and code (`UNAVAILABLE`) instead of the generic truncation text, so clients see the actual retryable 503 cause. Logs get the real status code too.
- `normalizeStreamingError` does the same for the abrupt-socket-close variant (`terminated: other side closed`), where the tail can also be fully buffered.
- `inferStreamingErrorStatusCode` now honors Google-style numeric `code` fields, but only in the 400–599 HTTP range (other providers use numeric codes for internal catalogues).
- Stealth providers keep full redaction: only the gateway-derived status reaches the client; the raw tail still feeds the internal-only log columns.

Client-visible result on a shed Flex stream, before → after:

```
"Upstream stream terminated unexpectedly before completion" (code stream_truncated, 502)
→ "This model is currently experiencing high demand. Spikes in demand are usually temporary. Please try again later." (code UNAVAILABLE, 503)
```

## Verification

- Reproduced live against the Gemini API: Flex on `gemini-3.7-flash` is shed both as upfront HTTP 503s and as mid-stream 200s ending in the JSON tail above; through a local gateway with this change, shed streams now emit the upstream 503 message/code (verified on several live sheds), and successful Flex streams are unaffected.
- New unit specs for `parseTrailingUpstreamError` (tail shapes, partial frames, truncated JSON) and `normalizeStreamingError` (termination with tail, redacted termination with tail).
- New integration test with a mock-server trigger (`TRIGGER_STREAM_TRAILING_ERROR`) reproducing the exact byte shape: content chunk, raw JSON tail, close without finish reason or `[DONE]`.
- `pnpm test:unit` — 287 files, 4773 passed. `pnpm build` and `pnpm format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5jB8iAZUuMvLJxcA6DMvZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of streaming responses that end with an upstream error.
  - Preserves meaningful error statuses, codes, and messages instead of showing a generic gateway error.
  - Ensures partial streamed content remains available alongside the reported error.
  - Redacts provider-sensitive details when appropriate while retaining diagnostic information internally.
  - Improved handling of malformed or incomplete trailing error data without disrupting existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->