### PR TITLE
ci: shard unit and e2e tests

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,24 @@
+name: setup
+description: Install Node, pnpm and dependencies (the repository must already be checked out)
+
+runs:
+  using: composite
+  steps:
+    - name: Collect versions
+      shell: bash
+      run: |
+        echo "nodejs_version=$(cat .tool-versions | grep 'nodejs' | cut -d ' ' -f 2)" >> "$GITHUB_ENV"
+        echo "pnpm_version=$(cat .tool-versions | grep 'pnpm' | cut -d ' ' -f 2)" >> "$GITHUB_ENV"
+
+    - uses: pnpm/action-setup@v6.0.10
+      with:
+        version: ${{ env.pnpm_version }}
+
+    - uses: actions/setup-node@v7.0.0
+      with:
+        node-version: ${{ env.nodejs_version }}
+        cache: pnpm
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,8 +7,15 @@ runs:
     - name: Collect versions
       shell: bash
       run: |
-        echo "nodejs_version=$(cat .tool-versions | grep 'nodejs' | cut -d ' ' -f 2)" >> "$GITHUB_ENV"
-        echo "pnpm_version=$(cat .tool-versions | grep 'pnpm' | cut -d ' ' -f 2)" >> "$GITHUB_ENV"
+        set -eu
+        # .tool-versions comes from the checked-out ref, which for e2e is an
+        # untrusted PR head. Take a single line and strip everything outside
+        # [A-Za-z0-9.-] so a crafted file cannot inject extra GITHUB_ENV entries.
+        read_version() {
+          grep -m1 "^$1 " .tool-versions | cut -d ' ' -f 2 | tr -cd 'A-Za-z0-9.-'
+        }
+        echo "nodejs_version=$(read_version nodejs)" >> "$GITHUB_ENV"
+        echo "pnpm_version=$(read_version pnpm)" >> "$GITHUB_ENV"
 
     - uses: pnpm/action-setup@v6.0.10
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,5 @@ jobs:
       cmd: pnpm build && pnpm run setup && bash .github/start.sh
 
   test:
-    uses: ./.github/workflows/run.yml
+    uses: ./.github/workflows/test-unit.yml
     secrets: inherit
-    with:
-      cmd: pnpm build && pnpm run setup && pnpm test:unit

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        shard: [1, 2, 3, 4, 5]
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
@@ -77,29 +77,18 @@ jobs:
           ref: ${{ needs.resolve.outputs.ref }}
           persist-credentials: false
 
