### PR TITLE
feat(billing): admin-configurable 3D Secure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -418,6 +418,16 @@ STRIPE_WEBHOOK_SECRET_TEST=whsec_your_stripe_sandbox_webhook_secret
 STRIPE_PRO_MONTHLY_PRICE_ID=price_your_pro_plan_price_id
 STRIPE_PRO_YEARLY_PRICE_ID=price_your_pro_plan_price_id
 
+# Optional override for the admin dashboard's "3D Secure when a card is added"
+# setting, which is where this is normally configured. Requests 3DS when a card
+# is saved or a subscription starts — never on a charge, so auto top-ups and
+# other off-session charges can't be challenged and can't break. `any` asks the
+# issuer to authenticate whenever it can, `challenge` also asks for an
+# interactive challenge instead of a frictionless approval. The issuer still
+# decides, so neither value guarantees one. Leave unset to use the admin
+# setting.
+# STRIPE_FORCE_3DS=challenge
+
 # One-time $1000 provider listing fee (used by the public /add-provider form)
 STRIPE_PROVIDER_LISTING_PRICE_ID=price_your_provider_listing_price_id
 

--- a/.env.unified.example
+++ b/.env.unified.example
@@ -188,6 +188,11 @@ STRIPE_WEBHOOK_SECRET_TEST=whsec_your_stripe_sandbox_webhook_secret
 STRIPE_PRO_MONTHLY_PRICE_ID=price_your_pro_plan_price_id
 STRIPE_PRO_YEARLY_PRICE_ID=price_your_pro_plan_price_id
 
+# Optional override for the admin dashboard's 3D Secure setting (`any` or
+# `challenge`), which requests 3DS when a card is added. Leave unset to use the
+# admin setting. Charges themselves are never challenged.
+# STRIPE_FORCE_3DS=challenge
+
 # Dev Plans Stripe Price IDs (for devpass.llmgateway.io)
 STRIPE_DEV_PLAN_LITE_PRICE_ID=price_your_dev_plan_lite_price_id
 STRIPE_DEV_PLAN_PRO_PRICE_ID=price_your_dev_plan_pro_price_id

--- a/apps/api/src/lib/three-d-secure.spec.ts
+++ b/apps/api/src/lib/three-d-secure.spec.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { deleteAll } from "@/testing.js";
+
+import { db, tables } from "@llmgateway/db";
+
+import {
+	FORCE_3DS_SETTING_ID,
+	getForcedThreeDSecure,
+	getForcedThreeDSecureMode,
+	parseThreeDSecureRequest,
+	setForcedThreeDSecureMode,
+	threeDSecureOptions,
+	threeDSecureSubscriptionSettings,
+} from "./three-d-secure.js";
+
+describe("parseThreeDSecureRequest", () => {
+	it("accepts the two requestable levels, case-insensitively", () => {
+		expect(parseThreeDSecureRequest("any")).toBe("any");
+		expect(parseThreeDSecureRequest(" Challenge ")).toBe("challenge");
+	});
+
+	it("treats `true` as a challenge request", () => {
+		expect(parseThreeDSecureRequest("true")).toBe("challenge");
+	});
+
+	it("ignores values Stripe would reject rather than passing them through", () => {
+		expect(parseThreeDSecureRequest("yes")).toBeUndefined();
+		expect(parseThreeDSecureRequest(null)).toBeUndefined();
+		// `automatic` is Stripe's default; sending it explicitly buys nothing.
+		expect(parseThreeDSecureRequest("automatic")).toBeUndefined();
+	});
+});
+
+describe("parameter shapes", () => {
+	it("spread to nothing when 3DS is not forced", () => {
+		expect(threeDSecureOptions(undefined)).toEqual({});
+		expect(threeDSecureSubscriptionSettings(undefined)).toEqual({});
+	});
+
+	it("nest the request where each Stripe resource expects it", () => {
+		expect(threeDSecureOptions("any")).toEqual({
+			payment_method_options: { card: { request_three_d_secure: "any" } },
+		});
+		expect(threeDSecureSubscriptionSettings("challenge")).toEqual({
+			payment_settings: {
+				payment_method_options: {
+					card: { request_three_d_secure: "challenge" },
+				},
+			},
+		});
+	});
+});
+
+describe("admin setting", () => {
+	beforeEach(async () => {
+		vi.stubEnv("STRIPE_FORCE_3DS", undefined);
+		await db.delete(tables.systemSetting);
+	});
+
+	afterEach(async () => {
+		vi.unstubAllEnvs();
+		await deleteAll();
+	});
+
+	it("is off until an admin turns it on", async () => {
+		expect(await getForcedThreeDSecureMode()).toBe("off");
+		expect(await getForcedThreeDSecure()).toBeUndefined();
+	});
+
+	it("round-trips the level an admin selects", async () => {
+		await setForcedThreeDSecureMode("challenge");
+
+		expect(await getForcedThreeDSecureMode()).toBe("challenge");
+		expect(await getForcedThreeDSecure()).toBe("challenge");
+	});
+
+	it("turns back off without leaving the old level active", async () => {
+		await setForcedThreeDSecureMode("any");
+		await setForcedThreeDSecureMode("off");
+
+		const row = await db.query.systemSetting.findFirst({
+			where: { id: FORCE_3DS_SETTING_ID },
+		});
+		expect(row?.enabled).toBe(false);
+		expect(await getForcedThreeDSecureMode()).toBe("off");
+		expect(await getForcedThreeDSecure()).toBeUndefined();
+	});
+
+	it("lets STRIPE_FORCE_3DS override the stored setting", async () => {
+		await setForcedThreeDSecureMode("any");
+		vi.stubEnv("STRIPE_FORCE_3DS", "challenge");
+
+		expect(await getForcedThreeDSecure()).toBe("challenge");
+		// The stored setting is untouched — the override is not persisted.
+		expect(await getForcedThreeDSecureMode()).toBe("any");
+	});
+
+	it("applies the env override even when the admin setting is off", async () => {
+		vi.stubEnv("STRIPE_FORCE_3DS", "any");
+
+		expect(await getForcedThreeDSecureMode()).toBe("off");
+		expect(await getForcedThreeDSecure()).toBe("any");
+	});
+});

