### PR TITLE
fix(api): resolve beacon country from LB header

### DIFF
--- a/apps/api/src/routes/beacon.spec.ts
+++ b/apps/api/src/routes/beacon.spec.ts
@@ -135,6 +135,44 @@ describe("beacon endpoint", () => {
 		});
 	});
 
+	it("should extract the country from the GCP client region header", async () => {
+		const beaconData = {
+			uuid: "123e4567-e89b-12d3-a456-426614174000",
+			type: "self-host",
+			timestamp: "2024-01-01T00:00:00.000Z",
+			version: "v0.0.0-unknown",
+		};
+
+		const response = await app.request("/beacon", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"X-Forwarded-For": "198.51.100.25, 203.0.113.1",
+				"X-Client-Region": "DE",
+				"X-Client-City": "Stuttgart",
+			},
+			body: JSON.stringify(beaconData),
+		});
+
+		expect(response.status).toBe(200);
+
+		expect(posthog.capture).toHaveBeenCalledWith({
+			distinctId: beaconData.uuid,
+			event: "self_hosted_installation_beacon",
+			properties: {
+				installation: beaconData.type,
+				timestamp: beaconData.timestamp,
+				source: "self_hosted_api",
+				version: beaconData.version,
+				client_ip: "198.51.100.25",
+				country: "DE",
+				region: undefined,
+				providers: [],
+				providers_count: 0,
+			},
+		});
+	});
+
 	it("should handle X-Real-IP fallback", async () => {
 		const beaconData = {
 			uuid: "123e4567-e89b-12d3-a456-426614174000",

--- a/apps/api/src/routes/beacon.ts
+++ b/apps/api/src/routes/beacon.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { getClientIpFromContext } from "@/lib/client-ip.js";
 import { posthog } from "@/posthog.js";
+import { getCountryFromHeaders } from "@/utils/request-country.js";
 
 import { logger } from "@llmgateway/logger";
 
@@ -48,24 +49,24 @@ const beaconRoute = createRoute({
 /**
  * Extracts region/country information from request headers
  */
-function extractRegionInfo(c: any): { country?: string; region?: string } {
+function extractRegionInfo(headers: Headers): {
+	country?: string;
+	region?: string;
+} {
 	const result: { country?: string; region?: string } = {};
 
-	// Cloudflare provides country code
-	const cfCountry = c.req.header("CF-IPCountry");
-	if (cfCountry && cfCountry !== "XX") {
-		// XX is unknown country in Cloudflare
-		result.country = cfCountry;
-	}
+	// Country comes from whichever geo header the edge proxy in front of the API
+	// attaches — GCP's X-Client-Region or Cloudflare's CF-IPCountry.
+	result.country = getCountryFromHeaders(headers);
 
 	// Cloudflare also provides region/state
-	const cfRegion = c.req.header("CF-Region");
+	const cfRegion = headers.get("CF-Region");
 	if (cfRegion) {
 		result.region = cfRegion;
 	}
 
 	// GCP Cloud Load Balancer headers (if available)
-	const gclbRegion = c.req.header("X-Google-Cloud-Region");
+	const gclbRegion = headers.get("X-Google-Cloud-Region");
 	if (gclbRegion && !result.region) {
 		result.region = gclbRegion;
 	}
@@ -78,13 +79,14 @@ beacon.openapi(beaconRoute, async (c) => {
 
 	// Extract IP and region information
 	const clientIP = getClientIpFromContext(c);
-	const regionInfo = extractRegionInfo(c);
+	const regionInfo = extractRegionInfo(c.req.raw.headers);
 
 	// Determine cloud provider based on headers
 	const cloudProvider = c.req.header("CF-Ray")
 		? "cloudflare"
 		: c.req.header("X-Google-Cloud-Region") ||
-			  c.req.header("X-Cloud-Trace-Context")
+			  c.req.header("X-Cloud-Trace-Context") ||
+			  c.req.header("X-Client-Region")
 			? "gcp"
 			: "unknown";
 


### PR DESCRIPTION
## Problem

While investigating why the signup country was always reported as `Unknown`, the beacon handler turned out to have the same defect the signup alert had before #3648: `extractRegionInfo` reads the country from `CF-IPCountry` only.

Production never sends that header — `internal.llmgateway.io` resolves straight to the GCP Application Load Balancer, with no Cloudflare in front — so the `country` property on every `self_hosted_installation_beacon` event was empty. Self-hosted installations post their beacon to `https://internal.llmgateway.io/beacon`, which is exactly the route that now carries the load balancer's geo headers.

## Approach

- Use the shared `getCountryFromHeaders` helper, so the beacon picks up `X-Client-Region` / `X-Client-Geo-Location` in addition to `CF-IPCountry`.
- Take a `Headers` object instead of the untyped `c: any` context.
- Count `X-Client-Region` as a GCP signal for `cloudProvider`.

Region/state is unchanged: the load balancer route does not set `{client_region_subdivision}`, so `CF-Region` / `X-Google-Cloud-Region` remain the only sources.

## Verification

Captured the traffic arriving at an API pod in production and confirmed the load balancer geo headers are present and correct on the route this endpoint is served from:

```
GET /... HTTP/1.1
host: internal.llmgateway.io
x-forwarded-for: <client>,<lb>
x-client-city: Stuttgart
x-client-region: DE
```

Unit specs: added a beacon case for the load balancer geo header; `beacon`, `request-country`, `country-blocking`, `client-ip` and `auth/config` suites pass (63 tests) against an isolated test database. `pnpm format` and `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved beacon location detection using client region headers.
  * Correctly records the client IP from forwarded request addresses.
  * Preserves provider-specific region detection while leaving unavailable region data undefined.

* **Tests**
  * Added coverage for client region and forwarded IP handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->