### PR TITLE
fix(admin): default catalog window to 15m

### DIFF
--- a/ee/admin/src/app/model-provider-mappings/page.tsx
+++ b/ee/admin/src/app/model-provider-mappings/page.tsx
@@ -8,6 +8,7 @@ import { TimeWindowSelector } from "@/components/time-window-selector";
 import { TokenBreakdown } from "@/components/token-breakdown";
 import { Button } from "@/components/ui/button";
 import {
+	CATALOG_PAGE_WINDOW_DEFAULT,
 	pageWindowOptionsWithMinutes,
 	parsePageWindow,
 	windowToFromTo,
@@ -64,7 +65,10 @@ export default async function ModelProviderMappingsPage({
 	const search = params?.search ?? "";
 	const sortBy = (params?.sortBy as MappingSortBy) ?? "logsCount";
 	const sortOrder = (params?.sortOrder as SortOrder) ?? "desc";
-	const pageWindow = parsePageWindow(params?.window);
+	const pageWindow = parsePageWindow(
+		params?.window,
+		CATALOG_PAGE_WINDOW_DEFAULT,
+	);
 	const { from, to } = windowToFromTo(pageWindow);
 
 	const $api = await createServerApiClient();

--- a/ee/admin/src/app/models/page.tsx
+++ b/ee/admin/src/app/models/page.tsx
@@ -8,6 +8,7 @@ import { TimeWindowSelector } from "@/components/time-window-selector";
 import { TokenBreakdown } from "@/components/token-breakdown";
 import { Button } from "@/components/ui/button";
 import {
+	CATALOG_PAGE_WINDOW_DEFAULT,
 	pageWindowOptionsWithMinutes,
 	parsePageWindow,
 	windowToFromTo,
@@ -79,7 +80,10 @@ export default async function ModelsPage({
 	const search = params?.search ?? "";
 	const sortBy = (params?.sortBy as ModelSortBy) ?? "logsCount";
 	const sortOrder = (params?.sortOrder as SortOrder) || "desc";
-	const pageWindow = parsePageWindow(params?.window);
+	const pageWindow = parsePageWindow(
+		params?.window,
+		CATALOG_PAGE_WINDOW_DEFAULT,
+	);
 	const { from, to } = windowToFromTo(pageWindow);
 	const limit = 50;
 	const offset = (page - 1) * limit;

--- a/ee/admin/src/app/providers/page.tsx
+++ b/ee/admin/src/app/providers/page.tsx
@@ -6,6 +6,7 @@ import { TimeWindowSelector } from "@/components/time-window-selector";
 import { TokenBreakdown } from "@/components/token-breakdown";
 import { Button } from "@/components/ui/button";
 import {
+	CATALOG_PAGE_WINDOW_DEFAULT,
 	pageWindowOptionsWithMinutes,
 	parsePageWindow,
 	windowToFromTo,
@@ -70,7 +71,10 @@ export default async function ProvidersPage({
 	const params = await searchParams;
 	const sortBy = (params?.sortBy as ProviderSortBy) ?? "logsCount";
 	const sortOrder = (params?.sortOrder as SortOrder) || "desc";
-	const pageWindow = parsePageWindow(params?.window);
+	const pageWindow = parsePageWindow(
+		params?.window,
+		CATALOG_PAGE_WINDOW_DEFAULT,
+	);
 	const { from, to } = windowToFromTo(pageWindow);
 
 	const $api = await createServerApiClient();

--- a/ee/admin/src/lib/page-window.spec.ts
+++ b/ee/admin/src/lib/page-window.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "vitest";
+
+import { CATALOG_PAGE_WINDOW_DEFAULT, parsePageWindow } from "./page-window";
+
+describe("parsePageWindow", () => {
+	test("uses the existing fallback by default", () => {
+		expect(parsePageWindow(undefined)).toBe("4h");
+	});
+
+	test("uses a page-specific fallback", () => {
+		expect(parsePageWindow(undefined, CATALOG_PAGE_WINDOW_DEFAULT)).toBe("15m");
+		expect(parsePageWindow("invalid", CATALOG_PAGE_WINDOW_DEFAULT)).toBe("15m");
+	});
+
+	test("keeps a valid query value", () => {
+		expect(parsePageWindow("1h", CATALOG_PAGE_WINDOW_DEFAULT)).toBe("1h");
+	});
+});

--- a/ee/admin/src/lib/page-window.ts
+++ b/ee/admin/src/lib/page-window.ts
@@ -14,6 +14,8 @@ export type PageWindow =
 	| "30d"
 	| "90d";
 
+export const CATALOG_PAGE_WINDOW_DEFAULT: PageWindow = "15m";
+
 export const pageWindowOptions: { value: PageWindow; label: string }[] = [
 	{ value: "1h", label: "1h" },
 	{ value: "2h", label: "2h" },
@@ -69,11 +71,14 @@ export function pageBucketSource(window: PageWindow): "hourly" | "minute" {
 	return HOURLY_PAGE_WINDOWS.has(window) ? "hourly" : "minute";
 }
 
-export function parsePageWindow(value: string | undefined): PageWindow {
+export function parsePageWindow(
+	value: string | undefined,
+	fallback: PageWindow = "4h",
+): PageWindow {
 	if (value && allValidWindows.has(value as PageWindow)) {
 		return value as PageWindow;
 	}
-	return "4h";
+	return fallback;
 }
 
 export function windowToFromTo(window: PageWindow): {


### PR DESCRIPTION
## Problem

The Models, Providers, and Model Mappings admin pages default to a four-hour statistics window, making recent routing behavior less prominent.

## Approach

- Add a shared 15-minute default for the three catalog pages.
- Preserve explicit URL-selected windows.
- Keep the existing four-hour fallback for unrelated admin pages.
- Cover both default and explicit window parsing.

## Verification

- `pnpm format`
- `pnpm build`
- `pnpm exec vitest run ee/admin/src/lib/page-window.spec.ts --no-file-parallelism`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Catalog pages now default to a 15-minute time window when no valid window is specified.
  - Existing valid time-window selections continue to be preserved.

- **Bug Fixes**
  - Invalid or missing time-window parameters now consistently fall back to the appropriate default.

- **Tests**
  - Added coverage for default handling, invalid values, and valid query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->