### PR TITLE
ci: reduce unit test shards to 5

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        shard: [1, 2, 3, 4, 5]
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1


### PR DESCRIPTION
Unit tests were split across 10 shards, but the extra parallelism buys little: each shard pays the full `pnpm run setup` (Docker services, schema push, seed) plus `build:core` before it runs a single spec, so the fixed per-shard overhead dominates the actual test time.

Halves the matrix to 5 shards. `strategy.job-total` is used for `--shard=N/T`, so no other change is needed — the merge job still aggregates every blob and reports the combined result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the unit-test workflow to run across 5 parallel test shards instead of 10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->