### PR TITLE
perf(admin): load DevPass data client-side

### DIFF
--- a/apps/api/src/routes/admin-devpass-gift-reset-passes.spec.ts
+++ b/apps/api/src/routes/admin-devpass-gift-reset-passes.spec.ts
@@ -26,8 +26,9 @@ interface DetailResponse {
 	transactions: { type: string; amount: string | null }[];
 }
 
-interface ListResponse {
-	kpis: { resetPassesSold: number; resetPassRevenue: number };
+interface KpisResponse {
+	resetPassesSold: number;
+	resetPassRevenue: number;
 }
 
 async function insertOrg(
@@ -240,13 +241,13 @@ describe("admin devpass gift reset passes", () => {
 		});
 		await giftRequest({ tier: "pro", count: 5 }, cookie);
 
-		const res = await app.request("/admin/devpass", {
+		const res = await app.request("/admin/devpass/kpis", {
 			headers: { Cookie: cookie },
 		});
 		expect(res.status).toBe(200);
-		const body = (await res.json()) as ListResponse;
-		expect(body.kpis.resetPassesSold).toBe(1);
-		expect(body.kpis.resetPassRevenue).toBe(29);
+		const body = (await res.json()) as KpisResponse;
+		expect(body.resetPassesSold).toBe(1);
+		expect(body.resetPassRevenue).toBe(29);
 	});
 
 	it("gifted passes are redeemable through the normal redeem flow", async () => {

--- a/apps/api/src/routes/admin-devpass-payg.spec.ts
+++ b/apps/api/src/routes/admin-devpass-payg.spec.ts
@@ -25,14 +25,15 @@ interface PaygSubscriber {
 
 interface ListResponse {
 	subscribers: PaygSubscriber[];
-	kpis: {
-		paygOptedIn: number;
-		paygBalanceHeld: number;
-		topupRevenueThisMonth: number;
-		topupRevenueAllTime: number;
-		totalOverflowCostCycle: number;
-		totalMargin: number;
-	};
+}
+
+interface KpisResponse {
+	paygOptedIn: number;
+	paygBalanceHeld: number;
+	topupRevenueThisMonth: number;
+	topupRevenueAllTime: number;
+	totalOverflowCostCycle: number;
+	totalMargin: number;
 }
 
 describe("admin devpass PAYG overflow reporting", () => {
@@ -135,13 +136,18 @@ describe("admin devpass PAYG overflow reporting", () => {
 		// All-time revenue: $79 plan payment + $26.25 top-up.
 		expect(sub!.allTimeRevenue).toBe(105.25);
 
-		expect(body.kpis.paygOptedIn).toBe(1);
-		expect(body.kpis.paygBalanceHeld).toBe(22);
-		expect(body.kpis.topupRevenueAllTime).toBe(26.25);
-		expect(body.kpis.topupRevenueThisMonth).toBe(26.25);
-		expect(body.kpis.totalOverflowCostCycle).toBe(3);
+		const kpisRes = await app.request("/admin/devpass/kpis", {
+			headers: { Cookie: cookie },
+		});
+		expect(kpisRes.status).toBe(200);
+		const kpis = (await kpisRes.json()) as KpisResponse;
+		expect(kpis.paygOptedIn).toBe(1);
+		expect(kpis.paygBalanceHeld).toBe(22);
+		expect(kpis.topupRevenueAllTime).toBe(26.25);
+		expect(kpis.topupRevenueThisMonth).toBe(26.25);
+		expect(kpis.totalOverflowCostCycle).toBe(3);
 		// Universe margin mirrors the per-org decomposition.
-		expect(body.kpis.totalMargin).toBe(79 - 237);
+		expect(kpis.totalMargin).toBe(79 - 237);
 	});
 
 	it("dedicated /admin/devpass/payg reports top-up revenue windows", async () => {

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -12521,7 +12521,6 @@ const devpassKpisSchema = z.object({
 const devpassListSchema = z.object({
 	subscribers: z.array(devpassSubscriberSchema),
 	total: z.number(),
-	kpis: devpassKpisSchema,
 	limit: z.number(),
 	offset: z.number(),
 });
@@ -12573,6 +12572,24 @@ const getDevpassSubscribers = createRoute({
 				},
 			},
 			description: "List of DevPass subscribers.",
+		},
+	},
+});
+
+// Split out of the list endpoint: the KPI strip aggregates the whole
+// subscriber universe and is far slower than one page of rows, so the admin
+// page loads the two independently instead of blocking on the sum.
+const getDevpassKpis = createRoute({
+	method: "get",
+	path: "/devpass/kpis",
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: devpassKpisSchema.openapi({}),
+				},
+			},
+			description: "DevPass KPI strip across the whole subscriber universe.",
 		},
 	},
 });
@@ -12979,27 +12996,31 @@ function deriveStatus(
 	return "active";
 }
 
-admin.openapi(getDevpassSubscribers, async (c) => {
-	const query = c.req.valid("query");
-	const limit = query.limit ?? 50;
-	const offset = query.offset ?? 0;
-	const search = query.search;
-	const tierFilter = query.tier;
-	const statusFilter = query.status;
-	const utilizationFilter = query.utilization;
-	const marginNegative = query.marginNegative ?? false;
-	const showChurned = query.showChurned ?? false;
-	const sortBy = query.sortBy ?? "subscribedSince";
-	const sortOrder = query.sortOrder ?? "desc";
+const devpassTierPriceExpr = sql<number>`CASE
+	WHEN ${tables.organization.devPlan} = 'lite' THEN ${DEV_PLAN_PRICES.lite}
+	WHEN ${tables.organization.devPlan} = 'pro' THEN ${DEV_PLAN_PRICES.pro}
+	WHEN ${tables.organization.devPlan} = 'max' THEN ${DEV_PLAN_PRICES.max}
+	ELSE 0
+END`;
 
-	const now = new Date();
-	const monthStart = new Date(
-		Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1),
+// Active subscriber universe: everything Stripe still counts as active,
+// including subs flagged to cancel at period end.
+function devpassActiveUniverseWhere() {
+	return and(
+		eq(tables.organization.kind, "devpass"),
+		ne(tables.organization.devPlan, "none"),
+		or(
+			isNull(tables.organization.devPlanExpiresAt),
+			sql`${tables.organization.devPlanExpiresAt} > NOW()`,
+		)!,
 	);
+}
 
-	// Subquery: real provider cost in current cycle, per org. Credits-mode cost
-	// only: BYOK ("api-keys") usage is paid by the customer's own provider key,
-	// so it is not a cost we bear and must not depress the margin.
+// Real provider cost in the current cycle, per org, plus the derived overflow
+// split. Credits-mode cost only: BYOK ("api-keys") usage is paid by the
+// customer's own provider key, so it is not a cost we bear and must not
+// depress the margin.
+function buildDevpassCycleCostExprs() {
 	const realCostSub = db
 		.select({
 			organizationId: tables.project.organizationId,
@@ -13023,6 +13044,35 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 		)
 		.groupBy(tables.project.organizationId)
 		.as("real_cost_sub");
+
+	const realCostExpr = sql<number>`COALESCE(CAST(${realCostSub.realCost} AS NUMERIC), 0)`;
+	// Cycle cost paid from the org's own credits (PAYG overflow) rather than
+	// the plan pool. The pool draw this cycle IS devPlanCreditsUsed (the worker
+	// increments it only for pool-funded usage, and renewal resets it together
+	// with the cycle window realCost is scoped to), so anything above it hit
+	// the org's `credits` balance.
+	const overflowCostExpr = sql<number>`GREATEST((${realCostExpr}) - CAST(${tables.organization.devPlanCreditsUsed} AS NUMERIC), 0)`;
+
+	return { realCostSub, realCostExpr, overflowCostExpr };
+}
+
+admin.openapi(getDevpassSubscribers, async (c) => {
+	const query = c.req.valid("query");
+	const limit = query.limit ?? 50;
+	const offset = query.offset ?? 0;
+	const search = query.search;
+	const tierFilter = query.tier;
+	const statusFilter = query.status;
+	const utilizationFilter = query.utilization;
+	const marginNegative = query.marginNegative ?? false;
+	const showChurned = query.showChurned ?? false;
+	const sortBy = query.sortBy ?? "subscribedSince";
+	const sortOrder = query.sortOrder ?? "desc";
+
+	const now = new Date();
+
+	const { realCostSub, realCostExpr, overflowCostExpr } =
+		buildDevpassCycleCostExprs();
 
 	// Subquery: first dev plan start (subscribedSince) and tier change count.
 	// Legacy rows used the generic "subscription_start" type before the
@@ -13218,12 +13268,7 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 		.groupBy(tables.transaction.organizationId)
 		.as("all_time_topups_sub");
 
-	const tierPriceExpr = sql<number>`CASE
-		WHEN ${tables.organization.devPlan} = 'lite' THEN ${DEV_PLAN_PRICES.lite}
-		WHEN ${tables.organization.devPlan} = 'pro' THEN ${DEV_PLAN_PRICES.pro}
-		WHEN ${tables.organization.devPlan} = 'max' THEN ${DEV_PLAN_PRICES.max}
-		ELSE 0
-	END`;
+	const tierPriceExpr = devpassTierPriceExpr;
 
 	const utilizationExpr = sql<number | null>`CASE
 		WHEN CAST(${tables.organization.devPlanCreditsLimit} AS NUMERIC) > 0
@@ -13232,13 +13277,6 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 		ELSE NULL
 	END`;
 
-	const realCostExpr = sql<number>`COALESCE(CAST(${realCostSub.realCost} AS NUMERIC), 0)`;
-	// Cycle cost paid from the org's own credits (PAYG overflow) rather than
-	// the plan pool. The pool draw this cycle IS devPlanCreditsUsed (the worker
-	// increments it only for pool-funded usage, and renewal resets it together
-	// with the cycle window realCost is scoped to), so anything above it hit
-	// the org's `credits` balance.
-	const overflowCostExpr = sql<number>`GREATEST((${realCostExpr}) - CAST(${tables.organization.devPlanCreditsUsed} AS NUMERIC), 0)`;
 	// Plan economics only: overflow cost is funded ~1:1 by the org's own
 	// top-ups, so counting it against the tier price would understate margin.
 	const marginExpr = sql<number>`(${tierPriceExpr}) - ((${realCostExpr}) - (${overflowCostExpr}))`;
@@ -13422,12 +13460,6 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 			eq(tables.organization.id, allTimeTopupsSub.organizationId),
 		);
 
-	const rows = await baseSelect
-		.where(whereClause)
-		.orderBy(orderFn(sortColumn), asc(tables.organization.id))
-		.limit(limit)
-		.offset(offset);
-
 	// Total count with same filters
 	const countSelect = db
 		.select({ count: sql<number>`COUNT(*)` })
@@ -13450,274 +13482,15 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 		)
 		.leftJoin(ownerSub, eq(tables.organization.id, ownerSub.organizationId));
 
-	const [countRow] = await countSelect.where(whereClause);
+	const [rows, [countRow]] = await Promise.all([
+		baseSelect
+			.where(whereClause)
+			.orderBy(orderFn(sortColumn), asc(tables.organization.id))
+			.limit(limit)
+			.offset(offset),
+		countSelect.where(whereClause),
+	]);
 	const total = Number(countRow?.count ?? 0);
-
-	// KPI strip — counts the full active subscriber base, matching Stripe's
-	// "active" filter which includes cancel-at-period-end subs until the period
-	// actually ends. `grossMrr` is the Stripe-aligned figure (what will be
-	// invoiced this period). `committedMrr` excludes subs flagged to cancel,
-	// representing the forward-looking MRR after impending churn lands.
-	const activeRows = await db
-		.select({
-			tier: tables.organization.devPlan,
-			cancelled: tables.organization.devPlanCancelled,
-			count: sql<number>`COUNT(*)`,
-		})
-		.from(tables.organization)
-		.where(
-			and(
-				eq(tables.organization.kind, "devpass"),
-				ne(tables.organization.devPlan, "none"),
-				or(
-					isNull(tables.organization.devPlanExpiresAt),
-					sql`${tables.organization.devPlanExpiresAt} > NOW()`,
-				)!,
-			),
-		)
-		.groupBy(tables.organization.devPlan, tables.organization.devPlanCancelled);
-
-	const activeByTier = { lite: 0, pro: 0, max: 0 };
-	const cancellingByTier = { lite: 0, pro: 0, max: 0 };
-	for (const r of activeRows) {
-		const tierKey = r.tier as keyof typeof activeByTier;
-		if (tierKey in activeByTier) {
-			const n = Number(r.count);
-			activeByTier[tierKey] += n;
-			if (r.cancelled) {
-				cancellingByTier[tierKey] += n;
-			}
-		}
-	}
-	const totalActive = activeByTier.lite + activeByTier.pro + activeByTier.max;
-	const liteMrr = activeByTier.lite * DEV_PLAN_PRICES.lite;
-	const proMrr = activeByTier.pro * DEV_PLAN_PRICES.pro;
-	const maxMrr = activeByTier.max * DEV_PLAN_PRICES.max;
-	const grossMrr = liteMrr + proMrr + maxMrr;
-	const cancellingLiteMrr = cancellingByTier.lite * DEV_PLAN_PRICES.lite;
-	const cancellingProMrr = cancellingByTier.pro * DEV_PLAN_PRICES.pro;
-	const cancellingMaxMrr = cancellingByTier.max * DEV_PLAN_PRICES.max;
-	const cancellingMrr = cancellingLiteMrr + cancellingProMrr + cancellingMaxMrr;
-	const committedMrr = grossMrr - cancellingMrr;
-	const cancelledPending =
-		cancellingByTier.lite + cancellingByTier.pro + cancellingByTier.max;
-
-	const [churnedRow] = await db
-		.select({
-			count: sql<number>`COUNT(DISTINCT ${tables.transaction.organizationId})`,
-		})
-		.from(tables.transaction)
-		.innerJoin(
-			tables.organization,
-			eq(tables.transaction.organizationId, tables.organization.id),
-		)
-		.where(
-			and(
-				eq(tables.organization.kind, "devpass"),
-				eq(tables.transaction.type, "dev_plan_start"),
-				eq(tables.organization.devPlan, "none"),
-			),
-		);
-	const churned = Number(churnedRow?.count ?? 0);
-
-	const [startsRow] = await db
-		.select({ count: sql<number>`COUNT(*)` })
-		.from(tables.transaction)
-		.innerJoin(
-			tables.organization,
-			eq(tables.transaction.organizationId, tables.organization.id),
-		)
-		.where(
-			and(
-				eq(tables.organization.kind, "devpass"),
-				eq(tables.transaction.type, "dev_plan_start"),
-				gte(tables.transaction.createdAt, monthStart),
-			),
-		);
-	const startsThisMonth = Number(startsRow?.count ?? 0);
-
-	const [endsRow] = await db
-		.select({ count: sql<number>`COUNT(*)` })
-		.from(tables.transaction)
-		.innerJoin(
-			tables.organization,
-			eq(tables.transaction.organizationId, tables.organization.id),
-		)
-		.where(
-			and(
-				eq(tables.organization.kind, "devpass"),
-				inArray(tables.transaction.type, ["dev_plan_cancel", "dev_plan_end"]),
-				gte(tables.transaction.createdAt, monthStart),
-			),
-		);
-	const endsThisMonth = Number(endsRow?.count ?? 0);
-
-	// Refunds this month for DevPass transactions. Mirrors the timeseries
-	// refund query (joins credit_refund rows to their original tx and filters
-	// to dev plan types, plus legacy subscription_* rows on DevPass orgs) but
-	// aggregates to a single month total so the KPI strip reflects refund
-	// activity that the snapshot-based MRR cards can't show.
-	const refundOriginalTx = aliasedTable(
-		tables.transaction,
-		"refund_original_tx",
-	);
-	const [refundsRow] = await db
-		.select({
-			count: sql<number>`COUNT(*)`,
-			total: sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`,
-		})
-		.from(tables.transaction)
-		.innerJoin(
-			refundOriginalTx,
-			eq(tables.transaction.relatedTransactionId, refundOriginalTx.id),
-		)
-		.innerJoin(
-			tables.organization,
-			eq(tables.transaction.organizationId, tables.organization.id),
-		)
-		.where(
-			and(
-				eq(tables.transaction.type, "credit_refund"),
-				eq(tables.transaction.status, "completed"),
-				gte(tables.transaction.createdAt, monthStart),
-				eq(tables.organization.kind, "devpass"),
-				inArray(refundOriginalTx.type, [
-					...DEV_PLAN_TX_TYPES,
-					...LEGACY_DEV_PLAN_TX_TYPES,
-				]),
-			),
-		);
-	const refundsThisMonth = Number(refundsRow?.count ?? 0);
-	const refundedAmountThisMonth = Number(refundsRow?.total ?? 0);
-
-	// All-time Reset Pass sales on DevPass orgs. These are one-time
-	// PaymentIntent purchases (no invoice), so no invoice dedup is needed;
-	// revenue is netted against completed refunds whose original transaction
-	// is a Reset Pass purchase, mirroring the all-time revenue subquery.
-	const [resetPassRow] = await db
-		.select({
-			count: sql<number>`COUNT(*)`,
-			total: sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`,
-		})
-		.from(tables.transaction)
-		.innerJoin(
-			tables.organization,
-			eq(tables.transaction.organizationId, tables.organization.id),
-		)
-		.where(
-			and(
-				eq(tables.transaction.type, "dev_plan_reset_pass"),
-				eq(tables.transaction.status, "completed"),
-				eq(tables.organization.kind, "devpass"),
-			),
-		);
-	const resetPassesSold = Number(resetPassRow?.count ?? 0);
-
-	const resetPassRefundOriginalTx = aliasedTable(
-		tables.transaction,
-		"reset_pass_refund_original_tx",
-	);
-	const [resetPassRefundRow] = await db
-		.select({
-			total: sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`,
-		})
-		.from(tables.transaction)
-		.innerJoin(
-			resetPassRefundOriginalTx,
-			eq(tables.transaction.relatedTransactionId, resetPassRefundOriginalTx.id),
-		)
-		.innerJoin(
-			tables.organization,
-			eq(tables.transaction.organizationId, tables.organization.id),
-		)
-		.where(
-			and(
-				eq(tables.transaction.type, "credit_refund"),
-				eq(tables.transaction.status, "completed"),
-				eq(tables.organization.kind, "devpass"),
-				eq(resetPassRefundOriginalTx.type, "dev_plan_reset_pass"),
-			),
-		);
-	const resetPassRevenue =
-		Number(resetPassRow?.total ?? 0) - Number(resetPassRefundRow?.total ?? 0);
-
-	// Weighted utilization across active subscribers
-	const [utilRow] = await db
-		.select({
-			totalUsed: sql<string>`COALESCE(SUM(CAST(${tables.organization.devPlanCreditsUsed} AS NUMERIC)), 0)`,
-			totalLimit: sql<string>`COALESCE(SUM(CAST(${tables.organization.devPlanCreditsLimit} AS NUMERIC)), 0)`,
-		})
-		.from(tables.organization)
-		.where(
-			and(
-				eq(tables.organization.kind, "devpass"),
-				ne(tables.organization.devPlan, "none"),
-				or(
-					isNull(tables.organization.devPlanExpiresAt),
-					sql`${tables.organization.devPlanExpiresAt} > NOW()`,
-				)!,
-			),
-		);
-	const totalUsed = Number(utilRow?.totalUsed ?? 0);
-	const totalLimit = Number(utilRow?.totalLimit ?? 0);
-	const weightedAvgUtilization =
-		totalLimit > 0 ? (totalUsed / totalLimit) * 100 : 0;
-
-	// Cycle-windowed totals across the active subscriber universe (not paginated)
-	const [universeRow] = await db
-		.select({
-			totalCost: sql<string>`COALESCE(SUM(CAST(${realCostSub.realCost} AS NUMERIC)), 0)`,
-			totalMrr: sql<string>`COALESCE(SUM(${tierPriceExpr}), 0)`,
-			totalOverflow: sql<string>`COALESCE(SUM(${overflowCostExpr}), 0)`,
-			paygOptedIn: sql<number>`COUNT(*) FILTER (WHERE ${tables.organization.devPlanPaygEnabled})`,
-			paygBalanceHeld: sql<string>`COALESCE(SUM(CAST(${tables.organization.credits} AS NUMERIC)), 0)`,
-		})
-		.from(tables.organization)
-		.leftJoin(
-			realCostSub,
-			eq(tables.organization.id, realCostSub.organizationId),
-		)
-		.where(
-			and(
-				eq(tables.organization.kind, "devpass"),
-				ne(tables.organization.devPlan, "none"),
-				or(
-					isNull(tables.organization.devPlanExpiresAt),
-					sql`${tables.organization.devPlanExpiresAt} > NOW()`,
-				)!,
-			),
-		);
-	const totalRealCostCycle = Number(universeRow?.totalCost ?? 0);
-	const totalMrrCycle = Number(universeRow?.totalMrr ?? 0);
-	const totalOverflowCostCycle = Number(universeRow?.totalOverflow ?? 0);
-	const paygOptedIn = Number(universeRow?.paygOptedIn ?? 0);
-	const paygBalanceHeld = Number(universeRow?.paygBalanceHeld ?? 0);
-	// Plan economics: overflow cost is funded by the orgs' own top-ups, so it
-	// doesn't count against plan MRR.
-	const totalMargin =
-		totalMrrCycle - (totalRealCostCycle - totalOverflowCostCycle);
-
-	// PAYG overflow top-up revenue on devpass orgs (gross Stripe amount).
-	const [topupRevenueRow] = await db
-		.select({
-			allTime: sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`,
-			thisMonth: sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)) FILTER (WHERE ${tables.transaction.createdAt} >= ${monthStart}), 0)`,
-		})
-		.from(tables.transaction)
-		.innerJoin(
-			tables.organization,
-			eq(tables.transaction.organizationId, tables.organization.id),
-		)
-		.where(
-			and(
-				eq(tables.transaction.type, "credit_topup"),
-				eq(tables.transaction.status, "completed"),
-				eq(tables.organization.kind, "devpass"),
-				sql`CAST(${tables.transaction.amount} AS NUMERIC) > 0`,
-			),
-		);
-	const topupRevenueAllTime = Number(topupRevenueRow?.allTime ?? 0);
-	const topupRevenueThisMonth = Number(topupRevenueRow?.thisMonth ?? 0);
 
 	const subscribers = rows.map((row) => {
 		const tier = row.tier;
@@ -13799,39 +13572,293 @@ admin.openapi(getDevpassSubscribers, async (c) => {
 		};
 	});
 
-	const kpiMarginPct =
-		totalMrrCycle > 0 ? (totalMargin / totalMrrCycle) * 100 : null;
-
 	return c.json({
 		subscribers,
 		total,
-		kpis: {
-			activeByTier,
-			totalActive,
-			cancelledPending,
-			churned,
-			grossMrr,
-			committedMrr,
-			startsThisMonth,
-			endsThisMonth,
-			netNewThisMonth: startsThisMonth - endsThisMonth,
-			refundsThisMonth,
-			refundedAmountThisMonth,
-			resetPassesSold,
-			resetPassRevenue,
-			paygOptedIn,
-			paygBalanceHeld,
-			topupRevenueThisMonth,
-			topupRevenueAllTime,
-			totalOverflowCostCycle,
-			weightedAvgUtilization,
-			totalRealCostCycle,
-			totalMrrCycle,
-			totalMargin,
-			marginPct: kpiMarginPct,
-		},
 		limit,
 		offset,
+	});
+});
+
+admin.openapi(getDevpassKpis, async (c) => {
+	const now = new Date();
+	const monthStart = new Date(
+		Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1),
+	);
+
+	const { realCostSub, overflowCostExpr } = buildDevpassCycleCostExprs();
+
+	const refundOriginalTx = aliasedTable(
+		tables.transaction,
+		"refund_original_tx",
+	);
+	const resetPassRefundOriginalTx = aliasedTable(
+		tables.transaction,
+		"reset_pass_refund_original_tx",
+	);
+
+	// Every KPI is an independent aggregate over the same universe, so they run
+	// concurrently rather than serially.
+	const [
+		activeRows,
+		[churnedRow],
+		[startsRow],
+		[endsRow],
+		[refundsRow],
+		[resetPassRow],
+		[resetPassRefundRow],
+		[utilRow],
+		[universeRow],
+		[topupRevenueRow],
+	] = await Promise.all([
+		// KPI strip — counts the full active subscriber base, matching Stripe's
+		// "active" filter which includes cancel-at-period-end subs until the period
+		// actually ends. `grossMrr` is the Stripe-aligned figure (what will be
+		// invoiced this period). `committedMrr` excludes subs flagged to cancel,
+		// representing the forward-looking MRR after impending churn lands.
+		db
+			.select({
+				tier: tables.organization.devPlan,
+				cancelled: tables.organization.devPlanCancelled,
+				count: sql<number>`COUNT(*)`,
+			})
+			.from(tables.organization)
+			.where(devpassActiveUniverseWhere())
+			.groupBy(
+				tables.organization.devPlan,
+				tables.organization.devPlanCancelled,
+			),
+		db
+			.select({
+				count: sql<number>`COUNT(DISTINCT ${tables.transaction.organizationId})`,
+			})
+			.from(tables.transaction)
+			.innerJoin(
+				tables.organization,
+				eq(tables.transaction.organizationId, tables.organization.id),
+			)
+			.where(
+				and(
+					eq(tables.organization.kind, "devpass"),
+					eq(tables.transaction.type, "dev_plan_start"),
+					eq(tables.organization.devPlan, "none"),
+				),
+			),
+		db
+			.select({ count: sql<number>`COUNT(*)` })
+			.from(tables.transaction)
+			.innerJoin(
+				tables.organization,
+				eq(tables.transaction.organizationId, tables.organization.id),
+			)
+			.where(
+				and(
+					eq(tables.organization.kind, "devpass"),
+					eq(tables.transaction.type, "dev_plan_start"),
+					gte(tables.transaction.createdAt, monthStart),
+				),
+			),
+		db
+			.select({ count: sql<number>`COUNT(*)` })
+			.from(tables.transaction)
+			.innerJoin(
+				tables.organization,
+				eq(tables.transaction.organizationId, tables.organization.id),
+			)
+			.where(
+				and(
+					eq(tables.organization.kind, "devpass"),
+					inArray(tables.transaction.type, ["dev_plan_cancel", "dev_plan_end"]),
+					gte(tables.transaction.createdAt, monthStart),
+				),
+			),
+		// Refunds this month for DevPass transactions. Mirrors the timeseries
+		// refund query (joins credit_refund rows to their original tx and filters
+		// to dev plan types, plus legacy subscription_* rows on DevPass orgs) but
+		// aggregates to a single month total so the KPI strip reflects refund
+		// activity that the snapshot-based MRR cards can't show.
+		db
+			.select({
+				count: sql<number>`COUNT(*)`,
+				total: sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`,
+			})
+			.from(tables.transaction)
+			.innerJoin(
+				refundOriginalTx,
+				eq(tables.transaction.relatedTransactionId, refundOriginalTx.id),
+			)
+			.innerJoin(
+				tables.organization,
+				eq(tables.transaction.organizationId, tables.organization.id),
+			)
+			.where(
+				and(
+					eq(tables.transaction.type, "credit_refund"),
+					eq(tables.transaction.status, "completed"),
+					gte(tables.transaction.createdAt, monthStart),
+					eq(tables.organization.kind, "devpass"),
+					inArray(refundOriginalTx.type, [
+						...DEV_PLAN_TX_TYPES,
+						...LEGACY_DEV_PLAN_TX_TYPES,
+					]),
+				),
+			),
+		// All-time Reset Pass sales on DevPass orgs. These are one-time
+		// PaymentIntent purchases (no invoice), so no invoice dedup is needed;
+		// revenue is netted against completed refunds whose original transaction
+		// is a Reset Pass purchase, mirroring the all-time revenue subquery.
+		db
+			.select({
+				count: sql<number>`COUNT(*)`,
+				total: sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`,
+			})
+			.from(tables.transaction)
+			.innerJoin(
+				tables.organization,
+				eq(tables.transaction.organizationId, tables.organization.id),
+			)
+			.where(
+				and(
+					eq(tables.transaction.type, "dev_plan_reset_pass"),
+					eq(tables.transaction.status, "completed"),
+					eq(tables.organization.kind, "devpass"),
+				),
+			),
+		db
+			.select({
+				total: sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`,
+			})
+			.from(tables.transaction)
+			.innerJoin(
+				resetPassRefundOriginalTx,
+				eq(
+					tables.transaction.relatedTransactionId,
+					resetPassRefundOriginalTx.id,
+				),
+			)
+			.innerJoin(
+				tables.organization,
+				eq(tables.transaction.organizationId, tables.organization.id),
+			)
+			.where(
+				and(
+					eq(tables.transaction.type, "credit_refund"),
+					eq(tables.transaction.status, "completed"),
+					eq(tables.organization.kind, "devpass"),
+					eq(resetPassRefundOriginalTx.type, "dev_plan_reset_pass"),
+				),
+			),
+		// Weighted utilization across active subscribers
+		db
+			.select({
+				totalUsed: sql<string>`COALESCE(SUM(CAST(${tables.organization.devPlanCreditsUsed} AS NUMERIC)), 0)`,
+				totalLimit: sql<string>`COALESCE(SUM(CAST(${tables.organization.devPlanCreditsLimit} AS NUMERIC)), 0)`,
+			})
+			.from(tables.organization)
+			.where(devpassActiveUniverseWhere()),
+		// Cycle-windowed totals across the active subscriber universe (not paginated)
+		db
+			.select({
+				totalCost: sql<string>`COALESCE(SUM(CAST(${realCostSub.realCost} AS NUMERIC)), 0)`,
+				totalMrr: sql<string>`COALESCE(SUM(${devpassTierPriceExpr}), 0)`,
+				totalOverflow: sql<string>`COALESCE(SUM(${overflowCostExpr}), 0)`,
+				paygOptedIn: sql<number>`COUNT(*) FILTER (WHERE ${tables.organization.devPlanPaygEnabled})`,
+				paygBalanceHeld: sql<string>`COALESCE(SUM(CAST(${tables.organization.credits} AS NUMERIC)), 0)`,
+			})
+			.from(tables.organization)
+			.leftJoin(
+				realCostSub,
+				eq(tables.organization.id, realCostSub.organizationId),
+			)
+			.where(devpassActiveUniverseWhere()),
+		// PAYG overflow top-up revenue on devpass orgs (gross Stripe amount).
+		db
+			.select({
+				allTime: sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`,
+				thisMonth: sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)) FILTER (WHERE ${tables.transaction.createdAt} >= ${monthStart}), 0)`,
+			})
+			.from(tables.transaction)
+			.innerJoin(
+				tables.organization,
+				eq(tables.transaction.organizationId, tables.organization.id),
+			)
+			.where(
+				and(
+					eq(tables.transaction.type, "credit_topup"),
+					eq(tables.transaction.status, "completed"),
+					eq(tables.organization.kind, "devpass"),
+					sql`CAST(${tables.transaction.amount} AS NUMERIC) > 0`,
+				),
+			),
+	]);
+
+	const activeByTier = { lite: 0, pro: 0, max: 0 };
+	const cancellingByTier = { lite: 0, pro: 0, max: 0 };
+	for (const r of activeRows) {
+		const tierKey = r.tier as keyof typeof activeByTier;
+		if (tierKey in activeByTier) {
+			const n = Number(r.count);
+			activeByTier[tierKey] += n;
+			if (r.cancelled) {
+				cancellingByTier[tierKey] += n;
+			}
+		}
+	}
+	const totalActive = activeByTier.lite + activeByTier.pro + activeByTier.max;
+	const liteMrr = activeByTier.lite * DEV_PLAN_PRICES.lite;
+	const proMrr = activeByTier.pro * DEV_PLAN_PRICES.pro;
+	const maxMrr = activeByTier.max * DEV_PLAN_PRICES.max;
+	const grossMrr = liteMrr + proMrr + maxMrr;
+	const cancellingLiteMrr = cancellingByTier.lite * DEV_PLAN_PRICES.lite;
+	const cancellingProMrr = cancellingByTier.pro * DEV_PLAN_PRICES.pro;
+	const cancellingMaxMrr = cancellingByTier.max * DEV_PLAN_PRICES.max;
+	const cancellingMrr = cancellingLiteMrr + cancellingProMrr + cancellingMaxMrr;
+	const committedMrr = grossMrr - cancellingMrr;
+	const cancelledPending =
+		cancellingByTier.lite + cancellingByTier.pro + cancellingByTier.max;
+
+	const startsThisMonth = Number(startsRow?.count ?? 0);
+	const endsThisMonth = Number(endsRow?.count ?? 0);
+	const resetPassRevenue =
+		Number(resetPassRow?.total ?? 0) - Number(resetPassRefundRow?.total ?? 0);
+
+	const totalUsed = Number(utilRow?.totalUsed ?? 0);
+	const totalLimit = Number(utilRow?.totalLimit ?? 0);
+	const weightedAvgUtilization =
+		totalLimit > 0 ? (totalUsed / totalLimit) * 100 : 0;
+
+	const totalRealCostCycle = Number(universeRow?.totalCost ?? 0);
+	const totalMrrCycle = Number(universeRow?.totalMrr ?? 0);
+	const totalOverflowCostCycle = Number(universeRow?.totalOverflow ?? 0);
+	// Plan economics: overflow cost is funded by the orgs' own top-ups, so it
+	// doesn't count against plan MRR.
+	const totalMargin =
+		totalMrrCycle - (totalRealCostCycle - totalOverflowCostCycle);
+
+	return c.json({
+		activeByTier,
+		totalActive,
+		cancelledPending,
+		churned: Number(churnedRow?.count ?? 0),
+		grossMrr,
+		committedMrr,
+		startsThisMonth,
+		endsThisMonth,
+		netNewThisMonth: startsThisMonth - endsThisMonth,
+		refundsThisMonth: Number(refundsRow?.count ?? 0),
+		refundedAmountThisMonth: Number(refundsRow?.total ?? 0),
+		resetPassesSold: Number(resetPassRow?.count ?? 0),
+		resetPassRevenue,
+		paygOptedIn: Number(universeRow?.paygOptedIn ?? 0),
+		paygBalanceHeld: Number(universeRow?.paygBalanceHeld ?? 0),
+		topupRevenueThisMonth: Number(topupRevenueRow?.thisMonth ?? 0),
+		topupRevenueAllTime: Number(topupRevenueRow?.allTime ?? 0),
+		totalOverflowCostCycle,
+		weightedAvgUtilization,
+		totalRealCostCycle,
+		totalMrrCycle,
+		totalMargin,
+		marginPct: totalMrrCycle > 0 ? (totalMargin / totalMrrCycle) * 100 : null,
 	});
 });
 

