### PR TITLE
feat(migration): add copy-prompt CTA to guides

### DIFF
--- a/apps/docs/components/copy-migration-prompt.tsx
+++ b/apps/docs/components/copy-migration-prompt.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { Check, Copy } from "lucide-react";
+import { usePostHog } from "posthog-js/react";
+import { useState } from "react";
+
+const DOCS_LINKS = `Read these docs first:
+- Quick start: https://docs.llmgateway.io/quick-start
+- Docs index for anything else: https://docs.llmgateway.io/llms.txt`;
+
+const OUTRO = `When you're done, list every file you changed and anything that needs manual follow-up, like creating an API key at https://llmgateway.io/signup and rotating old secrets. Don't refactor unrelated code.`;
+
+const prompts: Record<string, string> = {
+	openrouter: `Migrate this codebase from OpenRouter to LLM Gateway.
+
+${DOCS_LINKS}
+- Migration guide: https://docs.llmgateway.io/migrations/openrouter
+
+Then:
+1. Find every OpenRouter usage: the base URL https://openrouter.ai/api/v1, the OPENROUTER_API_KEY env var, and OpenRouter-only headers like HTTP-Referer and X-Title.
+2. Point the client at https://api.llmgateway.io/v1, read the key from LLM_GATEWAY_API_KEY, and drop the OpenRouter-only headers.
+3. Keep model names as they are — LLM Gateway supports the same provider/model format.
+4. Update .env.example and any README or docs that mention OpenRouter.
+
+${OUTRO}`,
+	"vercel-ai-gateway": `Migrate this codebase from the Vercel AI Gateway to LLM Gateway.
+
+${DOCS_LINKS}
+- Migration guide: https://docs.llmgateway.io/migrations/vercel-ai-gateway
+
+Then:
+1. Find every AI SDK provider in use (@ai-sdk/openai, @ai-sdk/anthropic, @ai-sdk/google, the Vercel AI Gateway provider) and their env keys.
+2. Install @llmgateway/ai-sdk-provider, create a single provider with createLLMGateway({ apiKey: process.env.LLM_GATEWAY_API_KEY }), and swap model calls like openai("gpt-5.2") to llmgateway("gpt-5.2").
+3. Leave the rest of the AI SDK code (generateText, streamText, tools) unchanged — it works as-is.
+4. Update .env.example and any README or docs that mention the old providers.
+
+${OUTRO}`,
+	litellm: `Migrate this codebase from our LiteLLM proxy to LLM Gateway.
+
+${DOCS_LINKS}
+- Migration guide: https://docs.llmgateway.io/migrations/litellm
+
+Then:
+1. Find every client that points at the LiteLLM proxy (base URLs like http://localhost:4000/v1), the LITELLM_API_KEY env var, and LiteLLM config files.
+2. Point the OpenAI-compatible clients at https://api.llmgateway.io/v1 and read the key from LLM_GATEWAY_API_KEY. Model names can stay the same, or use provider-prefixed IDs like openai/gpt-5.2 to pin a provider.
+3. Update .env.example and any README or docs that mention LiteLLM.
+4. List the proxy infrastructure (config files, deploy manifests) that can be decommissioned once traffic is verified — but don't delete anything yet.
+
+${OUTRO}`,
+};
+
+export function CopyMigrationPrompt({
+	slug,
+	provider,
+}: {
+	slug: string;
+	provider: string;
+}) {
+	const posthog = usePostHog();
+	const [copied, setCopied] = useState(false);
+
+	const prompt = prompts[slug];
+	if (!prompt) {
+		return null;
+	}
+
+	const handleCopy = async () => {
+		await navigator.clipboard.writeText(prompt);
+		posthog.capture("docs_migration_prompt_copied", { migration: slug });
+		setCopied(true);
+		setTimeout(() => setCopied(false), 2000);
+	};
+
+	return (
+		<div className="my-6 rounded-xl border border-fd-border bg-fd-card p-5">
+			<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+				<div>
+					<p className="my-0 text-sm font-semibold text-fd-foreground">
+						Let your AI agent do the migration
+					</p>
+					<p className="my-0 mt-1 text-[13px] leading-relaxed text-fd-muted-foreground">
+						Copy this prompt into Claude Code, Cursor, or any coding agent — it
+						reads our docs and handles the migration from {provider} for you.
+					</p>
+				</div>
+				<button
+					type="button"
+					onClick={handleCopy}
+					className="inline-flex w-fit shrink-0 cursor-pointer items-center gap-2 rounded-lg bg-fd-primary px-4 py-2 text-sm font-medium text-fd-primary-foreground transition-colors hover:bg-fd-primary/90"
+				>
+					{copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+					{copied ? "Copied!" : "Copy prompt"}
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/apps/docs/content/migrations/litellm.mdx
+++ b/apps/docs/content/migrations/litellm.mdx
@@ -6,10 +6,13 @@ icon: ArrowRightLeft
 
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Callout } from "fumadocs-ui/components/callout";
+import { CopyMigrationPrompt } from "@/components/copy-migration-prompt";
 
 <section>
 
 Running your own LiteLLM proxy works—until it doesn't. Scaling, monitoring, and keeping it running becomes another job. LLM Gateway gives you the same unified API with built-in analytics, caching, and a dashboard—without the infrastructure overhead.
+
+<CopyMigrationPrompt slug="litellm" provider="LiteLLM" />
 
 ## Quick Migration
 

--- a/apps/docs/content/migrations/openrouter.mdx
+++ b/apps/docs/content/migrations/openrouter.mdx
@@ -6,10 +6,13 @@ icon: ArrowRightLeft
 
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Callout } from "fumadocs-ui/components/callout";
+import { CopyMigrationPrompt } from "@/components/copy-migration-prompt";
 
 <section>
 
 LLM Gateway works just like OpenRouter—same API format, same model names—but with built-in analytics and the option to self-host. Migration takes two lines of code.
+
+<CopyMigrationPrompt slug="openrouter" provider="OpenRouter" />
 
 ## Quick Migration
 

--- a/apps/docs/content/migrations/vercel-ai-gateway.mdx
+++ b/apps/docs/content/migrations/vercel-ai-gateway.mdx
@@ -6,8 +6,11 @@ icon: ArrowRightLeft
 
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Callout } from "fumadocs-ui/components/callout";
+import { CopyMigrationPrompt } from "@/components/copy-migration-prompt";
 
 <section>
