### PR TITLE
feat(seo): apply August SEO + AI-SEO audit fixes

### DIFF
--- a/apps/code/public/llms.txt
+++ b/apps/code/public/llms.txt
@@ -8,6 +8,7 @@
 - Pro: $79/month — includes $237 of model usage.
 - Max: $179/month — includes $537 of model usage.
 - Every plan includes the newest frontier models as they are released and full cost tracking.
+- First-month guarantee: refund yourself from the dashboard within 14 days if you've used less than 20% of your monthly allowance.
 
 ## Key pages
 

--- a/apps/docs/content/index.mdx
+++ b/apps/docs/content/index.mdx
@@ -9,6 +9,17 @@ import { AIToolingCards } from "@/components/ai-tooling-cards";
 
 LLM Gateway is an open-source API gateway that sits between your applications and LLM providers like OpenAI, Anthropic, Google AI Studio, and more. It provides a unified, OpenAI-compatible API interface with built-in cost tracking, caching, and intelligent routing.
 
+## How it works
+
+Point your existing SDK at `https://api.llmgateway.io/v1` (or your self-hosted instance) and authenticate with an LLM Gateway API key — no code rewrites. The gateway routes each request to the right provider, tracks tokens and cost per model, provider, project, and API key, and fails over to a healthy provider when one errors. Pay per-token with prepaid credits at provider list rates, or bring your own provider keys (BYOK) for free.
+
+## Why use a gateway?
+
+- **One integration** — switch models or providers by changing a model string, not your code.
+- **Cost visibility** — usage analytics and cost breakdowns across every provider in one dashboard.
+- **Reliability** — automatic provider failover and response caching in front of every request.
+- **No lock-in** — open source (AGPLv3), self-hostable, and OpenAI-compatible end to end.
+
 ## Features
 
 <FeatureCards />

--- a/apps/playground/public/llms.txt
+++ b/apps/playground/public/llms.txt
@@ -1,19 +1,20 @@
-# LLM Gateway Chat
+# Lounge by LLM Gateway
 
-> LLM Gateway Chat (lounge.llmgateway.io) is an AI chat playground for talking to 200+ models from OpenAI, Anthropic, Google, xAI, DeepSeek, Meta, Mistral, and other providers in one place. It supports text chat, image and video generation, side-by-side multi-model group chats, and projects with knowledge files — on transparent provider-rate credits.
+> Lounge (lounge.llmgateway.io) is the members' lounge for AI: chat with 200+ models from OpenAI, Anthropic, Google, xAI, DeepSeek, Meta, Mistral, and other providers in one place. It supports text chat, image and video generation, side-by-side multi-model group chats, and projects with knowledge files — every frontier model, one membership.
 
-## Plans
+## Memberships
 
 - Starter: $9/month.
 - Plus: $19/month.
 - Pro: $49/month.
-- All plans are billed monthly and include a monthly credit allowance usable across every model; free to start with no credit card.
+- All memberships are billed monthly and include a monthly credit allowance usable across every model; free to start with no credit card.
+- First-month guarantee: refund yourself from the billing page within 14 days if you've used less than 20% of your allowance.
 
 ## Key pages
 