--- a/ee/admin/src/app/devpass/page.tsx
+++ b/ee/admin/src/app/devpass/page.tsx
@@ -197,7 +197,10 @@ export default async function DevpassPage({
 		status: status || undefined,
 		utilization: utilization || undefined,
 		marginNegative: marginNegative || undefined,
-		showChurned,
+		// Omitted rather than sent as `false`: the query string carries the
+		// literal "false", and the route's `z.coerce.boolean()` reads any
+		// non-empty string as true. Absent falls through to its `false` default.
+		showChurned: showChurned || undefined,
 		sortBy,
 		sortOrder,
 	};

--- a/ee/admin/src/app/devpass/page.tsx
+++ b/ee/admin/src/app/devpass/page.tsx
@@ -1,45 +1,22 @@
-import {
-	AlertCircle,
-	ArrowDown,
-	ArrowUp,
-	ArrowUpDown,
-	ChevronLeft,
-	ChevronRight,
-	Info,
-	RotateCcw,
-	Search,
-	Ticket,
-	TrendingDown,
-	TrendingUp,
-	Users,
-	Wallet,
-} from "lucide-react";
+import { Search } from "lucide-react";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
 
 import { DateRangePicker } from "@/components/date-range-picker";
+import { DevpassKpis } from "@/components/devpass-kpis";
+import {
+	DevpassResultCount,
+	DevpassSubscribersTable,
+} from "@/components/devpass-subscribers-table";
 import { DevpassTimeseriesChart } from "@/components/devpass-timeseries-chart";
 import { DevpassUsage } from "@/components/devpass-usage";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-	Table,
-	TableBody,
-	TableCell,
-	TableHead,
-	TableHeader,
-	TableRow,
-} from "@/components/ui/table";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { resolveDateRange } from "@/lib/date-range";
 import { requireSession } from "@/lib/require-session";
