### PR TITLE
feat(models): sync Novita mappings and pricing

### DIFF
--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -1783,6 +1783,43 @@ export const alibabaModels = [
 				],
 			},
 			{
+				providerId: "novita",
+				externalId: "qwen/qwen3.8-max",
+				inputPrice: "2e-6",
+				cachedInputPrice: "0.25e-6",
+				outputPrice: "6e-6",
+				requestPrice: "0",
+				contextSize: 1000000,
+				maxOutput: 131072,
+				// novita accepts every reasoning_effort tier but none of them changes
+				// the deployment's behaviour (thinking stays on even for "none"), so
+				// no tier is declared and reasoning_effort is left out of
+				// supportedParameters below
+				reasoning: true,
+				reasoningOutput: "omit",
+				streaming: true,
+				vision: true,
+				tools: true,
+				// Qwen thinking models reject tool_choice "required" or object
+				supportedToolChoices: ["auto", "none"],
+				jsonOutput: true,
+				jsonOutputSchema: true,
+				// novita's deployment 400s on the developer role
+				supportsDeveloperRole: false,
+				supportedParameters: [
+					"temperature",
+					"max_tokens",
+					"top_p",
+					"frequency_penalty",
+					"presence_penalty",
+					"stop",
+					"stream",
+					"tools",
+					"tool_choice",
+					"response_format",
+				],
+			},
+			{
 				providerId: "scx-ai-gp",
 				externalId: "qwen3.8-max",
 				inputPrice: "1.815e-6",

--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -260,6 +260,40 @@ export const moonshotModels = [
 				],
 			},
 			{
+				providerId: "novita",
+				externalId: "moonshotai/kimi-k2.5",
+				// About 40% of requests to novita's kimi-k2.5 deployment never
+				// respond — the connection just stays open until it times out. Plain
+				// chat, tool calls and tool results all hang at the same rate, while
+				// kimi-k2.6 and kimi-k2.7-code on the same key are unaffected
+				// (measured 2026-08-17), so keep it out of routing and e2e.
+				stability: "unstable",
+				test: "skip",
+				inputPrice: "0.6e-6",
+				cachedInputPrice: "0.1e-6",
+				outputPrice: "3.0e-6",
+				requestPrice: "0",
+				contextSize: 262144,
+				maxOutput: 262144,
+				reasoning: true,
+				// Moonshot thinking is a binary toggle (`thinking.type`), not a
+				// graduated effort: none/minimal disable it, low..max enable it.
+				reasoningEfforts: [
+					"none",
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max",
+				],
+				streaming: true,
+				vision: true,
+				tools: true,
+				jsonOutput: true,
+				jsonOutputSchema: true,
+			},
+			{
 				providerId: "together-ai",
 				externalId: "moonshotai/Kimi-K2.5",
 				// Together.ai intermittently returns 500 for this model (~98.7% uptime)
@@ -455,9 +489,9 @@ export const moonshotModels = [
 			{
 				providerId: "novita",
 				externalId: "moonshotai/kimi-k2.6",
-				inputPrice: "0.95e-6",
+				inputPrice: "0.8e-6",
 				cachedInputPrice: "0.16e-6",
-				outputPrice: "4.0e-6",
+				outputPrice: "3.4e-6",
 				requestPrice: "0",
 				contextSize: 262144,
 				maxOutput: 262144,
@@ -600,6 +634,29 @@ export const moonshotModels = [
 					"tool_choice",
 					"reasoning_effort",
 				],
+			},
+			{
+				providerId: "novita",
+				externalId: "moonshotai/kimi-k2.7-code",
+				inputPrice: "0.95e-6",
+				cachedInputPrice: "0.19e-6",
+				outputPrice: "4.0e-6",
+				requestPrice: "0",
+				contextSize: 262144,
+				maxOutput: 262144,
+				reasoning: true,
+				// Thinking is always on for kimi-k2.7-code: novita accepts `none` and
+				// `minimal` but keeps reasoning, so only low..max are offered.
+				reasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
+				streaming: true,
+				vision: true,
+				tools: true,
+				// novita 400s on forced tool_choice for this deployment
+				supportedToolChoices: ["auto", "none"],
+				jsonOutput: true,
+				jsonOutputSchema: true,
+				// novita's deployment 400s on the developer role
+				supportsDeveloperRole: false,
 			},
 			{
 				providerId: "nebius",

--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -260,40 +260,6 @@ export const moonshotModels = [
 				],
 			},
 			{
-				providerId: "novita",
-				externalId: "moonshotai/kimi-k2.5",
-				// About 40% of requests to novita's kimi-k2.5 deployment never
-				// respond — the connection just stays open until it times out. Plain
-				// chat, tool calls and tool results all hang at the same rate, while
-				// kimi-k2.6 and kimi-k2.7-code on the same key are unaffected
-				// (measured 2026-08-17), so keep it out of routing and e2e.
-				stability: "unstable",
-				test: "skip",
-				inputPrice: "0.6e-6",
-				cachedInputPrice: "0.1e-6",
-				outputPrice: "3.0e-6",
-				requestPrice: "0",
-				contextSize: 262144,
-				maxOutput: 262144,
-				reasoning: true,
-				// Moonshot thinking is a binary toggle (`thinking.type`), not a
-				// graduated effort: none/minimal disable it, low..max enable it.
-				reasoningEfforts: [
-					"none",
-					"minimal",
-					"low",
-					"medium",
-					"high",
-					"xhigh",
-					"max",
-				],
-				streaming: true,
-				vision: true,
-				tools: true,
-				jsonOutput: true,
-				jsonOutputSchema: true,
-			},
-			{
 				providerId: "together-ai",
 				externalId: "moonshotai/Kimi-K2.5",
 				// Together.ai intermittently returns 500 for this model (~98.7% uptime)

--- a/packages/models/src/models/tencent.ts
+++ b/packages/models/src/models/tencent.ts
@@ -41,6 +41,8 @@ export const tencentModels = [
 				reasoningEfforts: ["none", "low", "high"],
 				vision: false,
 				tools: true,
+				// novita 400s on a named function choice for this deployment
+				supportedToolChoices: ["auto", "none", "required"],
 				jsonOutputSchema: true,
 			},
 		],

--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -28,6 +28,33 @@ export const zaiModels = [
 				jsonOutput: true,
 			},
 			{
+				providerId: "novita",
+				externalId: "zai-org/glm-5.2",
+				inputPrice: "1.4e-6",
+				cachedInputPrice: "0.26e-6",
+				outputPrice: "4.4e-6",
+				requestPrice: "0",
+				contextSize: 1048576,
+				maxOutput: 131072,
+				streaming: true,
+				reasoning: true,
+				reasoningEfforts: [
+					"none",
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max",
+				],
+				vision: false,
+				tools: true,
+				// JSON mode is unreliable on this deployment: roughly half of the
+				// responses put the object in reasoning_content with empty content, and
+				// the rest markdown-fence it. json_schema behaves the same way.
+				jsonOutput: false,
+			},
+			{
 				providerId: "canopywave",
 				test: "skip", // over-reasons heavily and streams slowly (~1 tok/s), so the 60s streaming timeout is flaky
 				externalId: "zai/glm-5.2",
@@ -235,36 +262,33 @@ export const zaiModels = [
 			{
 				providerId: "novita",
 				externalId: "zai-org/glm-5.1",
-				inputPrice: "1.4e-6",
+				inputPrice: "1.38e-6",
 				cachedInputPrice: "0.26e-6",
 				outputPrice: "4.4e-6",
 				requestPrice: "0",
 				contextSize: 204800,
-				maxOutput: 131100,
+				maxOutput: 131072,
 				quantization: "fp8",
 				streaming: true,
 				reasoning: true,
+				reasoningEfforts: [
+					"none",
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max",
+				],
 				// novita's glm-5.1 reasons adaptively and omits reasoning_content
 				// for simple prompts; no parameter forces it on
 				reasoningOutput: "omit",
 				vision: false,
 				tools: true,
 				jsonOutput: true,
-				// novita disables thinking when reasoning_effort is forwarded
-				// (empty reasoning_content); omitting it reasons by default, so
-				// exclude reasoning_effort here (verified live 2026-07-14)
-				supportedParameters: [
-					"temperature",
-					"max_tokens",
-					"top_p",
-					"frequency_penalty",
-					"presence_penalty",
-					"stop",
-					"stream",
-					"response_format",
-					"tools",
-					"tool_choice",
-				],
+				// JSON mode consistently markdown-fences the object on this
+				// deployment, so normalize it defensively in both modes.
+				healStreamingJsonOutput: true,
 			},
 			{
 				providerId: "together-ai",
@@ -398,7 +422,7 @@ export const zaiModels = [
 				outputPrice: "3.2e-6",
 				requestPrice: "0",
 				contextSize: 202800,
-				maxOutput: 131100,
+				maxOutput: 131072,
 				quantization: "fp8",
 				streaming: true,
 				reasoning: true,


### PR DESCRIPTION
## Problem

Nine models the user asked about are served by Novita, but only five were in the
catalogue, and three of those carried values Novita no longer charges or accepts.

## What changed

Everything below is per Novita mapping. Prices, `contextSize` and `maxOutput`
come from Novita's `/openai/v1/models` rate card (`price_per_m / 10000` = USD/M);
capability flags were probed against the live deployments.

### Added

| Model | `externalId` | in / out / cached ($/M) | ctx | max out |
| --- | --- | --- | --- | --- |
| `qwen3.8-max` | `qwen/qwen3.8-max` | 2.00 / 6.00 / 0.25 | 1,000,000 | 131,072 |
| `kimi-k2.7-code` | `moonshotai/kimi-k2.7-code` | 0.95 / 4.00 / 0.19 | 262,144 | 262,144 |
| `glm-5.2` | `zai-org/glm-5.2` | 1.40 / 4.40 / 0.26 | 1,048,576 | 131,072 |

Capabilities probed live:

- `qwen3.8-max` — vision ✅, `json_object` + `json_schema` ✅, `tool_choice`
  `required`/named 400 → `supportedToolChoices: ["auto","none"]`, developer role
  400 → `supportsDeveloperRole: false`. Every `reasoning_effort` tier returns 200
  but none changes behaviour (thinking stays on even for `none`), so no tier is
  declared and `reasoning_effort` is not forwarded.
- `kimi-k2.7-code` — vision ✅, JSON ✅; `tool_choice` `required`/named and the
  developer role both 400. `none`/`minimal` are accepted but do not disable
  thinking, so only `low..max` are declared.
- `glm-5.2` — vision explicitly unsupported (`model features vision not support`),
  all four tool-choice modes ✅, `none` reliably disables thinking. JSON mode is
  `false`: about half the responses put the object in `reasoning_content` with
  empty `content` and the rest markdown-fence it — `json_schema` behaves the same.

### Corrected

- `kimi-k2.6` — input `0.95 → 0.80`, output `4.00 → 3.40`. Novita cut both rates;
  the cache rate (0.16) was already right.
- `glm-5.1` — input `1.40 → 1.38`.
- `glm-5` and `glm-5.1` — `maxOutput` `131100 → 131072`. The deployment rejects
  the advertised value outright: `max_tokens (current value: 131100) must be
  between 0 and 131072`.
- `glm-5.1` — the mapping excluded `reasoning_effort` from `supportedParameters`
  on the basis that Novita disabled thinking whenever it was forwarded. That is
  no longer true: `none` disables and `high` reasons heavily, so the full tier
  list is declared and the stale note removed. JSON mode consistently
  markdown-fences the object, so `healStreamingJsonOutput` is now set.
- `hy3` — named function `tool_choice` 400s (`required` works), so
  `supportedToolChoices: ["auto","none","required"]`. Pricing, context and the
  `jsonOutputSchema`-only JSON support were already correct — Novita rejects
  `json_object` for this model with `Supported formats: json_schema`.

### Deliberately not added

`kimi-k2.5` is served by Novita but is **not** mapped here. About 40% of requests
to that deployment never respond — the connection stays open until it times out.
Measured 4/10 hangs on plain chat and 4/8 on tool-result round trips, while
`kimi-k2.6` and `kimi-k2.7-code` on the same key were unaffected. A mapping
fenced off with `stability: "unstable"` + `test: "skip"` would still surface a
model we cannot serve, so nothing ships for it until Novita fixes the deployment.

## Verification

**Billing** — one request per mapping through the gateway with `x-no-fallback`,
each hand-computed and matched against `log.cost` exactly (reasoning tokens are
recorded but correctly not billed on top of `completion_tokens`):

| Mapping | prompt × in + completion × out | `log.cost` |
| --- | --- | --- |
| `qwen3.8-max` | 69×2e-6 + 77×6e-6 | 0.0006 |
| `kimi-k3` | 101×3e-6 + 260×15e-6 | 0.004203 |
| `kimi-k2.6` | 25×0.8e-6 + 274×3.4e-6 | 0.0009516 |
| `kimi-k2.7-code` | 26×0.95e-6 + 125×4e-6 | 0.0005247 |
| `glm-5` | 22×1e-6 + 241×3.2e-6 | 0.0007932 |
| `glm-5.1` | 30×1.38e-6 + 247×4.4e-6 | 0.0011282 |
| `glm-5.2` | 31×1.4e-6 + 225×4.4e-6 | 0.0010334 |
| `hy3` | 27×0.14e-6 + 249×0.58e-6 | 0.0001482 |

Prompt caching also verified: a repeated 4,011-token prompt reported
`cached_tokens: 3968` as a subset of `prompt_tokens`, matching the cost engine's
assumption.

**Specs** — `model-metadata`, `providers`, `realtime-models`, `compliance`,
`helpers` and `costs.spec.ts` all pass. `pnpm format` and a full `pnpm build`
are clean.

**e2e** — `TEST_MODELS="novita/qwen3.8-max,novita/kimi-k3,novita/kimi-k2.6,novita/kimi-k2.7-code,novita/glm-5,novita/glm-5.1,novita/glm-5.2,novita/hy3" FULL_MODE=true pnpm test:e2e`
→ 196 passed, 1 failed. The one failure was a harness log-flush race
(`Timed out waiting for log with request ID`) on `glm-5.2` non-streaming tool
calls, not a model failure: re-running the same suite scoped to
`TEST_MODELS="novita/glm-5.2" FULL_MODE=true` was fully green (106 passed, 0
failed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Novita support for Qwen 3.8 Max, Kimi K2.7 Code, and GLM 5.2.
  * Added reasoning, vision, streaming, tool use, and structured JSON capabilities where supported.
  * Expanded tool-selection options for Tencent Hy3.
* **Updates**
  * Reduced Novita pricing for Kimi K2.6.
  * Updated GLM model context, output limits, reasoning options, pricing, and streaming behavior.
  * Improved compatibility for tool choices and supported request parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->