-- [Chat](https://lounge.llmgateway.io): The chat playground.
+- [Lounge](https://lounge.llmgateway.io): The members' lounge for AI.
 - [Models](https://llmgateway.io/models): Every supported model with pricing and capabilities.
-- [LLM Gateway](https://llmgateway.io): The open-source gateway platform behind Chat.
+- [LLM Gateway](https://llmgateway.io): The open-source gateway platform behind Lounge.
 - [Pricing (machine-readable)](https://llmgateway.io/pricing.md): Plain-markdown pricing for the whole platform.
 
 ## Notes

--- a/apps/ui/public/pricing.md
+++ b/apps/ui/public/pricing.md
@@ -1,6 +1,6 @@
 # LLM Gateway — Pricing
 
-Last updated: 2026-07-10
+Last updated: 2026-08-15
 
 > One OpenAI-compatible API for 200+ models across 40+ providers. Per-token prices match each provider's published rates; LLM Gateway charges a flat 5% platform fee when you buy credits. Bringing your own provider keys is free, and self-hosting is free under AGPLv3.
 
@@ -24,6 +24,11 @@ Last updated: 2026-07-10
 
 - Price: custom — volume discounts, custom routing, unlimited data retention, 99.9% uptime SLA.
 - Details: https://llmgateway.io/enterprise — contact contact@llmgateway.io
+
+## Refunds
+
+- Self-serve, no support ticket: refund a purchase from the billing dashboard within 14 days while less than 20% of it has been used.
+- Applies to credit top-ups, DevPass plan payments, and Lounge memberships. DevPass Reset Passes: within 7 days, while the pass is unused.
 
 ## Related products
 

--- a/apps/ui/src/app/timeline/page.tsx
+++ b/apps/ui/src/app/timeline/page.tsx
@@ -41,15 +41,16 @@ function buildMonthMeta(month: TimelineMonthSummary | null): {
 		return { title: FALLBACK_TITLE, description: FALLBACK_DESCRIPTION };
 	}
 	const count = month.models.length;
+	// Two names keep the description under 160 chars even with long model names.
 	const names = month.models
-		.slice(0, 3)
+		.slice(0, 2)
 		.map((model) => model.name)
 		.join(", ");
 	return {
 		title: `New AI Model Releases — ${month.label} Timeline`,
 		description: `${count} AI model${count === 1 ? "" : "s"} released in ${
 			month.label
-		}${month.isCurrentMonth ? " so far" : ""} — ${names} — plus release dates for every major LLM: GPT, Claude, Gemini, DeepSeek and more. Updated daily.`,
+		}${month.isCurrentMonth ? " so far" : ""} — ${names} — plus every major LLM release date. Updated daily.`,
 	};
 }
 

--- a/apps/ui/src/components/pricing/pricing-faq.tsx
+++ b/apps/ui/src/components/pricing/pricing-faq.tsx
@@ -2,7 +2,11 @@ import Link from "next/link";
 
 import { JsonLd } from "@/components/seo/json-ld";
 
-import { MARKETING_STATS } from "@llmgateway/shared";
+import {
+	MARKETING_STATS,
+	SELF_REFUND_USAGE_PERCENT,
+	SELF_REFUND_WINDOW_DAYS,
+} from "@llmgateway/shared";
 
 interface PricingFaqItem {
 	question: string;
@@ -45,6 +49,10 @@ const FAQ_ITEMS: PricingFaqItem[] = [
 		question: "What does the Enterprise plan include?",
 		answer: `Enterprise adds volume discounts, custom routing, unlimited data retention, and a ${MARKETING_STATS.uptimeSla} uptime SLA on top of everything in the free plan.`,
 		links: [{ href: "/enterprise", label: "Explore Enterprise" }],
+	},
+	{
+		question: "Can I get a refund?",
+		answer: `Yes — refunds are self-serve. If you've used less than ${SELF_REFUND_USAGE_PERCENT}% of a credit purchase, open Billing in your dashboard and hit Refund on the charge within ${SELF_REFUND_WINDOW_DAYS} days of buying: the money goes back to your card, no support ticket needed.`,
 	},
 	{
 		question: "Can I self-host LLM Gateway?",


### PR DESCRIPTION
## Problem

The August manual run of the monthly SEO / AI-SEO audit surfaced a few gaps:

- The Lounge `llms.txt` still opened with "LLM Gateway Chat" / "AI chat playground", so AI engines ingesting it would cite the product under its pre-rebrand name.
- The new self-serve refund policy was answered in the DevPass FAQs but nowhere on the platform pricing surfaces — "can I get a refund" is a high-intent query for both people and buying agents.
- The `/timeline` meta description rendered at 199 chars (truncates in SERPs).
- The docs landing page was thin (~475 visible words) for the page that answers "what is LLM Gateway".

## Changes

- `apps/playground/public/llms.txt` — rebrand to "Lounge by LLM Gateway", membership vocabulary, and a first-month-guarantee line.
- `apps/ui/src/components/pricing/pricing-faq.tsx` — new "Can I get a refund?" entry (also emitted in the FAQPage JSON-LD), quoting `SELF_REFUND_USAGE_PERCENT` / `SELF_REFUND_WINDOW_DAYS` from `@llmgateway/shared` so the copy can't drift from what the endpoint enforces.
- `apps/ui/public/pricing.md` — new Refunds section covering credits, DevPass, Lounge, and Reset Passes; bumped the Last-updated date.
- `apps/code/public/llms.txt` — first-month-guarantee line under Plans.
- `apps/ui/src/app/timeline/page.tsx` — month meta description now lists 2 model names with a shorter tail (~130 chars for August data, ≤160 worst case).
- `apps/docs/content/index.mdx` — added "How it works" and "Why use a gateway?" sections; this also flows into `llms.txt` / `llms-full.txt`.

## Verification

- `pnpm format` and full `pnpm build` pass.
- Refund copy cross-checked against `computeSelfRefundEligibility` in `apps/api/src/lib/self-refund.ts` (14-day window, <20% usage, 7-day unused window for Reset Passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5jB8iAZUuMvLJxcA6DMvZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a 14-day first-month refund guarantee for eligible purchases with usage below 20%.
  - Added self-service refund guidance for credit top-ups, memberships, DevPass payments, and unused reset passes.
  - Added “How it works” and “Why use a gateway?” documentation covering routing, tracking, failover, caching, credits, BYOK, and self-hosting.
  - Updated Lounge messaging to reflect its membership-focused experience.

- **Documentation**
  - Clarified pricing, refund eligibility, gateway benefits, and timeline descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->