-import { createServerApiClient } from "@/lib/server-api";
 import { cn } from "@/lib/utils";
+
+import type { DevpassListQuery } from "@/components/devpass-subscribers-table";
 
 const SORT_BY_VALUES = [
 	"name",
@@ -90,137 +67,6 @@ function pickEnum<T extends readonly string[]>(
 	return (allowed as readonly string[]).includes(raw)
 		? (raw as T[number])
 		: fallback;
-}
-
-const currencyFormatter = new Intl.NumberFormat("en-US", {
-	style: "currency",
-	currency: "USD",
-	maximumFractionDigits: 2,
-});
-
-const currencyFormatterPrecise = new Intl.NumberFormat("en-US", {
-	style: "currency",
-	currency: "USD",
-	maximumFractionDigits: 4,
-});
-
-function formatDate(dateString: string | null) {
-	if (!dateString) {
-		return "—";
-	}
-	return new Date(dateString).toLocaleDateString("en-US", {
-		year: "numeric",
-		month: "short",
-		day: "numeric",
-	});
-}
-
-function getTierBadgeVariant(
-	tier: string,
-): "default" | "secondary" | "outline" {
-	switch (tier) {
-		case "max":
-			return "default";
-		case "pro":
-			return "secondary";
-		case "lite":
-			return "outline";
-		default:
-			return "outline";
-	}
-}
-
-function getStatusBadgeVariant(
-	status: string,
-): "default" | "secondary" | "outline" | "destructive" {
-	switch (status) {
-		case "active":
-			return "secondary";
-		case "cancelled_pending":
-			return "outline";
-		case "expired":
-			return "destructive";
-		case "churned":
-			return "outline";
-		default:
-			return "outline";
-	}
-}
-
-function formatStatus(status: string) {
-	if (status === "cancelled_pending") {
-		return "cancel pending";
-	}
-	return status;
-}
-
-function SortableHeader({
-	label,
-	sortKey,
-	currentSortBy,
-	currentSortOrder,
-	queryString,
-}: {
-	label: string;
-	sortKey: SortBy;
-	currentSortBy: SortBy;
-	currentSortOrder: SortOrder;
-	queryString: string;
-}) {
-	const isActive = currentSortBy === sortKey;
-	const nextOrder = isActive && currentSortOrder === "asc" ? "desc" : "asc";
-
-	const baseParams = new URLSearchParams(queryString);
-	baseParams.set("sortBy", sortKey);
-	baseParams.set("sortOrder", nextOrder);
-	baseParams.set("page", "1");
-	const href = `/devpass?${baseParams.toString()}`;
-
-	return (
-		<Link
-			href={href}
-			className={cn(
-				"flex items-center gap-1 hover:text-foreground transition-colors",
-				isActive ? "text-foreground" : "text-muted-foreground",
-			)}
-		>
-			{label}
-			{isActive ? (
-				currentSortOrder === "asc" ? (
-					<ArrowUp className="h-3.5 w-3.5" />
-				) : (
-					<ArrowDown className="h-3.5 w-3.5" />
-				)
-			) : (
-				<ArrowUpDown className="h-3.5 w-3.5 opacity-50" />
-			)}
-		</Link>
-	);
-}
-
-function UtilBar({ pct }: { pct: number | null }) {
-	if (pct === null) {
-		return <span className="text-muted-foreground">—</span>;
-	}
-	const clamped = Math.min(100, Math.max(0, pct));
-	const tone =
-		pct < 20
-			? "bg-amber-500"
-			: pct > 100
-				? "bg-rose-500"
-				: pct > 80
-					? "bg-orange-500"
-					: "bg-emerald-500";
-	return (
-		<div className="flex items-center gap-2">
-			<div className="h-1.5 w-20 overflow-hidden rounded-full bg-muted">
-				<div className={cn("h-full", tone)} style={{ width: `${clamped}%` }} />
-			</div>
-			<span className="tabular-nums text-xs text-muted-foreground">
-				{pct.toFixed(0)}%
-			</span>
-		</div>
-	);
 }
 
 function FilterPill({
@@ -292,26 +138,9 @@ function ToggleLink({
 	);
 }
 
-function SignInPrompt() {
-	return (
-		<div className="flex min-h-screen items-center justify-center px-4">
-			<div className="w-full max-w-md text-center">
-				<div className="mb-8">
-					<h1 className="text-3xl font-semibold tracking-tight">
-						Admin Dashboard
-					</h1>
-					<p className="mt-2 text-sm text-muted-foreground">
-						Sign in to access the admin dashboard
-					</p>
-				</div>
-				<Button asChild size="lg" className="w-full">
-					<Link href="/login">Sign In</Link>
-				</Button>
-			</div>
-		</div>
-	);
-}
-
+// Nothing is fetched server-side: the KPI strip, the chart, the usage cards and
+// the subscriber table each load independently on the client, so the shell
+// (header, filters) paints immediately instead of waiting on the slowest query.
 export default async function DevpassPage({
 	searchParams,
 }: {
@@ -360,35 +189,18 @@ export default async function DevpassPage({
 	const limit = 25;
 	const offset = (page - 1) * limit;
 
-	const $api = await createServerApiClient();
-	const { data } = await $api.GET("/admin/devpass", {
-		params: {
-			query: {
-				limit,
-				offset,
-				search: search || undefined,
-				tier: tier || undefined,
-				status: status || undefined,
-				utilization: utilization || undefined,
-				marginNegative: marginNegative || undefined,
-				showChurned,
-				sortBy,
-				sortOrder,
-			},
-		},
-	});
-
-	if (!data) {
-		return <SignInPrompt />;
-	}
-
-	// Dedicated PAYG top-up revenue query — independent of the subscriber
-	// list, range-aware via the shared date picker.
-	const { data: paygStats } = await $api.GET("/admin/devpass/payg", {
-		params: { query: { from, to } },
-	});
-
-	const totalPages = Math.ceil(data.total / limit);
+	const listQuery: DevpassListQuery = {
+		limit,
+		offset,
+		search: search || undefined,
+		tier: tier || undefined,
+		status: status || undefined,
+		utilization: utilization || undefined,
+		marginNegative: marginNegative || undefined,
+		showChurned,
+		sortBy,
+		sortOrder,
+	};
 
 	const queryParams = new URLSearchParams();
 	if (search) {
@@ -471,9 +283,6 @@ export default async function DevpassPage({
 		redirect(`/devpass?${sp.toString()}`);
 	}
 
-	const kpis = data.kpis;
-	const grossMrrAfterRefunds = kpis.grossMrr - kpis.refundedAmountThisMonth;
-
 	return (
 		<div className="mx-auto flex w-full max-w-[1920px] flex-col gap-6 px-4 py-8 md:px-8">
 			<header className="flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-center">
@@ -489,249 +298,7 @@ export default async function DevpassPage({
 				</Suspense>
 			</header>
 
-			<section className="space-y-3">
-				<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-					<div className="rounded-lg border border-border/60 bg-card p-4">
-						<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
-							<Users className="h-3.5 w-3.5" />
-							Active subscribers
-						</div>
-						<div className="mt-2 text-2xl font-semibold tabular-nums">
-							{kpis.totalActive}
-						</div>
-						<div className="mt-1 text-xs text-muted-foreground">
-							Lite {kpis.activeByTier.lite} · Pro {kpis.activeByTier.pro} · Max{" "}
-							{kpis.activeByTier.max}
-							{kpis.cancelledPending > 0 ? (
-								<>
-									{" "}
-									·{" "}
-									<span className="text-amber-600 dark:text-amber-400">
-										{kpis.cancelledPending} cancelling
-									</span>
-								</>
-							) : null}
-						</div>
-					</div>
-					<div className="rounded-lg border border-border/60 bg-card p-4">
-						<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
-							<Wallet className="h-3.5 w-3.5" />
-							Gross MRR
-						</div>
-						<div className="mt-2 flex items-baseline gap-2">
-							<span className="text-2xl font-semibold tabular-nums">
-								{currencyFormatter.format(kpis.grossMrr)}
-							</span>
-							<Tooltip>
-								<TooltipTrigger asChild>
-									<span
-										className={cn(
-											"inline-flex cursor-help items-center gap-1 rounded-md border px-1.5 py-0.5 text-xs font-semibold tabular-nums",
-											kpis.committedMrr !== kpis.grossMrr
-												? "border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400"
-												: "border-border/60 bg-muted/40 text-muted-foreground",
-										)}
-									>
-										<Info className="h-3 w-3" />
-										{currencyFormatter.format(kpis.committedMrr)} committed
-									</span>
-								</TooltipTrigger>
-								<TooltipContent className="max-w-xs">
-									Forward-looking MRR after pending churn. Excludes subs flagged
-									to cancel at period end (still billed by Stripe this cycle,
-									but gone next cycle).
-								</TooltipContent>
-							</Tooltip>
-						</div>
-						<div className="mt-1 text-xs text-muted-foreground">
-							Net after refunds this month:{" "}
-							<span
-								className={cn(
-									"font-medium tabular-nums",
-									grossMrrAfterRefunds < kpis.grossMrr
-										? "text-rose-600 dark:text-rose-400"
-										: "",
-								)}
-							>
-								{currencyFormatter.format(grossMrrAfterRefunds)}
-							</span>
-							{kpis.refundedAmountThisMonth > 0 ? (
-								<>
-									{" "}
-									after {currencyFormatter.format(
-										kpis.refundedAmountThisMonth,
-									)}{" "}
-									refunded
-								</>
-							) : null}
-						</div>
-						<div className="mt-1 text-xs text-muted-foreground">
-							Net new this month:{" "}
-							<span
-								className={cn(
-									"font-medium",
-									kpis.netNewThisMonth > 0
-										? "text-emerald-600 dark:text-emerald-400"
-										: kpis.netNewThisMonth < 0
-											? "text-rose-600 dark:text-rose-400"
-											: "",
-								)}
-							>
-								{kpis.netNewThisMonth > 0 ? "+" : ""}
-								{kpis.netNewThisMonth}
-							</span>{" "}
-							({kpis.startsThisMonth} starts / {kpis.endsThisMonth} ends)
-						</div>
-					</div>
-
-					<div className="rounded-lg border border-border/60 bg-card p-4">
-						<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
-							{kpis.totalMargin >= 0 ? (
-								<TrendingUp className="h-3.5 w-3.5" />
-							) : (
-								<TrendingDown className="h-3.5 w-3.5" />
-							)}
-							Cycle margin
-						</div>
-						<div className="mt-2 flex items-baseline gap-2">
-							<span
-								className={cn(
-									"text-2xl font-semibold tabular-nums",
-									kpis.totalMargin < 0
-										? "text-rose-600 dark:text-rose-400"
-										: "",
-								)}
-							>
-								{currencyFormatter.format(kpis.totalMargin)}
-							</span>
-							{kpis.marginPct !== null && kpis.marginPct !== undefined ? (
-								<span
-									className={cn(
-										"rounded-md border px-1.5 py-0.5 text-xs font-semibold tabular-nums",
-										kpis.marginPct < 0
-											? "border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-400"
-											: "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
-									)}
-									title="Profit margin: cycle margin / gross MRR"
-								>
-									{kpis.marginPct.toFixed(1)}% profit
-								</span>
-							) : null}
-						</div>
-						<div className="mt-1 text-xs text-muted-foreground">
-							{currencyFormatter.format(kpis.totalRealCostCycle)} provider cost
-							this cycle
-							{kpis.totalOverflowCostCycle > 0 ? (
-								<>
-									{" "}
-									(incl. {currencyFormatter.format(
-										kpis.totalOverflowCostCycle,
-									)}{" "}
-									PAYG overflow, excluded from margin)
-								</>
-							) : null}
-						</div>
-					</div>
-				</div>
-				<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
-					<div className="rounded-lg border border-border/60 bg-card p-4">
-						<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
-							<RotateCcw className="h-3.5 w-3.5" />
-							Refunds this month
-						</div>
-						<div
-							className={cn(
-								"mt-2 text-2xl font-semibold tabular-nums",
-								kpis.refundedAmountThisMonth > 0
-									? "text-rose-600 dark:text-rose-400"
-									: "",
-							)}
-						>
-							{currencyFormatter.format(kpis.refundedAmountThisMonth)}
-						</div>
-						<div className="mt-1 text-xs text-muted-foreground">
-							{kpis.refundsThisMonth} refund
-							{kpis.refundsThisMonth === 1 ? "" : "s"} processed
-						</div>
-					</div>
-					<div className="rounded-lg border border-border/60 bg-card p-4">
-						<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
-							<Ticket className="h-3.5 w-3.5" />
-							Reset passes sold
-						</div>
-						<div className="mt-2 text-2xl font-semibold tabular-nums">
-							{kpis.resetPassesSold}
-						</div>
-						<div className="mt-1 text-xs text-muted-foreground">
-							{currencyFormatter.format(kpis.resetPassRevenue)} all-time revenue
-						</div>
-					</div>
-					<div className="rounded-lg border border-border/60 bg-card p-4">
-						<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
-							<TrendingUp className="h-3.5 w-3.5" />
-							Avg utilization
-						</div>
-						<div className="mt-2 text-2xl font-semibold tabular-nums">
-							{kpis.weightedAvgUtilization.toFixed(1)}%
-						</div>
-						<div className="mt-1 text-xs text-muted-foreground">
-							Weighted across active subs
-						</div>
-					</div>
-					<div className="rounded-lg border border-border/60 bg-card p-4">
-						<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
-							<Wallet className="h-3.5 w-3.5" />
-							PAYG overflow
-						</div>
-						<div className="mt-2 flex items-baseline gap-2">
-							<span className="text-2xl font-semibold tabular-nums">
-								{kpis.paygOptedIn}
-							</span>
-							<span className="text-xs text-muted-foreground">opted in</span>
-						</div>
-						<div className="mt-1 text-xs text-muted-foreground">
-							{currencyFormatter.format(kpis.paygBalanceHeld)} balance held by
-							active subs
-						</div>
-					</div>
-					<div className="rounded-lg border border-border/60 bg-card p-4">
-						<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
-							<TrendingUp className="h-3.5 w-3.5" />
-							DevPass top-up revenue
-						</div>
-						<div className="mt-2 flex items-baseline gap-2">
-							<span className="text-2xl font-semibold tabular-nums">
-								{currencyFormatter.format(paygStats?.topups.allTime.net ?? 0)}
-							</span>
-							<span className="text-xs text-muted-foreground">
-								net, all-time
-							</span>
-						</div>
-						<div className="mt-1 text-xs text-muted-foreground">
-							{currencyFormatter.format(paygStats?.topups.thisMonth.net ?? 0)}{" "}
-							this month
-							{(paygStats?.topups.allTime.refunds ?? 0) > 0 ? (
-								<>
-									{" "}
-									·{" "}
-									<span className="text-rose-600 dark:text-rose-400">
-										{currencyFormatter.format(
-											paygStats?.topups.allTime.refunds ?? 0,
-										)}{" "}
-										refunded
-									</span>
-								</>
-							) : null}
-						</div>
-						{paygStats?.topups.range ? (
-							<div className="mt-1 text-xs text-muted-foreground">
-								{currencyFormatter.format(paygStats.topups.range.net)} in
-								selected range
-							</div>
-						) : null}
-					</div>
-				</div>
-			</section>
+			<DevpassKpis from={from} to={to} />
 
 			<DevpassTimeseriesChart from={from} to={to} />
 
@@ -883,347 +450,15 @@ export default async function DevpassPage({
 						paramName="showChurned"
 					/>
 				</div>
-				<p className="text-xs text-muted-foreground">
-					{data.total} subscriber{data.total === 1 ? "" : "s"} match current
-					filters
-				</p>
+				<DevpassResultCount query={listQuery} />
 			</form>
 
-			<div className="overflow-x-auto rounded-lg border border-border/60 bg-card">
-				<Table>
-					<TableHeader>
-						<TableRow>
-							<TableHead>
-								<SortableHeader
-									label="Subscriber"
-									sortKey="name"
-									currentSortBy={sortBy}
-									currentSortOrder={sortOrder}
-									queryString={queryString}
-								/>
-							</TableHead>
-							<TableHead>
-								<SortableHeader
-									label="Tier"
-									sortKey="tier"
-									currentSortBy={sortBy}
-									currentSortOrder={sortOrder}
-									queryString={queryString}
-								/>
-							</TableHead>
-							<TableHead>Status</TableHead>
-							<TableHead>
-								<SortableHeader
-									label="Utilization"
-									sortKey="utilizationPct"
-									currentSortBy={sortBy}
-									currentSortOrder={sortOrder}
-									queryString={queryString}
-								/>
-							</TableHead>
-							<TableHead>
-								<SortableHeader
-									label="Cycle"
-									sortKey="cycleStart"
-									currentSortBy={sortBy}
-									currentSortOrder={sortOrder}
-									queryString={queryString}
-								/>
-							</TableHead>
-							<TableHead>
-								<SortableHeader
-									label="Renews"
-									sortKey="expiresAt"
-									currentSortBy={sortBy}
-									currentSortOrder={sortOrder}
-									queryString={queryString}
-								/>
-							</TableHead>
-							<TableHead>
-								<SortableHeader
-									label="MRR"
-									sortKey="mrr"
-									currentSortBy={sortBy}
-									currentSortOrder={sortOrder}
-									queryString={queryString}
-								/>
-							</TableHead>
-							<TableHead>
-								<SortableHeader
-									label="Real cost"
-									sortKey="realCost"
-									currentSortBy={sortBy}
-									currentSortOrder={sortOrder}
-									queryString={queryString}
-								/>
-							</TableHead>
-							<TableHead>
-								<SortableHeader
-									label="Margin"
-									sortKey="margin"
-									currentSortBy={sortBy}
-									currentSortOrder={sortOrder}
-									queryString={queryString}
-								/>
-							</TableHead>
-							<TableHead>
-								<SortableHeader
-									label="PAYG"
-									sortKey="paygBalance"
-									currentSortBy={sortBy}
-									currentSortOrder={sortOrder}
-									queryString={queryString}
-								/>
-							</TableHead>
-							<TableHead>Premium (week)</TableHead>
-							<TableHead>
-								<SortableHeader
-									label="Cost (all-time)"
-									sortKey="allTimeCost"
-									currentSortBy={sortBy}
-									currentSortOrder={sortOrder}
-									queryString={queryString}
-								/>
-							</TableHead>
-							<TableHead>
-								<SortableHeader
-									label="Margin (all-time)"
-									sortKey="allTimeMargin"
-									currentSortBy={sortBy}
-									currentSortOrder={sortOrder}
-									queryString={queryString}
-								/>
-							</TableHead>
-							<TableHead>
-								<SortableHeader
-									label="Since"
-									sortKey="subscribedSince"
-									currentSortBy={sortBy}
-									currentSortOrder={sortOrder}
-									queryString={queryString}
-								/>
-							</TableHead>
-							<TableHead>Δ tier</TableHead>
-							<TableHead>Payments</TableHead>
-						</TableRow>
-					</TableHeader>
-					<TableBody>
-						{data.subscribers.length === 0 ? (
-							<TableRow>
-								<TableCell
-									colSpan={16}
-									className="h-24 text-center text-muted-foreground"
-								>
-									No subscribers match
-								</TableCell>
-							</TableRow>
-						) : (
-							data.subscribers.map((sub) => (
-								<TableRow key={sub.id}>
-									<TableCell>
-										<Link
-											href={`/devpass/${sub.id}`}
-											className="font-medium text-foreground hover:underline"
-										>
-											{sub.name}
-										</Link>
-										<p className="text-xs text-muted-foreground">
-											{sub.ownerEmail ?? sub.billingEmail}
-										</p>
-										{sub.ownerUsername && (
-											<p className="text-xs text-muted-foreground">
-												@{sub.ownerUsername}
-											</p>
-										)}
-									</TableCell>
-									<TableCell>
-										<Badge variant={getTierBadgeVariant(sub.tier)}>
-											{sub.tier}
-										</Badge>
-										{sub.pendingTier && (
-											<p className="mt-1 text-xs text-amber-600">
-												→ {sub.pendingTier} next cycle
-											</p>
-										)}
-									</TableCell>
-									<TableCell>
-										<Badge variant={getStatusBadgeVariant(sub.status)}>
-											{formatStatus(sub.status)}
-										</Badge>
-									</TableCell>
-									<TableCell>
-										<UtilBar pct={sub.utilizationPct} />
-										<p className="mt-1 text-xs tabular-nums text-muted-foreground">
-											{currencyFormatter.format(parseFloat(sub.creditsUsed))} /{" "}
-											{currencyFormatter.format(parseFloat(sub.creditsLimit))}
-										</p>
-									</TableCell>
-									<TableCell className="text-muted-foreground text-xs">
-										{sub.cycleDaysIn !== null ? `Day ${sub.cycleDaysIn}` : "—"}
-									</TableCell>
-									<TableCell className="text-muted-foreground text-xs">
-										{sub.expiresAt ? formatDate(sub.expiresAt) : "—"}
-									</TableCell>
-									<TableCell className="tabular-nums">
-										{currencyFormatter.format(sub.mrr)}
-									</TableCell>
-									<TableCell className="tabular-nums text-muted-foreground">
-										{currencyFormatterPrecise.format(sub.realCost)}
-									</TableCell>
-									<TableCell
-										className={cn(
-											"tabular-nums",
-											sub.margin < 0
-												? "text-rose-600 dark:text-rose-400"
-												: "text-emerald-600 dark:text-emerald-400",
-										)}
-									>
-										{currencyFormatter.format(sub.margin)}
-										{sub.cycleOverflowCost > 0 && (
-											<p
-												className="mt-0.5 text-xs font-normal text-muted-foreground"
-												title="Cycle cost paid from the org's own PAYG credits — excluded from plan margin"
-											>
-												+
-												{currencyFormatterPrecise.format(sub.cycleOverflowCost)}{" "}
-												overflow
-											</p>
-										)}
-									</TableCell>
-									<TableCell className="tabular-nums text-xs">
-										{sub.paygEnabled ? (
-											<>
-												<span className="font-medium">
-													{currencyFormatter.format(
-														parseFloat(sub.paygBalance),
-													)}
-												</span>
-												{sub.autoTopUpEnabled && (
-													<Badge variant="outline" className="ml-1.5">
-														auto
-													</Badge>
-												)}
-												{sub.allTimeTopUps > 0 && (
-													<p className="mt-0.5 text-muted-foreground">
-														{currencyFormatter.format(sub.allTimeTopUps)} topped
-														up
-													</p>
-												)}
-											</>
-										) : (
-											<span className="text-muted-foreground">—</span>
-										)}
-									</TableCell>
-									<TableCell className="tabular-nums text-xs">
-										{(() => {
-											const premUsed = parseFloat(sub.premiumCreditsUsed);
-											const premLimit = parseFloat(sub.premiumCreditsLimit);
-											if (premLimit <= 0) {
-												return <span className="text-muted-foreground">—</span>;
-											}
-											const pct = Math.min(
-												100,
-												Math.max(0, (premUsed / premLimit) * 100),
-											);
-											const tone =
-												pct >= 100
-													? "text-rose-600 dark:text-rose-400"
-													: pct >= 80
-														? "text-orange-600 dark:text-orange-400"
-														: "text-muted-foreground";
-											return (
-												<span className={tone}>
-													{currencyFormatter.format(premUsed)} /{" "}
-													{currencyFormatter.format(premLimit)}
-												</span>
-											);
-										})()}
-									</TableCell>
-									<TableCell className="tabular-nums text-muted-foreground">
-										{currencyFormatterPrecise.format(sub.allTimeCost)}
-									</TableCell>
-									<TableCell
-										className={cn(
-											"tabular-nums",
-											sub.allTimeMargin < 0
-												? "text-rose-600 dark:text-rose-400"
-												: "text-emerald-600 dark:text-emerald-400",
-										)}
-										title={`Revenue ${currencyFormatter.format(
-											sub.allTimeRevenue,
-										)} − cost ${currencyFormatterPrecise.format(sub.allTimeCost)}`}
-									>
-										{currencyFormatter.format(sub.allTimeMargin)}
-									</TableCell>
-									<TableCell className="text-muted-foreground text-xs">
-										{formatDate(sub.subscribedSince)}
-									</TableCell>
-									<TableCell className="tabular-nums text-muted-foreground text-xs">
-										{sub.tierChanges}
-									</TableCell>
-									<TableCell>
-										{sub.hasPaymentIssue ? (
-											<Badge variant="destructive" className="gap-1">
-												<AlertCircle className="h-3 w-3" />
-												failed
-											</Badge>
-										) : (
-											<span className="text-xs text-muted-foreground">ok</span>
-										)}
-									</TableCell>
-								</TableRow>
-							))
-						)}
-					</TableBody>
-				</Table>
-			</div>
-
-			{totalPages > 1 && (
-				<div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
-					<p className="text-sm text-muted-foreground">
-						Showing {offset + 1} to {Math.min(offset + limit, data.total)} of{" "}
-						{data.total}
-					</p>
-					<div className="flex items-center gap-2">
-						<Button variant="outline" size="sm" asChild disabled={page <= 1}>
-							<Link
-								href={`/devpass?${(() => {
-									const sp = new URLSearchParams(queryString);
-									sp.set("page", String(page - 1));
-									return sp.toString();
-								})()}`}
-								className={page <= 1 ? "pointer-events-none opacity-50" : ""}
-							>
-								<ChevronLeft className="h-4 w-4" />
-								Previous
-							</Link>
-						</Button>
-						<span className="text-sm text-muted-foreground">
-							Page {page} of {totalPages}
-						</span>
-						<Button
-							variant="outline"
-							size="sm"
-							asChild
-							disabled={page >= totalPages}
-						>
-							<Link
-								href={`/devpass?${(() => {
-									const sp = new URLSearchParams(queryString);
-									sp.set("page", String(page + 1));
-									return sp.toString();
-								})()}`}
-								className={
-									page >= totalPages ? "pointer-events-none opacity-50" : ""
-								}
-							>
-								Next
-								<ChevronRight className="h-4 w-4" />
-							</Link>
-						</Button>
-					</div>
-				</div>
-			)}
+			<DevpassSubscribersTable
+				query={listQuery}
+				queryString={queryString}
+				page={page}
+				limit={limit}
+			/>
 		</div>
 	);
 }

--- a/ee/admin/src/components/devpass-kpis.tsx
+++ b/ee/admin/src/components/devpass-kpis.tsx
@@ -1,0 +1,329 @@
+"use client";
+
+import {
+	Info,
+	RotateCcw,
+	Ticket,
+	TrendingDown,
+	TrendingUp,
+	Users,
+	Wallet,
+} from "lucide-react";
+
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useApi } from "@/lib/fetch-client";
+import { cn } from "@/lib/utils";
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+	maximumFractionDigits: 2,
+});
+
+function KpiCard({
+	icon,
+	label,
+	children,
+}: {
+	icon: React.ReactNode;
+	label: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="rounded-lg border border-border/60 bg-card p-4">
+			<div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+				{icon}
+				{label}
+			</div>
+			{children}
+		</div>
+	);
+}
+
+function KpiSkeleton({ count }: { count: number }) {
+	return (
+		<>
+			{Array.from({ length: count }, (_, i) => (
+				<div
+					key={i}
+					className="rounded-lg border border-border/60 bg-card p-4"
+					aria-hidden
+				>
+					<div className="h-3 w-32 animate-pulse rounded bg-muted/60" />
+					<div className="mt-3 h-7 w-24 animate-pulse rounded bg-muted/60" />
+					<div className="mt-2 h-3 w-40 animate-pulse rounded bg-muted/40" />
+				</div>
+			))}
+		</>
+	);
+}
+
+export function DevpassKpis({ from, to }: { from?: string; to?: string }) {
+	const $api = useApi();
+	const { data: kpis } = $api.useQuery("get", "/admin/devpass/kpis");
+	const { data: paygStats } = $api.useQuery("get", "/admin/devpass/payg", {
+		params: { query: { from, to } },
+	});
+
+	const grossMrrAfterRefunds = kpis
+		? kpis.grossMrr - kpis.refundedAmountThisMonth
+		: 0;
+
+	return (
+		<section className="space-y-3">
+			<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+				{!kpis ? (
+					<KpiSkeleton count={3} />
+				) : (
+					<>
+						<KpiCard
+							icon={<Users className="h-3.5 w-3.5" />}
+							label="Active subscribers"
+						>
+							<div className="mt-2 text-2xl font-semibold tabular-nums">
+								{kpis.totalActive}
+							</div>
+							<div className="mt-1 text-xs text-muted-foreground">
+								Lite {kpis.activeByTier.lite} · Pro {kpis.activeByTier.pro} ·
+								Max {kpis.activeByTier.max}
+								{kpis.cancelledPending > 0 ? (
+									<>
+										{" "}
+										·{" "}
+										<span className="text-amber-600 dark:text-amber-400">
+											{kpis.cancelledPending} cancelling
+										</span>
+									</>
+								) : null}
+							</div>
+						</KpiCard>
+						<KpiCard
+							icon={<Wallet className="h-3.5 w-3.5" />}
+							label="Gross MRR"
+						>
+							<div className="mt-2 flex items-baseline gap-2">
+								<span className="text-2xl font-semibold tabular-nums">
+									{currencyFormatter.format(kpis.grossMrr)}
+								</span>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<span
+											className={cn(
+												"inline-flex cursor-help items-center gap-1 rounded-md border px-1.5 py-0.5 text-xs font-semibold tabular-nums",
+												kpis.committedMrr !== kpis.grossMrr
+													? "border-amber-500/30 bg-amber-500/10 text-amber-600 dark:text-amber-400"
+													: "border-border/60 bg-muted/40 text-muted-foreground",
+											)}
+										>
+											<Info className="h-3 w-3" />
+											{currencyFormatter.format(kpis.committedMrr)} committed
+										</span>
+									</TooltipTrigger>
+									<TooltipContent className="max-w-xs">
+										Forward-looking MRR after pending churn. Excludes subs
+										flagged to cancel at period end (still billed by Stripe this
+										cycle, but gone next cycle).
+									</TooltipContent>
+								</Tooltip>
+							</div>
+							<div className="mt-1 text-xs text-muted-foreground">
+								Net after refunds this month:{" "}
+								<span
+									className={cn(
+										"font-medium tabular-nums",
+										grossMrrAfterRefunds < kpis.grossMrr
+											? "text-rose-600 dark:text-rose-400"
+											: "",
+									)}
+								>
+									{currencyFormatter.format(grossMrrAfterRefunds)}
+								</span>
+								{kpis.refundedAmountThisMonth > 0 ? (
+									<>
+										{" "}
+										after{" "}
+										{currencyFormatter.format(
+											kpis.refundedAmountThisMonth,
+										)}{" "}
+										refunded
+									</>
+								) : null}
+							</div>
+							<div className="mt-1 text-xs text-muted-foreground">
+								Net new this month:{" "}
+								<span
+									className={cn(
+										"font-medium",
+										kpis.netNewThisMonth > 0
+											? "text-emerald-600 dark:text-emerald-400"
+											: kpis.netNewThisMonth < 0
+												? "text-rose-600 dark:text-rose-400"
+												: "",
+									)}
+								>
+									{kpis.netNewThisMonth > 0 ? "+" : ""}
+									{kpis.netNewThisMonth}
+								</span>{" "}
+								({kpis.startsThisMonth} starts / {kpis.endsThisMonth} ends)
+							</div>
+						</KpiCard>
+						<KpiCard
+							icon={
+								kpis.totalMargin >= 0 ? (
+									<TrendingUp className="h-3.5 w-3.5" />
+								) : (
+									<TrendingDown className="h-3.5 w-3.5" />
+								)
+							}
+							label="Cycle margin"
+						>
+							<div className="mt-2 flex items-baseline gap-2">
+								<span
+									className={cn(
+										"text-2xl font-semibold tabular-nums",
+										kpis.totalMargin < 0
+											? "text-rose-600 dark:text-rose-400"
+											: "",
+									)}
+								>
+									{currencyFormatter.format(kpis.totalMargin)}
+								</span>
+								{kpis.marginPct !== null && kpis.marginPct !== undefined ? (
+									<span
+										className={cn(
+											"rounded-md border px-1.5 py-0.5 text-xs font-semibold tabular-nums",
+											kpis.marginPct < 0
+												? "border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-400"
+												: "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+										)}
+										title="Profit margin: cycle margin / gross MRR"
+									>
+										{kpis.marginPct.toFixed(1)}% profit
+									</span>
+								) : null}
+							</div>
+							<div className="mt-1 text-xs text-muted-foreground">
+								{currencyFormatter.format(kpis.totalRealCostCycle)} provider
+								cost this cycle
+								{kpis.totalOverflowCostCycle > 0 ? (
+									<>
+										{" "}
+										(incl.{" "}
+										{currencyFormatter.format(kpis.totalOverflowCostCycle)} PAYG
+										overflow, excluded from margin)
+									</>
+								) : null}
+							</div>
+						</KpiCard>
+					</>
+				)}
+			</div>
+			<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+				{!kpis ? (
+					<KpiSkeleton count={4} />
+				) : (
+					<>
+						<KpiCard
+							icon={<RotateCcw className="h-3.5 w-3.5" />}
+							label="Refunds this month"
+						>
+							<div
+								className={cn(
+									"mt-2 text-2xl font-semibold tabular-nums",
+									kpis.refundedAmountThisMonth > 0
+										? "text-rose-600 dark:text-rose-400"
+										: "",
+								)}
+							>
+								{currencyFormatter.format(kpis.refundedAmountThisMonth)}
+							</div>
+							<div className="mt-1 text-xs text-muted-foreground">
+								{kpis.refundsThisMonth} refund
+								{kpis.refundsThisMonth === 1 ? "" : "s"} processed
+							</div>
+						</KpiCard>
+						<KpiCard
+							icon={<Ticket className="h-3.5 w-3.5" />}
+							label="Reset passes sold"
+						>
+							<div className="mt-2 text-2xl font-semibold tabular-nums">
+								{kpis.resetPassesSold}
+							</div>
+							<div className="mt-1 text-xs text-muted-foreground">
+								{currencyFormatter.format(kpis.resetPassRevenue)} all-time
+								revenue
+							</div>
+						</KpiCard>
+						<KpiCard
+							icon={<TrendingUp className="h-3.5 w-3.5" />}
+							label="Avg utilization"
+						>
+							<div className="mt-2 text-2xl font-semibold tabular-nums">
+								{kpis.weightedAvgUtilization.toFixed(1)}%
+							</div>
+							<div className="mt-1 text-xs text-muted-foreground">
+								Weighted across active subs
+							</div>
+						</KpiCard>
+						<KpiCard
+							icon={<Wallet className="h-3.5 w-3.5" />}
+							label="PAYG overflow"
+						>
+							<div className="mt-2 flex items-baseline gap-2">
+								<span className="text-2xl font-semibold tabular-nums">
+									{kpis.paygOptedIn}
+								</span>
+								<span className="text-xs text-muted-foreground">opted in</span>
+							</div>
+							<div className="mt-1 text-xs text-muted-foreground">
+								{currencyFormatter.format(kpis.paygBalanceHeld)} balance held by
+								active subs
+							</div>
+						</KpiCard>
+					</>
+				)}
+				{!paygStats ? (
+					<KpiSkeleton count={1} />
+				) : (
+					<KpiCard
+						icon={<TrendingUp className="h-3.5 w-3.5" />}
+						label="DevPass top-up revenue"
+					>
+						<div className="mt-2 flex items-baseline gap-2">
+							<span className="text-2xl font-semibold tabular-nums">
+								{currencyFormatter.format(paygStats.topups.allTime.net)}
+							</span>
+							<span className="text-xs text-muted-foreground">
+								net, all-time
+							</span>
+						</div>
+						<div className="mt-1 text-xs text-muted-foreground">
+							{currencyFormatter.format(paygStats.topups.thisMonth.net)} this
+							month
+							{paygStats.topups.allTime.refunds > 0 ? (
+								<>
+									{" "}
+									·{" "}
+									<span className="text-rose-600 dark:text-rose-400">
+										{currencyFormatter.format(paygStats.topups.allTime.refunds)}{" "}
+										refunded
+									</span>
+								</>
+							) : null}
+						</div>
+						{paygStats.topups.range ? (
+							<div className="mt-1 text-xs text-muted-foreground">
+								{currencyFormatter.format(paygStats.topups.range.net)} in
+								selected range
+							</div>
+						) : null}
+					</KpiCard>
+				)}
+			</div>
+		</section>
+	);
+}

--- a/ee/admin/src/components/devpass-kpis.tsx
+++ b/ee/admin/src/components/devpass-kpis.tsx
@@ -9,6 +9,7 @@ import {
 	Users,
 	Wallet,
 } from "lucide-react";
+import Link from "next/link";
 
 import {
 	Tooltip,
@@ -62,12 +63,35 @@ function KpiSkeleton({ count }: { count: number }) {
 	);
 }
 
+function KpiError({ label }: { label: string }) {
+	return (
+		<div className="rounded-lg border border-border/60 bg-card p-4 text-sm text-muted-foreground">
+			Failed to load {label}. Reload the page, or{" "}
+			<Link href="/login" className="underline">
+				sign in
+			</Link>{" "}
+			again if your session expired.
+		</div>
+	);
+}
+
 export function DevpassKpis({ from, to }: { from?: string; to?: string }) {
 	const $api = useApi();
-	const { data: kpis } = $api.useQuery("get", "/admin/devpass/kpis");
-	const { data: paygStats } = $api.useQuery("get", "/admin/devpass/payg", {
-		params: { query: { from, to } },
-	});
+	// staleTime 0 (the provider default is 5 minutes): an admin who cancels or
+	// refunds on a detail page and navigates back must see the new numbers.
+	// The dialogs only call router.refresh(), which does not touch this cache.
+	const { data: kpis, error: kpisError } = $api.useQuery(
+		"get",
+		"/admin/devpass/kpis",
+		{},
+		{ staleTime: 0 },
+	);
+	const { data: paygStats, error: paygError } = $api.useQuery(
+		"get",
+		"/admin/devpass/payg",
+		{ params: { query: { from, to } } },
+		{ staleTime: 0 },
+	);
 
 	const grossMrrAfterRefunds = kpis
 		? kpis.grossMrr - kpis.refundedAmountThisMonth
@@ -76,7 +100,9 @@ export function DevpassKpis({ from, to }: { from?: string; to?: string }) {
 	return (
 		<section className="space-y-3">
 			<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-				{!kpis ? (
+				{kpisError ? (
+					<KpiError label="DevPass KPIs" />
+				) : !kpis ? (
 					<KpiSkeleton count={3} />
 				) : (
 					<>
@@ -223,7 +249,7 @@ export function DevpassKpis({ from, to }: { from?: string; to?: string }) {
 				)}
 			</div>
 			<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
-				{!kpis ? (
+				{kpisError ? null : !kpis ? (
 					<KpiSkeleton count={4} />
 				) : (
 					<>
@@ -286,7 +312,9 @@ export function DevpassKpis({ from, to }: { from?: string; to?: string }) {
 						</KpiCard>
 					</>
 				)}
-				{!paygStats ? (
+				{paygError ? (
+					<KpiError label="top-up revenue" />
+				) : !paygStats ? (
 					<KpiSkeleton count={1} />
 				) : (
 					<KpiCard

--- a/ee/admin/src/components/devpass-subscribers-table.tsx
+++ b/ee/admin/src/components/devpass-subscribers-table.tsx
@@ -160,13 +160,76 @@ function UtilBar({ pct }: { pct: number | null }) {
 
 // Both the filter card's match counter and the table below it render from the
 // same request — identical query keys, so TanStack Query dedupes them.
+//
+// staleTime 0 (the provider default is 5 minutes): an admin who cancels or
+// refunds on a detail page and navigates back must see the new row state. The
+// dialogs only call router.refresh(), which does not touch this cache.
 function useDevpassSubscribers(query: DevpassListQuery) {
 	const $api = useApi();
-	return $api.useQuery("get", "/admin/devpass", { params: { query } });
+	return $api.useQuery(
+		"get",
+		"/admin/devpass",
+		{ params: { query } },
+		{ staleTime: 0 },
+	);
+}
+
+function pageHref(queryString: string, targetPage: number) {
+	const sp = new URLSearchParams(queryString);
+	sp.set("page", String(targetPage));
+	return `/devpass?${sp.toString()}`;
+}
+
+// `disabled` on an `asChild` Button lands on the anchor, where it does nothing:
+// the link stays keyboard-reachable and reads as enabled. Render a real button
+// instead when the target page is out of range.
+function PageLink({
+	href,
+	disabled,
+	label,
+	icon,
+	iconAfter,
+}: {
+	href: string;
+	disabled: boolean;
+	label: string;
+	icon: React.ReactNode;
+	iconAfter?: boolean;
+}) {
+	const content = iconAfter ? (
+		<>
+			{label}
+			{icon}
+		</>
+	) : (
+		<>
+			{icon}
+			{label}
+		</>
+	);
+
+	if (disabled) {
+		return (
+			<Button variant="outline" size="sm" disabled>
+				{content}
+			</Button>
+		);
+	}
+
+	return (
+		<Button variant="outline" size="sm" asChild>
+			<Link href={href}>{content}</Link>
+		</Button>
+	);
 }
 
 export function DevpassResultCount({ query }: { query: DevpassListQuery }) {
-	const { data } = useDevpassSubscribers(query);
+	const { data, error } = useDevpassSubscribers(query);
+
+	if (error) {
+		// The table below states the failure; a second copy here adds nothing.
+		return null;
+	}
 
 	if (!data) {
 		return <div className="h-4 w-56 animate-pulse rounded bg-muted/40" />;
@@ -516,42 +579,22 @@ export function DevpassSubscribersTable({
 						{data.total}
 					</p>
 					<div className="flex items-center gap-2">
-						<Button variant="outline" size="sm" asChild disabled={page <= 1}>
-							<Link
-								href={`/devpass?${(() => {
-									const sp = new URLSearchParams(queryString);
-									sp.set("page", String(page - 1));
-									return sp.toString();
-								})()}`}
-								className={page <= 1 ? "pointer-events-none opacity-50" : ""}
-							>
-								<ChevronLeft className="h-4 w-4" />
-								Previous
-							</Link>
-						</Button>
+						<PageLink
+							href={pageHref(queryString, page - 1)}
+							disabled={page <= 1}
+							label="Previous"
+							icon={<ChevronLeft className="h-4 w-4" />}
+						/>
 						<span className="text-sm text-muted-foreground">
 							Page {page} of {totalPages}
 						</span>
-						<Button
-							variant="outline"
-							size="sm"
-							asChild
+						<PageLink
+							href={pageHref(queryString, page + 1)}
 							disabled={page >= totalPages}
-						>
-							<Link
-								href={`/devpass?${(() => {
-									const sp = new URLSearchParams(queryString);
-									sp.set("page", String(page + 1));
-									return sp.toString();
-								})()}`}
-								className={
-									page >= totalPages ? "pointer-events-none opacity-50" : ""
-								}
-							>
-								Next
-								<ChevronRight className="h-4 w-4" />
-							</Link>
-						</Button>
+							label="Next"
+							icon={<ChevronRight className="h-4 w-4" />}
+							iconAfter
+						/>
 					</div>
 				</div>
 			)}

--- a/ee/admin/src/components/devpass-subscribers-table.tsx
+++ b/ee/admin/src/components/devpass-subscribers-table.tsx
@@ -1,0 +1,560 @@
+"use client";
+
+import {
+	AlertCircle,
+	ArrowDown,
+	ArrowUp,
+	ArrowUpDown,
+	ChevronLeft,
+	ChevronRight,
+} from "lucide-react";
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { useApi } from "@/lib/fetch-client";
+import { cn } from "@/lib/utils";
+
+import type { paths } from "@/lib/api/v1";
+
+export type DevpassListQuery = NonNullable<
+	paths["/admin/devpass"]["get"]["parameters"]["query"]
+>;
+
+type SortBy = NonNullable<DevpassListQuery["sortBy"]>;
+type SortOrder = NonNullable<DevpassListQuery["sortOrder"]>;
+
+const COLUMN_COUNT = 16;
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+	maximumFractionDigits: 2,
+});
+
+const currencyFormatterPrecise = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+	maximumFractionDigits: 4,
+});
+
+function formatDate(dateString: string | null) {
+	if (!dateString) {
+		return "—";
+	}
+	return new Date(dateString).toLocaleDateString("en-US", {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+	});
+}
+
+function getTierBadgeVariant(
+	tier: string,
+): "default" | "secondary" | "outline" {
+	switch (tier) {
+		case "max":
+			return "default";
+		case "pro":
+			return "secondary";
+		default:
+			return "outline";
+	}
+}
+
+function getStatusBadgeVariant(
+	status: string,
+): "default" | "secondary" | "outline" | "destructive" {
+	switch (status) {
+		case "active":
+			return "secondary";
+		case "expired":
+			return "destructive";
+		default:
+			return "outline";
+	}
+}
+
+function formatStatus(status: string) {
+	if (status === "cancelled_pending") {
+		return "cancel pending";
+	}
+	return status;
+}
+
+function SortableHeader({
+	label,
+	sortKey,
+	currentSortBy,
+	currentSortOrder,
+	queryString,
+}: {
+	label: string;
+	sortKey: SortBy;
+	currentSortBy: SortBy;
+	currentSortOrder: SortOrder;
+	queryString: string;
+}) {
+	const isActive = currentSortBy === sortKey;
+	const nextOrder = isActive && currentSortOrder === "asc" ? "desc" : "asc";
+
+	const baseParams = new URLSearchParams(queryString);
+	baseParams.set("sortBy", sortKey);
+	baseParams.set("sortOrder", nextOrder);
+	baseParams.set("page", "1");
+
+	return (
+		<Link
+			href={`/devpass?${baseParams.toString()}`}
+			className={cn(
+				"flex items-center gap-1 hover:text-foreground transition-colors",
+				isActive ? "text-foreground" : "text-muted-foreground",
+			)}
+		>
+			{label}
+			{isActive ? (
+				currentSortOrder === "asc" ? (
+					<ArrowUp className="h-3.5 w-3.5" />
+				) : (
+					<ArrowDown className="h-3.5 w-3.5" />
+				)
+			) : (
+				<ArrowUpDown className="h-3.5 w-3.5 opacity-50" />
+			)}
+		</Link>
+	);
+}
+
+function UtilBar({ pct }: { pct: number | null }) {
+	if (pct === null) {
+		return <span className="text-muted-foreground">—</span>;
+	}
+	const clamped = Math.min(100, Math.max(0, pct));
+	const tone =
+		pct < 20
+			? "bg-amber-500"
+			: pct > 100
+				? "bg-rose-500"
+				: pct > 80
+					? "bg-orange-500"
+					: "bg-emerald-500";
+	return (
+		<div className="flex items-center gap-2">
+			<div className="h-1.5 w-20 overflow-hidden rounded-full bg-muted">
+				<div className={cn("h-full", tone)} style={{ width: `${clamped}%` }} />
+			</div>
+			<span className="tabular-nums text-xs text-muted-foreground">
+				{pct.toFixed(0)}%
+			</span>
+		</div>
+	);
+}
+
+// Both the filter card's match counter and the table below it render from the
+// same request — identical query keys, so TanStack Query dedupes them.
+function useDevpassSubscribers(query: DevpassListQuery) {
+	const $api = useApi();
+	return $api.useQuery("get", "/admin/devpass", { params: { query } });
+}
+
+export function DevpassResultCount({ query }: { query: DevpassListQuery }) {
+	const { data } = useDevpassSubscribers(query);
+
+	if (!data) {
+		return <div className="h-4 w-56 animate-pulse rounded bg-muted/40" />;
+	}
+
+	return (
+		<p className="text-xs text-muted-foreground">
+			{data.total} subscriber{data.total === 1 ? "" : "s"} match current filters
+		</p>
+	);
+}
+
+export function DevpassSubscribersTable({
+	query,
+	queryString,
+	page,
+	limit,
+}: {
+	query: DevpassListQuery;
+	queryString: string;
+	page: number;
+	limit: number;
+}) {
+	const { data, error } = useDevpassSubscribers(query);
+
+	const sortBy = query.sortBy ?? "subscribedSince";
+	const sortOrder = query.sortOrder ?? "desc";
+	const offset = (page - 1) * limit;
+	const totalPages = data ? Math.ceil(data.total / limit) : 0;
+
+	return (
+		<>
+			<div className="overflow-x-auto rounded-lg border border-border/60 bg-card">
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead>
+								<SortableHeader
+									label="Subscriber"
+									sortKey="name"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									queryString={queryString}
+								/>
+							</TableHead>
+							<TableHead>
+								<SortableHeader
+									label="Tier"
+									sortKey="tier"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									queryString={queryString}
+								/>
+							</TableHead>
+							<TableHead>Status</TableHead>
+							<TableHead>
+								<SortableHeader
+									label="Utilization"
+									sortKey="utilizationPct"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									queryString={queryString}
+								/>
+							</TableHead>
+							<TableHead>
+								<SortableHeader
+									label="Cycle"
+									sortKey="cycleStart"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									queryString={queryString}
+								/>
+							</TableHead>
+							<TableHead>
+								<SortableHeader
+									label="Renews"
+									sortKey="expiresAt"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									queryString={queryString}
+								/>
+							</TableHead>
+							<TableHead>
+								<SortableHeader
+									label="MRR"
+									sortKey="mrr"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									queryString={queryString}
+								/>
+							</TableHead>
+							<TableHead>
+								<SortableHeader
+									label="Real cost"
+									sortKey="realCost"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									queryString={queryString}
+								/>
+							</TableHead>
+							<TableHead>
+								<SortableHeader
+									label="Margin"
+									sortKey="margin"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									queryString={queryString}
+								/>
+							</TableHead>
+							<TableHead>
+								<SortableHeader
+									label="PAYG"
+									sortKey="paygBalance"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									queryString={queryString}
+								/>
+							</TableHead>
+							<TableHead>Premium (week)</TableHead>
+							<TableHead>
+								<SortableHeader
+									label="Cost (all-time)"
+									sortKey="allTimeCost"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									queryString={queryString}
+								/>
+							</TableHead>
+							<TableHead>
+								<SortableHeader
+									label="Margin (all-time)"
+									sortKey="allTimeMargin"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									queryString={queryString}
+								/>
+							</TableHead>
+							<TableHead>
+								<SortableHeader
+									label="Since"
+									sortKey="subscribedSince"
+									currentSortBy={sortBy}
+									currentSortOrder={sortOrder}
+									queryString={queryString}
+								/>
+							</TableHead>
+							<TableHead>Δ tier</TableHead>
+							<TableHead>Payments</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{error ? (
+							<TableRow>
+								<TableCell
+									colSpan={COLUMN_COUNT}
+									className="h-24 text-center text-muted-foreground"
+								>
+									Failed to load subscribers.{" "}
+									<Link href="/login" className="underline">
+										Sign in
+									</Link>{" "}
+									again if your session expired.
+								</TableCell>
+							</TableRow>
+						) : !data ? (
+							Array.from({ length: 10 }, (_, i) => (
+								<TableRow key={i}>
+									<TableCell colSpan={COLUMN_COUNT}>
+										<div className="h-6 animate-pulse rounded bg-muted/40" />
+									</TableCell>
+								</TableRow>
+							))
+						) : data.subscribers.length === 0 ? (
+							<TableRow>
+								<TableCell
+									colSpan={COLUMN_COUNT}
+									className="h-24 text-center text-muted-foreground"
+								>
+									No subscribers match
+								</TableCell>
+							</TableRow>
+						) : (
+							data.subscribers.map((sub) => (
+								<TableRow key={sub.id}>
+									<TableCell>
+										<Link
+											href={`/devpass/${sub.id}`}
+											className="font-medium text-foreground hover:underline"
+										>
+											{sub.name}
+										</Link>
+										<p className="text-xs text-muted-foreground">
+											{sub.ownerEmail ?? sub.billingEmail}
+										</p>
+										{sub.ownerUsername && (
+											<p className="text-xs text-muted-foreground">
+												@{sub.ownerUsername}
+											</p>
+										)}
+									</TableCell>
+									<TableCell>
+										<Badge variant={getTierBadgeVariant(sub.tier)}>
+											{sub.tier}
+										</Badge>
+										{sub.pendingTier && (
+											<p className="mt-1 text-xs text-amber-600">
+												→ {sub.pendingTier} next cycle
+											</p>
+										)}
+									</TableCell>
+									<TableCell>
+										<Badge variant={getStatusBadgeVariant(sub.status)}>
+											{formatStatus(sub.status)}
+										</Badge>
+									</TableCell>
+									<TableCell>
+										<UtilBar pct={sub.utilizationPct} />
+										<p className="mt-1 text-xs tabular-nums text-muted-foreground">
+											{currencyFormatter.format(parseFloat(sub.creditsUsed))} /{" "}
+											{currencyFormatter.format(parseFloat(sub.creditsLimit))}
+										</p>
+									</TableCell>
+									<TableCell className="text-muted-foreground text-xs">
+										{sub.cycleDaysIn !== null ? `Day ${sub.cycleDaysIn}` : "—"}
+									</TableCell>
+									<TableCell className="text-muted-foreground text-xs">
+										{sub.expiresAt ? formatDate(sub.expiresAt) : "—"}
+									</TableCell>
+									<TableCell className="tabular-nums">
+										{currencyFormatter.format(sub.mrr)}
+									</TableCell>
+									<TableCell className="tabular-nums text-muted-foreground">
+										{currencyFormatterPrecise.format(sub.realCost)}
+									</TableCell>
+									<TableCell
+										className={cn(
+											"tabular-nums",
+											sub.margin < 0
+												? "text-rose-600 dark:text-rose-400"
+												: "text-emerald-600 dark:text-emerald-400",
+										)}
+									>
+										{currencyFormatter.format(sub.margin)}
+										{sub.cycleOverflowCost > 0 && (
+											<p
+												className="mt-0.5 text-xs font-normal text-muted-foreground"
+												title="Cycle cost paid from the org's own PAYG credits — excluded from plan margin"
+											>
+												+
+												{currencyFormatterPrecise.format(sub.cycleOverflowCost)}{" "}
+												overflow
+											</p>
+										)}
+									</TableCell>
+									<TableCell className="tabular-nums text-xs">
+										{sub.paygEnabled ? (
+											<>
+												<span className="font-medium">
+													{currencyFormatter.format(
+														parseFloat(sub.paygBalance),
+													)}
+												</span>
+												{sub.autoTopUpEnabled && (
+													<Badge variant="outline" className="ml-1.5">
+														auto
+													</Badge>
+												)}
+												{sub.allTimeTopUps > 0 && (
+													<p className="mt-0.5 text-muted-foreground">
+														{currencyFormatter.format(sub.allTimeTopUps)} topped
+														up
+													</p>
+												)}
+											</>
+										) : (
+											<span className="text-muted-foreground">—</span>
+										)}
+									</TableCell>
+									<TableCell className="tabular-nums text-xs">
+										{(() => {
+											const premUsed = parseFloat(sub.premiumCreditsUsed);
+											const premLimit = parseFloat(sub.premiumCreditsLimit);
+											if (premLimit <= 0) {
+												return <span className="text-muted-foreground">—</span>;
+											}
+											const pct = Math.min(
+												100,
+												Math.max(0, (premUsed / premLimit) * 100),
+											);
+											const tone =
+												pct >= 100
+													? "text-rose-600 dark:text-rose-400"
+													: pct >= 80
+														? "text-orange-600 dark:text-orange-400"
+														: "text-muted-foreground";
+											return (
+												<span className={tone}>
+													{currencyFormatter.format(premUsed)} /{" "}
+													{currencyFormatter.format(premLimit)}
+												</span>
+											);
+										})()}
+									</TableCell>
+									<TableCell className="tabular-nums text-muted-foreground">
+										{currencyFormatterPrecise.format(sub.allTimeCost)}
+									</TableCell>
+									<TableCell
+										className={cn(
+											"tabular-nums",
+											sub.allTimeMargin < 0
+												? "text-rose-600 dark:text-rose-400"
+												: "text-emerald-600 dark:text-emerald-400",
+										)}
+										title={`Revenue ${currencyFormatter.format(
+											sub.allTimeRevenue,
+										)} − cost ${currencyFormatterPrecise.format(sub.allTimeCost)}`}
+									>
+										{currencyFormatter.format(sub.allTimeMargin)}
+									</TableCell>
+									<TableCell className="text-muted-foreground text-xs">
+										{formatDate(sub.subscribedSince)}
+									</TableCell>
+									<TableCell className="tabular-nums text-muted-foreground text-xs">
+										{sub.tierChanges}
+									</TableCell>
+									<TableCell>
+										{sub.hasPaymentIssue ? (
+											<Badge variant="destructive" className="gap-1">
+												<AlertCircle className="h-3 w-3" />
+												failed
+											</Badge>
+										) : (
+											<span className="text-xs text-muted-foreground">ok</span>
+										)}
+									</TableCell>
+								</TableRow>
+							))
+						)}
+					</TableBody>
+				</Table>
+			</div>
+
+			{data && totalPages > 1 && (
+				<div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
+					<p className="text-sm text-muted-foreground">
+						Showing {offset + 1} to {Math.min(offset + limit, data.total)} of{" "}
+						{data.total}
+					</p>
+					<div className="flex items-center gap-2">
+						<Button variant="outline" size="sm" asChild disabled={page <= 1}>
+							<Link
+								href={`/devpass?${(() => {
+									const sp = new URLSearchParams(queryString);
+									sp.set("page", String(page - 1));
+									return sp.toString();
+								})()}`}
+								className={page <= 1 ? "pointer-events-none opacity-50" : ""}
+							>
+								<ChevronLeft className="h-4 w-4" />
+								Previous
+							</Link>
+						</Button>
+						<span className="text-sm text-muted-foreground">
+							Page {page} of {totalPages}
+						</span>
+						<Button
+							variant="outline"
+							size="sm"
+							asChild
+							disabled={page >= totalPages}
+						>
+							<Link
+								href={`/devpass?${(() => {
+									const sp = new URLSearchParams(queryString);
+									sp.set("page", String(page + 1));
+									return sp.toString();
+								})()}`}
+								className={
+									page >= totalPages ? "pointer-events-none opacity-50" : ""
+								}
+							>
+								Next
+								<ChevronRight className="h-4 w-4" />
+							</Link>
+						</Button>
+					</div>
+				</div>
+			)}
+		</>
+	);
+}


### PR DESCRIPTION
## Problem

The admin DevPass page rendered nothing until two server-side API calls
finished. The list endpoint was the expensive one: on top of the paginated
subscriber query it computed the whole KPI strip — ten aggregates over the
entire subscriber universe (active counts, churn, month starts/ends, refunds,
Reset Pass sales, weighted utilization, cycle cost/MRR/overflow, top-up
revenue) — and ran every one of them serially, after the list query.

## Approach

**API**

- New `GET /admin/devpass/kpis` returns the KPI strip; its ten aggregates now
  run concurrently via `Promise.all` instead of one after another.
- `GET /admin/devpass` no longer computes or returns `kpis`, and its rows and
  count queries run in parallel.
- The shared cycle-cost subquery, tier-price expression and active-universe
  predicate moved to module scope so both handlers use one definition.

**Admin page**

The page now fetches nothing server-side — it only resolves the session and
parses search params, so the shell (header, filters, table chrome) paints
immediately. KPIs, the timeseries chart, the usage cards and the subscriber
table each load independently on the client with skeletons; a slow aggregate
no longer blocks the rest.

The filter pills, sort links and search form stay server-rendered — they are
plain URL links with no data dependency. The match counter and the table share
one query key, so they dedupe into a single request.

## Verification

Full `pnpm build`, `pnpm format`, and the four `admin-devpass-*` specs (19
tests) against an isolated stack. Locally, document TTFB for `/devpass` went
from ~350-750ms to ~80-170ms on seeded data; the gap widens with the number of
DevPass orgs, since the KPI aggregates scan the whole universe.

Two specs that asserted on `body.kpis` from the list endpoint now hit the new
KPI endpoint.

## Screenshots

Loaded page is unchanged.

**Before — light / dark**

<img width="1440" alt="DevPass admin page before, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/dedcce8fdbaad33ad1d3ff7729bf58e8b7eb602e/before-light.png" />
<img width="1440" alt="DevPass admin page before, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/dedcce8fdbaad33ad1d3ff7729bf58e8b7eb602e/before-dark.png" />

**After — light / dark**

<img width="1440" alt="DevPass admin page after, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/dedcce8fdbaad33ad1d3ff7729bf58e8b7eb602e/after-light.png" />
<img width="1440" alt="DevPass admin page after, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/dedcce8fdbaad33ad1d3ff7729bf58e8b7eb602e/after-dark.png" />

**After — first paint while the queries are still in flight** (API responses
delayed to make the state visible)

<img width="1440" alt="DevPass admin page skeleton state while data loads" src="https://raw.githubusercontent.com/theopenco/llmgateway/dedcce8fdbaad33ad1d3ff7729bf58e8b7eb602e/after-loading.png" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated KPI view for DevPass metrics, including subscribers, revenue, margin, refunds, utilization, and PAYG performance.
  * Added an interactive subscribers table with filtering, sorting, pagination, loading and error states, and subscriber details.
  * Improved dashboard loading with independent KPI and subscriber data sections.

* **Improvements**
  * DevPass reporting now loads KPI and subscriber information separately for a more responsive experience.
  * KPI calculations continue to exclude gifted passes from sold-pass counts and revenue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->