--- a/apps/api/src/lib/three-d-secure.ts
+++ b/apps/api/src/lib/three-d-secure.ts
@@ -1,0 +1,168 @@
+import { db, tables } from "@llmgateway/db";
+
+import type Stripe from "stripe";
+
+export type ThreeDSecureRequest =
+	Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Card.RequestThreeDSecure;
+
+/**
+ * The levels we ever request. Stripe also accepts `automatic`, but that is its
+ * default and sending it explicitly buys nothing, so it is never produced here.
+ */
+export type ForcedThreeDSecureLevel = Extract<
+	ThreeDSecureRequest,
+	"any" | "challenge"
+>;
+
+/** What the admin dashboard stores: `off` plus the two requestable levels. */
+export type ForcedThreeDSecureMode = ForcedThreeDSecureLevel | "off";
+
+/** Admin-configurable 3DS level, edited in the admin dashboard settings. */
+export const FORCE_3DS_SETTING_ID = "force_3ds";
+
+/**
+ * Parses a stored or configured 3DS level. `true` is accepted as an alias for
+ * `challenge`; anything else — including Stripe's own `automatic`, which is
+ * the default and buys nothing when sent explicitly — yields undefined.
+ */
+export function parseThreeDSecureRequest(
+	value: string | null | undefined,
+): ForcedThreeDSecureLevel | undefined {
+	const normalized = value?.trim().toLowerCase();
+
+	if (normalized === "any" || normalized === "challenge") {
+		return normalized;
+	}
+	if (normalized === "true") {
+		return "challenge";
+	}
+	return undefined;
+}
+
+/**
+ * `STRIPE_FORCE_3DS`, which overrides the admin setting so a deployment can
+ * force authentication on without dashboard access. Sync, so the admin API can
+ * report whether the toggle is currently overridden.
+ */
+export function getThreeDSecureEnvOverride():
+	ForcedThreeDSecureLevel | undefined {
+	return parseThreeDSecureRequest(process.env.STRIPE_FORCE_3DS);
+}
+
+/**
+ * How aggressively 3D Secure is requested when a card is first set up: the env
+ * override if set, otherwise the admin dashboard setting. Undefined means
+ * Stripe's SCA engine decides on its own, which is the default and the
+ * recommended setting.
+ *
+ * The issuer always has the final word: `any` asks it to authenticate whenever
+ * it can, `challenge` additionally asks for an interactive challenge rather
+ * than a frictionless approval, but neither guarantees one — an issuer may
+ * still approve silently or acknowledge the attempt without authenticating.
+ *
+ * Apply this ONLY where a customer is present *and* the card is being stored
+ * for later use: SetupIntents, `mode: "setup"` Checkout, and the first payment
+ * of a subscription. That one authentication is what lets Stripe claim an SCA
+ * exemption on the merchant-initiated charges that follow, so authenticating
+ * once here makes later off-session charges more likely to succeed, not less.
+ *
+ * Never apply it to a charge itself:
+ *   - Off-session charges (auto top-up, DevPass PAYG top-ups, Reset Passes)
+ *     have nobody present to answer a challenge, so requesting one would turn
+ *     them into `authentication_required` declines.
+ *   - Repeat on-session charges (credit top-ups on a saved card) were already
+ *     authenticated when the card was saved, so a second challenge adds
+ *     friction without adding protection.
+ */
+export async function getForcedThreeDSecure(): Promise<
+	ForcedThreeDSecureLevel | undefined
+> {
+	const envOverride = getThreeDSecureEnvOverride();
+	if (envOverride) {
+		return envOverride;
+	}
+
+	const setting = await db.query.systemSetting.findFirst({
+		where: { id: FORCE_3DS_SETTING_ID },
+	});
+	if (!setting?.enabled) {
+		return undefined;
+	}
+	return parseThreeDSecureRequest(setting.value);
+}
+
+/** The stored admin setting alone, ignoring any env override. */
+export async function getForcedThreeDSecureMode(): Promise<ForcedThreeDSecureMode> {
+	const setting = await db.query.systemSetting.findFirst({
+		where: { id: FORCE_3DS_SETTING_ID },
+	});
+	if (!setting?.enabled) {
+		return "off";
+	}
+	return parseThreeDSecureRequest(setting.value) ?? "off";
+}
+
+export async function setForcedThreeDSecureMode(
+	mode: ForcedThreeDSecureMode,
+): Promise<ForcedThreeDSecureMode> {
+	const enabled = mode !== "off";
+
+	await db
+		.insert(tables.systemSetting)
+		.values({ id: FORCE_3DS_SETTING_ID, enabled, value: mode })
+		.onConflictDoUpdate({
+			target: tables.systemSetting.id,
+			set: { enabled, value: mode, updatedAt: new Date() },
+		});
+
+	return mode;
+}
+
+/**
+ * Spreadable `payment_method_options` for PaymentIntents, SetupIntents and
+ * Checkout Sessions. Empty when 3DS is not forced, so the parameter is omitted
+ * entirely rather than sent as `automatic`.
+ */
+export function threeDSecureOptions(request: ThreeDSecureRequest | undefined): {
+	payment_method_options?: {
+		card: { request_three_d_secure: ThreeDSecureRequest };
+	};
+} {
+	if (!request) {
+		return {};
+	}
+	return {
+		payment_method_options: { card: { request_three_d_secure: request } },
+	};
+}
+
+/** Same, in the nested shape `subscriptions.create` expects. */
+export function threeDSecureSubscriptionSettings(
+	request: ThreeDSecureRequest | undefined,
+): {
+	payment_settings?: {
+		payment_method_options: {
+			card: { request_three_d_secure: ThreeDSecureRequest };
+		};
+	};
+} {
+	if (!request) {
+		return {};
+	}
+	return {
+		payment_settings: {
+			payment_method_options: { card: { request_three_d_secure: request } },
+		},
+	};
+}
+
+/**
+ * Resolves the configured 3DS level and shapes it for a card-setup
+ * SetupIntent or Checkout Session. Await this before building the params
+ * object and spread the result into it.
+ */
+export async function forcedThreeDSecureOptions(): Promise<
+	ReturnType<typeof threeDSecureOptions>
+> {
+	return threeDSecureOptions(await getForcedThreeDSecure());
+}

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -27,6 +27,11 @@ import {
 	getTokenWindowStartDate,
 	tokenWindowSchema,
 } from "@/lib/stats-window.js";
