### PR TITLE
fix(models): pin DeepSeek V4 Pro to 0813 snapshot

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -345,7 +345,7 @@ export const deepseekModels = [
 			},
 			{
 				providerId: "alibaba",
-				externalId: "deepseek-v4-pro",
+				externalId: "deepseek-v4-pro-0813",
 				inputPrice: "2.4e-6",
 				cachedInputPrice: "0.2e-6",
 				outputPrice: "4.8e-6",


### PR DESCRIPTION
## Summary
- Alibaba published a new dated snapshot of `deepseek-v4-pro` (`deepseek-v4-pro-0813`)
- Pin the Alibaba provider mapping's `externalId` to the dated snapshot instead of the floating alias, so routing stays on a fixed deployment

## Test plan
- [x] `pnpm format`
- [x] `pnpm build`
- [x] Verified `deepseek-v4-pro-0813` directly against Alibaba's DashScope API: plain completion, thinking-disabled mode, and `tool_choice: "required"` all behave the same as the previous alias (no capability drift, pricing unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Alibaba DeepSeek V4 Pro model identifier to ensure requests target the correct model version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->