### PR TITLE
feat(content): add conversion rail and FAQ schema

### DIFF
--- a/apps/ui/content-collections.ts
+++ b/apps/ui/content-collections.ts
@@ -34,6 +34,10 @@ const blog = defineCollection({
 		summary: z.string(),
 		draft: z.boolean().optional(),
 		categories: z.array(z.string()).default([]),
+		// Catalogue id of the model a post is specifically about, so the
+		// conversion rail can send the reader to that model instead of the
+		// full catalogue.
+		model: z.string().optional(),
 		faqs: z
 			.array(
 				z.object({

--- a/apps/ui/src/app/blog/[slug]/page.tsx
+++ b/apps/ui/src/app/blog/[slug]/page.tsx
@@ -15,6 +15,21 @@ import { CopyMarkdownButton } from "./copy-markdown-button";
 import type { Blog } from "content-collections";
 import type { Metadata } from "next";
 
+/**
+ * The rendered page appends the `faqs` frontmatter as its own section, so the
+ * copied markdown has to do the same — otherwise "copy as markdown" silently
+ * drops the Q&A that is visible on the page.
+ */
+function markdownWithFaqs(entry: Blog): string {
+	if (!entry.faqs.length) {
+		return entry.content;
+	}
+	const section = entry.faqs
+		.map((faq) => `### ${faq.question}\n\n${faq.answer}`)
+		.join("\n\n");
+	return `${entry.content.trimEnd()}\n\n## Frequently asked questions\n\n${section}\n`;
+}
+
 interface BlogEntryPageProps {
 	params: Promise<{ slug: string }>;
 }
@@ -144,7 +159,7 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
 								<ArrowLeftIcon className="mr-2 h-4 w-4" />
 								Back to blog
 							</Link>
-							<CopyMarkdownButton content={entry.content} />
+							<CopyMarkdownButton content={markdownWithFaqs(entry)} />
 						</div>
 
 						<article className="prose prose-lg dark:prose-invert max-w-none">

--- a/apps/ui/src/app/blog/[slug]/page.tsx
+++ b/apps/ui/src/app/blog/[slug]/page.tsx
@@ -4,9 +4,11 @@ import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { ContentConversionRail } from "@/components/content-conversion-rail";
 import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 import { getMarkdownOptions } from "@/lib/utils/markdown";
+import { plainTextFromMarkdown } from "@/lib/utils/plain-text";
 
 import { CopyMarkdownButton } from "./copy-markdown-button";
 
@@ -72,7 +74,10 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
 				mainEntity: entry.faqs.map((faq) => ({
 					"@type": "Question",
 					name: faq.question,
-					acceptedAnswer: { "@type": "Answer", text: faq.answer },
+					acceptedAnswer: {
+						"@type": "Answer",
+						text: plainTextFromMarkdown(faq.answer),
+					},
 				})),
 			}
 		: null;
@@ -206,7 +211,12 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
 													{faq.question}
 												</dt>
 												<dd className="mt-2 leading-relaxed text-muted-foreground">
-													{faq.answer}
+													{/* Answers carry the same inline links and code spans
+													    the body copy does, so they render as markdown
+													    rather than escaping to literal syntax. */}
+													<Markdown options={getMarkdownOptions()}>
+														{faq.answer}
+													</Markdown>
 												</dd>
 											</div>
 										))}
@@ -218,6 +228,15 @@ export default async function BlogEntryPage({ params }: BlogEntryPageProps) {
 				</main>
 				<Footer />
 			</div>
+			<ContentConversionRail
+				surface="blog"
+				// Follow whichever offer the post's inline cards already make, so the
+				// rail reinforces them instead of competing.
+				variant={
+					entry.content.includes('variant="devpass"') ? "devpass" : "gateway"
+				}
+				model={entry.model}
+			/>
 		</>
 	);
 }

--- a/apps/ui/src/app/guides/[slug]/page.tsx
+++ b/apps/ui/src/app/guides/[slug]/page.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { ContentConversionRail } from "@/components/content-conversion-rail";
 import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
 import { getMarkdownOptions } from "@/lib/utils/markdown";
@@ -153,6 +154,9 @@ export default async function GuidePage({ params }: GuidePageProps) {
 				</main>
 				<Footer />
 			</div>
+			{/* Integration guides are read by people wiring up a coding agent, so
+			    the flat-rate plan is the relevant offer. */}
+			<ContentConversionRail surface="guide" variant="devpass" />
 		</>
 	);
 }

--- a/apps/ui/src/app/timeline/page.tsx
+++ b/apps/ui/src/app/timeline/page.tsx
@@ -1,6 +1,7 @@
 import { ArrowRight, ArrowUpRight, Sparkles } from "lucide-react";
 import Link from "next/link";
 
+import { ContentConversionRail } from "@/components/content-conversion-rail";
 import Footer from "@/components/landing/footer";
 import { Navbar } from "@/components/landing/navbar";
 import { ModelCard } from "@/components/timeline/timeline-parts";
@@ -467,6 +468,7 @@ export default async function TimelinePage() {
 			</main>
 
 			<Footer />
+			<ContentConversionRail surface="timeline" variant="gateway" />
 		</>
 	);
 }