+
+<CopyMigrationPrompt slug="vercel-ai-gateway" provider="Vercel AI Gateway" />
 
 ## Quick Migration
 

--- a/apps/ui/src/app/migration/[slug]/copy-prompt-button.tsx
+++ b/apps/ui/src/app/migration/[slug]/copy-prompt-button.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { CheckIcon, CopyIcon } from "lucide-react";
+import { usePostHog } from "posthog-js/react";
+import { useState } from "react";
+
+export function CopyPromptButton({
+	prompt,
+	slug,
+}: {
+	prompt: string;
+	slug: string;
+}) {
+	const posthog = usePostHog();
+	const [copied, setCopied] = useState(false);
+
+	const handleCopy = async () => {
+		await navigator.clipboard.writeText(prompt);
+		posthog.capture("migration_prompt_copied", { migration: slug });
+		setCopied(true);
+		setTimeout(() => setCopied(false), 2000);
+	};
+
+	return (
+		<button
+			type="button"
+			onClick={handleCopy}
+			className="inline-flex shrink-0 items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+		>
+			{copied ? (
+				<CheckIcon className="h-4 w-4" />
+			) : (
+				<CopyIcon className="h-4 w-4" />
+			)}
+			{copied ? "Copied!" : "Copy prompt"}
+		</button>
+	);
+}

--- a/apps/ui/src/app/migration/[slug]/page.tsx
+++ b/apps/ui/src/app/migration/[slug]/page.tsx
@@ -4,7 +4,9 @@ import dynamic from "next/dynamic";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
+import { CopyPromptButton } from "@/app/migration/[slug]/copy-prompt-button";
 import { HeroRSC } from "@/components/landing/hero-rsc";
+import { getMigrationPrompt } from "@/lib/migration-prompts";
 import { getMarkdownOptions } from "@/lib/utils/markdown";
 
 import { allMigrations } from "content-collections";
