### PR TITLE
feat(admin): link DevPass org details

### DIFF
--- a/ee/admin/src/app/organizations/[orgId]/page.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/page.tsx
@@ -356,6 +356,11 @@ export default async function OrganizationPage({
 					</div>
 				</div>
 				<div className="flex flex-wrap items-center gap-2">
+					{org.kind === "devpass" && (
+						<Button variant="outline" size="sm" asChild>
+							<Link href={`/devpass/${orgId}`}>Open in DevPass</Link>
+						</Button>
+					)}
 					<ManageOrgDialog
 						orgName={org.name}
 						plan={org.plan}


### PR DESCRIPTION
## Problem

Admins viewing a DevPass organization from the general organization detail page have no direct path to its DevPass-specific controls and subscription data.

## Approach

Add an `Open in DevPass` header action for organizations whose immutable kind is `devpass`. The action links to the matching DevPass detail route and remains hidden for other organization kinds.

## Screenshots

### Before

<img width="1440" alt="Organization detail header before the DevPass link" src="https://raw.githubusercontent.com/theopenco/llmgateway/32354a49883507ee7ccfcef6867e218d4231c5ef/before.png" />

### After

<img width="1440" alt="Organization detail header with the Open in DevPass link" src="https://raw.githubusercontent.com/theopenco/llmgateway/32354a49883507ee7ccfcef6867e218d4231c5ef/after.png" />

## Verification

- `pnpm format`
- `pnpm build`
- Seeded local admin flow: confirmed the action appears once for a DevPass organization, points to the matching organization, and opens the DevPass detail page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Open in DevPass” link to organization headers for DevPass organizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->