+import {
+	getForcedThreeDSecureMode,
+	getThreeDSecureEnvOverride,
+	setForcedThreeDSecureMode,
+} from "@/lib/three-d-secure.js";
 import { adminMiddleware } from "@/middleware/admin.js";
 import { getStripe } from "@/routes/payments.js";
 import {
@@ -5172,6 +5177,85 @@ admin.openapi(updateBlockedSignupCountries, async (c) => {
 	}
 
 	return c.json({ countries: await setBlockedSignupCountries(countries) });
+});
+
+// --- Forced 3D Secure ---
+
+const forceThreeDSecureModeSchema = z.enum(["off", "any", "challenge"]);
+
+const forceThreeDSecureSchema = z
+	.object({
+		// The stored admin setting.
+		mode: forceThreeDSecureModeSchema,
+		// Set when STRIPE_FORCE_3DS overrides the admin setting, in which case
+		// `mode` is stored but not what customers actually get.
+		envOverride: forceThreeDSecureModeSchema.nullable(),
+		// What card flows actually request right now.
+		effectiveMode: forceThreeDSecureModeSchema,
+	})
+	.openapi({});
+
+async function forceThreeDSecureState() {
+	const mode = await getForcedThreeDSecureMode();
+	const envOverride = getThreeDSecureEnvOverride() ?? null;
+	return {
+		mode,
+		envOverride,
+		effectiveMode: envOverride ?? mode,
+	};
+}
+
+const getForceThreeDSecure = createRoute({
+	method: "get",
+	path: "/settings/force-3ds",
+	request: {},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: forceThreeDSecureSchema,
+				},
+			},
+			description:
+				"3D Secure level requested on customer-present card payments.",
+		},
+	},
+});
+
+const updateForceThreeDSecure = createRoute({
+	method: "put",
+	path: "/settings/force-3ds",
+	request: {
+		body: {
+			content: {
+				"application/json": {
+					schema: z.object({ mode: forceThreeDSecureModeSchema }).openapi({}),
+				},
+			},
+		},
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: forceThreeDSecureSchema,
+				},
+			},
+			description: "Updated 3D Secure setting.",
+		},
+	},
+});
+
+admin.openapi(getForceThreeDSecure, async (c) => {
+	return c.json(await forceThreeDSecureState());
+});
+
+admin.openapi(updateForceThreeDSecure, async (c) => {
+	const { mode } = c.req.valid("json");
+
+	await setForcedThreeDSecureMode(mode);
+
+	return c.json(await forceThreeDSecureState());
 });
 
 // --- Organization Rate Limit Handlers ---

--- a/apps/api/src/routes/chat-plans.ts
+++ b/apps/api/src/routes/chat-plans.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 import { voidPendingCycleRenewalInvoices } from "@/lib/pending-renewal.js";
 import { getStripeCardErrorMessage } from "@/lib/stripe-card-error.js";
+import { forcedThreeDSecureOptions } from "@/lib/three-d-secure.js";
 import { ensureStripeCustomer } from "@/stripe.js";
 import { getOrCreateChatOrg } from "@/utils/personal-org.js";
 
@@ -108,6 +109,7 @@ chatPlans.openapi(subscribe, async (c) => {
 				},
 			],
 			allow_promotion_codes: true,
