### PR TITLE
feat(models): align Runware pricing windows

### DIFF
--- a/apps/gateway/src/lib/costs.spec.ts
+++ b/apps/gateway/src/lib/costs.spec.ts
@@ -2370,6 +2370,40 @@ describe("peak / off-peak time-of-day pricing (DeepSeek)", () => {
 		expect(pro.cachedInputCost).toBeCloseTo(0.044);
 	});
 
+	it("keeps Runware flat while DeepSeek Flash changes price", async () => {
+		const calculateBlendedCosts = (provider: "deepseek" | "runware") =>
+			calculateCosts(
+				"deepseek-v4-flash",
+				provider,
+				null,
+				9_000_000,
+				1_000_000,
+				7_000_000,
+			);
+		const savings = (price: number, referencePrice: number) =>
+			(referencePrice - price) / referencePrice;
+
+		setTime("2026-08-17T12:00:00Z");
+		const deepseekOffPeak = await calculateBlendedCosts("deepseek");
+		const runwareOffPeak = await calculateBlendedCosts("runware");
+
+		expect(deepseekOffPeak.totalCost).toBeCloseTo(1.149);
+		expect(runwareOffPeak.totalCost).toBeCloseTo(0.403);
+		expect(
+			savings(runwareOffPeak.totalCost!, deepseekOffPeak.totalCost!),
+		).toBeCloseTo(0.65, 2);
+
+		setTime("2026-08-17T02:00:00Z");
+		const deepseekPeak = await calculateBlendedCosts("deepseek");
+		const runwarePeak = await calculateBlendedCosts("runware");
+
+		expect(deepseekPeak.totalCost).toBeCloseTo(2.298);
+		expect(runwarePeak.totalCost).toBeCloseTo(0.403);
+		expect(
+			savings(runwarePeak.totalCost!, deepseekPeak.totalCost!),
+		).toBeCloseTo(0.82, 2);
+	});
+
 	it("bills off-peak rates at the first window boundary (04:00 UTC)", async () => {
 		setTime("2026-08-17T04:00:00Z");
 

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -322,9 +322,10 @@ export interface ProviderModelMapping {
 	 * inputPrice/outputPrice/cachedInputPrice are the regular flat prices,
 	 * billed before `effectiveAt` (and always when `peakPricing` is absent).
 	 * On/after `effectiveAt`, `peak` applies while the current UTC hour falls
-	 * inside `hoursUtc` and `offPeak` applies otherwise. Only DeepSeek's
-	 * first-party API uses this today — peak 01:00-04:00 and 06:00-10:00 UTC
-	 * at double the off-peak rates, effective 2026-08-16.
+	 * inside `hoursUtc` and `offPeak` applies otherwise. DeepSeek's first-party
+	 * API uses peak 01:00-04:00 and 06:00-10:00 UTC at double the off-peak
+	 * rates, effective 2026-08-16. A provider with flat pricing across the same
+	 * comparison windows may declare identical peak and off-peak rates.
 	 */
 	peakPricing?: {
 		/**

--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -578,6 +578,26 @@ export const deepseekModels = [
 				inputPrice: "0.076e-6",
 				outputPrice: "0.153e-6",
 				cachedInputPrice: "0.014e-6",
+				// Runware stays flat while DeepSeek's first-party price changes by
+				// time of day. Identical tiers preserve Runware's list price while
+				// aligning the comparison windows with the upstream model.
+				peakPricing: {
+					effectiveAt: "2026-08-16T16:00:00Z",
+					peak: {
+						inputPrice: "0.076e-6",
+						outputPrice: "0.153e-6",
+						cachedInputPrice: "0.014e-6",
+					},
+					offPeak: {
+						inputPrice: "0.076e-6",
+						outputPrice: "0.153e-6",
+						cachedInputPrice: "0.014e-6",
+					},
+					hoursUtc: [
+						[1, 4],
+						[6, 10],
+					],
+				},
 				requestPrice: "0",
 				contextSize: 1048576,
 				maxOutput: 384000,


### PR DESCRIPTION
## Problem

DeepSeek V4 Flash now changes price between two UTC peak windows and off-peak hours. Runware serves the same model at a flat list price, so its mapping needs aligned comparison windows without inheriting DeepSeek's higher rates.

At a 7:2:1 cache-hit / cache-miss input / output mix, the published rates produce:

| Provider | Period | Blended price / M |
| --- | --- | ---: |
| DeepSeek | Off-peak | $0.1149 |
| DeepSeek | Peak | $0.2298 |
| Runware | Both | $0.0403 |

That makes Runware approximately 65% cheaper off-peak and 82% cheaper at peak.

## Approach

- Give the `runware/deepseek-v4-flash` mapping the same effective date and UTC windows as DeepSeek.
- Keep Runware's peak and off-peak tiers identical, preserving its flat published rates: $0.076/M input, $0.153/M output, and $0.014/M cached input.
- Cover billing and the blended comparison at both times.

The mapping remains `deepseek-v4-flash`, 1,048,576 context, 384,000 max output, FP8, with its existing streaming, reasoning, tool, and structured-output capabilities unchanged.

Prices were checked against the current public model pages:

- DeepSeek: https://api-docs.deepseek.com/quick_start/pricing/
- Runware: https://runware.ai/models/deepseek-v4-flash

## Verification

- `pnpm format`
- `pnpm build` — 17/17 tasks passed
- Focused Vitest run — 6 files, 210 tests passed against an isolated test database

A paid Runware e2e request was not run because a provider key was not configured in this workspace. Endpoint behavior and token extraction are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scheduled peak and off-peak pricing for Runware’s DeepSeek V4 Flash model, effective August 16, 2026.
  * Runware rates remain consistent across both pricing periods, enabling clearer cost comparisons with time-based provider pricing.

* **Documentation**
  * Updated pricing documentation to explain support for provider-specific peak and off-peak schedules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->