### PR TITLE
fix(payments): forward Stripe client errors

### DIFF
--- a/apps/api/src/routes/payments-payment-method.spec.ts
+++ b/apps/api/src/routes/payments-payment-method.spec.ts
@@ -5,6 +5,7 @@ import { app } from "@/index.js";
 import { createTestUser, deleteAll } from "@/testing.js";
 
 import { db, tables } from "@llmgateway/db";
+import { logger } from "@llmgateway/logger";
 
 const stripeMock = vi.hoisted(() => ({
 	customers: {
@@ -80,15 +81,18 @@ describe("payment intent payment method errors", () => {
 	});
 
 	afterEach(async () => {
+		vi.restoreAllMocks();
 		await deleteAll();
 	});
 
-	it("returns an actionable 400 for an unusable payment method", async () => {
+	it("forwards Stripe client errors and logs a warning", async () => {
+		const warn = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+		const stripeMessage =
+			"The provided PaymentMethod was previously used without Customer attachment.";
 		stripeMock.paymentIntents.create.mockRejectedValue(
 			new Stripe.errors.StripeInvalidRequestError({
 				type: "invalid_request_error",
-				message:
-					"The provided PaymentMethod was previously used without Customer attachment.",
+				message: stripeMessage,
 				param: "payment_method",
 				statusCode: 400,
 			}),
@@ -98,26 +102,43 @@ describe("payment intent payment method errors", () => {
 
 		expect(response.status).toBe(400);
 		expect(await response.json()).toMatchObject({
-			message:
-				"This card can no longer be used for this payment. Please re-enter your card details and try again.",
+			message: stripeMessage,
 		});
+		expect(warn).toHaveBeenCalledWith(
+			"Stripe client error on payment intent creation",
+			expect.objectContaining({
+				stripeMessage,
+				stripeStatusCode: 400,
+			}),
+		);
 	});
 
-	it("preserves Stripe status codes for other request errors", async () => {
+	it("forwards Stripe server errors and logs an error", async () => {
+		const logError = vi
+			.spyOn(logger, "error")
+			.mockImplementation(() => undefined);
+		const stripeMessage = "Stripe is temporarily unavailable.";
 		stripeMock.paymentIntents.create.mockRejectedValue(
-			new Stripe.errors.StripeInvalidRequestError({
-				type: "invalid_request_error",
-				message: "Invalid currency.",
-				param: "currency",
-				statusCode: 400,
+			new Stripe.errors.StripeAPIError({
+				type: "api_error",
+				message: stripeMessage,
+				statusCode: 503,
 			}),
 		);
 
 		const response = await createPaymentIntentRequest(token);
 
-		expect(response.status).toBe(400);
+		expect(response.status).toBe(503);
 		expect(await response.json()).toMatchObject({
-			message: "Invalid currency.",
+			message: stripeMessage,
 		});
+		expect(logError).toHaveBeenCalledWith(
+			"Stripe error on payment intent creation",
+			expect.any(Stripe.errors.StripeAPIError),
+			expect.objectContaining({
+				stripeMessage,
+				stripeStatusCode: 503,
+			}),
+		);
 	});
 });

--- a/apps/api/src/routes/payments-payment-method.spec.ts
+++ b/apps/api/src/routes/payments-payment-method.spec.ts
@@ -1,0 +1,123 @@
+import Stripe from "stripe";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db, tables } from "@llmgateway/db";
+
+const stripeMock = vi.hoisted(() => ({
+	customers: {
+		update: vi.fn(),
+	},
+	paymentIntents: {
+		create: vi.fn(),
+	},
+	paymentMethods: {
+		retrieve: vi.fn(),
+	},
+}));
+
+interface StripeModule {
+	default: typeof Stripe;
+}
+
+vi.mock("stripe", async (importOriginal) => {
+	const actual = await importOriginal<StripeModule>();
+	return {
+		default: Object.assign(
+			function MockStripe() {
+				return stripeMock;
+			},
+			{ errors: actual.default.errors },
+		),
+	};
+});
+
+process.env.STRIPE_SECRET_KEY ??= "sk_test_mock";
+
+const ORGANIZATION_ID = "test-payment-org";
+const STRIPE_CUSTOMER_ID = "cus_payment";
+const PAYMENT_METHOD_ID = "pm_detached";
+
+async function createPaymentIntentRequest(token: string) {
+	return await app.request("/payments/create-payment-intent", {
+		method: "POST",
+		headers: {
+			Cookie: token,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({
+			amount: 10,
+			organizationId: ORGANIZATION_ID,
+			stripePaymentMethodId: PAYMENT_METHOD_ID,
+		}),
+	});
+}
+
+describe("payment intent payment method errors", () => {
+	let token: string;
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		token = await createTestUser();
+		await db.insert(tables.organization).values({
+			id: ORGANIZATION_ID,
+			name: "Payment Test Organization",
+			billingEmail: "admin@example.com",
+			stripeCustomerId: STRIPE_CUSTOMER_ID,
+		});
+		await db.insert(tables.userOrganization).values({
+			userId: "test-user-id",
+			organizationId: ORGANIZATION_ID,
+			role: "owner",
+		});
+		stripeMock.paymentMethods.retrieve.mockResolvedValue({
+			id: PAYMENT_METHOD_ID,
+			customer: null,
+			card: { country: "US" },
+		});
+	});
+
+	afterEach(async () => {
+		await deleteAll();
+	});
+
+	it("returns an actionable 400 for an unusable payment method", async () => {
+		stripeMock.paymentIntents.create.mockRejectedValue(
+			new Stripe.errors.StripeInvalidRequestError({
+				type: "invalid_request_error",
+				message:
+					"The provided PaymentMethod was previously used without Customer attachment.",
+				param: "payment_method",
+				statusCode: 400,
+			}),
+		);
+
+		const response = await createPaymentIntentRequest(token);
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toMatchObject({
+			message:
+				"This card can no longer be used for this payment. Please re-enter your card details and try again.",
+		});
+	});
+
+	it("preserves Stripe status codes for other request errors", async () => {
+		stripeMock.paymentIntents.create.mockRejectedValue(
+			new Stripe.errors.StripeInvalidRequestError({
+				type: "invalid_request_error",
+				message: "Invalid currency.",
+				param: "currency",
+				statusCode: 400,
+			}),
+		);
+
+		const response = await createPaymentIntentRequest(token);
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toMatchObject({
+			message: "Invalid currency.",
+		});
+	});
+});

--- a/apps/api/src/routes/payments.ts
+++ b/apps/api/src/routes/payments.ts
@@ -210,39 +210,26 @@ payments.openapi(createPaymentIntent, async (c) => {
 			},
 		});
 	} catch (err) {
-		// Stripe cannot recover a PaymentMethod that was consumed without a
-		// customer or detached. This can happen when a duplicate-card webhook
-		// races this request, so ask the client to collect a fresh method.
-		if (
-			err instanceof Stripe.errors.StripeInvalidRequestError &&
-			err.param === "payment_method"
-		) {
-			logger.warn("Stripe rejected payment method on top-up intent", {
-				organizationId,
-				userId: user.id,
-				stripeCode: err.code,
-				stripeMessage: err.message,
-				stripeRequestId: err.requestId,
-			});
-			throw new HTTPException(400, {
-				message:
-					"This card can no longer be used for this payment. Please re-enter your card details and try again.",
-			});
-		}
-
 		if (err instanceof Stripe.errors.StripeError) {
-			logger.error("Stripe error on payment intent creation", err, {
+			const status = err.statusCode ?? 500;
+			const details = {
 				organizationId,
 				userId: user.id,
 				stripeType: err.type,
 				stripeCode: err.code,
+				stripeMessage: err.message,
 				stripeStatusCode: err.statusCode,
 				stripeRequestId: err.requestId,
-			});
+			};
+
+			if (status >= 400 && status < 500) {
+				logger.warn("Stripe client error on payment intent creation", details);
+			} else {
+				logger.error("Stripe error on payment intent creation", err, details);
+			}
 
 			throw new HTTPException(
-				(err.statusCode ?? 400) as
-					ClientErrorStatusCode | ServerErrorStatusCode,
+				status as ClientErrorStatusCode | ServerErrorStatusCode,
 				{
 					message: err.message,
 				},

--- a/apps/api/src/routes/payments.ts
+++ b/apps/api/src/routes/payments.ts
@@ -189,22 +189,68 @@ payments.openapi(createPaymentIntent, async (c) => {
 		isInternational,
 	});
 
-	const paymentIntent = await getStripe().paymentIntents.create({
-		amount: Math.round(feeBreakdown.totalAmount * 100),
-		currency: "usd",
-		description: `Credit purchase for ${amount} USD (including fees)`,
-		customer: stripeCustomerId,
-		...(stripePaymentMethodId ? { payment_method: stripePaymentMethodId } : {}),
-		metadata: {
-			organizationId,
-			baseAmount: amount.toString(),
-			platformFee: feeBreakdown.platformFee.toString(),
-			internationalFee: feeBreakdown.internationalFee.toString(),
-			isInternational: isInternational.toString(),
-			userEmail: user.email,
-			userId: user.id,
-		},
-	});
+	let paymentIntent: Stripe.PaymentIntent;
+	try {
+		paymentIntent = await getStripe().paymentIntents.create({
+			amount: Math.round(feeBreakdown.totalAmount * 100),
+			currency: "usd",
+			description: `Credit purchase for ${amount} USD (including fees)`,
+			customer: stripeCustomerId,
+			...(stripePaymentMethodId
+				? { payment_method: stripePaymentMethodId }
+				: {}),
+			metadata: {
+				organizationId,
+				baseAmount: amount.toString(),
+				platformFee: feeBreakdown.platformFee.toString(),
+				internationalFee: feeBreakdown.internationalFee.toString(),
+				isInternational: isInternational.toString(),
+				userEmail: user.email,
+				userId: user.id,
+			},
+		});
+	} catch (err) {
+		// Stripe cannot recover a PaymentMethod that was consumed without a
+		// customer or detached. This can happen when a duplicate-card webhook
+		// races this request, so ask the client to collect a fresh method.
+		if (
+			err instanceof Stripe.errors.StripeInvalidRequestError &&
+			err.param === "payment_method"
+		) {
+			logger.warn("Stripe rejected payment method on top-up intent", {
+				organizationId,
+				userId: user.id,
+				stripeCode: err.code,
+				stripeMessage: err.message,
+				stripeRequestId: err.requestId,
+			});
+			throw new HTTPException(400, {
+				message:
+					"This card can no longer be used for this payment. Please re-enter your card details and try again.",
+			});
+		}
+
+		if (err instanceof Stripe.errors.StripeError) {
+			logger.error("Stripe error on payment intent creation", err, {
+				organizationId,
+				userId: user.id,
+				stripeType: err.type,
+				stripeCode: err.code,
+				stripeStatusCode: err.statusCode,
+				stripeRequestId: err.requestId,
+			});
+
+			throw new HTTPException(
+				(err.statusCode ?? 400) as
+					ClientErrorStatusCode | ServerErrorStatusCode,
+				{
+					message: err.message,
+				},
+			);
+		}
+
+		throw err;
+	}
 
 	return c.json({
 		clientSecret: paymentIntent.client_secret ?? "",

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -1214,6 +1214,7 @@ export const providers: ProviderDefinition[] = [
 	{
 		id: "permafrost",
 		name: "Permafrost",
+		forwardsSafetyIdentifier: false,
 		description:
 			"Permafrost is a stealth provider with an OpenAI-compatible API.",
 		env: {


### PR DESCRIPTION
## Problem

Stripe client errors raised while creating a credit top-up intent reached the global handler, turning actionable upstream 4xx responses into generic internal server errors.

Current main also omitted the required safety-identifier capability flag from the recently added Permafrost provider, which prevented the monorepo build from reaching the payment tests.

## Approach

- Handle every Stripe error through one generic path; there is no PaymentMethod-specific code or message matching.
- Log Stripe 4xx responses as warnings and forward their original status and message to the client.
- Keep Stripe 5xx and statusless failures logged as errors, mapping statusless failures to 500.
- Add route-level regression tests for both logging levels and response forwarding.
- Mark Permafrost as not forwarding safety identifiers to restore the provider catalogue build.

## Verification

- `pnpm format`
- `pnpm exec vitest run --no-file-parallelism apps/api/src/routes/payments-payment-method.spec.ts`
- `pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment processing error handling and status reporting.
  * Invalid or already-used payment methods now prompt customers to re-enter card details.
  * Payment provider errors now return clearer, more accurate responses.

* **Reliability**
  * Improved handling of temporary payment service failures.
  * Added coverage for payment-method error scenarios.
  * Updated provider safety settings for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->