@@ -96,6 +98,27 @@ export default async function MigrationPage({ params }: MigrationPageProps) {
 							<p className="text-sm text-muted-foreground">
 								Published <time dateTime={migration.date}>{formattedDate}</time>
 							</p>
+							<div className="not-prose mt-6 rounded-xl border border-border bg-muted/50 p-5">
+								<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+									<div>
+										<p className="font-semibold">
+											Let your AI agent do the migration
+										</p>
+										<p className="mt-1 text-sm text-muted-foreground">
+											Copy this prompt into Claude Code, Cursor, or any coding
+											agent — it reads our docs and handles the migration from{" "}
+											{migration.fromProvider} for you.
+										</p>
+									</div>
+									<CopyPromptButton
+										prompt={getMigrationPrompt(
+											migration.slug,
+											migration.fromProvider,
+										)}
+										slug={migration.slug}
+									/>
+								</div>
+							</div>
 						</header>
 
 						<section

--- a/apps/ui/src/lib/migration-prompts.ts
+++ b/apps/ui/src/lib/migration-prompts.ts
@@ -1,0 +1,69 @@
+interface MigrationPromptParts {
+	intro: string;
+	steps: string;
+	outro?: string;
+}
+
+const DEFAULT_OUTRO =
+	"When you're done, list every file you changed and anything that needs manual follow-up, like creating an API key at https://llmgateway.io/signup and rotating old secrets. Don't refactor unrelated code.";
+
+const promptParts: Record<string, MigrationPromptParts> = {
+	openrouter: {
+		intro: "Migrate this codebase from OpenRouter to LLM Gateway.",
+		steps: `1. Find every OpenRouter usage: the base URL https://openrouter.ai/api/v1, the OPENROUTER_API_KEY env var, and OpenRouter-only headers like HTTP-Referer and X-Title.
+2. Point the client at https://api.llmgateway.io/v1, read the key from LLM_GATEWAY_API_KEY, and drop the OpenRouter-only headers.
+3. Keep model names as they are — LLM Gateway supports the same provider/model format.
+4. Update .env.example and any README or docs that mention OpenRouter.`,
+	},
+	"vercel-ai-gateway": {
+		intro: "Migrate this codebase from the Vercel AI Gateway to LLM Gateway.",
+		steps: `1. Find every AI SDK provider in use (@ai-sdk/openai, @ai-sdk/anthropic, @ai-sdk/google, the Vercel AI Gateway provider) and their env keys.
+2. Install @llmgateway/ai-sdk-provider, create a single provider with createLLMGateway({ apiKey: process.env.LLM_GATEWAY_API_KEY }), and swap model calls like openai("gpt-5.2") to llmgateway("gpt-5.2").
+3. Leave the rest of the AI SDK code (generateText, streamText, tools) unchanged — it works as-is.
+4. Update .env.example and any README or docs that mention the old providers.`,
+	},
+	litellm: {
+		intro: "Migrate this codebase from our LiteLLM proxy to LLM Gateway.",
+		steps: `1. Find every client that points at the LiteLLM proxy (base URLs like http://localhost:4000/v1), the LITELLM_API_KEY env var, and LiteLLM config files.
+2. Point the OpenAI-compatible clients at https://api.llmgateway.io/v1 and read the key from LLM_GATEWAY_API_KEY. Model names can stay the same, or use provider-prefixed IDs like openai/gpt-5.2 to pin a provider.
+3. Update .env.example and any README or docs that mention LiteLLM.
+4. List the proxy infrastructure (config files, deploy manifests) that can be decommissioned once traffic is verified — but don't delete anything yet.`,
+	},
+	portkey: {
+		intro: "Migrate this codebase from Portkey to LLM Gateway.",
+		steps: `1. Find every Portkey usage: the portkey-ai SDK, the base URL https://api.portkey.ai/v1, x-portkey-* headers, and virtual keys or config IDs.
+2. Replace them with the standard OpenAI SDK pointed at https://api.llmgateway.io/v1, authenticated with a Bearer token from LLM_GATEWAY_API_KEY — no custom headers or virtual keys.
+3. Pick providers via the model ID (e.g. openai/gpt-5.2) or use the bare model ID for smart routing. Note that provider keys move to the LLM Gateway dashboard under Settings > Provider Keys.
+4. Update .env.example and any README or docs that mention Portkey.`,
+	},
+	"github-copilot": {
+		intro:
+			"Move this project's AI coding workflows off GitHub Copilot's metered AI Credits and onto LLM Gateway.",
+		steps: `1. Ask me which coding agent I want (DevPass Code, Claude Code, Cline, Continue, or Codex CLI) and set it up to run through the gateway — for Claude Code that means setting ANTHROPIC_BASE_URL=https://api.llmgateway.io and ANTHROPIC_AUTH_TOKEN to my LLM Gateway API key.
+2. If this repo runs Copilot code review in CI, replace it with a workflow that reviews diffs via https://api.llmgateway.io/v1/chat/completions.
+3. Tell me which spend caps to set (per organization, project, and API key) in the LLM Gateway dashboard before rollout.`,
+		outro:
+			"I'll create an API key at https://llmgateway.io/signup. Inline completions can stay on Copilot's flat-fee plan — only chat and agentic workflows move. Don't refactor unrelated code.",
+	},
+};
+
+export function getMigrationPrompt(slug: string, fromProvider: string): string {
+	const parts = promptParts[slug] ?? {
+		intro: `Migrate this codebase from ${fromProvider} to LLM Gateway.`,
+		steps: `1. Find every place this codebase calls ${fromProvider}: base URLs, SDK clients, env vars, and custom headers.
+2. Point the OpenAI-compatible client at https://api.llmgateway.io/v1 and read the key from LLM_GATEWAY_API_KEY.
+3. Update .env.example and any README or docs that mention ${fromProvider}.`,
+	};
+
+	return `${parts.intro}
+
+Read these docs first:
+- Migration guide: https://llmgateway.io/migration/${slug}
+- Quick start: https://docs.llmgateway.io/quick-start
+- Docs index for anything else: https://docs.llmgateway.io/llms.txt
+
+Then:
+${parts.steps}
+
+${parts.outro ?? DEFAULT_OUTRO}`;
+}


### PR DESCRIPTION
## Problem

The migration guides tell readers how to migrate by hand, but most migrations today are done by an AI coding agent. There was no one-click way to hand the guide to an agent.

## Approach

Every migration guide now has a "Let your AI agent do the migration" card with a **Copy prompt** button. The prompt tells the agent to read our docs (migration guide, quick start, `llms.txt` index) and then perform the migration from that provider, ending with a changed-files summary and manual follow-ups.

- **apps/ui** (`/migration/[slug]`, all 5 guides): prompts live in `src/lib/migration-prompts.ts`, keyed by slug with a generic fallback so future guides get the CTA automatically. The card renders from the shared page template; the button fires a `migration_prompt_copied` PostHog event.
- **apps/docs** (`/migrations/*`, all 3 guides): self-contained `CopyMigrationPrompt` client component (docs already duplicates guide content from apps/ui, so the prompt copy follows the same pattern), fires `docs_migration_prompt_copied`.

Each prompt is provider-specific: OpenRouter/LiteLLM/Portkey swap base URLs, env vars and provider-only headers; Vercel AI Gateway swaps AI SDK providers for `@llmgateway/ai-sdk-provider`; GitHub Copilot (not an API product) sets up a gateway-backed coding agent and CI review instead.

Example (OpenRouter):

```
Migrate this codebase from OpenRouter to LLM Gateway.

Read these docs first:
- Migration guide: https://llmgateway.io/migration/openrouter
- Quick start: https://docs.llmgateway.io/quick-start
- Docs index for anything else: https://docs.llmgateway.io/llms.txt

Then:
1. Find every OpenRouter usage: the base URL https://openrouter.ai/api/v1, the OPENROUTER_API_KEY env var, and OpenRouter-only headers like HTTP-Referer and X-Title.
2. Point the client at https://api.llmgateway.io/v1, read the key from LLM_GATEWAY_API_KEY, and drop the OpenRouter-only headers.
3. Keep model names as they are — LLM Gateway supports the same provider/model format.
4. Update .env.example and any README or docs that mention OpenRouter.

When you're done, list every file you changed and anything that needs manual follow-up, like creating an API key at https://llmgateway.io/signup and rotating old secrets. Don't refactor unrelated code.
```

## Verification

- `pnpm format` and `turbo run build --filter=ui --filter=docs` pass.
- Clicked the button locally and confirmed the clipboard receives the full prompt, with the copied-state feedback.

https://claude.ai/code/session_01CjtpDdHK6CTFX5cH21LqjS

## Screenshots

`/migration/openrouter` before / after (light):

<img width="1440" alt="Before, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/c62f67257e1dfef445ae9d7ea3122ca9dca5f98b/before-openrouter-light.png" />
<img width="1440" alt="After with copy-prompt CTA, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/c62f67257e1dfef445ae9d7ea3122ca9dca5f98b/after-openrouter-light.png" />

Before / after (dark):

<img width="1440" alt="Before, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/c62f67257e1dfef445ae9d7ea3122ca9dca5f98b/before-openrouter-dark.png" />
<img width="1440" alt="After with copy-prompt CTA, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/c62f67257e1dfef445ae9d7ea3122ca9dca5f98b/after-openrouter-dark.png" />

`/migration/github-copilot` (the tool-setup prompt variant):

<img width="1440" alt="GitHub Copilot guide with copy-prompt CTA, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/c62f67257e1dfef445ae9d7ea3122ca9dca5f98b/after-copilot-light.png" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added AI-agent migration prompts for supported providers, including OpenRouter, Vercel AI Gateway, LiteLLM, Portkey, and GitHub Copilot.
  - Added migration prompt panels with provider-specific guidance and documentation links.
  - Added one-click copy actions with copied-state feedback on migration pages and documentation.
  - Added support for generic migration guidance when a provider is not specifically recognized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->