### PR TITLE
fix(models): correct deepinfra quantization metadata

### DIFF
--- a/packages/models/src/models/baai.ts
+++ b/packages/models/src/models/baai.ts
@@ -17,6 +17,7 @@ export const baaiModels = [
 				outputPrice: "0",
 				requestPrice: "0",
 				contextSize: 8192,
+				quantization: "fp32",
 				streaming: false,
 				tools: false,
 				jsonOutput: false,

--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -412,7 +412,7 @@ export const deepseekModels = [
 				requestPrice: "0",
 				contextSize: 1048576,
 				maxOutput: 64000,
-				quantization: "fp4",
+				quantization: "fp8",
 				streaming: true,
 				reasoning: true,
 				reasoningEfforts: ["none", "high", "max"],
@@ -667,7 +667,7 @@ export const deepseekModels = [
 				requestPrice: "0",
 				contextSize: 1000000,
 				maxOutput: 393216,
-				quantization: "fp4",
+				quantization: "fp8",
 				streaming: true,
 				reasoning: true,
 				// DeepInfra keeps thinking off unless an effort is requested, and


### PR DESCRIPTION
## What & why

The `quantization` field records the precision a provider actually serves ("Only set when the provider explicitly documents the serving precision"). Three deepinfra mappings disagreed with DeepInfra's own model pages:

- **DeepSeek-V4-Pro** — served at `fp8`, not `fp4` ([deepinfra.com/deepseek-ai/DeepSeek-V4-Pro](https://deepinfra.com/deepseek-ai/DeepSeek-V4-Pro))
- **DeepSeek-V4-Flash-0731** — served at `fp8`, not `fp4` ([deepinfra.com/deepseek-ai/DeepSeek-V4-Flash-0731](https://deepinfra.com/deepseek-ai/DeepSeek-V4-Flash-0731))

The previous `fp4` came from the Hugging Face repo-weights table ("FP4 + FP8 Mixed"), which is the downloadable checkpoint, not the precision the DeepInfra endpoint is served with — the page badge shows `fp8` for both.

- **BAAI/bge-m3** — the mapping lacked `quantization` entirely; DeepInfra documents fp32 serving on the model page ([deepinfra.com/BAAI/bge-m3](https://deepinfra.com/BAAI/bge-m3))

The remaining deepinfra mappings without `quantization` (Qwen3 embedding, reranker, and Ling-3.0-flash) stay absent: their DeepInfra pages and OpenRouter listings document no serving precision, so per the field's convention they are "unknown or undisclosed".

## Verification

- `pnpm build` green
- Values confirmed against DeepInfra model-page badges, not repo-weights tables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model provider configuration for more consistent quantization settings.
  * Updated BGE-M3 to use FP32 quantization.
  * Updated DeepSeek V4 Pro and V4 Flash to use FP8 quantization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->