--- a/apps/ui/src/app/timeline/page.tsx
+++ b/apps/ui/src/app/timeline/page.tsx
@@ -438,7 +438,10 @@ export default async function TimelinePage() {
 
 				<section className="border-t border-border/60">
 					<div className="container mx-auto px-4 py-14 md:py-20">
-						<div className="mx-auto flex max-w-3xl flex-col items-center gap-5 rounded-2xl border border-border/70 bg-card/50 px-6 py-10 text-center backdrop-blur md:py-12">
+						<div
+							data-inline-cta
+							className="mx-auto flex max-w-3xl flex-col items-center gap-5 rounded-2xl border border-border/70 bg-card/50 px-6 py-10 text-center backdrop-blur md:py-12"
+						>
 							<h2 className="font-display text-2xl font-bold tracking-tight text-balance md:text-3xl">
 								Route to any of these models with one API
 							</h2>

--- a/apps/ui/src/components/blog/blog-cta.tsx
+++ b/apps/ui/src/components/blog/blog-cta.tsx
@@ -30,7 +30,10 @@ export function BlogCta({
 
 	if (variant === "enterprise") {
 		return (
-			<div className="not-prose my-10 rounded-xl border bg-muted/30 p-6 sm:p-8">
+			<div
+				data-blog-cta
+				className="not-prose my-10 rounded-xl border bg-muted/30 p-6 sm:p-8"
+			>
 				<div className="font-mono text-[10px] uppercase tracking-[0.35em] text-muted-foreground">
 					LLM Gateway · Enterprise
 				</div>
@@ -69,7 +72,10 @@ export function BlogCta({
 
 	if (variant === "gateway") {
 		return (
-			<div className="not-prose my-10 rounded-xl border bg-muted/30 p-6 sm:p-8">
+			<div
+				data-blog-cta
+				className="not-prose my-10 rounded-xl border bg-muted/30 p-6 sm:p-8"
+			>
 				<div className="font-mono text-[10px] uppercase tracking-[0.35em] text-muted-foreground">
 					LLM Gateway
 				</div>
@@ -107,7 +113,10 @@ export function BlogCta({
 	}
 
 	return (
-		<div className="not-prose relative my-10 overflow-hidden rounded-xl border border-dashed border-stone-400/70 bg-stone-50/70 dark:border-stone-600/70 dark:bg-stone-900/30">
+		<div
+			data-blog-cta
+			className="not-prose relative my-10 overflow-hidden rounded-xl border border-dashed border-stone-400/70 bg-stone-50/70 dark:border-stone-600/70 dark:bg-stone-900/30"
+		>
 			<div className="p-6 sm:p-8">
 				<div className="flex flex-wrap items-baseline justify-between gap-2">
 					<div className="font-mono text-[10px] uppercase tracking-[0.35em] text-stone-500 dark:text-stone-400">

--- a/apps/ui/src/components/blog/blog-cta.tsx
+++ b/apps/ui/src/components/blog/blog-cta.tsx
@@ -31,7 +31,7 @@ export function BlogCta({
 	if (variant === "enterprise") {
 		return (
 			<div
-				data-blog-cta
+				data-inline-cta
 				className="not-prose my-10 rounded-xl border bg-muted/30 p-6 sm:p-8"
 			>
 				<div className="font-mono text-[10px] uppercase tracking-[0.35em] text-muted-foreground">
@@ -73,7 +73,7 @@ export function BlogCta({
 	if (variant === "gateway") {
 		return (
 			<div
-				data-blog-cta
+				data-inline-cta
 				className="not-prose my-10 rounded-xl border bg-muted/30 p-6 sm:p-8"
 			>
 				<div className="font-mono text-[10px] uppercase tracking-[0.35em] text-muted-foreground">
@@ -114,7 +114,7 @@ export function BlogCta({
 
 	return (
 		<div
-			data-blog-cta
+			data-inline-cta
 			className="not-prose relative my-10 overflow-hidden rounded-xl border border-dashed border-stone-400/70 bg-stone-50/70 dark:border-stone-600/70 dark:bg-stone-900/30"
 		>
 			<div className="p-6 sm:p-8">

--- a/apps/ui/src/components/content-conversion-rail.tsx
+++ b/apps/ui/src/components/content-conversion-rail.tsx
@@ -65,10 +65,11 @@ export function ContentConversionRail({
 		return () => window.removeEventListener("scroll", onScroll);
 	}, [dismissed]);
 
-	// Stand down while an inline BlogCta is on screen — two offers competing in
-	// the same viewport reads as pressure, and the card is the better one.
+	// Stand down while any inline offer is on screen — a blog card, or the
+	// timeline's own CTA block. Two offers competing in the same viewport reads
+	// as pressure, and the inline one is the better of the two.
 	useEffect(() => {
-		const cards = document.querySelectorAll("[data-blog-cta]");
+		const cards = document.querySelectorAll("[data-inline-cta]");
 		if (!cards.length || typeof IntersectionObserver === "undefined") {
 			return;
 		}

--- a/apps/ui/src/components/content-conversion-rail.tsx
+++ b/apps/ui/src/components/content-conversion-rail.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { ArrowRight, X } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { usePostHog } from "posthog-js/react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+type RailVariant = "devpass" | "gateway";
+
+interface ContentConversionRailProps {
+	/** Which offer to stand behind. Coding-agent content gets DevPass. */
+	variant?: RailVariant;
+	/** Surface name for analytics — "blog", "guide", "timeline". */
+	surface: string;
+	/**
+	 * Model slug to deep-link when the reader is on a page about one specific
+	 * model. Falls back to the full catalogue.
+	 */
+	model?: string;
+}
+
+const DISMISS_KEY = "llmgateway-rail-dismissed";
+
+// Reveal once the reader is past the opening, so the rail reads as a follow-up
+// rather than an interstitial on arrival.
+const REVEAL_AT = 0.28;
+
+export function ContentConversionRail({
+	variant = "gateway",
+	surface,
+	model,
+}: ContentConversionRailProps) {
+	const posthog = usePostHog();
+	const pathname = usePathname();
+	const [visible, setVisible] = useState(false);
+	const [dismissed, setDismissed] = useState(true);
+	const [cardOnScreen, setCardOnScreen] = useState(false);
+	const shownRef = useRef(false);
+
+	// Read the dismissal after mount so the server and client markup agree.
+	useEffect(() => {
+		try {
+			setDismissed(localStorage.getItem(DISMISS_KEY) === "1");
+		} catch {
+			setDismissed(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		if (dismissed) {
+			return;
+		}
+		const onScroll = () => {
+			const scrollable = document.body.scrollHeight - window.innerHeight;
+			if (scrollable <= 0) {
+				return;
+			}
+			setVisible(window.scrollY / scrollable >= REVEAL_AT);
+		};
+		onScroll();
+		window.addEventListener("scroll", onScroll, { passive: true });
+		return () => window.removeEventListener("scroll", onScroll);
+	}, [dismissed]);
+
+	// Stand down while an inline BlogCta is on screen — two offers competing in
+	// the same viewport reads as pressure, and the card is the better one.
+	useEffect(() => {
+		const cards = document.querySelectorAll("[data-blog-cta]");
+		if (!cards.length || typeof IntersectionObserver === "undefined") {
+			return;
+		}
+		const seen = new Set<Element>();
+		const observer = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					if (entry.isIntersecting) {
+						seen.add(entry.target);
+					} else {
+						seen.delete(entry.target);
+					}
+				}
+				setCardOnScreen(seen.size > 0);
+			},
+			{ rootMargin: "-10% 0px" },
+		);
+		cards.forEach((card) => observer.observe(card));
+		return () => observer.disconnect();
+	}, []);
+
+	const showing = visible && !dismissed && !cardOnScreen;
+
+	useEffect(() => {
+		if (showing && !shownRef.current) {
+			shownRef.current = true;
+			posthog.capture("conversion_rail_shown", { surface, variant });
+		}
+	}, [showing, posthog, surface, variant]);
+
+	const dismiss = useCallback(() => {
+		setDismissed(true);
+		try {
+			localStorage.setItem(DISMISS_KEY, "1");
+		} catch {
+			// A blocked storage write only costs us the persistence.
+		}
+		posthog.capture("conversion_rail_dismissed", { surface, variant });
+	}, [posthog, surface, variant]);
+
+	const track = (cta: string) => {
+		posthog.capture("cta_clicked", {
+			location: `rail_${surface}`,
+			cta,
+			variant,
+			path: pathname,
+		});
+	};
+
+	const isDevPass = variant === "devpass";
+	const href = isDevPass
+		? "https://devpass.llmgateway.io/pricing?utm_source=content&utm_medium=rail"
+		: model
+			? `/models/${model}`
+			: "/models";
+
+	return (
+		<div
+			aria-hidden={!showing}
+			inert={!showing || undefined}
+			className={cn(
+				"pointer-events-none fixed inset-x-0 bottom-0 z-40 flex justify-center pb-3 sm:pb-4",
+				// Extra right inset on small screens keeps the card clear of the
+				// floating support bubble, which otherwise covers the dismiss button.
+				"pl-3 pr-16 sm:px-3",
+				"transition-[opacity,transform] duration-300 ease-out motion-reduce:transition-none",
+				showing
+					? "translate-y-0 opacity-100"
+					: "pointer-events-none translate-y-3 opacity-0",
+			)}
+		>
+			<div
+				className={cn(
+					"pointer-events-auto flex w-full max-w-2xl items-center gap-3 rounded-xl px-3 py-2.5 sm:gap-4 sm:px-4",
+					"border border-dashed border-stone-400/70 bg-stone-50/90 backdrop-blur",
+					"shadow-[0_8px_30px_-12px_rgba(0,0,0,0.35)]",
+					"dark:border-stone-600/70 dark:bg-stone-900/90",
+				)}
+			>
+				<div className="min-w-0 flex-1">
+					{/* The eyebrow is a nicety on desktop and a space tax on a phone. */}
+					<div className="hidden font-mono text-[9px] uppercase tracking-[0.3em] text-stone-500 sm:block dark:text-stone-400">
+						{isDevPass ? "DevPass" : "LLM Gateway"}
+					</div>
+					<p className="truncate text-[13px] font-medium leading-snug text-foreground sm:mt-0.5 sm:text-sm">
+						{isDevPass ? "Every model, one flat rate" : "One key, every model"}
+					</p>
+				</div>
+
+				{/* Perforation, echoing the boarding-pass card this follows. */}
+				<div
+					aria-hidden
+					className="hidden h-8 w-px shrink-0 border-l border-dashed border-stone-400/70 dark:border-stone-600/70 sm:block"
+				/>
+
+				<Link
+					href={href}
+					prefetch={isDevPass ? undefined : true}
+					onClick={() => track(isDevPass ? "get_devpass" : "browse_models")}
+					className={cn(
+						"group/rail inline-flex shrink-0 items-center gap-1.5 rounded-lg px-3 py-1.5",
+						"bg-zinc-900 text-[13px] font-medium text-white transition-colors hover:bg-zinc-700",
+						"dark:bg-white dark:text-black dark:hover:bg-zinc-200",
+					)}
+				>
+					<span className="sm:hidden">{isDevPass ? "Plans" : "Models"}</span>
+					<span className="hidden sm:inline">
+						{isDevPass
+							? "See plans"
+							: model
+								? "Try this model"
+								: "Browse models"}
+					</span>
+					<ArrowRight className="h-3.5 w-3.5 transition-transform duration-200 ease-out group-hover/rail:translate-x-0.5 motion-reduce:transition-none" />
+				</Link>
+
+				<button
+					type="button"
+					onClick={dismiss}
+					aria-label="Dismiss"
+					className="shrink-0 rounded-md p-1 text-stone-500 transition-colors hover:bg-stone-200/70 hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current dark:text-stone-400 dark:hover:bg-stone-800"
+				>
+					<X className="h-4 w-4" />
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/apps/ui/src/components/providers.tsx
+++ b/apps/ui/src/components/providers.tsx
@@ -11,6 +11,7 @@ import { Toaster as SonnerToaster } from "sonner";
 
 import { ReferralHandler } from "@/components/referral-handler";
 import { SignupMethodTracker } from "@/components/signup-method-tracker";
+import { classifyChannel } from "@/lib/attribution";
 import { Toaster } from "@/lib/components/toaster";
 import { toast } from "@/lib/components/use-toast";
 import { AppConfigProvider } from "@/lib/config";
@@ -90,6 +91,17 @@ export function Providers({ children, config }: ProvidersProps) {
 				ui_host: host,
 				capture_pageview: "history_change",
 				autocapture: true,
+			});
+			const channel = classifyChannel(
+				document.referrer,
+				window.location.search,
+				window.location.hostname,
+			);
+			// On every event so it can segment behaviour, and set-once on the
+			// person so the first touch survives later visits.
+			posthog.register({ acquisition_channel: channel });
+			posthog.setPersonProperties(undefined, {
+				initial_acquisition_channel: channel,
 			});
 			setPosthogReady(true);
 		};

--- a/apps/ui/src/components/timeline/timeline-parts.tsx
+++ b/apps/ui/src/components/timeline/timeline-parts.tsx
@@ -105,7 +105,7 @@ export function ModelCard({ model, latestReleasedAt }: ModelCardProps) {
 						href={`/models/${encodeURIComponent(model.id)}`}
 						className="inline-flex items-center gap-1 text-xs font-medium"
 					>
-						View model details
+						Pricing, providers &amp; uptime
 						<ArrowUpRight className="h-3 w-3" />
 					</Link>
 				</Button>

--- a/apps/ui/src/content/blog/2026-06-18-api-key-rotation.md
+++ b/apps/ui/src/content/blog/2026-06-18-api-key-rotation.md
@@ -5,6 +5,13 @@ date: 2026-06-18
 title: "API Key Rotation: How We Secure Your API Keys"
 summary: "Rotating API keys shouldn't cause service interruption for production AI. Learn how LLM Gateway enables secure key rotation for both providers and the gateway."
 categories: ["Guides", "Engineering"]
+faqs:
+  - question: "Why should you rotate API keys?"
+    answer: "Rotating API keys regularly limits the window of opportunity for attackers if a key is silently leaked. It is also a core security control required to achieve and maintain compliance certifications like SOC 2 Type II or ISO 27001."
+  - question: "Can I rotate provider keys without redeploying my app?"
+    answer: "Yes. When using LLM Gateway in Bring Your Own Key (BYOK) mode, you update your OpenAI or Anthropic key once in the LLM Gateway dashboard. Since your applications only talk to the gateway, they require no code changes or redeployments."
+  - question: "How do I automate key rotation?"
+    answer: "You can use short-lived API keys with a configured Time-to-Live (TTL) expiration. In LLM Gateway, you can set keys to automatically expire after a set number of minutes, hours, or days—ideal for CI/CD runs, staging environments, or external contractors."
 image:
   src: "/blog/api-key-rotation.png"
   alt: "Secure API key rotation with LLM Gateway"
@@ -147,22 +154,6 @@ To keep your AI infrastructure secure, follow these principles:
 2. **Apply IAM Rules:** Narrow the scope of your keys. If a service only needs to run translation tasks using `gemini-2.5-flash`, configure an IAM rule on that key denying access to all other models. If the key is leaked, the exposure is limited.
 3. **Set Recurring Budgets:** Configure a spend limit (e.g., `$10 / day` or `$500 / month`) directly on the API key. If a developer runs an infinite loop or a key is compromised, the gateway will block requests before you receive a surprise bill.
 4. **Audit Key Activity:** Check the **Audit Logs** to see who created, modified, or deleted keys, and watch the **Security Events** log for key authentication failures or rate limit violations.
-
----
-
-## Frequently Asked Questions
-
-### Why should you rotate API keys?
-
-Rotating API keys regularly limits the window of opportunity for attackers if a key is silently leaked. It is also a core security control required to achieve and maintain compliance certifications like SOC 2 Type II or ISO 27001.
-
-### Can I rotate provider keys without redeploying my app?
-
-Yes. When using LLM Gateway in Bring Your Own Key (BYOK) mode, you update your OpenAI or Anthropic key once in the LLM Gateway dashboard. Since your applications only talk to the gateway, they require no code changes or redeployments.
-
-### How do I automate key rotation?
-
-You can use short-lived API keys with a configured Time-to-Live (TTL) expiration. In LLM Gateway, you can set keys to automatically expire after a set number of minutes, hours, or days—ideal for CI/CD runs, staging environments, or external contractors.
 
 ---
 

--- a/apps/ui/src/content/blog/2026-06-22-best-chatgpt-alternatives.md
+++ b/apps/ui/src/content/blog/2026-06-22-best-chatgpt-alternatives.md
@@ -5,6 +5,15 @@ date: "2026-06-22"
 title: "10 Best ChatGPT Alternatives in 2026"
 summary: "The best ChatGPT alternatives in 2026, compared honestly on models, features and price. Lounge by LLM Gateway leads — every frontier model plus image generation on one membership from $9/mo."
 categories: ["Guides"]
+faqs:
+  - question: "What is the best ChatGPT alternative in 2026?"
+    answer: "For most people it's Lounge, because it's the only option that gives you every frontier model — GPT-5, Claude Opus, Gemini, Grok and 200+ more — in one familiar chat app with image generation built in, starting at $9/mo. Single-vendor apps like Claude or Gemini are excellent if you're sure you'll only ever want that one company's models."
+  - question: "Is there a ChatGPT alternative that includes Claude and Gemini?"
+    answer: "Yes. Lounge runs OpenAI's GPT models alongside Claude, Gemini, Grok and hundreds of others, and you can switch between them inside the same conversation — so one subscription replaces ChatGPT Plus and the other AI subscriptions you'd otherwise stack on top."
+  - question: "How does Lounge compare to ChatGPT Plus on price?"
+    answer: "Both are around $20/mo, but ChatGPT Plus only buys OpenAI models. On Lounge the $19 Plus plan becomes about $47.50 of credits at provider rates that you can spend across every model, with pay-as-you-go top-ups as a fallback instead of a hard limit."
+  - question: "Can I generate images in Lounge?"
+    answer: "Yes. Image generation is built into the app, so you can create images alongside your text conversations without switching to a separate tool."
 image:
   src: "/blog/best-chatgpt-alternatives.png"
   alt: "The best ChatGPT alternatives in 2026 — multiple AI models accessible through one chat app"
@@ -287,26 +296,6 @@ HuggingChat from Hugging Face is a free interface to open-source models, ideal f
 **You mainly research:** Perplexity's cited, search-led answers are hard to beat for fact-finding — though Lounge covers general chat, images, and files in one place.
 
 **You want the lowest price with real models:** Lounge starts at $9/mo, and your subscription becomes credits worth more than you pay — spendable across any model.
-
----
-
-## Frequently Asked Questions
-
-### What is the best ChatGPT alternative in 2026?
-
-For most people it's Lounge, because it's the only option that gives you every frontier model — GPT-5, Claude Opus, Gemini, Grok and 200+ more — in one familiar chat app with image generation built in, starting at $9/mo. Single-vendor apps like Claude or Gemini are excellent if you're sure you'll only ever want that one company's models.
-
-### Is there a ChatGPT alternative that includes Claude and Gemini?
-
-Yes. Lounge runs OpenAI's GPT models alongside Claude, Gemini, Grok and hundreds of others, and you can switch between them inside the same conversation — so one subscription replaces ChatGPT Plus and the other AI subscriptions you'd otherwise stack on top.
-
-### How does Lounge compare to ChatGPT Plus on price?
-
-Both are around $20/mo, but ChatGPT Plus only buys OpenAI models. On Lounge the $19 Plus plan becomes about $47.50 of credits at provider rates that you can spend across every model, with pay-as-you-go top-ups as a fallback instead of a hard limit.
-
-### Can I generate images in Lounge?
-
-Yes. Image generation is built into the app, so you can create images alongside your text conversations without switching to a separate tool.
 
 ---
 

--- a/apps/ui/src/content/blog/2026-06-23-claude-opus-tokenizer-cost.md
+++ b/apps/ui/src/content/blog/2026-06-23-claude-opus-tokenizer-cost.md
@@ -5,6 +5,14 @@ date: "2026-06-23"
 title: "Claude Opus 4.8 Pricing and the Hidden Tokenizer Tax"
 summary: "Claude Opus 4.8 lists at $5/$25 per million tokens — the same as Opus 4.6. But Anthropic's newer tokenizer can turn the same text into up to ~35% more tokens, so your real bill can climb even when the sticker price doesn't."
 categories: ["Guides"]
+model: claude-opus-4-8
+faqs:
+  - question: "Did Claude Opus 4.8 get more expensive than Opus 4.6?"
+    answer: "The per-token price is the same — $5 input / $25 output per million. But the newer tokenizer (Opus 4.7+) can turn the same text into up to ~35% more tokens, so your real cost per request can be higher even though the rate didn't change."
+  - question: "How do I know how many tokens my requests actually use?"
+    answer: "Measure them. LLM Gateway logs exact input and output token counts and the real cost for every request, so you can see actual consumption per model instead of estimating from the list price."
+  - question: "Why does the same text cost different amounts on different models?"
+    answer: "Because each model's tokenizer splits text differently. A more granular tokenizer produces more tokens for the same words, raising cost even at a lower per-token rate. Always compare models on total cost for your real workload, not on the headline price."
 image:
   src: "/blog/claude-opus-tokenizer-cost.png"
   alt: "The same paragraph of text splitting into more tokens through a newer tokenizer"
@@ -55,20 +63,6 @@ To estimate before you switch, drop your real prompt and expected volume into th
 - **Cache repeat requests.** Cached responses cost nothing, no matter how the tokenizer counts. For FAQ bots, classification, and CI runs, response caching erases a large share of token spend.
 - **Route by difficulty.** Send simple requests to cheaper, token-efficient models and reserve Opus for the work that needs it. A gateway with automatic routing does this for you.
 - **Compare on total cost.** Use real token counts from your own logs when you evaluate a model change, so a "free" upgrade doesn't quietly raise your run rate.
-
-## Frequently Asked Questions
-
-### Did Claude Opus 4.8 get more expensive than Opus 4.6?
-
-The per-token price is the same — $5 input / $25 output per million. But the newer tokenizer (Opus 4.7+) can turn the same text into up to ~35% more tokens, so your real cost per request can be higher even though the rate didn't change.
-
-### How do I know how many tokens my requests actually use?
-
-Measure them. LLM Gateway logs exact input and output token counts and the real cost for every request, so you can see actual consumption per model instead of estimating from the list price.
-
-### Why does the same text cost different amounts on different models?
-
-Because each model's tokenizer splits text differently. A more granular tokenizer produces more tokens for the same words, raising cost even at a lower per-token rate. Always compare models on total cost for your real workload, not on the headline price.
 
 ## Measure tokens, not list prices
 

--- a/apps/ui/src/content/blog/2026-06-26-enterprise-llm-analytics.md
+++ b/apps/ui/src/content/blog/2026-06-26-enterprise-llm-analytics.md
@@ -5,6 +5,15 @@ date: "2026-06-26"
 title: "Enterprise LLM Analytics: See Where Every Dollar Goes"
 summary: "Most dashboards show what you spent, not where it went. LLM Gateway's enterprise LLM analytics break cost, requests, and tokens down by model, project, API key, and team member — no data warehouse to build. Member and organization-wide analytics are available on the Enterprise plan."
 categories: ["Announcements", "Product"]
+faqs:
+  - question: "What is enterprise LLM analytics?"
+    answer: "Enterprise LLM analytics is the cost-and-usage reporting layer for AI traffic running through a gateway — breaking spend, requests, and tokens down by model, project, API key, and team member so an organization can attribute and govern its LLM costs. In LLM Gateway it's built in, with member and organization-wide views on the Enterprise plan."
+  - question: "How do I attribute LLM costs to teams or people?"
+    answer: "Group your projects by team and use **Organization → Analytics** with the **Project** breakdown for per-team chargeback, or the **Members** view for per-person attribution. Member spend is attributed to whoever created each API key."
+  - question: "Do I need a data warehouse to analyze LLM usage?"
+    answer: "No. LLM Gateway computes analytics from pre-aggregated hourly rollups, so cost, request, and token breakdowns are available in the dashboard without an export pipeline, a warehouse, or a separate BI tool."
+  - question: "Which analytics require the Enterprise plan?"
+    answer: "Per-project cost-by-model analytics and per-API-key statistics are available on every plan. Organization-wide analytics and member analytics are Enterprise-only and limited to organization owners and admins."
 image:
   src: "/blog/enterprise-llm-analytics.png"
   alt: "Enterprise LLM analytics on LLM Gateway: cost, requests, and tokens broken down by model, project, API key, and team member"
@@ -103,24 +112,6 @@ Enterprise-only pages are flagged directly in the sidebar, so members can see wh
 | Member analytics                     | **Enterprise** (owners/admins) |
 
 For teams with compliance requirements, the same platform is [SOC 2 Type II](/blog/soc2-type-ii), so cost data and request metadata stay inside controls your security team can sign off on.
-
-## Frequently Asked Questions
-
-### What is enterprise LLM analytics?
-
-Enterprise LLM analytics is the cost-and-usage reporting layer for AI traffic running through a gateway — breaking spend, requests, and tokens down by model, project, API key, and team member so an organization can attribute and govern its LLM costs. In LLM Gateway it's built in, with member and organization-wide views on the Enterprise plan.
-
-### How do I attribute LLM costs to teams or people?
-
-Group your projects by team and use **Organization → Analytics** with the **Project** breakdown for per-team chargeback, or the **Members** view for per-person attribution. Member spend is attributed to whoever created each API key.
-
-### Do I need a data warehouse to analyze LLM usage?
-
-No. LLM Gateway computes analytics from pre-aggregated hourly rollups, so cost, request, and token breakdowns are available in the dashboard without an export pipeline, a warehouse, or a separate BI tool.
-
-### Which analytics require the Enterprise plan?
-
-Per-project cost-by-model analytics and per-API-key statistics are available on every plan. Organization-wide analytics and member analytics are Enterprise-only and limited to organization owners and admins.
 
 ## Start measuring where your spend goes
 

--- a/apps/ui/src/content/blog/2026-07-01-devpass-code.md
+++ b/apps/ui/src/content/blog/2026-07-01-devpass-code.md
@@ -13,7 +13,7 @@ faqs:
   - question: "Do I need a DevPass subscription to use it?"
     answer: "No. Pick the **LLM Gateway** provider and you're on pay-as-you-go with your own key or credits. The **LLM Gateway DevPass** provider is there for subscribers who want flat-rate coding usage."
   - question: "Which models can I use?"
-    answer: "Any text model LLM Gateway supports — about 190 today across Anthropic, OpenAI, Google, xAI, DeepSeek, and more. DevPass Code fetches the live catalog, so new models appear without an update."
+    answer: "Any text model LLM Gateway supports — the full catalogue across Anthropic, OpenAI, Google, xAI, DeepSeek, and more. DevPass Code fetches the live catalog, so new models appear without an update."
   - question: "How is this different from using opencode directly?"
     answer: "opencode supports dozens of providers and needs per-provider setup. DevPass Code is the same core with everything pointed at LLM Gateway: one browser login, one billing relationship, and a UI themed to match the gateway."
 image:

--- a/apps/ui/src/content/blog/2026-07-01-devpass-code.md
+++ b/apps/ui/src/content/blog/2026-07-01-devpass-code.md
@@ -5,6 +5,17 @@ date: "2026-07-01"
 title: "DevPass Code: A Terminal Coding Agent for LLM Gateway"
 summary: "DevPass Code is an open-source terminal coding agent that talks only to LLM Gateway. One browser login, every model, and no per-provider API keys to juggle. Use it pay-as-you-go or on a DevPass coding subscription."
 categories: ["Announcements", "Product"]
+faqs:
+  - question: "Is DevPass Code free?"
+    answer: "The tool is open source (MIT) and free to run. You pay only for the models you use through LLM Gateway — either pay-as-you-go credits or a DevPass subscription. There's no separate charge for the agent itself."
+  - question: "How do I install DevPass Code?"
+    answer: "`npm i -g devpass-code` on any platform with Node, or `brew install theopenco/tap/devpass-code` on macOS and Linux. An install script, an AUR package (`devpass-code-bin`), a Docker image, and Windows binaries are also available on [GitHub](https://github.com/theopenco/devpass-code)."
+  - question: "Do I need a DevPass subscription to use it?"
+    answer: "No. Pick the **LLM Gateway** provider and you're on pay-as-you-go with your own key or credits. The **LLM Gateway DevPass** provider is there for subscribers who want flat-rate coding usage."
+  - question: "Which models can I use?"
+    answer: "Any text model LLM Gateway supports — about 190 today across Anthropic, OpenAI, Google, xAI, DeepSeek, and more. DevPass Code fetches the live catalog, so new models appear without an update."
+  - question: "How is this different from using opencode directly?"
+    answer: "opencode supports dozens of providers and needs per-provider setup. DevPass Code is the same core with everything pointed at LLM Gateway: one browser login, one billing relationship, and a UI themed to match the gateway."
 image:
   src: "/blog/devpass-code-splash.png"
   alt: "The DevPass Code terminal splash screen, showing the model set to Claude Opus 4.8 through LLM Gateway"
@@ -72,28 +83,6 @@ devpass-code              # launch the TUI in your project
 ```
 
 If you'd rather not log in interactively, set `LLMGATEWAY_API_KEY` in your environment and DevPass Code will use it directly.
-
-## Frequently Asked Questions
-
-### Is DevPass Code free?
-
-The tool is open source (MIT) and free to run. You pay only for the models you use through LLM Gateway — either pay-as-you-go credits or a DevPass subscription. There's no separate charge for the agent itself.
-
-### How do I install DevPass Code?
-
-`npm i -g devpass-code` on any platform with Node, or `brew install theopenco/tap/devpass-code` on macOS and Linux. An install script, an AUR package (`devpass-code-bin`), a Docker image, and Windows binaries are also available on [GitHub](https://github.com/theopenco/devpass-code).
-
-### Do I need a DevPass subscription to use it?
-
-No. Pick the **LLM Gateway** provider and you're on pay-as-you-go with your own key or credits. The **LLM Gateway DevPass** provider is there for subscribers who want flat-rate coding usage.
-
-### Which models can I use?
-
-Any text model LLM Gateway supports — about 190 today across Anthropic, OpenAI, Google, xAI, DeepSeek, and more. DevPass Code fetches the live catalog, so new models appear without an update.
-
-### How is this different from using opencode directly?
-
-opencode supports dozens of providers and needs per-provider setup. DevPass Code is the same core with everything pointed at LLM Gateway: one browser login, one billing relationship, and a UI themed to match the gateway.
 
 ## Get started
 

--- a/apps/ui/src/content/blog/2026-07-05-chat-projects-knowledge-base.md
+++ b/apps/ui/src/content/blog/2026-07-05-chat-projects-knowledge-base.md
@@ -5,6 +5,17 @@ date: "2026-07-05"
 title: "Projects: A Knowledge Base for Your AI Chats"
 summary: "LLM Gateway Chat now has Projects: group related chats, upload files — PDFs and spreadsheets included — as a knowledge base, and get answers grounded in your own documents via RAG, with source citations, on any of 280+ models. Projects also remember durable facts across chats. Available to every Chat user."
 categories: ["Announcements", "Product"]
+faqs:
+  - question: "How is a project knowledge base different from attaching a file to a chat?"
+    answer: "An attachment lives and dies with one conversation, and large files eat your context window on every message. A knowledge base is indexed once and shared by every chat in the project — only the passages relevant to each question are sent to the model, so a 500 KB handbook doesn't cost you 500 KB of context per message."
+  - question: "Which models work with project knowledge bases?"
+    answer: "All of them. Retrieval happens before the model is called, so the grounded context works the same whether the chat runs GPT-5, Claude, Gemini, or any other model on the gateway — and you can switch models mid-project."
+  - question: "What file types can I upload?"
+    answer: "PDF and Excel (.xlsx/.xls) files, plus any text-based format: plain text, markdown, source code, CSV, JSON, YAML, XML, HTML, and logs. PDF text is extracted on upload; spreadsheets are converted sheet-by-sheet to CSV. Scanned image-only PDFs aren't supported yet."
+  - question: "How does project memory work?"
+    answer: 'After each assistant reply in a project chat, a small model extracts durable facts from the exchange — up to three per reply, deduplicated, capped at 50 per project — and saves them with an "Auto" badge on the project page. Every chat in the project sees them from then on. You can edit or delete any memory, or add your own manually; extraction runs after the reply streams, so it never slows a response down.'
+  - question: "Does RAG cost extra?"
+    answer: "No. Embeddings and memory extraction are billed to the same credits as your chats at standard gateway rates — for `text-embedding-3-small`, indexing a file works out to fractions of a cent."
 image:
   src: "/blog/chat-projects-knowledge-base.png"
   alt: "A glossy 3D circuit board with a glowing folder holding documents at its center, representing a project knowledge base feeding AI chats"
@@ -68,28 +79,6 @@ Current limits: 20 files per project, up to 500 KB of extracted text per file (b
 1. Open [lounge.llmgateway.io/projects](https://lounge.llmgateway.io/projects) and create a project.
 2. Add files to its knowledge base — a PDF is fine as-is — and optionally write instructions.
 3. Hit **New chat** and ask a question your documents can answer.
-
-## Frequently Asked Questions
-
-### How is a project knowledge base different from attaching a file to a chat?
-
-An attachment lives and dies with one conversation, and large files eat your context window on every message. A knowledge base is indexed once and shared by every chat in the project — only the passages relevant to each question are sent to the model, so a 500 KB handbook doesn't cost you 500 KB of context per message.
-
-### Which models work with project knowledge bases?
-
-All of them. Retrieval happens before the model is called, so the grounded context works the same whether the chat runs GPT-5, Claude, Gemini, or any other model on the gateway — and you can switch models mid-project.
-
-### What file types can I upload?
-
-PDF and Excel (.xlsx/.xls) files, plus any text-based format: plain text, markdown, source code, CSV, JSON, YAML, XML, HTML, and logs. PDF text is extracted on upload; spreadsheets are converted sheet-by-sheet to CSV. Scanned image-only PDFs aren't supported yet.
-
-### How does project memory work?
-
-After each assistant reply in a project chat, a small model extracts durable facts from the exchange — up to three per reply, deduplicated, capped at 50 per project — and saves them with an "Auto" badge on the project page. Every chat in the project sees them from then on. You can edit or delete any memory, or add your own manually; extraction runs after the reply streams, so it never slows a response down.
-
-### Does RAG cost extra?
-
-No. Embeddings and memory extraction are billed to the same credits as your chats at standard gateway rates — for `text-embedding-3-small`, indexing a file works out to fractions of a cent.
 
 ---
 

--- a/apps/ui/src/content/blog/2026-07-08-litellm-alternatives.md
+++ b/apps/ui/src/content/blog/2026-07-08-litellm-alternatives.md
@@ -5,6 +5,15 @@ date: 2026-07-08
 title: "8 Best LiteLLM Alternatives in 2026 (Compared)"
 summary: "The best LiteLLM alternatives in 2026, compared honestly — open-source gateways, managed routers, and enterprise platforms — and how to pick the right one."
 categories: ["Guides"]
+faqs:
+  - question: "What is the best open-source LiteLLM alternative?"
+    answer: "LLM Gateway (AGPLv3) is the most complete open-source alternative — the self-hosted version includes the dashboard, caching, guardrails, and analytics, not just the proxy. Bifrost is the best minimal option: a fast Go proxy you operate yourself."
+  - question: "Why do teams switch away from LiteLLM?"
+    answer: "Operations and gating. LiteLLM makes you run, scale, and monitor a Python proxy plus its Redis and Postgres dependencies, and features like SSO and audit logs require its paid enterprise tier. Teams switch when the proxy starts consuming real engineering time."
+  - question: "How hard is it to migrate from LiteLLM?"
+    answer: "The API call is a two-line change, since both LiteLLM and its alternatives expose OpenAI-compatible endpoints. Budgets, virtual keys, and fallback configs need to be recreated in the new gateway — see the [migration guide](https://docs.llmgateway.io/migrations/litellm)."
+  - question: "Is Helicone still a good LiteLLM alternative?"
+    answer: "Not for new deployments. Helicone entered maintenance mode after its 2026 acquisition by Mintlify. For observability with active development, LLM Gateway and Portkey both include request-level analytics."
 image:
   src: "/blog/litellm-alternatives.png"
   alt: "The best LiteLLM alternatives in 2026 — LLM gateway options branching from a central routing hub"
@@ -279,26 +288,6 @@ Whatever you pick, check the fee structure before you commit — see our breakdo
 ## Migrating Off LiteLLM
 
 Every gateway on this list speaks the OpenAI API, so the mechanical migration is small — usually a base URL and API key change. The real work is recreating your routing rules, budgets, and virtual keys. LLM Gateway maps them directly: fallback chains become smart routing, spend tracking becomes per-project analytics, and virtual keys become scoped API keys. The [LiteLLM migration guide](https://docs.llmgateway.io/migrations/litellm) walks through each piece.
-
-## Frequently Asked Questions
-
-### What is the best open-source LiteLLM alternative?
-
-LLM Gateway (AGPLv3) is the most complete open-source alternative — the self-hosted version includes the dashboard, caching, guardrails, and analytics, not just the proxy. Bifrost is the best minimal option: a fast Go proxy you operate yourself.
-
-### Why do teams switch away from LiteLLM?
-
-Operations and gating. LiteLLM makes you run, scale, and monitor a Python proxy plus its Redis and Postgres dependencies, and features like SSO and audit logs require its paid enterprise tier. Teams switch when the proxy starts consuming real engineering time.
-
-### How hard is it to migrate from LiteLLM?
-
-The API call is a two-line change, since both LiteLLM and its alternatives expose OpenAI-compatible endpoints. Budgets, virtual keys, and fallback configs need to be recreated in the new gateway — see the [migration guide](https://docs.llmgateway.io/migrations/litellm).
-
-### Is Helicone still a good LiteLLM alternative?
-
-Not for new deployments. Helicone entered maintenance mode after its 2026 acquisition by Mintlify. For observability with active development, LLM Gateway and Portkey both include request-level analytics.
-
----
 
 ## Try the Top Pick
 

--- a/apps/ui/src/content/blog/2026-07-12-github-copilot-alternatives.md
+++ b/apps/ui/src/content/blog/2026-07-12-github-copilot-alternatives.md
@@ -5,6 +5,15 @@ date: 2026-07-12
 title: "8 Best GitHub Copilot Alternatives in 2026 (Compared)"
 summary: "GitHub Copilot switched chat and agents to usage-based AI Credits on June 1, 2026, and bills jumped 10–50x for agentic teams. The best GitHub Copilot alternatives in 2026, compared honestly — flat-fee IDEs, open-source agents, and gateway-backed setups with hard spend caps."
 categories: ["Guides"]
+faqs:
+  - question: "Why did GitHub Copilot get so expensive in 2026?"
+    answer: "On June 1, 2026, GitHub moved Copilot Chat, agent mode, code review, and CLI from flat-fee plans to usage-based AI Credits (1 credit = $0.01, varying by model). Seat prices stayed at $10–$39/user/month, but usage above the included credits bills without a ceiling unless you manually set a budget."
+  - question: "What is the cheapest GitHub Copilot alternative?"
+    answer: "Open-source tools — Cline, Continue, and Aider — are free; you pay only token costs. Routed through LLM Gateway with prompt caching and a cheap default model, a typical developer's chat usage runs a few dollars a month. Flat-fee options start at $17–$29/month."
+  - question: "Can I cap what my team spends on AI coding tools?"
+    answer: "Yes, with a gateway. LLM Gateway enforces hard budget limits per organization, project, and API key, so an agent stops at the cap instead of billing past it. Copilot's spending budgets exist but are off by default; most flat-fee products cap by throttling your own usage."
+  - question: "Is GitHub Copilot still worth keeping for completions?"
+    answer: "Often, yes. Inline completions weren't moved to AI Credits — they're still effectively flat-fee, and Copilot's completions remain excellent. The common hybrid: keep Copilot Free (2,000 completions/month) or a $10 Pro seat for completions, and run chat and agents through a gateway you control."
 image:
   src: "/blog/github-copilot-alternatives.png"
   alt: "The best GitHub Copilot alternatives in 2026 — coding agents and editors connecting to models through a central gateway"
@@ -257,26 +266,6 @@ Whichever you pick, run your own numbers first — the [Copilot cost calculator]
 ## Migrating Off Copilot
 
 The good news: unlike a database, there's no data to move. Migration is choosing a replacement for each workflow — completions, chat, agents, code review — and pointing it at models you control. Most teams keep a cheap Copilot seat for completions and move everything else. The [GitHub Copilot migration guide](/migration/github-copilot) maps each Copilot feature to its gateway-backed replacement, including budget setup so the new stack can't reproduce the old bill.
-
-## Frequently Asked Questions
-
-### Why did GitHub Copilot get so expensive in 2026?
-
-On June 1, 2026, GitHub moved Copilot Chat, agent mode, code review, and CLI from flat-fee plans to usage-based AI Credits (1 credit = $0.01, varying by model). Seat prices stayed at $10–$39/user/month, but usage above the included credits bills without a ceiling unless you manually set a budget.
-
-### What is the cheapest GitHub Copilot alternative?
-
-Open-source tools — Cline, Continue, and Aider — are free; you pay only token costs. Routed through LLM Gateway with prompt caching and a cheap default model, a typical developer's chat usage runs a few dollars a month. Flat-fee options start at $17–$29/month.
-
-### Can I cap what my team spends on AI coding tools?
-
-Yes, with a gateway. LLM Gateway enforces hard budget limits per organization, project, and API key, so an agent stops at the cap instead of billing past it. Copilot's spending budgets exist but are off by default; most flat-fee products cap by throttling your own usage.
-
-### Is GitHub Copilot still worth keeping for completions?
-
-Often, yes. Inline completions weren't moved to AI Credits — they're still effectively flat-fee, and Copilot's completions remain excellent. The common hybrid: keep Copilot Free (2,000 completions/month) or a $10 Pro seat for completions, and run chat and agents through a gateway you control.
-
----
 
 ## Try the Top Pick
 

--- a/apps/ui/src/content/blog/2026-07-12-microsoft-copilot-enterprise-pricing.md
+++ b/apps/ui/src/content/blog/2026-07-12-microsoft-copilot-enterprise-pricing.md
@@ -5,6 +5,15 @@ date: 2026-07-12
 title: "Microsoft Copilot Enterprise Pricing in 2026, Explained"
 summary: "Microsoft repriced enterprise Copilot three times in June 2026: GitHub Copilot moved to usage-based AI Credits, Copilot Cowork added per-task billing on top of the $30 seat, and volume discounts expired. What it costs now — and the cost-control playbook enterprises are adopting instead."
 categories: ["Guides"]
+faqs:
+  - question: "How much does Microsoft 365 Copilot cost in 2026?"
+    answer: "$30 per user per month, on top of a qualifying Microsoft 365 license (E3 is now $39, E5 $60, Business Standard $14). Volume discounts on the add-on expired June 30, 2026, and agentic Copilot Cowork tasks bill separately at roughly $1–3 for light tasks, $4–7 for medium, and $7+ for heavy."
+  - question: "What is Copilot Cowork and how is it priced?"
+    answer: "Cowork is Microsoft's agentic mode that executes multi-step tasks across enterprise data. It launched globally June 16, 2026. Pricing is per task — driven by the model used, context retrieved, tool calls, and runtime — billed in Copilot Credits on top of the $30 Copilot license, via pay-as-you-go or a volume commitment."
+  - question: "How much does GitHub Copilot Enterprise cost after the June 2026 change?"
+    answer: "The seat is still $39 per user per month, but chat, agent mode, code review, and CLI usage now meter as AI Credits at $0.01 each with no default cap. Real-world overages range from a few dollars for light users to hundreds per developer for agent-heavy workflows."
+  - question: "How can enterprises cap Copilot-style AI spend?"
+    answer: "Put a gateway between your tools and the model providers. LLM Gateway enforces hard budget limits per organization, project, and API key, records cost per request, caches repeated context automatically, and passes provider prices through with no markup — so spend is visible, attributable, and bounded."
 image:
   src: "/blog/microsoft-copilot-enterprise-pricing.png"
   alt: "Microsoft Copilot enterprise pricing in 2026 — seat-based costs turning into metered usage flowing through a controlled gateway"
@@ -82,26 +91,6 @@ For enterprises specifically:
 - A **30-Day Production Pilot** for enterprise teams that want to validate real workloads before committing — see the [enterprise page](/enterprise)
 
 Migrating developer workloads takes an afternoon, not a quarter — the [GitHub Copilot migration guide](/migration/github-copilot) walks through it feature by feature.
-
-## Frequently Asked Questions
-
-### How much does Microsoft 365 Copilot cost in 2026?
-
-$30 per user per month, on top of a qualifying Microsoft 365 license (E3 is now $39, E5 $60, Business Standard $14). Volume discounts on the add-on expired June 30, 2026, and agentic Copilot Cowork tasks bill separately at roughly $1–3 for light tasks, $4–7 for medium, and $7+ for heavy.
-
-### What is Copilot Cowork and how is it priced?
-
-Cowork is Microsoft's agentic mode that executes multi-step tasks across enterprise data. It launched globally June 16, 2026. Pricing is per task — driven by the model used, context retrieved, tool calls, and runtime — billed in Copilot Credits on top of the $30 Copilot license, via pay-as-you-go or a volume commitment.
-
-### How much does GitHub Copilot Enterprise cost after the June 2026 change?
-
-The seat is still $39 per user per month, but chat, agent mode, code review, and CLI usage now meter as AI Credits at $0.01 each with no default cap. Real-world overages range from a few dollars for light users to hundreds per developer for agent-heavy workflows.
-
-### How can enterprises cap Copilot-style AI spend?
-
-Put a gateway between your tools and the model providers. LLM Gateway enforces hard budget limits per organization, project, and API key, records cost per request, caches repeated context automatically, and passes provider prices through with no markup — so spend is visible, attributable, and bounded.
-
----
 
 ## Get Ahead of the Next Repricing
 

--- a/apps/ui/src/content/blog/2026-07-19-best-open-source-llms.md
+++ b/apps/ui/src/content/blog/2026-07-19-best-open-source-llms.md
@@ -3,15 +3,15 @@ id: "blog-best-open-source-llms"
 slug: "best-open-source-llms"
 date: "2026-07-19"
 title: "9 Best Open-Source LLMs in 2026 (Compared)"
-summary: "The best open-source LLMs in 2026, ranked — Kimi K3 (weights expected by July 27), GLM-5.2, DeepSeek V4 Pro, MiniMax M3 and more, compared on license, context window, and real per-token price. All of them run through one API with LLM Gateway."
+summary: "The best open-source LLMs in 2026, ranked — Kimi K3, GLM-5.2, DeepSeek V4 Pro, MiniMax M3 and more, compared on license, context window, and real per-token price. All of them run through one API with LLM Gateway."
 categories: ["Guides"]
 faqs:
   - question: "What is the best open-source LLM in 2026?"
-    answer: "Kimi K3, by benchmark standing: 4th of 189 models on the Artificial Analysis Intelligence Index, level with Claude Opus 4.8 — though its weights are expected by July 27 and it is API-only until then. If price matters, GLM-5.2 delivers most of that capability with output at under a third of K3's price."
+    answer: "Kimi K3, by benchmark standing: 4th of 189 models on the Artificial Analysis Intelligence Index, level with Claude Opus 4.8. Moonshot published the full 2.8T-parameter weights on July 26, 2026, though at that size most teams still run it through an API rather than self-hosting. If price matters, GLM-5.2 delivers most of that capability with output at under a third of K3's price."
   - question: "What is the best small open-source LLM?"
     answer: "Qwen3.6-35B-A3B — Apache 2.0, multimodal, 3B active parameters, and it runs on a 24 GB consumer GPU while holding its own on agentic coding benchmarks."
   - question: "Are these models open source or open weight?"
-    answer: "Open weight: the trained weights are downloadable and self-hostable under permissive licenses (mostly MIT or Apache 2.0), but training data and code are generally not released. GLM-5.2, DeepSeek V4 Pro, Qwen3.6-35B-A3B, and gpt-oss-120b use standard OSI licenses; Llama uses Meta's community license. Kimi K3 is the exception for now: its weights are expected by July 27, 2026 and are unlicensed until Moonshot announces terms — today it is usable only through hosted APIs."
+    answer: 'Open weight: the trained weights are downloadable and self-hostable, but training data and code are generally not released. GLM-5.2, DeepSeek V4 Pro, Qwen3.6-35B-A3B, and gpt-oss-120b use standard OSI licenses; Llama uses Meta''s community license. Kimi K3 sits apart: its weights went up on July 26, 2026 under a custom "Kimi K3 License" rather than MIT or Apache 2.0, so read the LICENSE file before commercial self-hosting.'
   - question: "What is the cheapest way to use open-source LLMs?"
     answer: "Through a gateway at provider list prices. LLM Gateway adds no per-token markup — pay-as-you-go credits carry a 5% platform fee at top-up, and DevPass turns heavy coding-agent usage into a flat monthly rate."
 image:
@@ -21,7 +21,7 @@ image:
   height: 1024
 ---
 
-Open-source LLMs stopped being the budget option in 2026. Kimi K3 sits level with Claude Opus 4.8 on the Artificial Analysis Intelligence Index (its hosted API is live; the weights themselves are expected by July 27), GLM-5.2 held the top open-model spot before it, and the field behind them is deep enough that the hard part is choosing.
+Open-source LLMs stopped being the budget option in 2026. Kimi K3 sits level with Claude Opus 4.8 on the Artificial Analysis Intelligence Index (its hosted API is live and the weights went public on July 26, 2026), GLM-5.2 held the top open-model spot before it, and the field behind them is deep enough that the hard part is choosing.
 
 This ranking covers the nine best open-weight models right now — on license, context window, hardware reality, and the per-token price you actually pay. Every one of them is available through **LLM Gateway** with one key, at each provider's published rate, so you can A/B any two of them by changing one word in a request.
 

--- a/apps/ui/src/content/blog/2026-07-19-best-open-source-llms.md
+++ b/apps/ui/src/content/blog/2026-07-19-best-open-source-llms.md
@@ -5,6 +5,15 @@ date: "2026-07-19"
 title: "9 Best Open-Source LLMs in 2026 (Compared)"
 summary: "The best open-source LLMs in 2026, ranked — Kimi K3 (weights expected by July 27), GLM-5.2, DeepSeek V4 Pro, MiniMax M3 and more, compared on license, context window, and real per-token price. All of them run through one API with LLM Gateway."
 categories: ["Guides"]
+faqs:
+  - question: "What is the best open-source LLM in 2026?"
+    answer: "Kimi K3, by benchmark standing: 4th of 189 models on the Artificial Analysis Intelligence Index, level with Claude Opus 4.8 — though its weights are expected by July 27 and it is API-only until then. If price matters, GLM-5.2 delivers most of that capability with output at under a third of K3's price."
+  - question: "What is the best small open-source LLM?"
+    answer: "Qwen3.6-35B-A3B — Apache 2.0, multimodal, 3B active parameters, and it runs on a 24 GB consumer GPU while holding its own on agentic coding benchmarks."
+  - question: "Are these models open source or open weight?"
+    answer: "Open weight: the trained weights are downloadable and self-hostable under permissive licenses (mostly MIT or Apache 2.0), but training data and code are generally not released. GLM-5.2, DeepSeek V4 Pro, Qwen3.6-35B-A3B, and gpt-oss-120b use standard OSI licenses; Llama uses Meta's community license. Kimi K3 is the exception for now: its weights are expected by July 27, 2026 and are unlicensed until Moonshot announces terms — today it is usable only through hosted APIs."
+  - question: "What is the cheapest way to use open-source LLMs?"
+    answer: "Through a gateway at provider list prices. LLM Gateway adds no per-token markup — pay-as-you-go credits carry a 5% platform fee at top-up, and DevPass turns heavy coding-agent usage into a flat monthly rate."
 image:
   src: "/blog/best-open-source-llms.png"
   alt: "A podium of glowing processor chips of different sizes on a circuit board, representing the best open-source LLMs of 2026 ranked"
@@ -129,24 +138,6 @@ curl https://api.llmgateway.io/v1/chat/completions \
 ```
 
 Two ways to pay. **Pay-as-you-go**: top up from $10, pay the published per-token rates plus a 5% platform fee at top-up — right for shipping products. **[DevPass](https://devpass.llmgateway.io)**: flat $29/$79/$179 a month for coding agents, with roughly 3× your subscription price in model usage at provider rates. On DevPass, every model on this list except Kimi K3 is standard-tier with no weekly cap; K3 crosses the premium price threshold and draws from a weekly premium allowance.
-
-## Frequently Asked Questions
-
-### What is the best open-source LLM in 2026?
-
-Kimi K3, by benchmark standing: 4th of 189 models on the Artificial Analysis Intelligence Index, level with Claude Opus 4.8 — though its weights are expected by July 27 and it is API-only until then. If price matters, GLM-5.2 delivers most of that capability with output at under a third of K3's price.
-
-### What is the best small open-source LLM?
-
-Qwen3.6-35B-A3B — Apache 2.0, multimodal, 3B active parameters, and it runs on a 24 GB consumer GPU while holding its own on agentic coding benchmarks.
-
-### Are these models open source or open weight?
-
-Open weight: the trained weights are downloadable and self-hostable under permissive licenses (mostly MIT or Apache 2.0), but training data and code are generally not released. GLM-5.2, DeepSeek V4 Pro, Qwen3.6-35B-A3B, and gpt-oss-120b use standard OSI licenses; Llama uses Meta's community license. Kimi K3 is the exception for now: its weights are expected by July 27, 2026 and are unlicensed until Moonshot announces terms — today it is usable only through hosted APIs.
-
-### What is the cheapest way to use open-source LLMs?
-
-Through a gateway at provider list prices. LLM Gateway adds no per-token markup — pay-as-you-go credits carry a 5% platform fee at top-up, and DevPass turns heavy coding-agent usage into a flat monthly rate.
 
 ## Getting started
 

--- a/apps/ui/src/content/blog/2026-07-19-kimi-k3-claude-code.md
+++ b/apps/ui/src/content/blog/2026-07-19-kimi-k3-claude-code.md
@@ -5,6 +5,16 @@ date: "2026-07-19"
 title: "How to Use Kimi K3 with Claude Code, Cursor, and Cline"
 summary: "Kimi K3 in Claude Code takes three environment variables. This guide walks through the exact setup for Claude Code, Cursor, and Cline via LLM Gateway — plus what each tool does and doesn't route, and what K3 costs on a flat-rate DevPass plan."
 categories: ["Guides", "Integrations"]
+model: kimi-k3
+faqs:
+  - question: "Does Claude Code work with non-Anthropic models like Kimi K3?"
+    answer: "Yes. Claude Code sends Anthropic-format requests to whatever `ANTHROPIC_BASE_URL` points at. LLM Gateway accepts that format and translates to each provider behind the scenes, so `ANTHROPIC_MODEL=kimi-k3` just works — as does any other model in the catalog."
+  - question: "Can Cursor's Composer or autocomplete use Kimi K3?"
+    answer: "No. Cursor only honors a custom endpoint for the chat / plan panel; Composer, inline edit, and autocomplete stay on Cursor's backend regardless of your settings. For a full agent loop on K3, use Claude Code, Cline, or OpenCode."
+  - question: "Is Kimi K3 included in DevPass?"
+    answer: "Yes, on every tier, as a premium-tier model with a weekly allowance on top of your monthly credit pool. Standard-tier models — including GLM-5.2 and DeepSeek V4 Pro — have no weekly cap."
+  - question: "Which coding tool is best for Kimi K3?"
+    answer: "The ones that route their full agent loop through your endpoint: Claude Code, Cline, or OpenCode. Cursor is fine for K3-powered planning but keeps its agent features on its own models."
 image:
   src: "/blog/kimi-k3-claude-code.png"
   alt: "Circuit board with cables plugging coding tool icons into a central glowing chip, representing Kimi K3 connected to Claude Code, Cursor, and Cline"
@@ -78,24 +88,6 @@ Agent loops are token-hungry, which is exactly the case [DevPass](https://devpas
 Kimi K3 is a **premium-tier model** on DevPass (it crosses the $15-per-million-output threshold), so it draws from a weekly premium allowance — roughly $10 per week on Lite, $36 on Pro, $97 on Max. The practical pattern: K3 for planning and the gnarly bugs, a standard-tier model like GLM-5.2 or DeepSeek V4 Pro for the bulk of the loop — both uncapped within your monthly allowance. Pro and Max include one and two Reset Passes per cycle if you burn the premium allowance early.
 
 Prefer straight metering? Pay-as-you-go credits work with the identical setup: top up from $10, pay Moonshot's published rates ($3.00/M input, $0.30/M cached, $15.00/M output) plus a 5% platform fee at top-up. K3's cached-input pricing matters here — agent loops re-send the same context every step, and cache hits bill at a tenth of the fresh rate.
-
-## Frequently Asked Questions
-
-### Does Claude Code work with non-Anthropic models like Kimi K3?
-
-Yes. Claude Code sends Anthropic-format requests to whatever `ANTHROPIC_BASE_URL` points at. LLM Gateway accepts that format and translates to each provider behind the scenes, so `ANTHROPIC_MODEL=kimi-k3` just works — as does any other model in the catalog.
-
-### Can Cursor's Composer or autocomplete use Kimi K3?
-
-No. Cursor only honors a custom endpoint for the chat / plan panel; Composer, inline edit, and autocomplete stay on Cursor's backend regardless of your settings. For a full agent loop on K3, use Claude Code, Cline, or OpenCode.
-
-### Is Kimi K3 included in DevPass?
-
-Yes, on every tier, as a premium-tier model with a weekly allowance on top of your monthly credit pool. Standard-tier models — including GLM-5.2 and DeepSeek V4 Pro — have no weekly cap.
-
-### Which coding tool is best for Kimi K3?
-
-The ones that route their full agent loop through your endpoint: Claude Code, Cline, or OpenCode. Cursor is fine for K3-powered planning but keeps its agent features on its own models.
 
 ## Getting started
 

--- a/apps/ui/src/content/blog/2026-07-19-kimi-k3-vs-claude-opus.md
+++ b/apps/ui/src/content/blog/2026-07-19-kimi-k3-vs-claude-opus.md
@@ -5,6 +5,16 @@ date: "2026-07-19"
 title: "Kimi K3 vs Claude Opus 4.8: Benchmarks, Price, Verdict"
 summary: "Kimi K3 ties Claude Opus 4.8 on GPQA Diamond, costs 40% less per token, and its weights are expected by July 27 — but Opus still leads where it counts for some teams. A fact-checked comparison of benchmarks, pricing, and context windows, and how to A/B both through one API."
 categories: ["Guides"]
+model: kimi-k3
+faqs:
+  - question: "Is Kimi K3 as good as Claude Opus 4.8?"
+    answer: "On aggregate intelligence benchmarks, yes — Artificial Analysis ranks them level, and they are statistically tied on GPQA Diamond. On production coding-agent work, Opus 4.8 still has the deeper published record (88.6% SWE-bench Verified) and the more mature harness ecosystem. On frontend code generation, blind developer testing ranked K3 first."
+  - question: "How much cheaper is Kimi K3 than Claude Opus 4.8?"
+    answer: "40% on every token class: $3.00 vs $5.00 per million input, $0.30 vs $0.50 cached, $15.00 vs $25.00 output."
+  - question: "Can I switch between Kimi K3 and Claude Opus 4.8 without code changes?"
+    answer: "Yes. Through LLM Gateway both are the same OpenAI-compatible endpoint — swap the `model` field between `kimi-k3` and `claude-opus-4-8` and nothing else changes. Costs for both land in one dashboard."
+  - question: "Is Kimi K3 open source?"
+    answer: "Not yet. Kimi K3's weights are expected by July 27, 2026 and the license has not been announced; until then it is API-only, like Opus 4.8 — the difference is that Opus stays closed. See [our Kimi K3 overview](/blog/kimi-k3) for the full release details."
 image:
   src: "/blog/kimi-k3-vs-claude-opus.png"
   alt: "Two glowing processor chips facing each other on a circuit board with a balance scale between them, representing Kimi K3 versus Claude Opus 4.8"
@@ -73,24 +83,6 @@ Run a week on `kimi-k3`, a week on `claude-opus-4-8`, and read the answer off yo
 ## Flat rate or pay-as-you-go
 
 Both models count as **premium-tier** on [DevPass](https://devpass.llmgateway.io) ($29/$79/$179 per month), drawing from the weekly premium allowance — so a flat-rate plan covers the A/B test without a separate Anthropic subscription. On pay-as-you-go credits you pay the per-token rates above plus a 5% platform fee at top-up, from $10.
-
-## Frequently Asked Questions
-
-### Is Kimi K3 as good as Claude Opus 4.8?
-
-On aggregate intelligence benchmarks, yes — Artificial Analysis ranks them level, and they are statistically tied on GPQA Diamond. On production coding-agent work, Opus 4.8 still has the deeper published record (88.6% SWE-bench Verified) and the more mature harness ecosystem. On frontend code generation, blind developer testing ranked K3 first.
-
-### How much cheaper is Kimi K3 than Claude Opus 4.8?
-
-40% on every token class: $3.00 vs $5.00 per million input, $0.30 vs $0.50 cached, $15.00 vs $25.00 output.
-
-### Can I switch between Kimi K3 and Claude Opus 4.8 without code changes?
-
-Yes. Through LLM Gateway both are the same OpenAI-compatible endpoint — swap the `model` field between `kimi-k3` and `claude-opus-4-8` and nothing else changes. Costs for both land in one dashboard.
-
-### Is Kimi K3 open source?
-
-Not yet. Kimi K3's weights are expected by July 27, 2026 and the license has not been announced; until then it is API-only, like Opus 4.8 — the difference is that Opus stays closed. See [our Kimi K3 overview](/blog/kimi-k3) for the full release details.
 
 ## Getting started
 

--- a/apps/ui/src/content/blog/2026-07-19-kimi-k3-vs-claude-opus.md
+++ b/apps/ui/src/content/blog/2026-07-19-kimi-k3-vs-claude-opus.md
@@ -3,7 +3,7 @@ id: "blog-kimi-k3-vs-claude-opus"
 slug: "kimi-k3-vs-claude-opus"
 date: "2026-07-19"
 title: "Kimi K3 vs Claude Opus 4.8: Benchmarks, Price, Verdict"
-summary: "Kimi K3 ties Claude Opus 4.8 on GPQA Diamond, costs 40% less per token, and its weights are expected by July 27 — but Opus still leads where it counts for some teams. A fact-checked comparison of benchmarks, pricing, and context windows, and how to A/B both through one API."
+summary: "Kimi K3 ties Claude Opus 4.8 on GPQA Diamond, costs 40% less per token, and its weights are public while Opus stays closed — but Opus still leads where it counts for some teams. A fact-checked comparison of benchmarks, pricing, and context windows, and how to A/B both through one API."
 categories: ["Guides"]
 model: kimi-k3
 faqs:
@@ -14,7 +14,7 @@ faqs:
   - question: "Can I switch between Kimi K3 and Claude Opus 4.8 without code changes?"
     answer: "Yes. Through LLM Gateway both are the same OpenAI-compatible endpoint — swap the `model` field between `kimi-k3` and `claude-opus-4-8` and nothing else changes. Costs for both land in one dashboard."
   - question: "Is Kimi K3 open source?"
-    answer: "Not yet. Kimi K3's weights are expected by July 27, 2026 and the license has not been announced; until then it is API-only, like Opus 4.8 — the difference is that Opus stays closed. See [our Kimi K3 overview](/blog/kimi-k3) for the full release details."
+    answer: 'Yes. Moonshot published the full Kimi K3 weights on July 26, 2026, under a custom "Kimi K3 License" rather than MIT or Apache 2.0 — check the LICENSE file before commercial self-hosting. Opus 4.8 stays closed, so this is the sharpest difference between them. See [our Kimi K3 overview](/blog/kimi-k3) for the full release details.'
 image:
   src: "/blog/kimi-k3-vs-claude-opus.png"
   alt: "Two glowing processor chips facing each other on a circuit board with a balance scale between them, representing Kimi K3 versus Claude Opus 4.8"

--- a/apps/ui/src/content/blog/2026-07-19-kimi-k3.md
+++ b/apps/ui/src/content/blog/2026-07-19-kimi-k3.md
@@ -5,6 +5,16 @@ date: "2026-07-19"
 title: "Kimi K3 and China's Open-Weight Model Wave"
 summary: "Kimi K3 is the largest open-weight model ever released — 2.8T parameters, a 1M-token context, and benchmark scores next to Claude Opus 4.8. Here is what it costs, how it compares to GLM-5.2, DeepSeek V4 Pro, and MiniMax M3, and how to run all of them through one API with LLM Gateway — on a flat-rate DevPass plan or pay-as-you-go credits."
 categories: ["Guides"]
+model: kimi-k3
+faqs:
+  - question: "Is Kimi K3 open source?"
+    answer: 'Kimi K3 is an open-weight model. Moonshot AI announced it on July 16, 2026 and published the full 2.8T-parameter weights on Hugging Face on July 26, 2026, under a custom "Kimi K3 License" (not MIT — read the LICENSE file before commercial self-hosting). A 2.8T mixture-of-experts model demands cluster-scale hardware, which is why most teams run it through an API — see [the open-weights breakdown](/blog/kimi-k3-open-weights) for what self-hosting actually takes.'
+  - question: "How much does Kimi K3 cost?"
+    answer: "Through LLM Gateway, Kimi K3 costs $3.00 per million input tokens, $0.30 per million cached input tokens, and $15.00 per million output tokens — Moonshot's published rates. On a DevPass plan it is included in the flat monthly price as a premium-tier model."
+  - question: "What is Kimi K3's context window?"
+    answer: "1,048,576 tokens — a full 1M-token context, with output defaulting to 131K tokens and configurable up to the same 1M. The same headline context as GLM-5.2 and DeepSeek V4 Pro."
+  - question: "Can I use Kimi K3 with Claude Code or Cursor?"
+    answer: "Yes. LLM Gateway exposes OpenAI- and Anthropic-compatible endpoints, so point your tool's base URL at `https://api.llmgateway.io/v1` with your key and select `kimi-k3` as the model. In Claude Code and Cline the full agent loop routes through LLM Gateway; Cursor honors an external endpoint only in its chat/plan panel — Composer, inline edit, and autocomplete stay on Cursor's own backend. With DevPass this is covered by the flat monthly rate. Step-by-step setup for each tool: [How to Use Kimi K3 with Claude Code, Cursor, and Cline](/blog/kimi-k3-claude-code)."
 image:
   src: "/blog/kimi-k3.png"
   alt: "Glossy circuit board with a glowing central chip radiating light traces, representing Kimi K3 and open-weight models routing through one gateway"
@@ -93,24 +103,6 @@ One gating detail to know: at $15 per million output tokens, Kimi K3 counts as a
 For production apps, PAYG credits skip the subscription entirely. Top up from $10, pay each provider's published per-token price as you go, and LLM Gateway adds a flat 5% platform fee at top-up — the per-token rates themselves are pass-through. You keep the same single endpoint, automatic failover, prompt caching, and cost dashboard, metered to the token.
 
 The two models work together: DevPass for your own coding agents, PAYG for the product you ship.
-
-## Frequently Asked Questions
-
-### Is Kimi K3 open source?
-
-Kimi K3 is an open-weight model. Moonshot AI announced it on July 16, 2026 and published the full 2.8T-parameter weights on Hugging Face on July 26, 2026, under a custom "Kimi K3 License" (not MIT — read the LICENSE file before commercial self-hosting). A 2.8T mixture-of-experts model demands cluster-scale hardware, which is why most teams run it through an API — see [the open-weights breakdown](/blog/kimi-k3-open-weights) for what self-hosting actually takes.
-
-### How much does Kimi K3 cost?
-
-Through LLM Gateway, Kimi K3 costs $3.00 per million input tokens, $0.30 per million cached input tokens, and $15.00 per million output tokens — Moonshot's published rates. On a DevPass plan it is included in the flat monthly price as a premium-tier model.
-
-### What is Kimi K3's context window?
-
-1,048,576 tokens — a full 1M-token context, with output defaulting to 131K tokens and configurable up to the same 1M. The same headline context as GLM-5.2 and DeepSeek V4 Pro.
-
-### Can I use Kimi K3 with Claude Code or Cursor?
-
-Yes. LLM Gateway exposes OpenAI- and Anthropic-compatible endpoints, so point your tool's base URL at `https://api.llmgateway.io/v1` with your key and select `kimi-k3` as the model. In Claude Code and Cline the full agent loop routes through LLM Gateway; Cursor honors an external endpoint only in its chat/plan panel — Composer, inline edit, and autocomplete stay on Cursor's own backend. With DevPass this is covered by the flat monthly rate. Step-by-step setup for each tool: [How to Use Kimi K3 with Claude Code, Cursor, and Cline](/blog/kimi-k3-claude-code).
 
 ## Getting started
 

--- a/apps/ui/src/content/blog/2026-07-19-kimi-k3.md
+++ b/apps/ui/src/content/blog/2026-07-19-kimi-k3.md
@@ -14,7 +14,7 @@ faqs:
   - question: "What is Kimi K3's context window?"
     answer: "1,048,576 tokens — a full 1M-token context, with output defaulting to 131K tokens and configurable up to the same 1M. The same headline context as GLM-5.2 and DeepSeek V4 Pro."
   - question: "Can I use Kimi K3 with Claude Code or Cursor?"
-    answer: "Yes. LLM Gateway exposes OpenAI- and Anthropic-compatible endpoints, so point your tool's base URL at `https://api.llmgateway.io/v1` with your key and select `kimi-k3` as the model. In Claude Code and Cline the full agent loop routes through LLM Gateway; Cursor honors an external endpoint only in its chat/plan panel — Composer, inline edit, and autocomplete stay on Cursor's own backend. With DevPass this is covered by the flat monthly rate. Step-by-step setup for each tool: [How to Use Kimi K3 with Claude Code, Cursor, and Cline](/blog/kimi-k3-claude-code)."
+    answer: "Yes. LLM Gateway exposes OpenAI- and Anthropic-compatible endpoints, so point Claude Code at `https://api.llmgateway.io` and OpenAI-compatible tools such as Cursor and Cline at `https://api.llmgateway.io/v1`, then select `kimi-k3` as the model. In Claude Code and Cline the full agent loop routes through LLM Gateway; Cursor honors an external endpoint only in its chat/plan panel — Composer, inline edit, and autocomplete stay on Cursor's own backend. With DevPass this is covered by the flat monthly rate. Step-by-step setup for each tool: [How to Use Kimi K3 with Claude Code, Cursor, and Cline](/blog/kimi-k3-claude-code)."
 image:
   src: "/blog/kimi-k3.png"
   alt: "Glossy circuit board with a glowing central chip radiating light traces, representing Kimi K3 and open-weight models routing through one gateway"

--- a/apps/ui/src/content/blog/2026-07-22-openrouter-vs-vercel-vs-llmgateway-performance.md
+++ b/apps/ui/src/content/blog/2026-07-22-openrouter-vs-vercel-vs-llmgateway-performance.md
@@ -5,6 +5,15 @@ date: "2026-07-22"
 title: "OpenRouter vs Vercel vs LLMGateway Performance"
 summary: "We measured AI gateway performance with an open-source TTFT benchmark: 75 cold + 75 warm interleaved runs of claude-haiku-4.5 against LLM Gateway and OpenRouter, with phase-by-phase timings and raw data published. LLM Gateway reached first token ~35% faster cold and ~34% faster warm, and here is exactly how to reproduce the numbers."
 categories: ["Engineering"]
+faqs:
+  - question: "What is TTFT and why does it matter more than TTFB?"
+    answer: "TTFT (time to first token) is the delay between sending a request and receiving the first piece of model output in the stream. TTFB (time to first byte) only measures when the server starts responding — a gateway can stream headers immediately while the model is still silent. For anything a user watches in real time, TTFT is the latency they actually experience."
+  - question: "What is a good TTFT for an AI gateway?"
+    answer: "It depends on the model and your distance from the gateway's edge, so compare gateways against each other rather than an absolute bar. In this AI gateway performance benchmark, first tokens from claude-haiku-4.5 arrived in roughly 800–900ms through LLM Gateway and 1200–1400ms through OpenRouter, measured from the same machine in the same session."
+  - question: "Are these results valid from every location?"
+    answer: "No — latency benchmarks are a property of the vantage point, and the benchmark's own README is explicit about it. Our numbers come from one residential connection on one day; the author's Vercel numbers come from another. The script is open source and takes minutes to run, so measure from where your servers actually live."
+  - question: "Does LLM Gateway support the same models as OpenRouter?"
+    answer: "LLM Gateway routes an overlapping catalogue — the full list is on the [models page](https://llmgateway.io/models), spanning the major closed and open-weight providers on the [providers page](https://llmgateway.io/providers). Requests use the OpenAI-compatible format either way, so moving a workload between the two is a base URL and key change."
 image:
   src: "/blog/openrouter-vs-vercel-vs-llmgateway-performance.png"
   alt: "Glossy circuit board with a glowing stopwatch on the central chip and light traces racing toward it, representing an AI gateway latency benchmark"
@@ -126,24 +135,6 @@ It prints per-run lines while it works, then a medians table, and dumps raw per-
 A gateway earns its hop with failover, unified billing, and one API across [every model it routes](https://llmgateway.io/models). But you pay its latency on every single request, forever. That makes time to first token one of the few gateway properties worth measuring before you commit — and one of the easiest, since the tooling is open source and takes minutes to run.
 
 If you are on OpenRouter today, LLM Gateway speaks the same OpenAI-compatible API — switching means changing the base URL and swapping in an LLM Gateway API key, covered in the [OpenRouter migration guide](https://docs.llmgateway.io/migrations/openrouter).
-
-## Frequently Asked Questions
-
-### What is TTFT and why does it matter more than TTFB?
-
-TTFT (time to first token) is the delay between sending a request and receiving the first piece of model output in the stream. TTFB (time to first byte) only measures when the server starts responding — a gateway can stream headers immediately while the model is still silent. For anything a user watches in real time, TTFT is the latency they actually experience.
-
-### What is a good TTFT for an AI gateway?
-
-It depends on the model and your distance from the gateway's edge, so compare gateways against each other rather than an absolute bar. In this AI gateway performance benchmark, first tokens from claude-haiku-4.5 arrived in roughly 800–900ms through LLM Gateway and 1200–1400ms through OpenRouter, measured from the same machine in the same session.
-
-### Are these results valid from every location?
-
-No — latency benchmarks are a property of the vantage point, and the benchmark's own README is explicit about it. Our numbers come from one residential connection on one day; the author's Vercel numbers come from another. The script is open source and takes minutes to run, so measure from where your servers actually live.
-
-### Does LLM Gateway support the same models as OpenRouter?
-
-LLM Gateway routes an overlapping catalogue — the full list is on the [models page](https://llmgateway.io/models), spanning the major closed and open-weight providers on the [providers page](https://llmgateway.io/providers). Requests use the OpenAI-compatible format either way, so moving a workload between the two is a base URL and key change.
 
 ---
 

--- a/apps/ui/src/content/blog/2026-07-23-open-source-openrouter-alternatives.md
+++ b/apps/ui/src/content/blog/2026-07-23-open-source-openrouter-alternatives.md
@@ -5,6 +5,15 @@ date: 2026-07-23
 title: "6 Best Open-Source OpenRouter Alternatives in 2026"
 summary: "The best open-source OpenRouter alternatives in 2026 — self-hostable AI gateways compared by what ships in the open core, what stays paid, and what you'll actually operate."
 categories: ["Guides"]
+faqs:
+  - question: "Is there a fully open-source version of OpenRouter?"
+    answer: "No project replicates OpenRouter's hosted marketplace exactly, but LLM Gateway comes closest as an open-source platform: one OpenAI-compatible API over 200+ models, with routing, caching, analytics, and a dashboard you self-host. Proxies like LiteLLM and Bifrost cover the routing layer alone."
+  - question: "Do self-hosted gateways charge any fees?"
+    answer: "No. A self-hosted gateway routes your requests using your own provider keys, so you pay providers directly with no platform fee and no BYOK metering. Your costs are provider spend plus the infrastructure you run the gateway on."
+  - question: "Which open-source LLM gateway is easiest to run?"
+    answer: "Bifrost is the simplest artifact (one Go binary); LLM Gateway is the simplest full platform (one Docker command including UI and analytics). LiteLLM needs Redis and Postgres alongside the proxy for production use, and Envoy AI Gateway assumes a Kubernetes practice."
+  - question: "Can I start self-hosted and switch to managed later?"
+    answer: "With LLM Gateway, yes — the managed cloud runs the same AGPLv3 codebase and API, so the integration doesn't change. Portkey and Kong also offer managed paths. LiteLLM, Bifrost, and Envoy AI Gateway are self-host only."
 image:
   src: "/blog/open-source-openrouter-alternatives.png"
   alt: "Open-source OpenRouter alternatives — a glowing open-box gateway on a circuit board routing to multiple model chips"
@@ -191,26 +200,6 @@ Envoy AI Gateway extends CNCF's Envoy Gateway with native LLM traffic support. T
 **Governance is the requirement:** Portkey Gateway, with eyes open about the cloud storage dependency.
 
 **You already run Kong or Kubernetes/Envoy:** Kong AI Gateway or Envoy AI Gateway respectively — extend what you have.
-
-## Frequently Asked Questions
-
-### Is there a fully open-source version of OpenRouter?
-
-No project replicates OpenRouter's hosted marketplace exactly, but LLM Gateway comes closest as an open-source platform: one OpenAI-compatible API over 200+ models, with routing, caching, analytics, and a dashboard you self-host. Proxies like LiteLLM and Bifrost cover the routing layer alone.
-
-### Do self-hosted gateways charge any fees?
-
-No. A self-hosted gateway routes your requests using your own provider keys, so you pay providers directly with no platform fee and no BYOK metering. Your costs are provider spend plus the infrastructure you run the gateway on.
-
-### Which open-source LLM gateway is easiest to run?
-
-Bifrost is the simplest artifact (one Go binary); LLM Gateway is the simplest full platform (one Docker command including UI and analytics). LiteLLM needs Redis and Postgres alongside the proxy for production use, and Envoy AI Gateway assumes a Kubernetes practice.
-
-### Can I start self-hosted and switch to managed later?
-
-With LLM Gateway, yes — the managed cloud runs the same AGPLv3 codebase and API, so the integration doesn't change. Portkey and Kong also offer managed paths. LiteLLM, Bifrost, and Envoy AI Gateway are self-host only.
-
----
 
 ## Run the Top Pick Tonight
 

--- a/apps/ui/src/content/blog/2026-07-23-openrouter-alternatives-for-enterprise.md
+++ b/apps/ui/src/content/blog/2026-07-23-openrouter-alternatives-for-enterprise.md
@@ -5,6 +5,15 @@ date: 2026-07-23
 title: "OpenRouter Alternatives for Enterprise Teams (2026)"
 summary: "Six enterprise OpenRouter alternatives compared on the criteria procurement actually checks — self-hosting and VPC deployment, SSO and audit logs, guardrails, SLAs, and compliance posture."
 categories: ["Guides"]
+faqs:
+  - question: "Does OpenRouter have an enterprise plan?"
+    answer: "Yes — it adds spend controls, higher BYOK allowances, and support. What it can't change is the architecture: OpenRouter is cloud-only, so requirements like self-hosting, VPC deployment, or keeping prompts inside your network boundary can't be met at any tier."
+  - question: "What is the best enterprise alternative to OpenRouter?"
+    answer: 'It depends on the binding constraint. LLM Gateway is the strongest all-around pick: SOC 2 Type II, SAML SSO, audit logs, gateway-level guardrails, and both managed and self-hosted deployment. If the requirement is strictly "nothing leaves our VPC," TrueFoundry or self-hosted LLM Gateway fit best.'
+  - question: "Can enterprises keep their negotiated provider pricing?"
+    answer: "Yes, with gateways that support bring-your-own-keys without markup. LLM Gateway charges 0% on BYOK traffic, so requests route through your existing OpenAI, Anthropic, or Google contracts at your negotiated rates. OpenRouter's BYOK is free only up to a monthly cap, then takes 5%."
+  - question: "Are AWS Bedrock and Azure AI Foundry really OpenRouter alternatives?"
+    answer: 'For single-cloud enterprises, yes — they answer the same "one governed endpoint for models" need. The trade is breadth and portability: each covers only its own catalog, with no cross-provider routing, so many teams pair or replace them with a cloud-neutral gateway.'
 image:
   src: "/blog/openrouter-alternatives-for-enterprise.png"
   alt: "Enterprise OpenRouter alternatives — a shielded gateway vault on a circuit board with audit and compliance icons"
@@ -199,26 +208,6 @@ Azure AI Foundry brings OpenAI's models plus a partner catalog under Azure's ide
 **Cloud commitment decides everything:** Bedrock on AWS, AI Foundry on Azure — accepting single-cloud catalogs and no cross-provider failover.
 
 For the wider field including developer-oriented options, see the [10 best OpenRouter alternatives in 2026](/blog/openrouter-alternatives); if open source is the requirement, the [open-source OpenRouter alternatives](/blog/open-source-openrouter-alternatives) list goes deeper.
-
-## Frequently Asked Questions
-
-### Does OpenRouter have an enterprise plan?
-
-Yes — it adds spend controls, higher BYOK allowances, and support. What it can't change is the architecture: OpenRouter is cloud-only, so requirements like self-hosting, VPC deployment, or keeping prompts inside your network boundary can't be met at any tier.
-
-### What is the best enterprise alternative to OpenRouter?
-
-It depends on the binding constraint. LLM Gateway is the strongest all-around pick: SOC 2 Type II, SAML SSO, audit logs, gateway-level guardrails, and both managed and self-hosted deployment. If the requirement is strictly "nothing leaves our VPC," TrueFoundry or self-hosted LLM Gateway fit best.
-
-### Can enterprises keep their negotiated provider pricing?
-
-Yes, with gateways that support bring-your-own-keys without markup. LLM Gateway charges 0% on BYOK traffic, so requests route through your existing OpenAI, Anthropic, or Google contracts at your negotiated rates. OpenRouter's BYOK is free only up to a monthly cap, then takes 5%.
-
-### Are AWS Bedrock and Azure AI Foundry really OpenRouter alternatives?
-
-For single-cloud enterprises, yes — they answer the same "one governed endpoint for models" need. The trade is breadth and portability: each covers only its own catalog, with no cross-provider routing, so many teams pair or replace them with a cloud-neutral gateway.
-
----
 
 ## Start With the Pilot
 

--- a/apps/ui/src/content/blog/2026-07-23-openrouter-alternatives.md
+++ b/apps/ui/src/content/blog/2026-07-23-openrouter-alternatives.md
@@ -5,6 +5,15 @@ date: 2026-07-23
 title: "10 Best OpenRouter Alternatives in 2026 (Compared)"
 summary: "The 10 best OpenRouter alternatives in 2026, compared honestly — open-source gateways, managed routers, and enterprise platforms — with fees, self-hosting, and routing side by side."
 categories: ["Guides"]
+faqs:
+  - question: "What is the best OpenRouter alternative in 2026?"
+    answer: "LLM Gateway is the strongest overall alternative: it's the only gateway that is open source (AGPLv3), self-hostable, and offered as a managed cloud with zero BYOK markup. Which option is best for you depends on the constraint driving the switch — fees, self-hosting, latency, or governance."
+  - question: "Is there an open-source alternative to OpenRouter?"
+    answer: "Yes — several. LLM Gateway (AGPLv3) is the most complete, shipping the dashboard, caching, analytics, and routing, not just a proxy. LiteLLM and Bifrost are solid open-source proxies you operate yourself. See the full [open-source OpenRouter alternatives](/blog/open-source-openrouter-alternatives) list."
+  - question: "Why do developers switch away from OpenRouter?"
+    answer: "Four reasons come up most: the 5.5% fee on credit purchases, the BYOK fee after the free monthly cap, the lack of any self-hosting option, and gateway latency in interactive apps. Teams with compliance requirements switch because a cloud-only gateway can't meet data-residency rules at any price."
+  - question: "How hard is it to migrate from OpenRouter?"
+    answer: "Usually minutes. OpenRouter and its alternatives expose OpenAI-compatible endpoints, so the change is a base URL and API key, plus model-name prefixes in some cases. The [migration guide](https://docs.llmgateway.io/migrations/openrouter) covers the details."
 image:
   src: "/blog/openrouter-alternatives.png"
   alt: "The best OpenRouter alternatives in 2026 — AI gateway routes branching from a central hub on a circuit board"
@@ -339,26 +348,6 @@ Every gateway on this list speaks the OpenAI API, so the mechanical migration is
 ```
 
 The real work is recreating provider preferences, spend limits, and app attribution in the new gateway. The [OpenRouter migration guide](https://docs.llmgateway.io/migrations/openrouter) maps each piece, including model-name differences and the AI SDK provider swap.
-
-## Frequently Asked Questions
-
-### What is the best OpenRouter alternative in 2026?
-
-LLM Gateway is the strongest overall alternative: it's the only gateway that is open source (AGPLv3), self-hostable, and offered as a managed cloud with zero BYOK markup. Which option is best for you depends on the constraint driving the switch — fees, self-hosting, latency, or governance.
-
-### Is there an open-source alternative to OpenRouter?
-
-Yes — several. LLM Gateway (AGPLv3) is the most complete, shipping the dashboard, caching, analytics, and routing, not just a proxy. LiteLLM and Bifrost are solid open-source proxies you operate yourself. See the full [open-source OpenRouter alternatives](/blog/open-source-openrouter-alternatives) list.
-
-### Why do developers switch away from OpenRouter?
-
-Four reasons come up most: the 5.5% fee on credit purchases, the BYOK fee after the free monthly cap, the lack of any self-hosting option, and gateway latency in interactive apps. Teams with compliance requirements switch because a cloud-only gateway can't meet data-residency rules at any price.
-
-### How hard is it to migrate from OpenRouter?
-
-Usually minutes. OpenRouter and its alternatives expose OpenAI-compatible endpoints, so the change is a base URL and API key, plus model-name prefixes in some cases. The [migration guide](https://docs.llmgateway.io/migrations/openrouter) covers the details.
-
----
 
 ## Try the Top Pick
 

--- a/apps/ui/src/content/blog/2026-07-26-generate-audio-api.md
+++ b/apps/ui/src/content/blog/2026-07-26-generate-audio-api.md
@@ -5,6 +5,13 @@ date: "2026-07-26"
 title: "How to Generate Audio with a Text-to-Speech API"
 summary: "A text-to-speech API tutorial: synthesize speech with ElevenLabs, OpenAI, Gemini, and Qwen voices through one OpenAI-compatible endpoint, choose voices and formats, steer delivery with instructions, and track the cost of every clip."
 categories: ["Guides"]
+faqs:
+  - question: "Which text-to-speech models are available through the API?"
+    answer: "Everything on the [models page with the audio filter](https://llmgateway.io/models?filters=1&audioGeneration=true) — spanning ElevenLabs, OpenAI, Google, and Alibaba voices — through one endpoint. The catalog updates as providers ship new models."
+  - question: "Can I stream the audio as it generates?"
+    answer: "Not yet. The endpoint returns the complete audio file in a single response; there is no chunked or SSE streaming output for now."
+  - question: "How do I pick a voice without writing code?"
+    answer: "Use the [Audio Studio in Lounge](https://lounge.llmgateway.io/audio) — it generates speech from up to three models side by side with per-model voice, format, and speed controls."
 image:
   src: "/blog/generate-audio-api.png"
   alt: "A glowing waveform and speaker on a circuit board, representing a text-to-speech API"
@@ -87,20 +94,6 @@ The same gateway also exposes `POST /v1/audio/transcriptions` for speech-to-text
 ## What does a clip cost?
 
 Billing varies by model family: some models bill on token usage reported by the provider, others on input character count. Either way the gateway logs each request with its exact cost, visible per request on the [Activity page](https://docs.llmgateway.io/learn/activity) and aggregated in your [usage dashboards](https://docs.llmgateway.io/learn/usage-metrics). Per-model pricing is on the [models page](https://llmgateway.io/models?filters=1&audioGeneration=true), and [API key spend limits](https://docs.llmgateway.io/learn/api-keys) cap the blast radius of batch narration jobs.
-
-## Frequently Asked Questions
-
-### Which text-to-speech models are available through the API?
-
-Everything on the [models page with the audio filter](https://llmgateway.io/models?filters=1&audioGeneration=true) — spanning ElevenLabs, OpenAI, Google, and Alibaba voices — through one endpoint. The catalog updates as providers ship new models.
-
-### Can I stream the audio as it generates?
-
-Not yet. The endpoint returns the complete audio file in a single response; there is no chunked or SSE streaming output for now.
-
-### How do I pick a voice without writing code?
-
-Use the [Audio Studio in Lounge](https://lounge.llmgateway.io/audio) — it generates speech from up to three models side by side with per-model voice, format, and speed controls.
 
 ---
 

--- a/apps/ui/src/content/blog/2026-07-26-generate-images-api.md
+++ b/apps/ui/src/content/blog/2026-07-26-generate-images-api.md
@@ -5,6 +5,15 @@ date: "2026-07-26"
 title: "How to Generate Images with One API (2026 Guide)"
 summary: "A practical AI image generation API tutorial: call gpt-image-2, Gemini, and Seedream through one OpenAI-compatible endpoint, pick sizes and quality, edit existing images, and see the exact cost of every generation."
 categories: ["Guides"]
+faqs:
+  - question: "Which image generation models can I use through the API?"
+    answer: "Every model on the [models page with the image filter](https://llmgateway.io/models?filters=1&imageGeneration=true) — including OpenAI, Google, ByteDance, Alibaba, xAI, and more — through the same endpoint. The list updates as new models ship."
+  - question: "Do I need separate API keys per provider?"
+    answer: "No. One LLM Gateway key covers every provider. You can bring your own provider keys for free, or use pay-as-you-go credits with a flat 5% platform fee."
+  - question: "Can I generate images conversationally?"
+    answer: "Yes. Multimodal models like `gemini-3-pro-image-preview` can return images through `/v1/chat/completions`, which is useful for iterative editing in a chat UI. The [image generation docs](https://docs.llmgateway.io/features/image-generation) cover the chat flow."
+  - question: "Is there a way to try models before writing code?"
+    answer: "The [Image Studio in Lounge](https://lounge.llmgateway.io/image) generates 1, 2, or 4 images per prompt and lets you compare models side by side."
 image:
   src: "/blog/generate-images-api.png"
   alt: "A glowing image frame being generated on a circuit board, representing an AI image generation API"
@@ -129,24 +138,6 @@ See the [AI SDK developer docs](https://docs.llmgateway.io/developers/ai-sdk-ima
 ## Know what every image costs
 
 Every generation is logged with its exact cost. The [Activity page](https://docs.llmgateway.io/learn/activity) shows per-request image output costs, and the [dashboard](https://docs.llmgateway.io/learn/dashboard) rolls them up by model and project — so you can compare not just output quality across models, but price per image. Set a [spending limit on the API key](https://docs.llmgateway.io/learn/api-keys) if you want a hard cap.
-
-## Frequently Asked Questions
-
-### Which image generation models can I use through the API?
-
-Every model on the [models page with the image filter](https://llmgateway.io/models?filters=1&imageGeneration=true) — including OpenAI, Google, ByteDance, Alibaba, xAI, and more — through the same endpoint. The list updates as new models ship.
-
-### Do I need separate API keys per provider?
-
-No. One LLM Gateway key covers every provider. You can bring your own provider keys for free, or use pay-as-you-go credits with a flat 5% platform fee.
-
-### Can I generate images conversationally?
-
-Yes. Multimodal models like `gemini-3-pro-image-preview` can return images through `/v1/chat/completions`, which is useful for iterative editing in a chat UI. The [image generation docs](https://docs.llmgateway.io/features/image-generation) cover the chat flow.
-
-### Is there a way to try models before writing code?
-
-The [Image Studio in Lounge](https://lounge.llmgateway.io/image) generates 1, 2, or 4 images per prompt and lets you compare models side by side.
 
 ---
 

--- a/apps/ui/src/content/blog/2026-07-26-generate-videos-api.md
+++ b/apps/ui/src/content/blog/2026-07-26-generate-videos-api.md
@@ -5,6 +5,13 @@ date: "2026-07-26"
 title: "How to Generate AI Videos with an API"
 summary: "An AI video generation API tutorial: submit async jobs to Veo, Seedance, and KLING through one OpenAI-compatible endpoint, poll or receive signed webhooks, download the MP4, and keep per-second costs visible."
 categories: ["Guides"]
+faqs:
+  - question: "How long does AI video generation take?"
+    answer: "Minutes, not seconds — depending on the model, duration, and resolution. That's why the API is asynchronous: submit, then poll or take a webhook. 4K jobs stay `in_progress` until the upscaled output is ready."
+  - question: "Which video model is cheapest for prototyping?"
+    answer: "Prototype on a low-priced tier like Seedance 2.0 Mini at 480p or 720p, then re-render the winning prompt on a premium model at 1080p — same request body, different `model` and `size`."
+  - question: "Can I generate videos without writing code first?"
+    answer: "Yes — the [Video Studio in Lounge](https://lounge.llmgateway.io/video) runs the same models with resolution, duration, and audio controls in the browser."
 image:
   src: "/blog/generate-videos-api.png"
   alt: "A glowing film clapperboard rendering frames on a circuit board, representing an AI video generation API"
@@ -130,20 +137,6 @@ Frame inputs and reference inputs can't be combined in one request, and referenc
 ## Watch the spend
 
 Video is the most expensive modality you'll route, so treat cost as a first-class output: every job is logged with its per-second price, the [Activity page](https://docs.llmgateway.io/learn/activity) breaks out video output costs, and [API key spending limits](https://docs.llmgateway.io/learn/api-keys) put a hard cap on how much a runaway batch job can burn.
-
-## Frequently Asked Questions
-
-### How long does AI video generation take?
-
-Minutes, not seconds — depending on the model, duration, and resolution. That's why the API is asynchronous: submit, then poll or take a webhook. 4K jobs stay `in_progress` until the upscaled output is ready.
-
-### Which video model is cheapest for prototyping?
-
-Prototype on a low-priced tier like Seedance 2.0 Mini at 480p or 720p, then re-render the winning prompt on a premium model at 1080p — same request body, different `model` and `size`.
-
-### Can I generate videos without writing code first?
-
-Yes — the [Video Studio in Lounge](https://lounge.llmgateway.io/video) runs the same models with resolution, duration, and audio controls in the browser.
 
 ---
 

--- a/apps/ui/src/content/blog/2026-07-26-track-llm-usage-spend-api.md
+++ b/apps/ui/src/content/blog/2026-07-26-track-llm-usage-spend-api.md
@@ -5,6 +5,15 @@ date: "2026-07-26"
 title: "How to Track LLM Usage and Spend with the API"
 summary: "An LLM cost tracking tutorial: read the exact USD cost of every request from the response's usage object, segment spend by user and feature with metadata headers, enforce hard budgets with per-key spending limits, and audit everything in the dashboard."
 categories: ["Guides"]
+faqs:
+  - question: "Does cost tracking work with streaming?"
+    answer: "Yes. The final usage chunk of a streamed response includes `cost` and `cost_details`, identical to non-streaming responses."
+  - question: "Does this work if I bring my own provider keys?"
+    answer: "Yes. Requests routed through your own provider keys are logged and costed the same way — the dashboard splits spend between credits and BYOK traffic."
+  - question: "Can I track image, video, and audio costs too?"
+    answer: "Yes. The usage schema includes image input/output, audio, and video cost fields, and the dashboards break modality costs out — see the guides on [image](/blog/generate-images-api), [video](/blog/generate-videos-api), and [audio](/blog/generate-audio-api) generation."
+  - question: "Is cost tracking gated to a paid plan?"
+    answer: "No. Cost breakdown in API responses is available to all users, on both hosted and self-hosted deployments."
 image:
   src: "/blog/track-llm-usage-spend-api.png"
   alt: "A glowing cost meter and coins on a circuit board, representing LLM usage and spend tracking"
@@ -119,24 +128,6 @@ Everything above also lands in the dashboard, per project and per organization:
 - [**Organization Analytics**](https://docs.llmgateway.io/learn/org-analytics) and [**Member Analytics**](https://docs.llmgateway.io/learn/member-analytics) — roll-ups across projects and per team member
 
 Costs are split between credits and bring-your-own provider keys, and image, video, and audio generations carry their own cost components — so multimodal workloads stay as accountable as text.
-
-## Frequently Asked Questions
-
-### Does cost tracking work with streaming?
-
-Yes. The final usage chunk of a streamed response includes `cost` and `cost_details`, identical to non-streaming responses.
-
-### Does this work if I bring my own provider keys?
-
-Yes. Requests routed through your own provider keys are logged and costed the same way — the dashboard splits spend between credits and BYOK traffic.
-
-### Can I track image, video, and audio costs too?
-
-Yes. The usage schema includes image input/output, audio, and video cost fields, and the dashboards break modality costs out — see the guides on [image](/blog/generate-images-api), [video](/blog/generate-videos-api), and [audio](/blog/generate-audio-api) generation.
-
-### Is cost tracking gated to a paid plan?
-
-No. Cost breakdown in API responses is available to all users, on both hosted and self-hosted deployments.
 
 ---
 

--- a/apps/ui/src/content/blog/2026-08-04-gdpr-compliant-llm-routing.md
+++ b/apps/ui/src/content/blog/2026-08-04-gdpr-compliant-llm-routing.md
@@ -5,6 +5,15 @@ date: "2026-08-04"
 title: "GDPR-Compliant LLM Routing, Enforced at the Gateway"
 summary: "How to keep LLM traffic GDPR-compliant in practice: restrict routing to GDPR-compliant providers, filter by provider headquarters, pin regions, and block non-compliant requests before any data leaves your gateway."
 categories: ["Guides"]
+faqs:
+  - question: "Can I force LLM traffic to stay with GDPR-compliant providers?"
+    answer: "Yes. LLM Gateway's provider compliance policies (Enterprise plan) include a GDPR requirement that removes non-compliant providers from routing entirely. Requests that would otherwise reach a non-compliant provider are rejected with a `403` before any data leaves the gateway."
+  - question: "What happens when a provider's GDPR status is unknown?"
+    answer: "It's treated as non-compliant. Every requirement in a compliance policy is fail-closed: a provider passes only when its published data policy explicitly satisfies the requirement."
+  - question: "Can I restrict routing to providers headquartered in specific countries?"
+    answer: "Yes. The Provider Headquarters filter allows only providers based in your selected countries, composes with the certification and data-policy requirements, and blocks providers with unknown headquarters while active."
+  - question: "Does GDPR compliance require self-hosting the gateway?"
+    answer: "No — the compliance policy, headquarters filter, and retention controls all work on the managed cloud. Self-hosting the AGPLv3 core is the option for teams whose policy requires the gateway itself, not just the providers, to run inside their own boundary."
 image:
   src: "/blog/gdpr-compliant-llm-routing.png"
   alt: "GDPR-compliant LLM routing concept — a glowing shield gate on a circuit board filtering request traces"
@@ -78,24 +87,6 @@ For teams that need the gateway itself inside their boundary, the core is AGPLv3
 ## Custom providers and self-attestation
 
 If you route to deployments you operate yourself — an EU-region deployment in your own cloud account, for instance — those [custom providers](https://docs.llmgateway.io/features/custom-providers) have no published data policy, so an active compliance policy blocks them by default. An organization owner can record a self-attestation of the deployment's posture (GDPR status, logging, training, operating country), which the gateway evaluates with the same fail-closed rules. Attestation changes are recorded in the audit log.
-
-## Frequently Asked Questions
-
-### Can I force LLM traffic to stay with GDPR-compliant providers?
-
-Yes. LLM Gateway's provider compliance policies (Enterprise plan) include a GDPR requirement that removes non-compliant providers from routing entirely. Requests that would otherwise reach a non-compliant provider are rejected with a `403` before any data leaves the gateway.
-
-### What happens when a provider's GDPR status is unknown?
-
-It's treated as non-compliant. Every requirement in a compliance policy is fail-closed: a provider passes only when its published data policy explicitly satisfies the requirement.
-
-### Can I restrict routing to providers headquartered in specific countries?
-
-Yes. The Provider Headquarters filter allows only providers based in your selected countries, composes with the certification and data-policy requirements, and blocks providers with unknown headquarters while active.
-
-### Does GDPR compliance require self-hosting the gateway?
-
-No — the compliance policy, headquarters filter, and retention controls all work on the managed cloud. Self-hosting the AGPLv3 core is the option for teams whose policy requires the gateway itself, not just the providers, to run inside their own boundary.
 
 <BlogCta variant="enterprise" location="bottom" />
 

--- a/apps/ui/src/content/blog/2026-08-04-helicone-alternatives.md
+++ b/apps/ui/src/content/blog/2026-08-04-helicone-alternatives.md
@@ -5,6 +5,15 @@ date: "2026-08-04"
 title: "8 Best Helicone Alternatives in 2026 (Compared)"
 summary: "Helicone entered maintenance mode after the Mintlify acquisition in March 2026. The 8 best Helicone alternatives in 2026, compared honestly — gateways with built-in analytics and dedicated LLM observability platforms — and how to pick between them."
 categories: ["Guides"]
+faqs:
+  - question: "Is Helicone still maintained in 2026?"
+    answer: "Helicone is in maintenance mode following its acquisition by Mintlify in March 2026 — existing deployments keep working, but there's no active feature development. That's workable for current users and the wrong bet for new deployments."
+  - question: "What is the best Helicone alternative?"
+    answer: "For the way most teams actually used Helicone — a proxy that made costs and latency visible — LLM Gateway is the closest one-for-one replacement: the same base-URL adoption with analytics included, plus multi-provider routing Helicone never had. For deep traces and evals, Langfuse is the open-source standard."
+  - question: "Do I need a gateway or an observability platform?"
+    answer: "Ask what you'd lose tomorrow if Helicone vanished. If it's cost/latency visibility, a gateway with built-in analytics replaces it and improves your routing. If it's span-level agent traces and evals, you want a dedicated platform — and the two work together."
+  - question: "How hard is it to migrate off Helicone?"
+    answer: "If you adopted Helicone via its proxy URL, migrating to another proxy-style tool is the same one-line change. Moving to an SDK-based platform (Langfuse, LangSmith) is a bigger step: you're adding instrumentation, not just redirecting traffic."
 image:
   src: "/blog/helicone-alternatives.png"
   alt: "The best Helicone alternatives in 2026 — a glowing analytics dashboard chip observing request traces on a circuit board"
@@ -256,26 +265,6 @@ PostHog added LLM analytics to its open-source product-analytics platform: token
 **You're buying one enterprise suite:** Portkey — after reading up on the acquisition.
 
 And remember the camps compose: a gateway carrying your traffic and an observability platform tracing your agents is a normal 2026 stack, not a duplication.
-
-## Frequently Asked Questions
-
-### Is Helicone still maintained in 2026?
-
-Helicone is in maintenance mode following its acquisition by Mintlify in March 2026 — existing deployments keep working, but there's no active feature development. That's workable for current users and the wrong bet for new deployments.
-
-### What is the best Helicone alternative?
-
-For the way most teams actually used Helicone — a proxy that made costs and latency visible — LLM Gateway is the closest one-for-one replacement: the same base-URL adoption with analytics included, plus multi-provider routing Helicone never had. For deep traces and evals, Langfuse is the open-source standard.
-
-### Do I need a gateway or an observability platform?
-
-Ask what you'd lose tomorrow if Helicone vanished. If it's cost/latency visibility, a gateway with built-in analytics replaces it and improves your routing. If it's span-level agent traces and evals, you want a dedicated platform — and the two work together.
-
-### How hard is it to migrate off Helicone?
-
-If you adopted Helicone via its proxy URL, migrating to another proxy-style tool is the same one-line change. Moving to an SDK-based platform (Langfuse, LangSmith) is a bigger step: you're adding instrumentation, not just redirecting traffic.
-
----
 
 ## Try the Top Pick
 

--- a/apps/ui/src/content/blog/2026-08-04-kimi-k3-api.md
+++ b/apps/ui/src/content/blog/2026-08-04-kimi-k3-api.md
@@ -5,6 +5,16 @@ date: "2026-08-04"
 title: "Kimi K3 API Guide: Pricing, Reasoning, and Setup"
 summary: "How to use the Kimi K3 API in practice: endpoints, pricing ($3/$0.30/$15 per million tokens), the reasoning_effort parameter, tool calls, JSON output, the 1M-token context — and how to route it through one OpenAI-compatible endpoint with automatic failover."
 categories: ["Guides"]
+model: kimi-k3
+faqs:
+  - question: "How much does the Kimi K3 API cost?"
+    answer: "$3 per million input tokens, $0.30 per million cached input tokens, and $15 per million output tokens. Reasoning tokens count as output. With the >90% cache-hit rates Moonshot reports for coding workloads, effective input cost in agent sessions lands far below the sticker price."
+  - question: "Can I turn off reasoning on Kimi K3?"
+    answer: "No — K3 always reasons. You control depth with `reasoning_effort` (`low`, `high`, or `max` on Moonshot's native deployment, defaulting to `max`). Use `low` to keep reasoning-token spend down on simple calls."
+  - question: "Is the Kimi K3 API OpenAI-compatible?"
+    answer: "Yes. Moonshot exposes OpenAI- and Anthropic-compatible endpoints, and through LLM Gateway you use the standard `/v1/chat/completions` surface with any OpenAI SDK — plus routing across every provider that serves K3, not just Moonshot."
+  - question: "Does Kimi K3 really have a 1M-token context?"
+    answer: "Yes — 1,048,576 tokens, with output configurable up to the same limit. Budget for it: a fully-loaded uncached prompt costs about $3, so pair long contexts with prompt caching and sticky sessions."
 image:
   src: "/blog/kimi-k3-api.png"
   alt: "Kimi K3 API concept — a glowing API socket connecting to a large model chip on a circuit board"
@@ -122,24 +132,6 @@ For agent loops and coding sessions — exactly the workloads where Moonshot mea
 ## Flat-rate access on DevPass
 
 If your Kimi K3 usage comes from coding tools rather than an application, [DevPass](https://devpass.llmgateway.io) covers it at a flat monthly rate instead of per-token billing. K3 is a **premium-tier** model on DevPass — every plan includes a weekly premium allowance for it, alongside the standard-tier open-weight models with no weekly cap. The [Claude Code setup guide](/blog/kimi-k3-claude-code) shows the five-minute configuration.
-
-## Frequently Asked Questions
-
-### How much does the Kimi K3 API cost?
-
-$3 per million input tokens, $0.30 per million cached input tokens, and $15 per million output tokens. Reasoning tokens count as output. With the >90% cache-hit rates Moonshot reports for coding workloads, effective input cost in agent sessions lands far below the sticker price.
-
-### Can I turn off reasoning on Kimi K3?
-
-No — K3 always reasons. You control depth with `reasoning_effort` (`low`, `high`, or `max` on Moonshot's native deployment, defaulting to `max`). Use `low` to keep reasoning-token spend down on simple calls.
-
-### Is the Kimi K3 API OpenAI-compatible?
-
-Yes. Moonshot exposes OpenAI- and Anthropic-compatible endpoints, and through LLM Gateway you use the standard `/v1/chat/completions` surface with any OpenAI SDK — plus routing across every provider that serves K3, not just Moonshot.
-
-### Does Kimi K3 really have a 1M-token context?
-
-Yes — 1,048,576 tokens, with output configurable up to the same limit. Budget for it: a fully-loaded uncached prompt costs about $3, so pair long contexts with prompt caching and sticky sessions.
 
 ## Getting started
 

--- a/apps/ui/src/content/blog/2026-08-04-kimi-k3-open-weights.md
+++ b/apps/ui/src/content/blog/2026-08-04-kimi-k3-open-weights.md
@@ -5,6 +5,16 @@ date: "2026-08-04"
 title: "Kimi K3 Open Weights Are Out: What You Can Actually Do"
 summary: "Moonshot released the Kimi K3 open weights on July 26, 2026 — 2.8T parameters, the largest open-weight model ever shipped. What's in the release, what it takes to run Kimi K3 locally, the license caveat, and the hosted routes that don't need a GPU cluster."
 categories: ["Guides"]
+model: kimi-k3
+faqs:
+  - question: "Are the Kimi K3 weights really open?"
+    answer: 'The full 2.8T-parameter weights are downloadable from Hugging Face, so it''s an open-weight release in the practical sense. The license is a custom "Kimi K3 License", not MIT or Apache — read the LICENSE file in the repository before any commercial self-hosting decision.'
+  - question: "Can I run Kimi K3 on my own hardware?"
+    answer: "Only at cluster scale. At MXFP4 the weights alone are roughly 1.4 TB, so plan for a multi-node GPU deployment on vLLM or SGLang. For everyone else, the hosted route through an API is the realistic option."
+  - question: "What does Kimi K3 cost through an API?"
+    answer: "Through LLM Gateway, Kimi K3 runs at $3 per million input tokens, $0.30 per million cached input tokens, and $15 per million output tokens — the same rates Moonshot publishes. On DevPass it's a premium-tier model covered by the weekly premium allowance."
+  - question: "Why release the weights at all?"
+    answer: "Open weights widen the hosting market, make the model auditable, and give large customers the escape hatch they increasingly demand. Moonshot follows a pattern that GLM, DeepSeek, and MiniMax established: hosted-first economics, open-weight trust."
 image:
   src: "/blog/kimi-k3-open-weights.png"
   alt: "Kimi K3 open weights release — a massive glowing model chip being unlocked on a circuit board"
@@ -70,23 +80,5 @@ On [DevPass](https://devpass.llmgateway.io), Kimi K3 is a premium-tier model —
 ## What the release changes
 
 The precedent matters more than the download count. K3 at 2.8T proves frontier-scale MoE models can ship as open weights with quantization-aware 4-bit deployment as the intended path — and it resets expectations for [the open-weight wave](/blog/best-open-source-llms) behind it. For most teams, the practical consequence isn't self-hosting; it's leverage. Hosted pricing for open-weight models faces competition that closed models never do.
-
-## Frequently Asked Questions
-
-### Are the Kimi K3 weights really open?
-
-The full 2.8T-parameter weights are downloadable from Hugging Face, so it's an open-weight release in the practical sense. The license is a custom "Kimi K3 License", not MIT or Apache — read the LICENSE file in the repository before any commercial self-hosting decision.
-
-### Can I run Kimi K3 on my own hardware?
-
-Only at cluster scale. At MXFP4 the weights alone are roughly 1.4 TB, so plan for a multi-node GPU deployment on vLLM or SGLang. For everyone else, the hosted route through an API is the realistic option.
-
-### What does Kimi K3 cost through an API?
-
-Through LLM Gateway, Kimi K3 runs at $3 per million input tokens, $0.30 per million cached input tokens, and $15 per million output tokens — the same rates Moonshot publishes. On DevPass it's a premium-tier model covered by the weekly premium allowance.
-
-### Why release the weights at all?
-
-Open weights widen the hosting market, make the model auditable, and give large customers the escape hatch they increasingly demand. Moonshot follows a pattern that GLM, DeepSeek, and MiniMax established: hosted-first economics, open-weight trust.
 
 <BlogCta variant="gateway" location="bottom" />

--- a/apps/ui/src/content/blog/2026-08-04-llm-compliance-checklist.md
+++ b/apps/ui/src/content/blog/2026-08-04-llm-compliance-checklist.md
@@ -5,6 +5,15 @@ date: "2026-08-04"
 title: "The LLM Compliance Checklist for Production Teams"
 summary: "An eight-point LLM compliance checklist for putting model traffic in production: provider vetting, routing restrictions, data residency, retention, access control, and the audit trail — with what to enforce at the gateway versus document by hand."
 categories: ["Guides"]
+faqs:
+  - question: "What should an LLM compliance checklist cover?"
+    answer: "Provider inventory, routing restrictions, geographic control, retention (yours and your providers'), access gating, an audit trail, coverage for internal deployments, and diligence on the gateway vendor itself. The distinguishing question for each: is it enforced mechanically, or documented and hoped for?"
+  - question: "Can compliance rules be enforced before data reaches a provider?"
+    answer: "Yes — that's the point of enforcing at the gateway. LLM Gateway blocks requests that would violate the compliance policy with a `403` before any data leaves the gateway, on both automatic routing and pinned-provider requests."
+  - question: "Which parts of this need an Enterprise plan?"
+    answer: "Provider compliance policies, the headquarters filter, org-level restrictions over IAM, custom retention periods, and audit logs are [Enterprise features](https://llmgateway.io/enterprise). Metadata-only retention, the provider directory, and self-hosting the AGPLv3 core are available to everyone."
+  - question: "Does self-hosting remove the need for this checklist?"
+    answer: "No — self-hosting moves the gateway inside your boundary but your traffic still fans out to providers. Points 1–5 apply identically; you're just running the enforcement point yourself."
 image:
   src: "/blog/llm-compliance-checklist.png"
   alt: "LLM compliance checklist concept — a glowing clipboard chip with checkmarks on a circuit board"
@@ -86,23 +95,5 @@ The gateway sees everything, so it has to clear a higher bar than the providers 
 | 6   | Audit trail                    | Security events + audit logs                    | Enterprise |
 | 7   | Custom-deployment attestations | Self-attestation, fail-closed evaluation        | Enterprise |
 | 8   | Gateway vendor diligence       | SOC 2 Type II + trust center + AGPLv3 source    | —          |
-
-## Frequently Asked Questions
-
-### What should an LLM compliance checklist cover?
-
-Provider inventory, routing restrictions, geographic control, retention (yours and your providers'), access gating, an audit trail, coverage for internal deployments, and diligence on the gateway vendor itself. The distinguishing question for each: is it enforced mechanically, or documented and hoped for?
-
-### Can compliance rules be enforced before data reaches a provider?
-
-Yes — that's the point of enforcing at the gateway. LLM Gateway blocks requests that would violate the compliance policy with a `403` before any data leaves the gateway, on both automatic routing and pinned-provider requests.
-
-### Which parts of this need an Enterprise plan?
-
-Provider compliance policies, the headquarters filter, org-level restrictions over IAM, custom retention periods, and audit logs are [Enterprise features](https://llmgateway.io/enterprise). Metadata-only retention, the provider directory, and self-hosting the AGPLv3 core are available to everyone.
-
-### Does self-hosting remove the need for this checklist?
-
-No — self-hosting moves the gateway inside your boundary but your traffic still fans out to providers. Points 1–5 apply identically; you're just running the enforcement point yourself.
 
 <BlogCta variant="enterprise" location="bottom" />

--- a/apps/ui/src/content/blog/2026-08-04-llm-data-retention.md
+++ b/apps/ui/src/content/blog/2026-08-04-llm-data-retention.md
@@ -5,6 +5,15 @@ date: "2026-08-04"
 title: "LLM Data Retention: What to Store, and for How Long"
 summary: "A practical guide to LLM data retention: when storing full prompts and responses helps, when metadata is enough, what it costs, and how to set a retention policy your compliance team will sign off on."
 categories: ["Guides"]
+faqs:
+  - question: "Does LLM Gateway store my prompts by default?"
+    answer: "No. The default retention level is metadata-only: timestamps, models, token counts, and costs, with no request or response payloads. Full payload storage is an explicit opt-in per organization, available on standard pay-as-you-go organizations."
+  - question: "How much does LLM data retention cost?"
+    answer: "Metadata retention is free. Full payload retention costs $0.01 per 1 million tokens across all token types, billed per request and itemized in `usage.cost_details.data_storage_cost`."
+  - question: "How long does LLM Gateway keep stored request data?"
+    answer: "On the managed cloud, 30 days by default, after which records are deleted automatically; Enterprise organizations can configure custom retention periods to match their audit or data-minimization requirements. Payload retention itself is only configurable on standard pay-as-you-go organizations — DevPass and chat subscriptions stay metadata-only. Self-hosted deployments set their own retention periods through environment variables."
+  - question: "Can I keep LLM logs inside my own infrastructure?"
+    answer: "Yes — self-host the AGPLv3 gateway and all stored data lives in your own PostgreSQL database, with retention configured through environment variables and no per-token storage fee."
 image:
   src: "/blog/llm-data-retention.png"
   alt: "LLM data retention concept — a glowing vault chip on a circuit board holding request records"
@@ -68,23 +77,5 @@ All stored data is encrypted at rest, access is restricted to organization membe
 Retention controls what _you_ keep. The other half of the question is what your _providers_ keep — whether they log prompts, train on them, and where they're headquartered. That's governed by [provider compliance policies](https://docs.llmgateway.io/features/compliance), which block requests to providers that don't meet your requirements before any data leaves the gateway.
 
 For the full picture, see the [LLM compliance checklist](/blog/llm-compliance-checklist) and our guide to [GDPR-compliant LLM routing](/blog/gdpr-compliant-llm-routing). Our own handling of your data is covered by a SOC 2 Type II report — see [the announcement](/blog/soc2-type-ii) or request the report at [security.llmgateway.io](https://security.llmgateway.io/).
-
-## Frequently Asked Questions
-
-### Does LLM Gateway store my prompts by default?
-
-No. The default retention level is metadata-only: timestamps, models, token counts, and costs, with no request or response payloads. Full payload storage is an explicit opt-in per organization, available on standard pay-as-you-go organizations.
-
-### How much does LLM data retention cost?
-
-Metadata retention is free. Full payload retention costs $0.01 per 1 million tokens across all token types, billed per request and itemized in `usage.cost_details.data_storage_cost`.
-
-### How long does LLM Gateway keep stored request data?
-
-On the managed cloud, 30 days by default, after which records are deleted automatically; Enterprise organizations can configure custom retention periods to match their audit or data-minimization requirements. Payload retention itself is only configurable on standard pay-as-you-go organizations — DevPass and chat subscriptions stay metadata-only. Self-hosted deployments set their own retention periods through environment variables.
-
-### Can I keep LLM logs inside my own infrastructure?
-
-Yes — self-host the AGPLv3 gateway and all stored data lives in your own PostgreSQL database, with retention configured through environment variables and no per-token storage fee.
 
 <BlogCta variant="enterprise" location="bottom" />

--- a/apps/ui/src/content/blog/2026-08-04-portkey-alternatives.md
+++ b/apps/ui/src/content/blog/2026-08-04-portkey-alternatives.md
@@ -5,6 +5,15 @@ date: "2026-08-04"
 title: "8 Best Portkey Alternatives in 2026 (Compared)"
 summary: "The 8 best Portkey alternatives in 2026, compared honestly — open-source gateways, managed routers, and VPC platforms — with fees, self-hosting, governance, and who each option genuinely fits after the Palo Alto Networks acquisition."
 categories: ["Guides"]
+faqs:
+  - question: "What is the best Portkey alternative in 2026?"
+    answer: "LLM Gateway is the strongest overall alternative: fully open source (AGPLv3), self-hostable, offered as a managed cloud, with governance — compliance policies, audit logs, guardrails — built in rather than metered per log. The right choice depends on what you used Portkey for: governance (LLM Gateway, TrueFoundry, Kong) or routing (Vercel AI Gateway, OpenRouter)."
+  - question: "Is Portkey still an independent company?"
+    answer: "No. Palo Alto Networks' acquisition of Portkey closed in May 2026, and the product is being folded into Prisma AIRS. Existing deployments keep working; the roadmap and sales motion now run through Palo Alto Networks."
+  - question: "Is there a fully open-source Portkey alternative?"
+    answer: "Portkey's Gateway 2.0 open-sourced much of the stack under MIT, but persistent storage and compliance features remain cloud-only. LLM Gateway (AGPLv3), LiteLLM, and Bifrost are self-hostable end to end — LLM Gateway is the one that ships the dashboard, analytics, and governance rather than just a proxy."
+  - question: "How hard is it to migrate off Portkey?"
+    answer: "The API change is minutes — both sides speak the OpenAI format. Budget the real time for recreating routing configs, budgets, guardrails, and permissions in the new platform, and for updating any code that used Portkey-specific headers or the Portkey SDK wrapper."
 image:
   src: "/blog/portkey-alternatives.png"
   alt: "The best Portkey alternatives in 2026 — gateway routes diverging from a central hub on a circuit board"
@@ -287,26 +296,6 @@ Portkey's gateway speaks the OpenAI format, so the mechanical change is small �
 ```
 
 The real work is recreating what lived in Portkey's dashboard: routing configs, budgets, guardrails, and team permissions. Map each to the new platform before you cut over — on LLM Gateway that's [routing](https://docs.llmgateway.io/features/routing), per-key limits, [guardrails](https://llmgateway.io/enterprise/guardrails), and [compliance policies](https://docs.llmgateway.io/features/compliance).
-
-## Frequently Asked Questions
-
-### What is the best Portkey alternative in 2026?
-
-LLM Gateway is the strongest overall alternative: fully open source (AGPLv3), self-hostable, offered as a managed cloud, with governance — compliance policies, audit logs, guardrails — built in rather than metered per log. The right choice depends on what you used Portkey for: governance (LLM Gateway, TrueFoundry, Kong) or routing (Vercel AI Gateway, OpenRouter).
-
-### Is Portkey still an independent company?
-
-No. Palo Alto Networks' acquisition of Portkey closed in May 2026, and the product is being folded into Prisma AIRS. Existing deployments keep working; the roadmap and sales motion now run through Palo Alto Networks.
-
-### Is there a fully open-source Portkey alternative?
-
-Portkey's Gateway 2.0 open-sourced much of the stack under MIT, but persistent storage and compliance features remain cloud-only. LLM Gateway (AGPLv3), LiteLLM, and Bifrost are self-hostable end to end — LLM Gateway is the one that ships the dashboard, analytics, and governance rather than just a proxy.
-
-### How hard is it to migrate off Portkey?
-
-The API change is minutes — both sides speak the OpenAI format. Budget the real time for recreating routing configs, budgets, guardrails, and permissions in the new platform, and for updating any code that used Portkey-specific headers or the Portkey SDK wrapper.
-
----
 
 ## Try the Top Pick
 

--- a/apps/ui/src/content/blog/2026-08-08-ai-gateway-benchmark.md
+++ b/apps/ui/src/content/blog/2026-08-08-ai-gateway-benchmark.md
@@ -5,6 +5,13 @@ date: "2026-08-08"
 title: "Ranked #1 on an Independent AI Gateway Benchmark"
 summary: "In the August 7 run of computesdk's independent AI gateway benchmark, LLM Gateway ranked first of six gateways with a composite score of 90.8 — driven by the tightest tail latency in the field, not the fastest median. Here's what the benchmark measures, what our numbers actually show, and how to run it yourself."
 categories: ["Engineering"]
+faqs:
+  - question: "What does an AI gateway benchmark actually measure?"
+    answer: "A good one measures the latency the gateway itself adds, isolated from the model provider's own speed. computesdk's harness does this by running a direct-to-provider control alongside the gateways, pointing everything at the same model, and running all participants round-robin so they share the same network conditions. It separates cold requests (fresh connection, including DNS, TCP, and TLS) from warm ones (pooled connection), because those fail in different ways."
+  - question: "Does an AI gateway add latency compared to calling the provider directly?"
+    answer: "Yes. A gateway is an extra network hop, and no routing layer makes that free — in the August 7 run our warm TTFT median was 629 ms against the direct baseline's 615 ms. The question worth asking is what you get for it: failover across providers, unified billing and usage analytics, and a single API across model vendors. And the overhead is small enough that connection handling dominates it, which is why the tail, not the median, is where gateways actually differ."
+  - question: "How do I run the AI gateway benchmark myself?"
+    answer: "Clone [computesdk/benchmarks](https://github.com/computesdk/benchmarks), set an API key for each gateway you want to include, and run `pnpm bench:ai-gateway`. Gateways without keys are skipped, so you can benchmark just your own stack against the direct-to-provider control. Results are written to `results/ai-gateway/` as JSON, including every individual iteration, so you can compute your own percentiles rather than trusting anyone's composite."
 image:
   src: "/blog/ai-gateway-benchmark.png"
   alt: "A circuit board with a glowing stopwatch on the central chip surrounded by a podium and rising bar chart, representing AI gateway latency benchmarks"
@@ -92,20 +99,6 @@ pnpm bench:ai-gateway --iterations 20
 `7548e7584940` is the commit holding the August 7 results. `--iterations 20` matches that run's 20 cold and 20 warm probes per gateway; the default is 10. Any gateway whose API key isn't set is skipped, so the command above measures us against the direct-to-Anthropic control — add the other gateways' keys to reproduce the full leaderboard.
 
 Results land in `results/ai-gateway/`, and the composite weighting is in `benchmarks/ai-gateway/scoring.ts`.
-
-## Frequently Asked Questions
-
-### What does an AI gateway benchmark actually measure?
-
-A good one measures the latency the gateway itself adds, isolated from the model provider's own speed. computesdk's harness does this by running a direct-to-provider control alongside the gateways, pointing everything at the same model, and running all participants round-robin so they share the same network conditions. It separates cold requests (fresh connection, including DNS, TCP, and TLS) from warm ones (pooled connection), because those fail in different ways.
-
-### Does an AI gateway add latency compared to calling the provider directly?
-
-Yes. A gateway is an extra network hop, and no routing layer makes that free — in the August 7 run our warm TTFT median was 629 ms against the direct baseline's 615 ms. The question worth asking is what you get for it: failover across providers, unified billing and usage analytics, and a single API across model vendors. And the overhead is small enough that connection handling dominates it, which is why the tail, not the median, is where gateways actually differ.
-
-### How do I run the AI gateway benchmark myself?
-
-Clone [computesdk/benchmarks](https://github.com/computesdk/benchmarks), set an API key for each gateway you want to include, and run `pnpm bench:ai-gateway`. Gateways without keys are skipped, so you can benchmark just your own stack against the direct-to-provider control. Results are written to `results/ai-gateway/` as JSON, including every individual iteration, so you can compute your own percentiles rather than trusting anyone's composite.
 
 ---
 

--- a/apps/ui/src/content/blog/2026-08-12-vercel-ai-gateway-alternative.md
+++ b/apps/ui/src/content/blog/2026-08-12-vercel-ai-gateway-alternative.md
@@ -5,6 +5,15 @@ date: "2026-08-12"
 title: "A Vercel AI Gateway Alternative Without the Rewrite"
 summary: "Switching off the Vercel AI Gateway used to mean rewriting how your AI SDK app resolves models — and losing provider-native web search on the way out. LLM Gateway now implements the AI SDK's own gateway protocol, so the migration is one line and your bare model strings keep working."
 categories: ["Announcements", "Engineering"]
+faqs:
+  - question: "Is there a Vercel AI Gateway alternative that works without changing my code?"
+    answer: "Yes — as long as your app uses the AI SDK. LLM Gateway implements the same gateway protocol `@ai-sdk/gateway` speaks, so setting `globalThis.AI_SDK_DEFAULT_PROVIDER` to a `createGateway({ baseURL })` instance is the entire migration. Model strings, tool definitions, streaming, and the message-part rendering in your UI all stay as they are."
+  - question: "Why can't I just use an OpenAI-compatible provider instead?"
+    answer: "You can, and for a simple text app it works. What you lose is everything that lives above the OpenAI wire format: provider-native web search, the `source-url` citation parts your sources UI renders, and `getAvailableModels()` for the model picker. `@ai-sdk/openai-compatible` has no annotation handling at all, so citations cannot survive that path even if the gateway returns them."
+  - question: "Which AI SDK versions are supported?"
+    answer: "AI SDK 5, 6, and 7 — language model specification versions 2, 3, and 4. Each `@ai-sdk/gateway` major has a different default base-URL path, so use the matching prefix from the table above. The specification version travels in a request header and the gateway answers in the shape that version expects, including its usage-reporting format."
+  - question: "Do I have to move everything at once?"
+    answer: "No. `createGateway({ baseURL })` produces an ordinary provider instance, so you can point one route at LLM Gateway and leave the rest where it is. Set `globalThis.AI_SDK_DEFAULT_PROVIDER` only when you are ready for every bare model string to move."
 image:
   src: "/blog/vercel-ai-gateway-alternative.png"
   alt: "A circuit board with a glowing doorway on the central chip, representing a drop-in Vercel AI Gateway alternative for the AI SDK"
@@ -134,24 +143,6 @@ Honest limits, so you find them here rather than in production:
 - Three call options have no chat-completions equivalent — `stopSequences`, `seed`, and `topK`. They are reported as `unsupported` warnings on the result rather than silently dropped, so you can see what did not reach the provider.
 
 No plan gating: this works on the free plan with any API key.
-
-## Frequently Asked Questions
-
-### Is there a Vercel AI Gateway alternative that works without changing my code?
-
-Yes — as long as your app uses the AI SDK. LLM Gateway implements the same gateway protocol `@ai-sdk/gateway` speaks, so setting `globalThis.AI_SDK_DEFAULT_PROVIDER` to a `createGateway({ baseURL })` instance is the entire migration. Model strings, tool definitions, streaming, and the message-part rendering in your UI all stay as they are.
-
-### Why can't I just use an OpenAI-compatible provider instead?
-
-You can, and for a simple text app it works. What you lose is everything that lives above the OpenAI wire format: provider-native web search, the `source-url` citation parts your sources UI renders, and `getAvailableModels()` for the model picker. `@ai-sdk/openai-compatible` has no annotation handling at all, so citations cannot survive that path even if the gateway returns them.
-
-### Which AI SDK versions are supported?
-
-AI SDK 5, 6, and 7 — language model specification versions 2, 3, and 4. Each `@ai-sdk/gateway` major has a different default base-URL path, so use the matching prefix from the table above. The specification version travels in a request header and the gateway answers in the shape that version expects, including its usage-reporting format.
-
-### Do I have to move everything at once?
-
-No. `createGateway({ baseURL })` produces an ordinary provider instance, so you can point one route at LLM Gateway and leave the rest where it is. Set `globalThis.AI_SDK_DEFAULT_PROVIDER` only when you are ready for every bare model string to move.
 
 ---
 

--- a/apps/ui/src/content/blog/2026-08-15-kimi-api-status.md
+++ b/apps/ui/src/content/blog/2026-08-15-kimi-api-status.md
@@ -5,6 +5,16 @@ date: "2026-08-15"
 title: "Is Kimi Down? How to Check Kimi K3 API Status"
 summary: "Your coding agent started erroring and you need to know whether Kimi is down or your request is wrong. Here is how to read Kimi K3 API status per provider, tell an outage from a client error, and keep working through both."
 categories: ["Guides"]
+model: kimi-k3
+faqs:
+  - question: "Does Moonshot publish a Kimi status page?"
+    answer: "Not a public one covering the API. The practical substitute is measured uptime from a client that sends real traffic — which is what the [Kimi K3 uptime page](https://llmgateway.io/models/kimi-k3/uptime) reports, broken out by provider."
+  - question: "Why is Kimi K3 up for someone else but down for me?"
+    answer: "Almost always because you are on different providers. The same model ID can resolve to Moonshot for one caller and an independent host for another, and their incidents are unrelated."
+  - question: "How is uptime measured?"
+    answer: "It is the share of requests that completed successfully on the upstream provider over the last four hours. Client errors from your own request and gateway-side errors are both excluded, so the figure reflects provider reliability."
+  - question: "Will failover slow my requests down?"
+    answer: "Only the failed attempt costs you. Routing scores providers before the request goes out, so healthy traffic is not retried — and a provider that is timing out is scored down before it becomes your default."
 image:
   src: "/blog/kimi-api-status.png"
   alt: "Glowing status indicator on a circuit board with three parallel routes flowing into it, representing per-provider uptime monitoring for Kimi K3"
@@ -70,24 +80,6 @@ That is the honest test of one provider. Drop the header and the model prefix, a
 - **Switch models for the session.** If every host is struggling, an [open-weight alternative](https://llmgateway.io/models/open-source) keeps the agent moving. Same key, same endpoint, one string changes.
 - **Read the error body, not just the status code.** Upstream errors are passed through rather than flattened, so the provider's own message tells you whether it is capacity, a content filter, or a bad parameter.
 - **Check your own history.** The dashboard logs every request with the provider that served it, so you can see exactly when the failures started and which host they came from.
-
-## Frequently Asked Questions
-
-### Does Moonshot publish a Kimi status page?
-
-Not a public one covering the API. The practical substitute is measured uptime from a client that sends real traffic — which is what the [Kimi K3 uptime page](https://llmgateway.io/models/kimi-k3/uptime) reports, broken out by provider.
-
-### Why is Kimi K3 up for someone else but down for me?
-
-Almost always because you are on different providers. The same model ID can resolve to Moonshot for one caller and an independent host for another, and their incidents are unrelated.
-
-### How is uptime measured?
-
-It is the share of requests that completed successfully on the upstream provider over the last four hours. Client errors from your own request and gateway-side errors are both excluded, so the figure reflects provider reliability.
-
-### Will failover slow my requests down?
-
-Only the failed attempt costs you. Routing scores providers before the request goes out, so healthy traffic is not retried — and a provider that is timing out is scored down before it becomes your default.
 
 ## Getting started
 

--- a/apps/ui/src/content/blog/2026-08-15-what-is-an-ai-coding-plan.md
+++ b/apps/ui/src/content/blog/2026-08-15-what-is-an-ai-coding-plan.md
@@ -5,6 +5,15 @@ date: "2026-08-15"
 title: "What Is an AI Coding Plan? Limits and Costs Explained"
 summary: "An AI coding plan is a flat monthly fee that covers model usage inside your coding agent. This explains what a coding plan actually includes, how monthly allowances and weekly premium caps work, and how to size one against your real usage."
 categories: ["Guides"]
+faqs:
+  - question: "Is an AI coding plan cheaper than paying per token?"
+    answer: "For steady daily use, usually yes, because the allowance is metered at provider list rates with no markup. For occasional or bursty use, per-token credits cost less — you pay for the days you actually code instead of a monthly floor."
+  - question: "What is a premium model on a coding plan?"
+    answer: "The frontier flagships, the most expensive models per token. They draw on both the monthly allowance and a weekly ceiling. Standard models — the open-weight and mid-tier options — have no weekly cap."
+  - question: "Can I use my own coding agent, or am I locked into theirs?"
+    answer: "That depends on the vendor, and it is worth checking. A plan built on an OpenAI- or Anthropic-compatible endpoint works across the approved coding and agent tools — Claude Code, Cline, OpenCode, Cursor — rather than only inside one vendor's editor, which stops being useful the day you switch editors. What a flat-rate plan does not cover is wiring the key into your own application or batch job: that is general API traffic, and it belongs on pay-as-you-go credits. Check the [DevPass terms](https://devpass.llmgateway.io/legal/terms) for the current approved-tool list."
+  - question: "What happens to unused allowance at the end of the month?"
+    answer: "On most plans it expires at renewal rather than rolling over. The exception worth knowing about is a mid-cycle upgrade, where the unused remainder carries onto the new tier because you already paid for it."
 image:
   src: "/blog/what-is-an-ai-coding-plan.png"
   alt: "Glossy 3D circuit board with a central meter dial surrounded by coin and terminal icons, representing a metered flat-rate coding plan"
@@ -71,24 +80,6 @@ Guessing a tier is how people end up angry in week two. Two approaches that work
 **Start one tier below your guess.** Upgrades are immediate and the unused remainder of your current cycle rolls over onto the new tier's allowance rather than being forfeited, so moving up mid-month costs you nothing in wasted allowance. Moving down is a downgrade at renewal. Given that asymmetry, guessing low is cheaper than guessing high.
 
 If you mostly drive standard models and reach for a flagship on hard problems, Lite goes further than its price suggests. If a frontier model is your default and the agent runs all day, the weekly cap — not the monthly pool — is what you will hit, and that is a Pro or Max question.
-
-## Frequently Asked Questions
-
-### Is an AI coding plan cheaper than paying per token?
-
-For steady daily use, usually yes, because the allowance is metered at provider list rates with no markup. For occasional or bursty use, per-token credits cost less — you pay for the days you actually code instead of a monthly floor.
-
-### What is a premium model on a coding plan?
-
-The frontier flagships, the most expensive models per token. They draw on both the monthly allowance and a weekly ceiling. Standard models — the open-weight and mid-tier options — have no weekly cap.
-
-### Can I use my own coding agent, or am I locked into theirs?
-
-That depends on the vendor, and it is worth checking. A plan built on an OpenAI- or Anthropic-compatible endpoint works across the approved coding and agent tools — Claude Code, Cline, OpenCode, Cursor — rather than only inside one vendor's editor, which stops being useful the day you switch editors. What a flat-rate plan does not cover is wiring the key into your own application or batch job: that is general API traffic, and it belongs on pay-as-you-go credits. Check the [DevPass terms](https://devpass.llmgateway.io/legal/terms) for the current approved-tool list.
-
-### What happens to unused allowance at the end of the month?
-
-On most plans it expires at renewal rather than rolling over. The exception worth knowing about is a mid-cycle upgrade, where the unused remainder carries onto the new tier because you already paid for it.
 
 ## Getting started
 

--- a/apps/ui/src/lib/attribution.spec.ts
+++ b/apps/ui/src/lib/attribution.spec.ts
@@ -55,6 +55,21 @@ describe("classifyChannel", () => {
 		);
 	});
 
+	// Meta appends fbclid to organic shares as well as ads, so it cannot stand
+	// alone as a paid signal without booking organic social as ad traffic.
+	it("does not treat fbclid alone as paid", () => {
+		expect(
+			classifyChannel("https://www.facebook.com/", "?fbclid=abc123", HOST),
+		).toBe("social");
+		expect(
+			classifyChannel(
+				"https://www.facebook.com/",
+				"?fbclid=abc123&utm_medium=cpc",
+				HOST,
+			),
+		).toBe("paid");
+	});
+
 	it("marks same-site and sibling hosts as internal", () => {
 		expect(classifyChannel("https://llmgateway.io/blog", "", HOST)).toBe(
 			"internal",

--- a/apps/ui/src/lib/attribution.spec.ts
+++ b/apps/ui/src/lib/attribution.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyChannel } from "./attribution";
+
+const HOST = "llmgateway.io";
+
+describe("classifyChannel", () => {
+	it("treats a missing referrer as direct", () => {
+		expect(classifyChannel("", "", HOST)).toBe("direct");
+	});
+
+	it("classifies search engines", () => {
+		expect(classifyChannel("https://www.google.com/", "", HOST)).toBe(
+			"organic_search",
+		);
+		expect(classifyChannel("https://www.google.com.hk/", "", HOST)).toBe(
+			"organic_search",
+		);
+		expect(classifyChannel("https://duckduckgo.com/", "", HOST)).toBe(
+			"organic_search",
+		);
+	});
+
+	it("separates AI assistants from generic referrals", () => {
+		expect(classifyChannel("https://chatgpt.com/", "", HOST)).toBe(
+			"ai_assistant",
+		);
+		expect(classifyChannel("https://www.perplexity.ai/", "", HOST)).toBe(
+			"ai_assistant",
+		);
+		expect(classifyChannel("https://gemini.google.com/app", "", HOST)).toBe(
+			"ai_assistant",
+		);
+		expect(classifyChannel("https://example.dev/post", "", HOST)).toBe(
+			"referral",
+		);
+	});
+
+	it("classifies social sources", () => {
+		expect(classifyChannel("https://t.co/abc", "", HOST)).toBe("social");
+		expect(classifyChannel("https://www.reddit.com/r/x", "", HOST)).toBe(
+			"social",
+		);
+	});
+
+	// Ads commonly arrive with a search-engine referrer, so the click id has to
+	// win or every paid click is miscounted as organic.
+	it("prefers a click identifier over the referrer", () => {
+		expect(
+			classifyChannel("https://www.google.com/", "?gclid=abc123", HOST),
+		).toBe("paid");
+		expect(classifyChannel("", "?utm_medium=cpc", HOST)).toBe("paid");
+		expect(classifyChannel("https://www.bing.com/", "?msclkid=xyz", HOST)).toBe(
+			"paid",
+		);
+	});
+
+	it("marks same-site and sibling hosts as internal", () => {
+		expect(classifyChannel("https://llmgateway.io/blog", "", HOST)).toBe(
+			"internal",
+		);
+		expect(classifyChannel("https://devpass.llmgateway.io/", "", HOST)).toBe(
+			"internal",
+		);
+	});
+
+	it("falls back to direct on an unparseable referrer", () => {
+		expect(classifyChannel("not a url", "", HOST)).toBe("direct");
+	});
+});

--- a/apps/ui/src/lib/attribution.ts
+++ b/apps/ui/src/lib/attribution.ts
@@ -72,13 +72,16 @@ export function classifyChannel(
 	const params = new URLSearchParams(search);
 	const medium = params.get("utm_medium")?.toLowerCase() ?? "";
 
-	// Any click identifier or paid medium settles it before the referrer matters:
+	// A click identifier or paid medium settles it before the referrer matters:
 	// ad platforms often arrive with a search-engine referrer.
+	//
+	// `fbclid` is deliberately absent — Meta appends it to ordinary organic
+	// links shared on Facebook and Instagram too, so treating it as proof of a
+	// paid click would book a large share of organic social as ad traffic.
 	if (
 		params.get("gclid") ||
 		params.get("wbraid") ||
 		params.get("gbraid") ||
-		params.get("fbclid") ||
 		params.get("msclkid") ||
 		params.get("ttclid") ||
 		["cpc", "ppc", "paid", "paidsearch", "paid-search", "display"].includes(

--- a/apps/ui/src/lib/attribution.ts
+++ b/apps/ui/src/lib/attribution.ts
@@ -1,0 +1,115 @@
+export type AcquisitionChannel =
+	| "paid"
+	| "organic_search"
+	| "ai_assistant"
+	| "social"
+	| "referral"
+	| "internal"
+	| "direct";
+
+const SEARCH_HOSTS = [
+	"google.",
+	"bing.com",
+	"duckduckgo.com",
+	"search.brave.com",
+	"yandex.",
+	"baidu.com",
+	"ecosia.org",
+	"startpage.com",
+	"qwant.com",
+];
+
+// Assistants send real, high-intent traffic, and lumping them into "referral"
+// hides the one channel that is growing on its own.
+const ASSISTANT_HOSTS = [
+	"chatgpt.com",
+	"chat.openai.com",
+	"perplexity.ai",
+	"claude.ai",
+	"gemini.google.com",
+	"copilot.microsoft.com",
+	"you.com",
+	"phind.com",
+];
+
+const SOCIAL_HOSTS = [
+	"t.co",
+	"x.com",
+	"twitter.com",
+	"linkedin.com",
+	"reddit.com",
+	"news.ycombinator.com",
+	"facebook.com",
+	"instagram.com",
+	"youtube.com",
+	"bsky.app",
+	"mastodon.",
+	"discord.com",
+];
+
+function hostMatches(host: string, needles: string[]): boolean {
+	return needles.some((needle) =>
+		needle.endsWith(".")
+			? host.includes(needle)
+			: host === needle ||
+				host.endsWith(`.${needle}`) ||
+				host === `www.${needle}`,
+	);
+}
+
+/**
+ * First-touch channel for a visit.
+ *
+ * PostHog derives its own channel type at query time, which makes it awkward to
+ * segment on and impossible to filter in-product. This records an explicit,
+ * durable value instead, and separates AI assistants from generic referrals.
+ */
+export function classifyChannel(
+	referrer: string,
+	search: string,
+	currentHost: string,
+): AcquisitionChannel {
+	const params = new URLSearchParams(search);
+	const medium = params.get("utm_medium")?.toLowerCase() ?? "";
+
+	// Any click identifier or paid medium settles it before the referrer matters:
+	// ad platforms often arrive with a search-engine referrer.
+	if (
+		params.get("gclid") ||
+		params.get("wbraid") ||
+		params.get("gbraid") ||
+		params.get("fbclid") ||
+		params.get("msclkid") ||
+		params.get("ttclid") ||
+		["cpc", "ppc", "paid", "paidsearch", "paid-search", "display"].includes(
+			medium,
+		)
+	) {
+		return "paid";
+	}
+
+	if (!referrer) {
+		return "direct";
+	}
+
+	let host: string;
+	try {
+		host = new URL(referrer).hostname.toLowerCase();
+	} catch {
+		return "direct";
+	}
+
+	if (host === currentHost.toLowerCase() || host.endsWith(".llmgateway.io")) {
+		return "internal";
+	}
+	if (hostMatches(host, ASSISTANT_HOSTS)) {
+		return "ai_assistant";
+	}
+	if (hostMatches(host, SEARCH_HOSTS)) {
+		return "organic_search";
+	}
+	if (hostMatches(host, SOCIAL_HOSTS)) {
+		return "social";
+	}
+	return "referral";
+}

--- a/apps/ui/src/lib/utils/plain-text.spec.ts
+++ b/apps/ui/src/lib/utils/plain-text.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { plainTextFromMarkdown } from "./plain-text";
+
+describe("plainTextFromMarkdown", () => {
+	it("keeps link labels and drops the target", () => {
+		expect(
+			plainTextFromMarkdown(
+				"See the [migration guide](https://example.com/x).",
+			),
+		).toBe("See the migration guide.");
+	});
+
+	it("strips emphasis", () => {
+		expect(plainTextFromMarkdown("**bold** and *italic* and _under_")).toBe(
+			"bold and italic and under",
+		);
+	});
+
+	// The underscore rule would otherwise chew through an identifier once the
+	// backticks are gone.
+	it("leaves underscores inside code spans alone", () => {
+		expect(plainTextFromMarkdown("Run `foo_bar_baz` first")).toBe(
+			"Run foo_bar_baz first",
+		);
+		expect(
+			plainTextFromMarkdown("`npm i -g devpass-code` on any platform"),
+		).toBe("npm i -g devpass-code on any platform");
+	});
+
+	// A digit-based placeholder would be destroyed by any answer mentioning a
+	// number, so the restore step has to be collision-proof.
+	it("survives numbers in the surrounding prose", () => {
+		expect(
+			plainTextFromMarkdown("Set `max_tokens` to 4096 for 2 of the 3 models"),
+		).toBe("Set max_tokens to 4096 for 2 of the 3 models");
+	});
+
+	it("handles images before links", () => {
+		expect(plainTextFromMarkdown("![alt text](/img.png) follows")).toBe(
+			"alt text follows",
+		);
+	});
+
+	it("collapses whitespace", () => {
+		expect(plainTextFromMarkdown("a\n\nb   c")).toBe("a b c");
+	});
+});

--- a/apps/ui/src/lib/utils/plain-text.ts
+++ b/apps/ui/src/lib/utils/plain-text.ts
@@ -1,0 +1,21 @@
+/**
+ * Flattens the small subset of markdown used in FAQ answers to plain text.
+ *
+ * Structured data carries the same answers the page renders, but schema.org
+ * consumers show `acceptedAnswer.text` verbatim — leaving `[label](url)` or
+ * backticks in place would surface the raw syntax in a rich result.
+ */
+export function plainTextFromMarkdown(value: string): string {
+	return (
+		value
+			// Images before links: the leading ! would otherwise survive the link rule.
+			.replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+			.replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+			.replace(/`([^`]+)`/g, "$1")
+			.replace(/\*\*([^*]+)\*\*/g, "$1")
+			.replace(/(^|[^*])\*([^*]+)\*/g, "$1$2")
+			.replace(/(^|[^_])_([^_]+)_/g, "$1$2")
+			.replace(/\s+/g, " ")
+			.trim()
+	);
+}

--- a/apps/ui/src/lib/utils/plain-text.ts
+++ b/apps/ui/src/lib/utils/plain-text.ts
@@ -1,3 +1,7 @@
+// Private-use code point, so a placeholder can never collide with real prose
+// (a digit-based marker would be eaten by any answer that mentions a number).
+const SENTINEL = "";
+
 /**
  * Flattens the small subset of markdown used in FAQ answers to plain text.
  *
@@ -6,16 +10,27 @@
  * backticks in place would surface the raw syntax in a rich result.
  */
 export function plainTextFromMarkdown(value: string): string {
-	return (
-		value
-			// Images before links: the leading ! would otherwise survive the link rule.
-			.replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
-			.replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
-			.replace(/`([^`]+)`/g, "$1")
-			.replace(/\*\*([^*]+)\*\*/g, "$1")
-			.replace(/(^|[^*])\*([^*]+)\*/g, "$1$2")
-			.replace(/(^|[^_])_([^_]+)_/g, "$1$2")
-			.replace(/\s+/g, " ")
-			.trim()
+	// Code spans are lifted out before emphasis is stripped: an identifier like
+	// `snake_case_name` is not italics, and running the underscore rule over it
+	// would eat characters out of the middle of the word.
+	const spans: string[] = [];
+	const withPlaceholders = value.replace(/`([^`]+)`/g, (_, code: string) => {
+		spans.push(code);
+		return `${SENTINEL}${spans.length - 1}${SENTINEL}`;
+	});
+
+	const flattened = withPlaceholders
+		// Images before links: the leading ! would otherwise survive the link rule.
+		.replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+		.replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+		.replace(/\*\*([^*]+)\*\*/g, "$1")
+		.replace(/(^|[^*])\*([^*]+)\*/g, "$1$2")
+		.replace(/(^|[^_])_([^_]+)_/g, "$1$2")
+		.replace(/\s+/g, " ")
+		.trim();
+
+	return flattened.replace(
+		new RegExp(`${SENTINEL}(\\d+)${SENTINEL}`, "g"),
+		(_, index: string) => spans[Number(index)] ?? "",
 	);
 }


### PR DESCRIPTION
Follow-on to #3620, which has merged — this branch is rebased onto it, so nothing here repeats that work.

## Problem

Three gaps left over on the same surfaces:

- **Long-form pages have no standing offer.** Blog posts, integration guides and the timeline carry navigation and prose, but between the inline cards there is nothing to act on. A reader convinced halfway down has to go hunting for the next step.
- **In-body FAQ sections produce no structured data.** The blog template already renders a `faqs:` frontmatter field as its own section and emits FAQPage JSON-LD from it — but only 2 of 72 posts used the field. The other 33 wrote their FAQ as prose, invisible to anything reading structured data. A post could not simply add the field either: it would then render the questions twice.
- **Visits carry no channel.** Nothing on a pageview records where the reader came from, so behaviour cannot be segmented by acquisition source in-product.

## Changes

**Conversion rail.** New `ContentConversionRail`, mounted on blog posts, guides and the timeline. Most of the design decisions here are about restraint:

- Reveals only once the reader is past the opening, so it reads as a follow-up rather than an interstitial on arrival.
- Stands down while an inline `BlogCta` is on screen (`IntersectionObserver` over `[data-blog-cta]`). Two offers in one viewport reads as pressure, and the card is the better of the two.
- Dismissible, with the choice persisted. `aria-hidden` + `inert` while hidden, so it is not reachable by keyboard or screen reader in that state.
- Takes its visual language from the boarding-pass card it follows — dashed edge, mono eyebrow, a perforation rule before the button.
- On small screens it insets from the right to clear the floating support bubble, which otherwise sat on top of the dismiss button, and drops the eyebrow so the line fits.
- The gateway variant points at the model catalogue rather than signup, and deep-links to a specific model when the post is about one.

**FAQ structured data.** Moved in-body FAQ sections into `faqs:` frontmatter across 32 posts, matching the convention `best-ai-coding-plans` already used. Coverage goes from 2 posts to 34, 132 questions in total. Two supporting changes so nothing is lost in the move:

- Answers now render through `Markdown`, because the prose versions carry inline links and code spans that would otherwise show as literal syntax.
- The JSON-LD copy is flattened by a new `plainTextFromMarkdown` helper — schema consumers print `acceptedAnswer.text` verbatim, so markdown there would surface raw in a rich result.

The migration refused any post whose answers it could not bound confidently rather than mangling them; the single post it skipped uses a different heading structure and is untouched.

**Acquisition channel.** `classifyChannel` records a channel on first pageview, as a super property on every event and a set-once person property for first touch. It separates AI assistants from generic referrals, and prefers a click identifier (`gclid`, `msclkid`, …) over the referrer — ad clicks routinely arrive with a search-engine referrer and would otherwise count as organic. Unit tested.

**Timeline links.** The per-model link said "View model details"; it now names what is actually behind it.

## Notes for the reviewer

- `apps/ui/AGENTS.md` / `CLAUDE.md` are regenerated by `next dev` and deliberately left out of this branch.
- This is new UI on marketing pages rather than a dashboard screen, so per the repo's screenshot rule there are none here; behaviour was verified in a browser instead (below).
- Revenue-side recommendations from the same review — the cap-hit offer ordering, a pre-cap trigger, and a cancellation save flow — are not in scope here. They live in `apps/code`, change what a customer is offered at the moment they are deciding to leave, and want their own PR.

## Verification

- `pnpm format`, full `pnpm build` (17/17), and `vitest run apps/ui/src` (83 tests, 10 files) all pass on the rebased branch.
- Driven in a real browser against a local dev server: the rail is absent on arrival, appears past the reveal threshold, disappears while an inline card is on screen and returns after it, and its dismiss button is clear of the support bubble at 390px wide with the label fitting untruncated.
- Verified per surface — guides render the DevPass variant, timeline and blog the gateway variant.
- FAQ output checked on a migrated post: rendered answers contain real anchors with no raw markdown, and the FAQPage JSON-LD carries its questions with the syntax stripped.
- Confirmed the diff against `main` re-adds no `<BlogCta>` and no `seoTitle`, so there is no overlap with #3620.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5HLjSX5HyHDvf9MRZAanm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added contextual conversion prompts to blog posts, guides, and timeline pages, with relevant offers and dismissal controls.
  - Added model associations for selected articles to provide more relevant conversion options.
  - Blog FAQs now support Markdown formatting and structured metadata.

- **Improvements**
  - Enhanced acquisition-channel tracking for more accurate visit attribution.
  - Updated model card messaging to highlight pricing, providers, and uptime.
  - Added responsive and accessible behavior to conversion prompts.

- **Documentation**
  - Standardized FAQ content across numerous blog articles without duplicating it in the article body.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->