-      - name: Collect versions
-        run: |
-          echo "nodejs_version=$(cat .tool-versions | grep 'nodejs' | cut -d ' ' -f 2)" >> "$GITHUB_ENV"
-          echo "pnpm_version=$(cat .tool-versions | grep 'pnpm' | cut -d ' ' -f 2)" >> "$GITHUB_ENV"
-
-      - uses: pnpm/action-setup@v6.0.10
-        with:
-          version: ${{ env.pnpm_version }}
-
-      - uses: actions/setup-node@v7.0.0
-        with:
-          node-version: ${{ env.nodejs_version }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
 
       - name: Setup and run e2e shard ${{ matrix.shard }}
         run: |
           set -eux
           pnpm run setup
           export DATABASE_URL=postgres://postgres:pw@localhost:5432/test
-          E2E_TEST=true pnpm vitest run -c vitest/vitest.e2e.config.mts --no-file-parallelism --shard=${{ matrix.shard }}/10 --reporter=blob --outputFile=e2e-results-${{ matrix.shard }}.blob || true
+          # Never fail here: the merge job reports the combined result, and a
+          # failing shard must still upload its blob so that report is complete.
+          E2E_TEST=true pnpm vitest run -c vitest/vitest.e2e.config.mts --no-file-parallelism \
+            --shard=${{ matrix.shard }}/${{ strategy.job-total }} \
+            --reporter=blob --outputFile=e2e-results-${{ matrix.shard }}.blob || true
         env:
           LLM_OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           LLM_ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -166,22 +155,7 @@ jobs:
           ref: ${{ needs.resolve.outputs.ref }}
           persist-credentials: false
 
-      - name: Collect versions
-        run: |
-          echo "nodejs_version=$(cat .tool-versions | grep 'nodejs' | cut -d ' ' -f 2)" >> "$GITHUB_ENV"
-          echo "pnpm_version=$(cat .tool-versions | grep 'pnpm' | cut -d ' ' -f 2)" >> "$GITHUB_ENV"
-
-      - uses: pnpm/action-setup@v6.0.10
-        with:
-          version: ${{ env.pnpm_version }}
-
-      - uses: actions/setup-node@v7.0.0
-        with:
-          node-version: ${{ env.nodejs_version }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
 
       - name: Download all shard results
         uses: actions/download-artifact@v8

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -19,22 +19,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Collect versions
-        run: |
-          echo "nodejs_version=$(cat .tool-versions | grep 'nodejs' | cut -d ' ' -f 2)" >> "$GITHUB_ENV"
-          echo "pnpm_version=$(cat .tool-versions | grep 'pnpm' | cut -d ' ' -f 2)" >> "$GITHUB_ENV"
-
-      - uses: pnpm/action-setup@v6.0.10
-        with:
-          version: ${{ env.pnpm_version }}
-
-      - uses: actions/setup-node@v7.0.0
-        with:
-          node-version: ${{ env.nodejs_version }}
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
 
       - name: ${{ inputs.cmd }}
         env:

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -26,7 +26,9 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -eux
-          pnpm build
+          # `setup` runs build:core itself. A full `pnpm build` would add ~15min
+          # per shard to build the five Next.js apps, which no spec file needs —
+          # the `build` job already covers that.
           pnpm run setup
           # Never fail here: the merge job reports the combined result, and a
           # failing shard must still upload its blob so that report is complete.

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -1,0 +1,78 @@
+name: test-unit
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  shard:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup
+
+      - name: Run unit test shard ${{ matrix.shard }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -eux
+          pnpm build
+          pnpm run setup
+          # Never fail here: the merge job reports the combined result, and a
+          # failing shard must still upload its blob so that report is complete.
+          pnpm vitest run --no-file-parallelism \
+            --shard=${{ matrix.shard }}/${{ strategy.job-total }} \
+            --reporter=blob --outputFile=unit-results-${{ matrix.shard }}.blob || true
+
+      - name: Upload shard results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: unit-results-${{ matrix.shard }}
+          path: unit-results-${{ matrix.shard }}.blob
+          retention-days: 1
+          if-no-files-found: ignore
+
+  # Named `run` so the aggregated check stays `test / run`, which is what the
+  # branch ruleset requires.
+  run:
+    runs-on: ubuntu-latest
+    needs: shard
+    if: always()
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup
+
+      - name: Download all shard results
+        uses: actions/download-artifact@v8
+        with:
+          path: ./unit-results
+          pattern: unit-results-*
+
+      - name: Merge reports and show final results
+        run: |
+          mkdir -p .vitest-reports
+          find ./unit-results -name "*.blob" -exec mv {} .vitest-reports/ \;
+          # Fails if any test failed, providing the final status.
+          pnpm vitest run --merge-reports
+
+      - name: Fail if any shard did not succeed
+        if: always() && needs.shard.result != 'success'
+        run: |
+          echo "shard result was '${{ needs.shard.result }}', expected 'success'."
+          echo "At least one shard failed to run before it could produce results, so the merged report above is incomplete."
+          exit 1


### PR DESCRIPTION
## Problem

The unit test job ran all 297 spec files serially in one runner. The `test / run` check was taking **~30 min**.

## Approach

Split the unit suite across **ten parallel shards**. Each shard runs `vitest --shard=N/10 --reporter=blob` and uploads its blob; an aggregate job downloads all blobs and runs `vitest --merge-reports` for the combined result. Same shape the e2e workflow already used (e2e stays at ten shards).

**The required status check name is preserved.** The new reusable workflow's aggregate job is named `run` and `ci.yml` still calls it as the `test` job, so the check stays `test / run` — no ruleset change needed. The shards appear as additional, non-required `test / shard (N)` checks.

Also in here:

- **Dropped the redundant `pnpm build` from the test shards.** `pnpm run setup` already runs `build:core`, so the old command additionally built the five Next.js apps — 15 min per shard that no spec file needs and that the `build` job already covers. This was worth more than the sharding itself.
- Both suites derive the shard total from `strategy.job-total` instead of repeating the count in `--shard`, so the matrix list is the single source of truth.
- The repeated checkout/versions/pnpm/node/install block (in `run.yml` and twice in `e2e.yml`) is extracted into a `.github/actions/setup` composite action, and the `.tool-versions` read is sanitized before it reaches `$GITHUB_ENV` (that file comes from the checked-out ref, which for e2e is an untrusted PR head — this clears a critical CodeQL `actions/envvar-injection` alert present on main today).

## Result

`test / run`: **~30 min → ~14.7 min**, measured on this PR.

Per-shard breakdown at ten shards: `build:core` 9m25s, docker/schema push 46s, seed 1m00s, **actual tests 1m08s**.

The tests are no longer the bottleneck — they are 8% of the job. `build:core`, which every shard pays in full, is 64% of it. Shard count is now past the point of diminishing returns (five shards gave 16.0 min, ten gives 14.7 min for double the runner minutes); the remaining ~11 min is fixed per-shard overhead that more parallelism cannot touch.

**The next real win is Turbo's cache**, which currently reports `could not connect to the cache` in CI and locally, so every job builds cold. Restoring it — either fixing the configured remote cache or backing `.turbo` with `actions/cache` — would cut `build:core` on the common case where a PR touches only a package or two, and would speed up `lint`, `build` and `generate` by the same amount. Left out of this PR because it is a separate change affecting all four jobs.

## Verification

Ran the full unit suite locally against an isolated stack, unsharded and then sharded:

| | files | tests |
|---|---|---|
| unsharded baseline | 297 | 4919 |
| sharded, merged | 297 | 4919 |

No tests lost or duplicated, and shard times are evenly balanced (12.4-13.9 min in CI at ten shards) since the slowest single file is 28s against a 739s total.

Failure deltas between the two local runs were each chased down and are pre-existing flakiness, not order-dependence introduced by sharding: `dev-plans-payg` (3.7s baseline, one-off 439s network stall in the shard, 8s green re-run), `keys-api` and `openai-content-filter` (green in isolation), `sync-models` (failed in the *baseline*, passed sharded), `admin-devpass-payg` (time-of-day-dependent date window, fails in isolation too).

Also confirmed `vitest --merge-reports` exits non-zero with zero blobs present, so a run where every shard dies before producing results fails loudly instead of reporting a silent green.