### PR TITLE
feat(admin): link org billing to Stripe

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -498,6 +498,9 @@ const transactionSchema = z.object({
 	// Off-Stripe payment channel and its reference, set on manual payments only.
 	paymentMethod: z.string().nullable(),
 	externalReference: z.string().nullable(),
+	stripePaymentIntentId: z.string().nullable(),
+	stripeInvoiceId: z.string().nullable(),
+	stripeRefundId: z.string().nullable(),
 });
 
 const transactionsListSchema = z.object({
@@ -3047,6 +3050,9 @@ admin.openapi(getOrganizationTransactions, async (c) => {
 			description: tables.transaction.description,
 			paymentMethod: tables.transaction.paymentMethod,
 			externalReference: tables.transaction.externalReference,
+			stripePaymentIntentId: tables.transaction.stripePaymentIntentId,
+			stripeInvoiceId: tables.transaction.stripeInvoiceId,
+			stripeRefundId: tables.transaction.stripeRefundId,
 		})
 		.from(tables.transaction)
 		.where(eq(tables.transaction.organizationId, orgId))
@@ -3087,6 +3093,9 @@ admin.openapi(getOrganizationTransactions, async (c) => {
 			description: t.description,
 			paymentMethod: t.paymentMethod,
 			externalReference: t.externalReference,
+			stripePaymentIntentId: t.stripePaymentIntentId,
+			stripeInvoiceId: t.stripeInvoiceId,
+			stripeRefundId: t.stripeRefundId,
 		})),
 		total,
 		limit,

--- a/ee/admin/src/app/organizations/[orgId]/page.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/page.tsx
@@ -3,6 +3,7 @@ import {
 	Building2,
 	ChevronLeft,
 	ChevronRight,
+	ExternalLink,
 	FolderOpen,
 	Key,
 	KeyRound,
@@ -42,6 +43,7 @@ import { KEY_STATUS_DEFAULT, parseKeyStatus } from "@/lib/key-status";
 import { getOrgDeletionBlockedReason } from "@/lib/org-deletion";
 import { requireSession } from "@/lib/require-session";
 import { createServerApiClient } from "@/lib/server-api";
+import { stripeSearchUrl, stripeTransactionUrl } from "@/lib/stripe-dashboard";
 
 import { ApiKeysTable } from "./api-keys-table";
 import { AuditLogsTab } from "./audit-logs-tab";
@@ -322,6 +324,17 @@ export default async function OrganizationPage({
 					<div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
 						<span>{org.billingEmail}</span>
 						<span>•</span>
+						<a
+							href={stripeSearchUrl(org.billingEmail)}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="inline-flex items-center gap-1 text-blue-600 hover:underline"
+							title={`Search Stripe for ${org.billingEmail}`}
+						>
+							<ExternalLink className="h-3 w-3" />
+							Stripe
+						</a>
+						<span>•</span>
 						<span>Created {formatDate(org.createdAt)}</span>
 					</div>
 					<div className="flex flex-wrap items-center gap-2">
@@ -529,68 +542,87 @@ export default async function OrganizationPage({
 										<TableHead>Status</TableHead>
 										<TableHead>Reference</TableHead>
 										<TableHead>Description</TableHead>
+										<TableHead>Stripe</TableHead>
 									</TableRow>
 								</TableHeader>
 								<TableBody>
 									{transactions.length === 0 ? (
 										<TableRow>
 											<TableCell
-												colSpan={7}
+												colSpan={8}
 												className="h-24 text-center text-muted-foreground"
 											>
 												No transactions found
 											</TableCell>
 										</TableRow>
 									) : (
-										transactions.map((transaction) => (
-											<TableRow key={transaction.id}>
-												<TableCell className="text-muted-foreground">
-													{formatDate(transaction.createdAt)}
-												</TableCell>
-												<TableCell>
-													<Badge
-														variant={getTransactionTypeBadgeVariant(
-															transaction.type,
+										transactions.map((transaction) => {
+											const stripeUrl = stripeTransactionUrl(transaction);
+											return (
+												<TableRow key={transaction.id}>
+													<TableCell className="text-muted-foreground">
+														{formatDate(transaction.createdAt)}
+													</TableCell>
+													<TableCell>
+														<Badge
+															variant={getTransactionTypeBadgeVariant(
+																transaction.type,
+															)}
+														>
+															{formatTransactionType(transaction.type)}
+														</Badge>
+													</TableCell>
+													<TableCell className="tabular-nums">
+														{transaction.amount
+															? currencyFormatter.format(
+																	parseFloat(transaction.amount),
+																)
+															: "—"}
+													</TableCell>
+													<TableCell className="tabular-nums">
+														{transaction.creditAmount
+															? creditsFormatter.format(
+																	parseFloat(transaction.creditAmount),
+																)
+															: "—"}
+													</TableCell>
+													<TableCell>
+														<Badge
+															variant={
+																transaction.status === "completed"
+																	? "secondary"
+																	: transaction.status === "failed"
+																		? "destructive"
+																		: "outline"
+															}
+														>
+															{transaction.status}
+														</Badge>
+													</TableCell>
+													<TableCell className="max-w-[180px] truncate font-mono text-xs text-muted-foreground">
+														{transaction.externalReference ?? "—"}
+													</TableCell>
+													<TableCell className="max-w-[200px] truncate text-muted-foreground">
+														{transaction.description ?? "—"}
+													</TableCell>
+													<TableCell>
+														{stripeUrl ? (
+															<a
+																href={stripeUrl}
+																target="_blank"
+																rel="noopener noreferrer"
+																className="inline-flex items-center gap-1 text-blue-600 hover:underline"
+															>
+																<ExternalLink className="h-3 w-3" />
+																View
+															</a>
+														) : (
+															<span className="text-muted-foreground">—</span>
 														)}
-													>
-														{formatTransactionType(transaction.type)}
-													</Badge>
-												</TableCell>
-												<TableCell className="tabular-nums">
-													{transaction.amount
-														? currencyFormatter.format(
-																parseFloat(transaction.amount),
-															)
-														: "—"}
-												</TableCell>
-												<TableCell className="tabular-nums">
-													{transaction.creditAmount
-														? creditsFormatter.format(
-																parseFloat(transaction.creditAmount),
-															)
-														: "—"}
-												</TableCell>
-												<TableCell>
-													<Badge
-														variant={
-															transaction.status === "completed"
-																? "secondary"
-																: transaction.status === "failed"
-																	? "destructive"
-																	: "outline"
-														}
-													>
-														{transaction.status}
-													</Badge>
-												</TableCell>
-												<TableCell className="max-w-[180px] truncate font-mono text-xs text-muted-foreground">
-													{transaction.externalReference ?? "—"}
-												</TableCell>
-												<TableCell className="max-w-[200px] truncate text-muted-foreground">
-													{transaction.description ?? "—"}
-												</TableCell>
-											</TableRow>
-										))
+													</TableCell>
+												</TableRow>
+											);
+										})
 									)}
 								</TableBody>
 							</Table>

--- a/ee/admin/src/lib/stripe-dashboard.ts
+++ b/ee/admin/src/lib/stripe-dashboard.ts
@@ -1,0 +1,31 @@
+const BASE = "https://dashboard.stripe.com";
+
+/**
+ * Stripe Dashboard search across customers, payments and invoices. Used to jump
+ * from an organization to everything Stripe knows about its billing contact.
+ */
+export function stripeSearchUrl(query: string) {
+	return `${BASE}/search?query=${encodeURIComponent(query)}`;
+}
+
+/**
+ * Deep link for a transaction row, preferring the most specific object we
+ * recorded. Refund rows normally also carry the payment intent, so the refund
+ * fallback goes through search — there is no stable refund detail route.
+ */
+export function stripeTransactionUrl(transaction: {
+	stripePaymentIntentId?: string | null;
+	stripeInvoiceId?: string | null;
+	stripeRefundId?: string | null;
+}) {
+	if (transaction.stripePaymentIntentId) {
+		return `${BASE}/payments/${transaction.stripePaymentIntentId}`;
+	}
+	if (transaction.stripeInvoiceId) {
+		return `${BASE}/invoices/${transaction.stripeInvoiceId}`;
+	}
+	if (transaction.stripeRefundId) {
+		return stripeSearchUrl(transaction.stripeRefundId);
+	}
+	return null;
+}


### PR DESCRIPTION
Jumping from an organization in the admin dashboard to its Stripe activity meant copying the billing email into the Stripe dashboard by hand, and individual transaction rows gave no way to reach the payment behind them at all.

- The organization header now carries a **Stripe** link next to the billing email that opens a Stripe Dashboard search for that address (user email is the eventual target; billing email is what the org record has today).
- The transactions table gains a **Stripe** column that opens the payment intent, falling back to the invoice, and to a search on the refund id for rows that only carry one. Rows with no Stripe object show a dash.

URL building lives in `ee/admin/src/lib/stripe-dashboard.ts`; the admin transactions endpoint now returns the `stripePaymentIntentId` / `stripeInvoiceId` / `stripeRefundId` it already stored.

### Organization header

| | Before | After |
| --- | --- | --- |
| Light | <img width="700" alt="header before, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/9581fa58e62560c6c93143325e76eb01f2d253f0/before-header-light.png" /> | <img width="700" alt="header after, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/9581fa58e62560c6c93143325e76eb01f2d253f0/after-header-light.png" /> |
| Dark | <img width="700" alt="header before, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/9581fa58e62560c6c93143325e76eb01f2d253f0/before-header-dark.png" /> | <img width="700" alt="header after, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/9581fa58e62560c6c93143325e76eb01f2d253f0/after-header-dark.png" /> |

### Transactions table

| | Before | After |
| --- | --- | --- |
| Light | <img width="700" alt="transactions before, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/9581fa58e62560c6c93143325e76eb01f2d253f0/before-transactions-light.png" /> | <img width="700" alt="transactions after, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/9581fa58e62560c6c93143325e76eb01f2d253f0/after-transactions-light.png" /> |
| Dark | <img width="700" alt="transactions before, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/9581fa58e62560c6c93143325e76eb01f2d253f0/before-transactions-dark.png" /> | <img width="700" alt="transactions after, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/9581fa58e62560c6c93143325e76eb01f2d253f0/after-transactions-dark.png" /> |

Verified locally against seeded data on an isolated stack: `pnpm format`, `pnpm build`, and both links resolving to the expected Stripe URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Stripe Dashboard links to organization billing emails.
  * Added a Stripe column to transaction tables, linking to payment intents, invoices, or refunds when available.
  * Transaction details now include Stripe payment, invoice, and refund identifiers.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->