### PR TITLE
fix(e2e): skip responses multi-turn for image models

### DIFF
--- a/apps/gateway/src/responses.e2e.ts
+++ b/apps/gateway/src/responses.e2e.ts
@@ -48,6 +48,14 @@ const TOOL_CALL_DENYLIST = new Set<string>([
 ]);
 
 const responsesTestModels = oneModelPerProvider(testModels);
+// Image-generation mappings answer every request with an image (the Responses
+// layer emits placeholder output text), so the multi-turn name-recall
+// assertion is unsatisfiable for them; they still run the single-turn case.
+// Only reachable when TEST_MODELS pins image-only models for a provider.
+const responsesMultiTurnModels = responsesTestModels.filter(
+	(m) =>
+		!m.providers.some((p: ProviderModelMapping) => p.imageGenerations === true),
+);
 const responsesToolCallModels = oneModelPerProvider(toolCallModels).filter(
 	(m) => !TOOL_CALL_DENYLIST.has(m.model),
 );
@@ -157,7 +165,7 @@ describe("e2e", getConcurrentTestOptions(), () => {
 		},
 	);
 
-	test.each(responsesTestModels)(
+	test.each(responsesMultiTurnModels)(
 		"responses multi-turn $model",
 		getTestOptions(),
 		async ({ model }) => {


### PR DESCRIPTION
## Summary

Verified both third-gen Alibaba image models (`alibaba/qwen-image-3.0` and `alibaba/qwen-image-3.0-pro`, added in #3440) end-to-end, and fixed the one structurally broken e2e case that surfaced.

`responses.e2e.ts`'s multi-turn case asks *"What is my name?"* and asserts the text answer contains the name. An `imageGenerations` mapping answers every request with an image — the Responses conversion layer emits the placeholder output text `"image generated"` — so the assertion is unsatisfiable no matter what the provider does. The case is only reachable when `TEST_MODELS` pins image-only models for a provider (normal runs pick a text model per provider), which is exactly the scoped verification run for the qwen image models. Image models still run the single-turn case, which validates the Responses conversion layer, usage accounting, and log row.

## Testing

`CI=true TEST_MODELS="alibaba/qwen-image-3.0,alibaba/qwen-image-3.0-pro" FULL_MODE=true pnpm test:e2e`:

- ✅ basic 'alibaba/qwen-image-3.0' / 'alibaba/qwen-image-3.0-pro'
- ✅ image output 'alibaba/qwen-image-3.0' / 'alibaba/qwen-image-3.0-pro'
- ✅ responses single-turn 'alibaba/qwen-image-3.0'
- ✅ images.e2e.ts
- responses multi-turn: correctly has no cases for image-only pins after this fix (before: failed with `expected 'image generated' to contain 'ada'` through 5 CI retries / 755s)

Live upstream probes confirm both DashScope model ids generate successfully (~47–75s per image, `usage.output_image_type: qima_output_2k` reported, matching the `perImagePrice` tier resolution).

The only remaining failures in the run are `apps/api/src/routes/keys-provider.e2e.ts` env-key validation cases (AtlasCloud/Azure/Azure AI Foundry/DeepInfra/ElevenLabs/Sakana/Xiaomi) — they validate real `.env` keys against live providers, the failing set varies between runs, and they fail identically on plain `main` in this environment; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-turn Responses API coverage by excluding models that only support image generation.
  * Preserved existing single-turn model coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->