+			...(await forcedThreeDSecureOptions()),
 			success_url: `${process.env.PLAYGROUND_URL ?? "http://localhost:3003"}/?chat_plan_success=true`,
 			cancel_url: `${process.env.PLAYGROUND_URL ?? "http://localhost:3003"}/pricing?canceled=true`,
 			metadata: {

--- a/apps/api/src/routes/dev-plans-payg.spec.ts
+++ b/apps/api/src/routes/dev-plans-payg.spec.ts
@@ -249,6 +249,7 @@ describe("dev-plan PAYG top-up", () => {
 	});
 
 	afterEach(async () => {
+		vi.unstubAllEnvs();
 		await db.delete(tables.transaction);
 		await deleteAll();
 	});
@@ -309,6 +310,22 @@ describe("dev-plan PAYG top-up", () => {
 		// in handlePaymentIntentSucceeded — the org is credited by the webhook.
 		expect(params.metadata.baseAmount).toBe("25");
 		expect(params.metadata.organizationId).toBe(ORG_ID);
+	});
+
+	it("never requests 3DS off-session, even when forced globally", async () => {
+		vi.stubEnv("STRIPE_FORCE_3DS", "challenge");
+		await insertOrg();
+
+		const res = await topUpRequest(
+			{ amount: 25, purchaseId: "attempt-fixed-1" },
+			token,
+		);
+		expect(res.status).toBe(200);
+
+		// Nobody is present to answer a challenge here, so requesting one would
+		// only turn the charge into an `authentication_required` decline.
+		const params = stripeMock.paymentIntents.create.mock.calls[0][0];
+		expect(params.payment_method_options).toBeUndefined();
 	});
 
 	it("falls back to the customer's default payment method", async () => {

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -11,6 +11,7 @@ import {
 	refundFeedbackBodySchema,
 } from "@/lib/self-refund.js";
 import { getStripeCardErrorMessage } from "@/lib/stripe-card-error.js";
+import { forcedThreeDSecureOptions } from "@/lib/three-d-secure.js";
 import { posthog } from "@/posthog.js";
 import {
 	ensureStripeCustomer,
@@ -460,6 +461,7 @@ devPlans.openapi(subscribe, async (c) => {
 			customer: stripeCustomerId,
 			mode: "setup",
 			payment_method_types: ["card"],
+			...(await forcedThreeDSecureOptions()),
 			success_url: `${process.env.CODE_URL ?? "http://localhost:3004"}/dashboard?setup_session_id={CHECKOUT_SESSION_ID}`,
 			cancel_url: `${process.env.CODE_URL ?? "http://localhost:3004"}/dashboard?canceled=true`,
 			metadata: {
@@ -2922,6 +2924,7 @@ devPlans.openapi(createSetupIntent, async (c) => {
 		customer: stripeCustomerId,
 		payment_method_types: ["card"],
 		usage: "off_session",
+		...(await forcedThreeDSecureOptions()),
 		metadata: {
 			organizationId: personalOrg.id,
 			subscriptionType: "dev_plan_update",

--- a/apps/api/src/routes/payments-3ds.spec.ts
+++ b/apps/api/src/routes/payments-3ds.spec.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { app } from "@/index.js";
+import { setForcedThreeDSecureMode } from "@/lib/three-d-secure.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db, tables } from "@llmgateway/db";
+
+import type Stripe from "stripe";
+
+const stripeMock = vi.hoisted(() => ({
+	customers: {
+		update: vi.fn(),
+	},
+	paymentIntents: {
+		create: vi.fn(),
+	},
+	setupIntents: {
+		create: vi.fn(),
+	},
+	paymentMethods: {
+		retrieve: vi.fn(),
+	},
+	checkout: {
+		sessions: {
+			create: vi.fn(),
+		},
+	},
+}));
+
+interface StripeModule {
+	default: typeof Stripe;
+}
+
+vi.mock("stripe", async (importOriginal) => {
+	const actual = await importOriginal<StripeModule>();
+	return {
+		default: Object.assign(
+			function MockStripe() {
+				return stripeMock;
+			},
+			{ errors: actual.default.errors },
+		),
+	};
+});
+
+process.env.STRIPE_SECRET_KEY ??= "sk_test_mock";
+
+const ORGANIZATION_ID = "test-3ds-org";
+const STRIPE_CUSTOMER_ID = "cus_3ds";
+const PAYMENT_METHOD_ID = "pm_3ds";
+
+function post(path: string, token: string, body: unknown) {
+	return app.request(path, {
+		method: "POST",
+		headers: {
+			Cookie: token,
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify(body),
+	});
+}
+
+describe("forced 3D Secure on customer-present card flows", () => {
+	let token: string;
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		vi.stubEnv("STRIPE_FORCE_3DS", undefined);
+		await db.delete(tables.systemSetting);
+		token = await createTestUser();
+		await db.insert(tables.organization).values({
+			id: ORGANIZATION_ID,
+			name: "3DS Test Organization",
+			billingEmail: "admin@example.com",
+			stripeCustomerId: STRIPE_CUSTOMER_ID,
+		});
+		await db.insert(tables.userOrganization).values({
+			userId: "test-user-id",
+			organizationId: ORGANIZATION_ID,
+			role: "owner",
+		});
+		stripeMock.paymentMethods.retrieve.mockResolvedValue({
+			id: PAYMENT_METHOD_ID,
+			customer: STRIPE_CUSTOMER_ID,
+			card: { country: "US" },
+		});
+		stripeMock.paymentIntents.create.mockResolvedValue({
+			id: "pi_test",
+			client_secret: "pi_test_secret_1",
+			status: "requires_action",
+		});
+		stripeMock.setupIntents.create.mockResolvedValue({
+			id: "seti_test",
+			client_secret: "seti_test_secret_1",
+		});
+		stripeMock.checkout.sessions.create.mockResolvedValue({
+			id: "cs_test",
+			url: "https://checkout.stripe.com/c/pay/cs_test",
+		});
+	});
+
+	afterEach(async () => {
+		vi.unstubAllEnvs();
+		vi.restoreAllMocks();
+		await deleteAll();
+	});
+
+	it("omits the option entirely when 3DS is not forced", async () => {
+		const setup = await post("/payments/create-setup-intent", token, {
+			organizationId: ORGANIZATION_ID,
+		});
+		expect(setup.status).toBe(200);
+		expect(
+			stripeMock.setupIntents.create.mock.calls[0][0].payment_method_options,
+		).toBeUndefined();
+	});
+
+	it("requests 3DS when saving a card", async () => {
+		vi.stubEnv("STRIPE_FORCE_3DS", "any");
+
+		const res = await post("/payments/create-setup-intent", token, {
+			organizationId: ORGANIZATION_ID,
+		});
+
+		expect(res.status).toBe(200);
+		expect(
+			stripeMock.setupIntents.create.mock.calls[0][0].payment_method_options,
+		).toEqual({ card: { request_three_d_secure: "any" } });
+	});
+
+	it("requests the level an admin selected in the dashboard", async () => {
+		await setForcedThreeDSecureMode("any");
+
+		const res = await post("/payments/create-setup-intent", token, {
+			organizationId: ORGANIZATION_ID,
+		});
+
+		expect(res.status).toBe(200);
+		expect(
+			stripeMock.setupIntents.create.mock.calls[0][0].payment_method_options,
+		).toEqual({ card: { request_three_d_secure: "any" } });
+	});
+
+	it("lets the env variable override the admin setting", async () => {
+		await setForcedThreeDSecureMode("any");
+		vi.stubEnv("STRIPE_FORCE_3DS", "challenge");
+
+		const res = await post("/payments/create-setup-intent", token, {
+			organizationId: ORGANIZATION_ID,
+		});
+
+		expect(res.status).toBe(200);
+		expect(
+			stripeMock.setupIntents.create.mock.calls[0][0].payment_method_options,
+		).toEqual({ card: { request_three_d_secure: "challenge" } });
+	});
+
+	// The charge legs below are what auto top-up reuses. None of them may carry
+	// a 3DS request, however loudly the platform setting asks for one: the card
+	// was already authenticated when it was saved, and a scheduled charge has
+	// nobody present to answer a second challenge.
+	it("never requests 3DS on a charge, even when forced", async () => {
+		await setForcedThreeDSecureMode("challenge");
+		vi.stubEnv("STRIPE_FORCE_3DS", "challenge");
+
+		const intent = await post("/payments/create-payment-intent", token, {
+			amount: 10,
+			organizationId: ORGANIZATION_ID,
+			stripePaymentMethodId: PAYMENT_METHOD_ID,
+		});
+		expect(intent.status).toBe(200);
+		expect(
+			stripeMock.paymentIntents.create.mock.calls[0][0].payment_method_options,
+		).toBeUndefined();
+
+		const checkout = await post("/payments/create-checkout-session", token, {
+			amount: 10,
+			organizationId: ORGANIZATION_ID,
+		});
+		expect(checkout.status).toBe(200);
+		expect(
+			stripeMock.checkout.sessions.create.mock.calls[0][0]
+				.payment_method_options,
+		).toBeUndefined();
+	});
+});

--- a/apps/api/src/routes/payments.e2e.ts
+++ b/apps/api/src/routes/payments.e2e.ts
@@ -1,6 +1,14 @@
 import "dotenv/config";
 import Stripe from "stripe";
-import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 
 import { app } from "@/index.js";
 import { deleteAll } from "@/testing.js";
@@ -37,6 +45,10 @@ describe.skipIf(!stripeTestingEnabled)(
 
 		beforeAll(async () => {
 			await deleteAll();
+		});
+
+		afterEach(() => {
+			vi.unstubAllEnvs();
 		});
 
 		afterAll(async () => {
@@ -190,6 +202,109 @@ describe.skipIf(!stripeTestingEnabled)(
 				},
 			);
 			expect(confirmedIntent.status).toBe("succeeded");
+		});
+
+		// The point of forcing 3DS only at card-setup time: the add-card step
+		// authenticates, and the off-session charge that later reuses that card
+		// — the shape auto top-up runs on — still goes through untouched.
+		// `pm_card_visa` supports 3DS without requiring it, so Stripe's SCA
+		// engine lets it through frictionlessly unless we ask otherwise.
+		test("forced 3DS authenticates the card setup but never the charge", async () => {
+			const { token, orgId } = await setupTestData();
+			const stripe = new Stripe(stripeKey!, { apiVersion: "2025-04-30.basil" });
+
+			// Save a card with 3DS off so there is a usable saved card to charge.
+			const setupRes = await app.request("/payments/create-setup-intent", {
+				method: "POST",
+				headers: { "Content-Type": "application/json", Cookie: token },
+				body: JSON.stringify({ organizationId: orgId }),
+			});
+			expect(setupRes.status).toBe(200);
+			const { clientSecret: setupSecret } = (await setupRes.json()) as {
+				clientSecret: string;
+			};
+
+			const organization = await db.query.organization.findFirst({
+				where: { id: orgId },
+			});
+			stripeCustomerIds.push(organization!.stripeCustomerId!);
+
+			const confirmedSetup = await stripe.setupIntents.confirm(
+				setupSecret.split("_secret")[0],
+				{
+					payment_method: "pm_card_visa",
+					return_url: "https://llmgateway.io/",
+				},
+			);
+			expect(confirmedSetup.status).toBe("succeeded");
+			const stripePaymentMethodId =
+				typeof confirmedSetup.payment_method === "string"
+					? confirmedSetup.payment_method
+					: confirmedSetup.payment_method!.id;
+
+			const [savedCard] = await db
+				.insert(tables.paymentMethod)
+				.values({
+					stripePaymentMethodId,
+					organizationId: orgId,
+					type: "card",
+					isDefault: true,
+				})
+				.returning({ id: tables.paymentMethod.id });
+
+			// Everything below runs with 3DS forced as hard as it goes.
+			vi.stubEnv("STRIPE_FORCE_3DS", "challenge");
+
+			// Adding a card authenticates: this is the one interactive moment,
+			// and Stripe.js renders the challenge for it.
+			const forcedSetupRes = await app.request(
+				"/payments/create-setup-intent",
+				{
+					method: "POST",
+					headers: { "Content-Type": "application/json", Cookie: token },
+					body: JSON.stringify({ organizationId: orgId }),
+				},
+			);
+			expect(forcedSetupRes.status).toBe(200);
+			const { clientSecret: forcedSetupSecret } =
+				(await forcedSetupRes.json()) as { clientSecret: string };
+			const forcedSetup = await stripe.setupIntents.confirm(
+				forcedSetupSecret.split("_secret")[0],
+				{
+					payment_method: "pm_card_visa",
+					return_url: "https://llmgateway.io/",
+				},
+			);
+			expect(forcedSetup.status).toBe("requires_action");
+			expect(forcedSetup.next_action?.type).toBe("redirect_to_url");
+
+			// The off-session charge on the saved card does not. This endpoint
+			// creates the same `off_session: true, confirm: true` PaymentIntent
+			// the auto top-up worker does, so a challenge here would surface as
+			// a 402 `authentication_required` instead of a completed top-up.
+			const chargeRes = await app.request(
+				"/payments/top-up-with-saved-method",
+				{
+					method: "POST",
+					headers: { "Content-Type": "application/json", Cookie: token },
+					body: JSON.stringify({
+						amount: CREDIT_TOP_UP_MIN_AMOUNT,
+						paymentMethodId: savedCard.id,
+						organizationId: orgId,
+					}),
+				},
+			);
+			expect(chargeRes.status).toBe(200);
+			expect(await chargeRes.json()).toMatchObject({ success: true });
+
+			const charges = await stripe.paymentIntents.list({
+				customer: organization!.stripeCustomerId!,
+				limit: 1,
+			});
+			expect(charges.data[0].status).toBe("succeeded");
+			expect(
+				charges.data[0].payment_method_options?.card?.request_three_d_secure,
+			).not.toBe("challenge");
 		});
 	},
 );

--- a/apps/api/src/routes/payments.ts
+++ b/apps/api/src/routes/payments.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 import { assertCreditPurchaseAllowed } from "@/lib/credit-purchase-guard.js";
 import { computeReferralBonus } from "@/lib/referral-bonus.js";
+import { forcedThreeDSecureOptions } from "@/lib/three-d-secure.js";
 import { ensureStripeCustomer } from "@/stripe.js";
 
 import { logAuditEvent } from "@llmgateway/audit";
@@ -202,6 +203,9 @@ payments.openapi(createPaymentIntent, async (c) => {
 			...(stripePaymentMethodId
 				? { payment_method: stripePaymentMethodId }
 				: {}),
+			// Deliberately no forced 3DS: the card was already authenticated by
+			// the SetupIntent that saved it, so challenging again would be a
+			// second prompt in the same checkout for no added protection.
 			metadata: {
 				organizationId,
 				baseAmount: amount.toString(),
@@ -317,9 +321,13 @@ payments.openapi(createSetupIntent, async (c) => {
 	// out of confirmCardSetup "used but unattached", and create-payment-intent
 	// races the setup_intent.succeeded webhook's attach — losing the race
 	// makes Stripe reject the PaymentIntent outright.
+	// Authenticating the card here also helps the later off-session charges it
+	// is saved for: an initially authenticated credential is what lets Stripe
+	// claim an SCA exemption on merchant-initiated top-ups.
 	const setupIntent = await getStripe().setupIntents.create({
 		customer: stripeCustomerId,
 		usage: "off_session",
+		...(await forcedThreeDSecureOptions()),
 		metadata: {
 			organizationId,
 		},

--- a/apps/api/src/routes/subscriptions.ts
+++ b/apps/api/src/routes/subscriptions.ts
@@ -2,6 +2,7 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
+import { forcedThreeDSecureOptions } from "@/lib/three-d-secure.js";
 import { ensureStripeCustomer } from "@/stripe.js";
 
 import { logAuditEvent } from "@llmgateway/audit";
@@ -127,6 +128,7 @@ subscriptions.openapi(createProSubscription, async (c) => {
 				},
 			],
 			allow_promotion_codes: true,
+			...(await forcedThreeDSecureOptions()),
 			success_url: `${process.env.UI_URL ?? "http://localhost:3002"}/dashboard/${organization.id}/org/billing?success=true`,
 			cancel_url: `${process.env.UI_URL ?? "http://localhost:3002"}/dashboard/${organization.id}/org/billing?canceled=true`,
 			metadata: {

--- a/apps/api/src/stripe.ts
+++ b/apps/api/src/stripe.ts
@@ -26,6 +26,11 @@ import {
 } from "@llmgateway/shared";
 
 import { computeReferralBonus } from "./lib/referral-bonus.js";
+import {
+	getForcedThreeDSecure,
+	threeDSecureSubscriptionSettings,
+	type ThreeDSecureRequest,
+} from "./lib/three-d-secure.js";
 import { posthog } from "./posthog.js";
 import { getStripe, type StripeMode } from "./routes/payments.js";
 import {
@@ -794,8 +799,16 @@ async function detachDuplicateCardPaymentMethods(
 	}
 }
 
-function shouldForceDevPlan3dsChallenge(): boolean {
-	return process.env.STRIPE_DEV_PLAN_FORCE_3DS === "true";
+/**
+ * `STRIPE_DEV_PLAN_FORCE_3DS=true` forces a challenge on DevPass subscriptions
+ * only; otherwise the account-wide setting (admin dashboard or
+ * `STRIPE_FORCE_3DS`) applies.
+ */
+async function devPlanThreeDSecure(): Promise<ThreeDSecureRequest | undefined> {
+	if (process.env.STRIPE_DEV_PLAN_FORCE_3DS === "true") {
+		return "challenge";
+	}
+	return await getForcedThreeDSecure();
 }
 
 async function resolvePaymentMethodFromSetupSession(
@@ -992,17 +1005,7 @@ export async function finalizeDevPlanSetupSession(
 				items: [{ price: priceId }],
 				default_payment_method: paymentMethod.id,
 				payment_behavior: "default_incomplete",
-				...(shouldForceDevPlan3dsChallenge()
-					? {
-							payment_settings: {
-								payment_method_options: {
-									card: {
-										request_three_d_secure: "challenge" as const,
-									},
-								},
-							},
-						}
-					: {}),
+				...threeDSecureSubscriptionSettings(await devPlanThreeDSecure()),
 				metadata: {
 					organizationId,
 					subscriptionType: "dev_plan",

--- a/apps/worker/src/worker.spec.ts
+++ b/apps/worker/src/worker.spec.ts
@@ -403,6 +403,58 @@ describe("worker", () => {
 			);
 		});
 
+		test("never requests 3DS, whatever the platform setting says", async () => {
+			vi.clearAllMocks();
+			// Both levers on at once: the admin dashboard row and the env
+			// override. Neither may reach an auto top-up.
+			vi.stubEnv("STRIPE_FORCE_3DS", "challenge");
+			await db.insert(tables.systemSetting).values({
+				id: "force_3ds",
+				enabled: true,
+				value: "challenge",
+			});
+
+			await db.insert(tables.organization).values({
+				id: "org-devpass-payg-3ds",
+				name: "DevPass PAYG 3DS",
+				billingEmail: "billing@example.com",
+				kind: "devpass",
+				devPlan: "pro",
+				devPlanPaygEnabled: true,
+				devPlanStripeSubscriptionId: "sub_devpass_3ds",
+				credits: "2",
+				autoTopUpEnabled: true,
+				autoTopUpThreshold: "10",
+				autoTopUpAmount: "25",
+				stripeCustomerId: "cus_devpass_3ds",
+			});
+
+			stripeMock.subscriptions.retrieve.mockResolvedValue({
+				default_payment_method: "pm_devpass_3ds",
+			});
+			stripeMock.paymentMethods.retrieve.mockResolvedValue({
+				customer: "cus_devpass_3ds",
+				card: { country: "US" },
+			});
+			stripeMock.paymentIntents.create.mockResolvedValue({
+				id: "pi_devpass_3ds",
+				status: "succeeded",
+			});
+
+			await processAutoTopUp();
+
+			// Nobody is present to answer a challenge on a scheduled charge, so
+			// requesting one would turn every auto top-up into an
+			// `authentication_required` decline.
+			expect(stripeMock.paymentIntents.create).toHaveBeenCalledTimes(1);
+			const params = stripeMock.paymentIntents.create.mock.calls[0][0];
+			expect(params.off_session).toBe(true);
+			expect(params.payment_method_options).toBeUndefined();
+
+			await db.delete(tables.systemSetting);
+			vi.unstubAllEnvs();
+		});
+
 		test("stops before charging when PAYG is disabled mid-pass", async () => {
 			// The charging test above already invoked the payment mocks.
 			vi.clearAllMocks();

--- a/ee/admin/src/app/settings/page.tsx
+++ b/ee/admin/src/app/settings/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 
 import { BlockedSignupCountriesForm } from "@/components/blocked-signup-countries-form";
 import { CreditPurchaseBlockToggle } from "@/components/credit-purchase-block-toggle";
+import { ForceThreeDSecureForm } from "@/components/force-three-d-secure-form";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -14,9 +15,13 @@ import {
 import {
 	getBlockedSignupCountries,
 	getCreditPurchaseBlock,
+	getForceThreeDSecure,
 	updateBlockedSignupCountries,
 	updateCreditPurchaseBlock,
+	updateForceThreeDSecure,
 } from "@/lib/admin-settings";
+
+import type { ForceThreeDSecureMode } from "@/lib/admin-settings";
 
 function SignInPrompt() {
 	return (
@@ -39,12 +44,18 @@ function SignInPrompt() {
 }
 
 export default async function SettingsPage() {
-	const [creditPurchaseBlock, blockedSignupCountries] = await Promise.all([
-		getCreditPurchaseBlock(),
-		getBlockedSignupCountries(),
-	]);
+	const [creditPurchaseBlock, blockedSignupCountries, forceThreeDSecure] =
+		await Promise.all([
+			getCreditPurchaseBlock(),
+			getBlockedSignupCountries(),
+			getForceThreeDSecure(),
+		]);
 
-	if (creditPurchaseBlock === null || blockedSignupCountries === null) {
+	if (
+		creditPurchaseBlock === null ||
+		blockedSignupCountries === null ||
+		forceThreeDSecure === null
+	) {
 		return <SignInPrompt />;
 	}
 
@@ -59,6 +70,13 @@ export default async function SettingsPage() {
 		"use server";
 
 		return await updateBlockedSignupCountries(countries);
+	}
+
+	async function handleSaveThreeDSecure(mode: ForceThreeDSecureMode) {
+		"use server";
+
+		const result = await updateForceThreeDSecure(mode);
+		return { ok: result.state !== null, message: result.message };
 	}
 
 	return (
@@ -108,6 +126,27 @@ export default async function SettingsPage() {
 					<BlockedSignupCountriesForm
 						countries={blockedSignupCountries.countries}
 						onSave={handleSaveCountries}
+					/>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>3D Secure when a card is added</CardTitle>
+					<CardDescription>
+						Requests issuer authentication when a customer saves a card or
+						starts a subscription — never on a charge. Later top-ups and
+						scheduled auto top-ups run on the card authenticated here, so they
+						are never challenged and cannot break. The issuer still decides, so
+						neither level guarantees a challenge, and forcing one costs some
+						conversion on the add-card step.
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<ForceThreeDSecureForm
+						mode={forceThreeDSecure.mode}
+						envOverride={forceThreeDSecure.envOverride}
+						onSave={handleSaveThreeDSecure}
 					/>
 				</CardContent>
 			</Card>

--- a/ee/admin/src/components/force-three-d-secure-form.tsx
+++ b/ee/admin/src/components/force-three-d-secure-form.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+
+import type { ForceThreeDSecureMode } from "@/lib/admin-settings";
+
+const modeLabels: Record<ForceThreeDSecureMode, string> = {
+	off: "Off — let Stripe decide (recommended)",
+	any: "Any — request authentication whenever the issuer supports it",
+	challenge: "Challenge — also ask for an interactive challenge",
+};
+
+interface ForceThreeDSecureFormProps {
+	mode: ForceThreeDSecureMode;
+	envOverride: ForceThreeDSecureMode | null;
+	onSave: (
+		mode: ForceThreeDSecureMode,
+	) => Promise<{ ok: boolean; message: string | null }>;
+}
+
+export function ForceThreeDSecureForm({
+	mode,
+	envOverride,
+	onSave,
+}: ForceThreeDSecureFormProps) {
+	const router = useRouter();
+	const [pending, startTransition] = useTransition();
+	const [error, setError] = useState<string | null>(null);
+	const [saved, setSaved] = useState(false);
+
+	const handleChange = (next: string) => {
+		setError(null);
+		setSaved(false);
+		startTransition(async () => {
+			const result = await onSave(next as ForceThreeDSecureMode);
+			if (!result.ok) {
+				setError(result.message);
+				return;
+			}
+			setSaved(true);
+			router.refresh();
+		});
+	};
+
+	return (
+		<div className="flex flex-col gap-2">
+			<Label htmlFor="force-3ds">Requested level</Label>
+			<Select value={mode} disabled={pending} onValueChange={handleChange}>
+				<SelectTrigger id="force-3ds" className="w-full">
+					<SelectValue />
+				</SelectTrigger>
+				<SelectContent>
+					{Object.entries(modeLabels).map(([value, label]) => (
+						<SelectItem key={value} value={value}>
+							{label}
+						</SelectItem>
+					))}
+				</SelectContent>
+			</Select>
+			{envOverride && (
+				<p className="text-sm text-muted-foreground">
+					Overridden by the <code>STRIPE_FORCE_3DS</code> environment variable,
+					which is set to <code>{envOverride}</code>. Card flows use that level
+					regardless of the value selected here until the variable is removed.
+				</p>
+			)}
+			{error && <p className="text-sm text-destructive">{error}</p>}
+			{saved && !error && (
+				<p className="text-sm text-muted-foreground">Saved.</p>
+			)}
+		</div>
+	);
+}

--- a/ee/admin/src/lib/admin-settings.ts
+++ b/ee/admin/src/lib/admin-settings.ts
@@ -38,3 +38,27 @@ export async function updateBlockedSignupCountries(countries: string[]) {
 	}
 	return { countries: data.countries, message: null };
 }
+
+export type ForceThreeDSecureMode = "off" | "any" | "challenge";
+
+export async function getForceThreeDSecure() {
+	const $api = await createServerApiClient();
+	const { data } = await $api.GET("/admin/settings/force-3ds");
+	return data ?? null;
+}
+
+export async function updateForceThreeDSecure(mode: ForceThreeDSecureMode) {
+	const $api = await createServerApiClient();
+	const { data, error } = await $api.PUT("/admin/settings/force-3ds", {
+		body: { mode },
+	});
+	if (!data) {
+		return {
+			state: null,
+			message:
+				(error as { message?: string } | undefined)?.message ??
+				"Failed to update the 3D Secure setting.",
+		};
+	}
+	return { state: data, message: null };
+}


### PR DESCRIPTION
## Problem

3D Secure was not configurable. Stripe's SCA engine decided on every card
payment, and there was no way to request issuer authentication during a
card-testing wave without a deploy. The one existing lever,
`STRIPE_DEV_PLAN_FORCE_3DS`, only covered DevPass subscriptions.

The hard constraint is that a 3DS challenge is **un-answerable on an
off-session charge**. Auto top-up, DevPass PAYG top-ups and Reset Passes
run with nobody present, so a requested challenge there does not prompt
anyone — it comes back as an `authentication_required` decline and the
charge simply fails.

## Approach

A platform-wide setting in the admin dashboard (Settings → 3D Secure),
stored as a `force_3ds` `system_setting` row alongside the credit-purchase
kill switch and the signup country blocklist. No migration: that table
already carries `enabled` plus a `value` payload.

`STRIPE_FORCE_3DS` remains as an env override that wins over the stored
setting, so a deployment can force authentication on without dashboard
access. When it is set, the dashboard says so and shows which level is
actually in force, rather than displaying a value that isn't being used.
`STRIPE_DEV_PLAN_FORCE_3DS` still overrides both, for DevPass only.

**Enforcement is limited to card-setup events**, which is the part worth
reviewing carefully:

| Requested | Not requested |
| --- | --- |
| Save-a-card SetupIntents (dashboard, DevPass) | Credit top-up PaymentIntents |
| DevPass `mode: "setup"` Checkout | Hosted top-up Checkout |
| First payment of a Pro/Lounge/DevPass subscription | End-user wallet top-ups |
| | Provider-listing checkout |
| | Auto top-up, DevPass PAYG, Reset Passes |

Authenticating once when the card is stored is what lets Stripe claim an
SCA exemption on the merchant-initiated charges that follow, so this
placement should make later off-session charges *more* likely to succeed,
not less. Challenging the charges themselves would be redundant anyway —
in the save-card top-up flow the SetupIntent has already authenticated the
card moments earlier, so a second challenge in the same checkout adds
friction without adding protection.

Because the resolved level now comes from the database, the helper is
async and each call site awaits it before building its Stripe params.

## Deliberate omissions

- Users who top up **without** saving the card get no forced 3DS, since
  that path has no setup step. This follows from scoping to card setup.
- No caching around the settings read. These are checkout-frequency
  endpoints and the credit-purchase guard already queries on the same
  path; adding a cache would need a measured reason.
- Forcing a challenge is not a guarantee. The issuer decides, and
  `attempt_acknowledged` (rather than full authentication) is a normal
  outcome — observed in sandbox on a card that supports 3DS.

## Verification

Against real Stripe test mode, with `challenge` forced:

```
SetupIntent (add card)             → requires_action  ✔ authenticates
top-up-with-saved-method (charge)  → 200, succeeded   ✔ no challenge
```

That charge endpoint builds the same `off_session: true, confirm: true`
PaymentIntent the auto top-up worker does, so it stands in for the
scheduled path; the worker's own cron was not driven against live Stripe.

Also driven end-to-end through the dashboard on a local seeded stack:
selecting a level in the admin UI, with no env var set anywhere, produced
a live PaymentIntent carrying `request_three_d_secure: challenge` and a
completed 3DS (ECI 06, v2.1.0); switching back to Off produced a charge
with no 3DS.

Tests: a worker regression test turns on both levers at once and asserts
the auto top-up intent carries `off_session: true` and no
`payment_method_options`; route tests cover the DB-backed path, the env
override, and that no charge ever carries the option.

## Screenshots

The settings page gains one card at the bottom; the existing two cards are
unchanged.

<img width="1016" alt="Admin settings — 3D Secure card, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/d8cc59a8d238d128f7feb1ceb4bc7af1828993c4/admin-3ds-light.png" />

<img width="1016" alt="Admin settings — 3D Secure card, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/d8cc59a8d238d128f7feb1ceb4bc7af1828993c4/admin-3ds-dark.png" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added admin controls for enforcing Stripe 3D Secure authentication.
  - Supports Off, Any authentication, or Challenge-required modes.
  - Added optional `STRIPE_FORCE_3DS` configuration override with environment settings taking precedence.
  - Applied configurable authentication to card setup, subscription signup, and checkout flows.
  - Added visibility into the configured, environment, and effective 3D Secure modes.

- **Bug Fixes**
  - Preserved successful off-session payments and top-ups without unnecessary authentication challenges.

- **Tests**
  - Expanded coverage for configuration precedence, validation, payment flows, and authentication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->