### PR TITLE
fix(api): order sole-member org teardown

### DIFF
--- a/apps/api/src/lib/account-deletion.spec.ts
+++ b/apps/api/src/lib/account-deletion.spec.ts
@@ -617,6 +617,8 @@ describe("tearDownSoleMemberOrganizations", () => {
 			billingEmail: "admin@example.com",
 			plan: "pro",
 			stripeSubscriptionId: "sub_second",
+			// Explicitly younger than the seeded org so teardown reaches it second.
+			createdAt: new Date(Date.now() + 60_000),
 		});
 		await db.insert(tables.userOrganization).values({
 			userId: USER_ID,

--- a/apps/api/src/lib/account-deletion.ts
+++ b/apps/api/src/lib/account-deletion.ts
@@ -166,8 +166,13 @@ export async function findSoleMemberOrganizations(
 		return [];
 	}
 
+	// Teardown cancels subscriptions org by org and stops at the first Stripe
+	// failure, so the order has to be reproducible: without it, which orgs were
+	// already cancelled before an outage depends on the row order Postgres
+	// happens to return.
 	const organizations = await db.query.organization.findMany({
 		where: { id: { in: soleOrgIds } },
+		orderBy: { createdAt: "asc", id: "asc" },
 	});
 
 	return organizations


### PR DESCRIPTION
## Problem

`test / run` fails intermittently on `main` with:

```
FAIL apps/api/src/lib/account-deletion.spec.ts > tearDownSoleMemberOrganizations
     > does not cancel a second org's subscription when the first fails
AssertionError: expected [ 'sub_second' ] to not include 'sub_second'
```

`findSoleMemberOrganizations` fetches the organizations with no `ORDER BY`, so Postgres is free to return them in any order. `tearDownSoleMemberOrganizations` iterates that list and stops at the first Stripe cancellation failure, so which org gets cancelled before an outage aborts the loop is nondeterministic. The test asserts the second org is untouched when the first fails, and fails whenever the second org comes back first.

That is a real (if small) production wrinkle too: during a Stripe outage, the set of subscriptions already cancelled before the abort should be reproducible, not down to row order.

## Approach

Order the query by `createdAt` (with `id` as tiebreak) so teardown always walks the user's organizations oldest-first, and pin the second fixture org's `createdAt` in the spec so the test does not depend on two `defaultNow()` inserts landing on distinct timestamps.

## Verification

Reproduced the failure deterministically by flipping the new ordering to `desc` — that yields exactly the CI assertion error, confirming the order dependence is the cause. With the fix, `apps/api/src/lib/account-deletion.spec.ts` passes on three consecutive runs (34 tests) against an isolated per-worktree database.