### PR TITLE
fix(models): restore vertex flex on 3.7 flash

### DIFF
--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -1323,9 +1323,7 @@ export const googleModels = [
 			{
 				providerId: "google-vertex",
 				externalId: "gemini-3.7-flash",
-				// Vertex rejects Flex for this model ("Flex API is not supported
-				// for model"), so only priority is declared
-				serviceTiers: ["priority"],
+				serviceTiers: ["flex", "priority"],
 				serviceTierRegions: ["global"],
 				// introductory pricing until 2026-12-31; $1.50/$7.50 from 2027-01-01
 				inputPrice: "0.75e-6",


### PR DESCRIPTION
## Problem

`google-vertex/gemini-3.7-flash` rejects `service_tier: "flex"` with
`unsupported_service_tier`, even though every other Gemini Vertex mapping
in the catalogue offers Flex and Google's Flex PayGo docs list the model
on the global endpoint.

The mapping was added on the model's launch day (#3592), where a live
probe returned `400 "Flex API is not supported for model"`, so only
`priority` was declared. That is the same day-one rollout gap that
produced #3170 → #3176 for `gemini-3.6-flash`.

## Fix

Declare `serviceTiers: ["flex", "priority"]` on the `google-vertex`
mapping and drop the now-stale comment. Catalogue-only change; the tier
headers, pricing multipliers and e2e cases are all derived from it.

## Verification

- **Direct Vertex probe** (global endpoint, OAuth,
  `X-Vertex-AI-LLM-Request-Type: shared` +
  `X-Vertex-AI-LLM-Shared-Request-Type: flex`): HTTP 200 with
  `usageMetadata.trafficType: ON_DEMAND_FLEX`, three consecutive runs.
  Priority still returns `ON_DEMAND_PRIORITY`.
- **Through the gateway** (local build, `x-no-fallback`): `flex` →
  `requested_service_tier: flex`, `used_service_tier: flex`, input cost
  `9 × 0.75e-6 × 0.5 = 3.375e-6` (Flex 0.5× multiplier). `priority` →
  `9 × 0.75e-6 × 1.8 = 1.215e-5`.
- **E2E**: `TEST_MODELS="google-vertex/gemini-3.7-flash" FULL_MODE=true
  pnpm test:e2e` — the two new Flex cases (non-streaming + streaming,
  including the multiplier-scaled cost assertion) pass alongside the
  existing Priority ones. The only failures in the scoped run are in
  `keys-provider.e2e.ts` for unrelated providers whose keys are missing
  from this machine's local env.
- **Unit**: 299/301 files pass. The two failures
  (`onboarding-sponsorship.spec.ts`, and a `logs.spec.ts` case that
  hardcodes the default gateway port) reproduce on the unmodified
  baseline and on the isolated-stack ports respectively.
- `pnpm format` and full `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)