### PR TITLE
fix(providers): simplify training data

### DIFF
--- a/apps/api/src/routes/admin-org-details.ts
+++ b/apps/api/src/routes/admin-org-details.ts
@@ -213,7 +213,6 @@ const complianceAttestationSchema = z.object({
 	iso27001: z.boolean().nullish(),
 	gdpr: z.boolean().nullish(),
 	apiTraining: z.boolean().nullish(),
-	consumerTraining: z.boolean().nullish(),
 	promptLogging: z.boolean().nullish(),
 	retentionPeriod: z.string().nullish(),
 	headquarters: z.string().nullish(),

--- a/apps/api/src/routes/keys-provider.ts
+++ b/apps/api/src/routes/keys-provider.ts
@@ -66,7 +66,6 @@ export const complianceAttestationSchema = z.object({
 	iso27001: z.boolean().nullable().optional(),
 	gdpr: z.boolean().nullable().optional(),
 	apiTraining: z.boolean().nullable().optional(),
-	consumerTraining: z.boolean().nullable().optional(),
 	promptLogging: z.boolean().nullable().optional(),
 	retentionPeriod: z.string().max(64).nullable().optional(),
 	headquarters: z

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -1351,7 +1351,6 @@ describe("api", () => {
 				iso27001: true,
 				gdpr: true,
 				apiTraining: false,
-				consumerTraining: false,
 				promptLogging: false,
 				headquarters: "US",
 			},

--- a/apps/gateway/src/lib/compliance.spec.ts
+++ b/apps/gateway/src/lib/compliance.spec.ts
@@ -46,7 +46,6 @@ describe("isProviderIdCompliant with custom providers", () => {
 			iso27001: true,
 			gdpr: true,
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			headquarters: "US",
 		};

--- a/apps/ui/src/components/custom-models/compliance-attestation-card.tsx
+++ b/apps/ui/src/components/custom-models/compliance-attestation-card.tsx
@@ -54,19 +54,16 @@ const TRI_STATE_FIELDS: { key: TriStateKey; label: string }[] = [
 	{ key: "iso27001", label: "ISO 27001 certified" },
 	{ key: "gdpr", label: "GDPR compliant" },
 	{ key: "apiTraining", label: "Trains on API prompts" },
-	{ key: "consumerTraining", label: "Trains on consumer data" },
 	{ key: "promptLogging", label: "Logs prompts" },
 ];
 
-type TriStateKey =
-	"iso27001" | "gdpr" | "apiTraining" | "consumerTraining" | "promptLogging";
+type TriStateKey = "iso27001" | "gdpr" | "apiTraining" | "promptLogging";
 
 interface FormState {
 	soc2: "unknown" | "1" | "2";
 	iso27001: string;
 	gdpr: string;
 	apiTraining: string;
-	consumerTraining: string;
 	promptLogging: string;
 	retentionPeriod: string;
 	headquarters: string;
@@ -101,7 +98,6 @@ function buildInitialState(
 		iso27001: triStateFromValue(attestation?.iso27001),
 		gdpr: triStateFromValue(attestation?.gdpr),
 		apiTraining: triStateFromValue(attestation?.apiTraining),
-		consumerTraining: triStateFromValue(attestation?.consumerTraining),
 		promptLogging: triStateFromValue(attestation?.promptLogging),
 		retentionPeriod: attestation?.retentionPeriod ?? "",
 		headquarters: attestation?.headquarters ?? "",
@@ -201,7 +197,6 @@ export function ComplianceAttestationCard({
 			iso27001: triStateToValue(form.iso27001),
 			gdpr: triStateToValue(form.gdpr),
 			apiTraining: triStateToValue(form.apiTraining),
-			consumerTraining: triStateToValue(form.consumerTraining),
 			promptLogging: triStateToValue(form.promptLogging),
 			retentionPeriod:
 				form.retentionPeriod.trim() === "" ? null : form.retentionPeriod.trim(),

--- a/apps/ui/src/components/providers/hero.tsx
+++ b/apps/ui/src/components/providers/hero.tsx
@@ -176,18 +176,6 @@ export function Hero({ providerId }: HeroProps) {
 											/>
 										</div>
 										<div className="flex items-center gap-2">
-											<Database className="h-3.5 w-3.5 text-muted-foreground" />
-											<span className="text-muted-foreground">
-												Consumer Training:
-											</span>
-											<DataPolicyBadge
-												value={provider.dataPolicy.consumerTraining}
-												labelTrue="Yes"
-												labelFalse="No"
-												dangerIfTrue
-											/>
-										</div>
-										<div className="flex items-center gap-2">
 											<Eye className="h-3.5 w-3.5 text-muted-foreground" />
 											<span className="text-muted-foreground">
 												Prompt Logging:

--- a/apps/ui/src/components/providers/providers-grid.tsx
+++ b/apps/ui/src/components/providers/providers-grid.tsx
@@ -97,41 +97,6 @@ function formatUptime(pct: number | null | undefined): string {
 	return `${pct.toFixed(2)}%`;
 }
 
-function speedBadge(ttft: number | null | undefined) {
-	if (ttft === null || ttft === undefined) {
-		return null;
-	}
-	if (ttft < 350) {
-		return {
-			label: "Blazing",
-			className:
-				"bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 ring-emerald-500/20",
-			dot: "bg-emerald-500",
-		};
-	}
-	if (ttft < 800) {
-		return {
-			label: "Fast",
-			className: "bg-sky-500/10 text-sky-600 dark:text-sky-400 ring-sky-500/20",
-			dot: "bg-sky-500",
-		};
-	}
-	if (ttft < 1800) {
-		return {
-			label: "Steady",
-			className:
-				"bg-amber-500/10 text-amber-600 dark:text-amber-400 ring-amber-500/20",
-			dot: "bg-amber-500",
-		};
-	}
-	return {
-		label: "Patient",
-		className:
-			"bg-rose-500/10 text-rose-600 dark:text-rose-400 ring-rose-500/20",
-		dot: "bg-rose-500",
-	};
-}
-
 interface ProvidersGridProps {
 	/** When set, only providers headquartered in this ISO 3166-1 alpha-2 code are shown. */
 	countryCode?: string;
@@ -413,7 +378,6 @@ export function ProvidersGrid({
 			) : (
 				<div className="grid gap-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
 					{filteredAndSorted.map((provider) => {
-						const badge = speedBadge(provider.stats?.avgTimeToFirstToken);
 						return (
 							<Card
 								key={provider.id}
@@ -436,16 +400,6 @@ export function ProvidersGrid({
 									<div className="space-y-2">
 										<div className="flex flex-wrap items-center gap-2">
 											<CardTitle className="text-xl">{provider.name}</CardTitle>
-											{badge && (
-												<span
-													className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ring-1 ring-inset ${badge.className}`}
-												>
-													<span
-														className={`h-1.5 w-1.5 rounded-full ${badge.dot}`}
-													/>
-													{badge.label}
-												</span>
-											)}
 										</div>
 										<CardDescription className="line-clamp-2 leading-relaxed">
 											{provider.description}

--- a/packages/models/src/compliance.spec.ts
+++ b/packages/models/src/compliance.spec.ts
@@ -73,7 +73,6 @@ describe("isProviderCompliant", () => {
 	it("requires each active attribute to be explicitly satisfied", () => {
 		const provider = makeProvider({
 			apiTraining: true,
-			consumerTraining: true,
 			promptLogging: true,
 			soc2: 2,
 		});
@@ -103,7 +102,6 @@ describe("isProviderCompliant", () => {
 			isProviderCompliant(
 				makeProvider({
 					apiTraining: false,
-					consumerTraining: false,
 					promptLogging: false,
 				}),
 				policy,
@@ -113,7 +111,6 @@ describe("isProviderCompliant", () => {
 			isProviderCompliant(
 				makeProvider({
 					apiTraining: null,
-					consumerTraining: null,
 					promptLogging: null,
 				}),
 				policy,
@@ -131,7 +128,6 @@ describe("isProviderCompliant", () => {
 			isProviderCompliant(
 				makeProvider({
 					apiTraining: false,
-					consumerTraining: false,
 					promptLogging: false,
 					soc2: 2,
 				}),
@@ -143,7 +139,6 @@ describe("isProviderCompliant", () => {
 			isProviderCompliant(
 				makeProvider({
 					apiTraining: false,
-					consumerTraining: false,
 					promptLogging: false,
 					iso27001: true,
 				}),
@@ -155,7 +150,6 @@ describe("isProviderCompliant", () => {
 			isProviderCompliant(
 				makeProvider({
 					apiTraining: false,
-					consumerTraining: false,
 					promptLogging: false,
 					soc2: 1,
 				}),
@@ -167,7 +161,6 @@ describe("isProviderCompliant", () => {
 			isProviderCompliant(
 				makeProvider({
 					apiTraining: false,
-					consumerTraining: false,
 					promptLogging: false,
 				}),
 				policy,
@@ -178,13 +171,11 @@ describe("isProviderCompliant", () => {
 	it("distinguishes SOC 2 Type 1 from Type 2", () => {
 		const type1 = makeProvider({
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			soc2: 1,
 		});
 		const type2 = makeProvider({
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			soc2: 2,
 		});
@@ -205,7 +196,6 @@ describe("isProviderCompliant", () => {
 		// A provider with no SOC 2 report fails both.
 		const none = makeProvider({
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 		});
 		expect(
@@ -278,7 +268,6 @@ describe("isProviderCompliant", () => {
 		const compliant = makeProvider(
 			{
 				apiTraining: false,
-				consumerTraining: false,
 				promptLogging: false,
 				soc2: 2,
 			},
@@ -288,7 +277,6 @@ describe("isProviderCompliant", () => {
 		const wrongCountry = makeProvider(
 			{
 				apiTraining: false,
-				consumerTraining: false,
 				promptLogging: false,
 				soc2: 2,
 			},
@@ -410,7 +398,6 @@ describe("isModelAllowedByPolicy", () => {
 describe("isProviderCompliant with provider lists", () => {
 	const compliantDataPolicy = {
 		apiTraining: false,
-		consumerTraining: false,
 		promptLogging: false,
 		soc2: 2 as const,
 	};
@@ -588,7 +575,6 @@ describe("isAttestationCompliant", () => {
 			iso27001: openai.dataPolicy?.iso27001 ?? null,
 			gdpr: openai.dataPolicy?.gdpr ?? null,
 			apiTraining: openai.dataPolicy?.apiTraining ?? null,
-			consumerTraining: openai.dataPolicy?.consumerTraining ?? null,
 			promptLogging: openai.dataPolicy?.promptLogging ?? null,
 			retentionPeriod: openai.dataPolicy?.retentionPeriod ?? null,
 			headquarters: openai.headquarters ?? null,
@@ -687,7 +673,6 @@ describe("compliance failure reasons", () => {
 		const provider = makeProvider(
 			{
 				apiTraining: true,
-				consumerTraining: true,
 				promptLogging: true,
 				soc2: 1,
 			},
@@ -712,7 +697,6 @@ describe("compliance failure reasons", () => {
 		const provider = makeProvider(
 			{
 				apiTraining: false,
-				consumerTraining: false,
 				promptLogging: false,
 				soc2: 2,
 			},
@@ -806,7 +790,6 @@ describe("blockStealthProviders", () => {
 		env: { required: { apiKey: "TEST", baseUrl: "TEST_BASE_URL" } },
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			soc2: 2,
 			iso27001: true,

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -101,7 +101,6 @@ export interface ServiceTier {
 
 export interface ProviderDataPolicy {
 	apiTraining: boolean | null;
-	consumerTraining: boolean | null;
 	promptLogging: boolean | null;
 	retentionPeriod?: string | null;
 	/**
@@ -259,7 +258,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			retentionPeriod: "0 days",
 			soc2: null,
@@ -291,7 +289,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: true,
 			promptLogging: true,
 			retentionPeriod: null,
 			soc2: 2,
@@ -338,7 +335,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: true,
 			promptLogging: true,
 			retentionPeriod: "30 days",
 			soc2: 2,
@@ -387,7 +383,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: true,
 			promptLogging: true,
 			retentionPeriod: "55 days",
 			soc2: 2,
@@ -507,7 +502,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			retentionPeriod: "0 days",
 			soc2: 2,
@@ -550,7 +544,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			retentionPeriod: "0 days",
 			soc2: 2,
@@ -592,7 +585,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			retentionPeriod: "0 days",
 			soc2: 2,
@@ -671,7 +663,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			retentionPeriod: "0 days",
 			soc2: 2,
@@ -699,7 +690,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			retentionPeriod: "0 days",
 			soc2: 2,
@@ -726,7 +716,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: true,
 			retentionPeriod: "30 days",
 			soc2: 2,
@@ -756,7 +745,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "CN",
 		dataPolicy: {
 			apiTraining: true,
-			consumerTraining: true,
 			promptLogging: true,
 			retentionPeriod: null,
 		},
@@ -820,7 +808,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "CN",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: null,
 			promptLogging: true,
 			retentionPeriod: null,
 			iso27001: true,
@@ -846,7 +833,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			retentionPeriod: "0 days",
 		},
@@ -875,7 +861,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: null,
 		dataPolicy: {
 			apiTraining: null,
-			consumerTraining: null,
 			promptLogging: null,
 			retentionPeriod: "varies by service; Enterprise ZDR available",
 			soc2: 2,
@@ -989,7 +974,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			retentionPeriod: "0 days",
 			soc2: 2,
@@ -1048,7 +1032,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			retentionPeriod: "0 days",
 			soc2: 2,
@@ -1101,7 +1084,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			retentionPeriod: "0 days",
 			soc2: 2,
@@ -1138,7 +1120,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			retentionPeriod: "0 days",
 			soc2: 2,
@@ -1169,7 +1150,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "CN",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			retentionPeriod: "0 days",
 		},
@@ -1196,7 +1176,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "CN",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: null,
 			promptLogging: false,
 			retentionPeriod: "0 days",
 		},
@@ -1223,7 +1202,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			retentionPeriod: "0 days",
 			soc2: 2,
@@ -1251,7 +1229,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "NL",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			retentionPeriod: "0 days",
 			soc2: 2,
@@ -1278,7 +1255,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "FR",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: true,
 			retentionPeriod: "30 days",
 			soc2: 2,
@@ -1307,7 +1283,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			retentionPeriod: "0 days",
 			soc2: 2,
@@ -1336,7 +1311,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: null,
-			consumerTraining: null,
 			promptLogging: null,
 			retentionPeriod: null,
 			soc2: 2,
@@ -1363,7 +1337,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			retentionPeriod: "0 days",
 			soc2: 2,
@@ -1391,7 +1364,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "AU",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			retentionPeriod: "0 days",
 			soc2: 1,
@@ -1419,7 +1391,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "AU",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			retentionPeriod: "0 days",
 			soc2: 1,
@@ -1464,7 +1435,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: null,
 			retentionPeriod: null,
 		},
@@ -1491,7 +1461,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "CN",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: null,
 			promptLogging: false,
 			retentionPeriod: "24 hours",
 			soc2: 2,
@@ -1524,7 +1493,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "CN",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: null,
 			promptLogging: true,
 			retentionPeriod: null,
 		},
@@ -1551,7 +1519,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: true,
 			retentionPeriod: null,
 		},
@@ -1582,7 +1549,6 @@ export const providers: ProviderDefinition[] = [
 			// Paid (pay-as-you-go) services are never trained on; only the free
 			// unpaid tier may be used for training per the Data Commitments page.
 			apiTraining: false,
-			consumerTraining: true,
 			promptLogging: true,
 			retentionPeriod: null,
 			soc2: null,
@@ -1668,7 +1634,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "CN",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: null,
 			promptLogging: true,
 			retentionPeriod: "30 days",
 		},
@@ -1697,7 +1662,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			retentionPeriod: "0 days",
 			soc2: 2,
@@ -1752,7 +1716,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: true,
 			retentionPeriod: null,
 			soc2: 2,
@@ -1784,7 +1747,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "GB",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: true,
 			retentionPeriod: "30 days",
 		},
@@ -1843,7 +1805,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			retentionPeriod: "0 days",
 			soc2: 2,
@@ -1872,7 +1833,6 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "US",
 		dataPolicy: {
 			apiTraining: false,
-			consumerTraining: false,
 			promptLogging: false,
 			retentionPeriod: "0 days",
 		},
@@ -1957,7 +1917,6 @@ export interface ProviderComplianceAttestation {
 	iso27001?: boolean | null;
 	gdpr?: boolean | null;
 	apiTraining?: boolean | null;
-	consumerTraining?: boolean | null;
 	promptLogging?: boolean | null;
 	retentionPeriod?: string | null;
 	/** ISO 3166-1 alpha-2 country the deployment is operated from. */
@@ -2238,7 +2197,6 @@ export function getAttestationComplianceFailures(
 	return getDataPolicyComplianceFailures(
 		{
 			apiTraining: attestation.apiTraining ?? null,
-			consumerTraining: attestation.consumerTraining ?? null,
 			promptLogging: attestation.promptLogging ?? null,
 			retentionPeriod: attestation.retentionPeriod ?? null,
 			soc2: attestation.soc2 ?? null,


### PR DESCRIPTION
Removes the provider speed classification badge and retires the unused consumer-training field across catalogue data, API validation, and provider interfaces. API-training remains the single training signal.

Validation:
- `pnpm format`
- `pnpm build`
- `pnpm exec vitest run --no-file-parallelism packages/models/src/compliance.spec.ts apps/gateway/src/lib/compliance.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the Consumer Training field from provider compliance attestations and related data-policy information.
  * Updated compliance forms and API responses to reflect the streamlined policy details.
  * Provider cards no longer display TTFT speed badges beside provider names; TTFT remains available in provider statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->