### PR TITLE
fix(api): grant billed tier on devpass renewal

### DIFF
--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -20,6 +20,7 @@ import {
 	isDevPlanCardDedupeEnforced,
 } from "@/stripe.js";
 import { findDefaultOrganization } from "@/utils/default-org.js";
+import { getDevPlanPriceId } from "@/utils/dev-plan-prices.js";
 import { LEGACY_DEV_PLAN_TX_TYPES } from "@/utils/devpass-filter.js";
 import {
 	buildInvoiceDataForTransaction,
@@ -207,24 +208,6 @@ function getPurchasedResetPasses(
 		case "max":
 			return org.devPlanResetPassesMax;
 	}
-}
-
-function getDevPlanPriceId(
-	tier: DevPlanTier,
-	cycle: DevPlanCycle = "monthly",
-): string | undefined {
-	const monthlyKeys: Record<DevPlanTier, string> = {
-		lite: "STRIPE_DEV_PLAN_LITE_PRICE_ID",
-		pro: "STRIPE_DEV_PLAN_PRO_PRICE_ID",
-		max: "STRIPE_DEV_PLAN_MAX_PRICE_ID",
-	};
-	const annualKeys: Record<DevPlanTier, string> = {
-		lite: "STRIPE_DEV_PLAN_LITE_ANNUAL_PRICE_ID",
-		pro: "STRIPE_DEV_PLAN_PRO_ANNUAL_PRICE_ID",
-		max: "STRIPE_DEV_PLAN_MAX_ANNUAL_PRICE_ID",
-	};
-	const key = cycle === "annual" ? annualKeys[tier] : monthlyKeys[tier];
-	return process.env[key];
 }
 
 function getStripeId(value: string | { id?: string } | null | undefined) {

--- a/apps/api/src/stripe.spec.ts
+++ b/apps/api/src/stripe.spec.ts
@@ -289,6 +289,7 @@ function makeInvoiceEvent(overrides: {
 	invoiceId: string;
 	metadata?: Record<string, string>;
 	periodEnd?: number;
+	priceId?: string;
 }): Stripe.InvoicePaymentSucceededEvent {
 	return {
 		id: "evt_test_invoice",
@@ -305,8 +306,21 @@ function makeInvoiceEvent(overrides: {
 				metadata: overrides.metadata ?? { organizationId: ORG_ID },
 				lines: {
 					data:
-						overrides.periodEnd !== undefined
-							? [{ period: { end: overrides.periodEnd } }]
+						overrides.periodEnd !== undefined || overrides.priceId
+							? [
+									{
+										...(overrides.periodEnd !== undefined
+											? { period: { end: overrides.periodEnd } }
+											: {}),
+										...(overrides.priceId
+											? {
+													pricing: {
+														price_details: { price: overrides.priceId },
+													},
+												}
+											: {}),
+									},
+								]
 							: [],
 				},
 			},
@@ -445,6 +459,103 @@ describe("handleInvoicePaymentSucceeded — dev plan credit reset", () => {
 		expect(txns).toHaveLength(1);
 		expect(txns[0].type).toBe("dev_plan_renewal");
 		expect(txns[0].creditAmount).toBe("537");
+	});
+
+	test("grants the billed tier and defers the pending change when the invoice billed the old tier", async () => {
+		// Repro of a production incident: the MAX cycle's renewal invoice was
+		// drafted (at the MAX price) at the period boundary, the first charge
+		// attempt failed, and the customer then scheduled a max→pro downgrade.
+		// The price swap doesn't touch the already-finalized invoice, so when the
+		// retry succeeded days later the customer had paid the MAX price — but
+		// the handler granted the pending PRO allotment. The renewal must follow
+		// the invoice: grant MAX and keep the downgrade pending for the next
+		// cycle (whose invoice bills the swapped PRO price).
+		vi.stubEnv("STRIPE_DEV_PLAN_MAX_PRICE_ID", "price_test_max");
+		try {
+			await db.insert(tables.organization).values({
+				id: ORG_ID,
+				name: "Acme Co",
+				billingEmail: "billing@acme.test",
+				devPlan: "max",
+				devPlanPendingTier: "pro",
+				devPlanCreditsLimit: "537",
+				devPlanCreditsUsed: "400",
+				devPlanStripeSubscriptionId: SUB_ID,
+				devPlanCancelled: false,
+			});
+
+			await handleInvoicePaymentSucceeded(
+				makeInvoiceEvent({
+					billingReason: "subscription_cycle",
+					amountPaid: 17900,
+					invoiceId: "in_cycle_billed_old_tier_001",
+					priceId: "price_test_max",
+				}),
+			);
+
+			const org = await db.query.organization.findFirst({
+				where: { id: { eq: ORG_ID } },
+			});
+			expect(org?.devPlan).toBe("max");
+			expect(org?.devPlanPendingTier).toBe("pro");
+			expect(org?.devPlanCreditsUsed).toBe("0");
+			expect(org?.devPlanCreditsLimit).toBe("537");
+
+			const txns = await db.query.transaction.findMany({
+				where: { organizationId: { eq: ORG_ID } },
+			});
+			expect(txns).toHaveLength(1);
+			expect(txns[0].type).toBe("dev_plan_renewal");
+			expect(txns[0].creditAmount).toBe("537");
+			expect(txns[0].description).toBe("Dev Plan MAX renewed");
+		} finally {
+			vi.unstubAllEnvs();
+		}
+	});
+
+	test("applies the pending change when the invoice billed the new tier", async () => {
+		// The normal scheduled-downgrade flow: the price swap landed before the
+		// renewal invoice was drafted, so the invoice bills the new (pro) price
+		// and the pending change applies and clears.
+		vi.stubEnv("STRIPE_DEV_PLAN_PRO_PRICE_ID", "price_test_pro");
+		try {
+			await db.insert(tables.organization).values({
+				id: ORG_ID,
+				name: "Acme Co",
+				billingEmail: "billing@acme.test",
+				devPlan: "max",
+				devPlanPendingTier: "pro",
+				devPlanCreditsLimit: "537",
+				devPlanCreditsUsed: "400",
+				devPlanStripeSubscriptionId: SUB_ID,
+				devPlanCancelled: false,
+			});
+
+			await handleInvoicePaymentSucceeded(
+				makeInvoiceEvent({
+					billingReason: "subscription_cycle",
+					amountPaid: 7900,
+					invoiceId: "in_cycle_billed_new_tier_001",
+					priceId: "price_test_pro",
+				}),
+			);
+
+			const org = await db.query.organization.findFirst({
+				where: { id: { eq: ORG_ID } },
+			});
+			expect(org?.devPlan).toBe("pro");
+			expect(org?.devPlanPendingTier).toBeNull();
+			expect(org?.devPlanCreditsLimit).toBe("237");
+
+			const txns = await db.query.transaction.findMany({
+				where: { organizationId: { eq: ORG_ID } },
+			});
+			expect(txns).toHaveLength(1);
+			expect(txns[0].creditAmount).toBe("237");
+			expect(txns[0].description).toBe("Dev Plan PRO renewed");
+		} finally {
+			vi.unstubAllEnvs();
+		}
 	});
 
 	test("emails an invoice on renewal, falling back to the org's own billing email when no default org exists", async () => {

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -28,6 +28,7 @@ import {
 import { computeReferralBonus } from "./lib/referral-bonus.js";
 import { posthog } from "./posthog.js";
 import { getStripe, type StripeMode } from "./routes/payments.js";
+import { getDevPlanTierFromInvoice } from "./utils/dev-plan-prices.js";
 import {
 	notifyChatPlanCancelled,
 	notifyChatPlanRenewed,
@@ -4038,12 +4039,30 @@ export async function handleInvoicePaymentSucceeded(event: {
 		}
 
 		// A scheduled tier change (downgrade, or an upgrade deferred to renewal)
-		// takes effect now, at the renewal boundary: the tier the user selected
-		// mid-cycle becomes the active plan for the new period. When there's no
-		// pending change this is just the current tier. The credit allotment and
-		// the tier we persist below both follow this effective tier.
-		const effectiveTier = (organization.devPlanPendingTier ??
+		// normally takes effect now, at the renewal boundary: the tier the user
+		// selected mid-cycle becomes the active plan for the new period. But the
+		// invoice is the source of truth for what the customer was charged:
+		// Stripe drafts the cycle-renewal invoice at the period boundary, so a
+		// change scheduled after drafting (but before the invoice is paid — the
+		// window is hours to days under dunning) swaps the subscription price
+		// without touching this invoice, which still bills the old tier. Granting
+		// the pending tier then mismatches the charge (e.g. billed the MAX price,
+		// granted PRO credits). So grant the tier the invoice billed and carry
+		// the pending change to the next renewal, whose invoice bills the swapped
+		// price. When no line matches a known dev plan price, fall back to the
+		// pending tier as before.
+		const billedTier = getDevPlanTierFromInvoice(invoice);
+		const scheduledTier = organization.devPlanPendingTier as DevPlanTier | null;
+		const effectiveTier = (billedTier ??
+			scheduledTier ??
 			organization.devPlan) as DevPlanTier;
+		const remainingPendingTier =
+			scheduledTier && scheduledTier !== effectiveTier ? scheduledTier : null;
+		if (remainingPendingTier) {
+			logger.warn(
+				`Dev plan renewal invoice ${invoice.id} for organization ${organizationId} billed tier ${effectiveTier}, but a change to ${remainingPendingTier} was scheduled after the invoice was drafted; granting the billed tier and deferring the change to the next renewal`,
+			);
+		}
 		const creditsLimit = getDevPlanCreditsLimit(effectiveTier);
 
 		// Create transaction record for dev plan renewal
@@ -4088,14 +4107,15 @@ export async function handleInvoicePaymentSucceeded(event: {
 		// Reset credits used and update billing cycle start. Also reset the
 		// limit to the full tier allotment: mid-cycle upgrades leave the limit
 		// above it (unused-credit rollover), and that rollover only lasts until
-		// this renewal. Persist the effective tier and clear the pending
-		// downgrade so a scheduled downgrade becomes the active plan now. Clear
-		// any dunning freeze state since the limit is now authoritative again.
+		// this renewal. Persist the effective tier; a pending change is cleared
+		// when this renewal applied it, and kept when the invoice billed the old
+		// tier (it applies at the next renewal instead). Clear any dunning freeze
+		// state since the limit is now authoritative again.
 		await db
 			.update(tables.organization)
 			.set({
 				devPlan: effectiveTier,
-				devPlanPendingTier: null,
+				devPlanPendingTier: remainingPendingTier,
 				devPlanCreditsLimit: creditsLimit.toString(),
 				devPlanCreditsUsed: "0",
 				devPlanPremiumCreditsUsed: "0",

--- a/apps/api/src/utils/dev-plan-prices.ts
+++ b/apps/api/src/utils/dev-plan-prices.ts
@@ -1,0 +1,57 @@
+import type { DevPlanCycle, DevPlanTier } from "@llmgateway/shared";
+import type Stripe from "stripe";
+
+const DEV_PLAN_PRICE_ENV_KEYS: Record<
+	DevPlanCycle,
+	Record<DevPlanTier, string>
+> = {
+	monthly: {
+		lite: "STRIPE_DEV_PLAN_LITE_PRICE_ID",
+		pro: "STRIPE_DEV_PLAN_PRO_PRICE_ID",
+		max: "STRIPE_DEV_PLAN_MAX_PRICE_ID",
+	},
+	annual: {
+		lite: "STRIPE_DEV_PLAN_LITE_ANNUAL_PRICE_ID",
+		pro: "STRIPE_DEV_PLAN_PRO_ANNUAL_PRICE_ID",
+		max: "STRIPE_DEV_PLAN_MAX_ANNUAL_PRICE_ID",
+	},
+};
+
+export function getDevPlanPriceId(
+	tier: DevPlanTier,
+	cycle: DevPlanCycle = "monthly",
+): string | undefined {
+	return process.env[DEV_PLAN_PRICE_ENV_KEYS[cycle][tier]];
+}
+
+function getDevPlanTierFromPriceId(priceId: string): DevPlanTier | null {
+	for (const cycle of Object.keys(DEV_PLAN_PRICE_ENV_KEYS) as DevPlanCycle[]) {
+		for (const tier of Object.keys(
+			DEV_PLAN_PRICE_ENV_KEYS[cycle],
+		) as DevPlanTier[]) {
+			if (process.env[DEV_PLAN_PRICE_ENV_KEYS[cycle][tier]] === priceId) {
+				return tier;
+			}
+		}
+	}
+	return null;
+}
+
+// The tier an invoice actually billed, resolved from its line items' price
+// ids. Null when no line carries a known dev plan price (e.g. the price env
+// vars are unset, or the invoice predates line pricing data).
+export function getDevPlanTierFromInvoice(
+	invoice: Stripe.Invoice,
+): DevPlanTier | null {
+	for (const line of invoice.lines?.data ?? []) {
+		const priceId = line.pricing?.price_details?.price;
+		if (!priceId) {
+			continue;
+		}
+		const tier = getDevPlanTierFromPriceId(priceId);
+		if (tier) {
+			return tier;
+		}
+	}
+	return null;
+}


### PR DESCRIPTION
## Problem

A customer organization was charged the MAX renewal price but granted the PRO credit allotment. Stripe drafts the cycle-renewal invoice at the period boundary and only finalizes/charges it later — hours to days later under dunning. A tier change scheduled inside that window swaps the subscription price without touching the already-drafted invoice, so the invoice still bills the old tier. The renewal webhook then applied `devPlanPendingTier` unconditionally, granting the new tier's credits against the old tier's charge.

Sequence in the incident:

1. Cycle ends; Stripe drafts the renewal invoice at the current (MAX) price.
2. First charge attempt fails; dunning begins.
3. Customer schedules a downgrade to PRO — the price swap lands on the subscription, not the finalized invoice.
4. Days later the retry succeeds: the customer paid the MAX price, but the webhook granted PRO credits.

## Approach

The invoice is the source of truth for what was charged. The renewal handler now resolves the billed tier from the invoice line's price id (`getDevPlanTierFromInvoice`, matching the `STRIPE_DEV_PLAN_*_PRICE_ID` env vars for both cycles) and grants that tier. When the billed tier disagrees with the pending change, the pending change is kept instead of cleared, so it applies at the next renewal — whose invoice bills the swapped price. When no line matches a known dev plan price, behavior is unchanged (pending tier applies).

`getDevPlanPriceId` moved from `routes/dev-plans.ts` into the new `utils/dev-plan-prices.ts` so the webhook handler can share the mapping without an import cycle.

Chat plans are unaffected: they have no pending-tier mechanism.

## Verification

- New specs: renewal invoice billing the old tier grants the old tier and keeps the pending change; invoice billing the new tier applies and clears it as before.
- `apps/api/src/stripe.spec.ts` (40 tests) and `apps/api/src/routes/dev-plans.spec.ts` (28 tests) pass against an isolated stack; `pnpm format` and `turbo run build --filter=api` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Development plan renewals now correctly identify the tier billed on the invoice.
  * Scheduled tier changes are applied only when the billed tier matches the pending change.
  * Pending tier changes are preserved when the invoice reflects the current tier.
  * Improved handling of monthly and annual pricing across Lite, Pro, and Max plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->