### PR TITLE
fix(api): link Discord support escalations

### DIFF
--- a/apps/api/src/routes/public-chat-support.ts
+++ b/apps/api/src/routes/public-chat-support.ts
@@ -895,6 +895,7 @@ publicChatSupport.post("/escalate", async (c) => {
 			name,
 			email,
 			conversationId,
+			adminConversationUrl,
 			ipAddress,
 			lastMessage: lastUserMessage,
 		}),

--- a/apps/api/src/utils/discord.spec.ts
+++ b/apps/api/src/utils/discord.spec.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { notifyChatSupportEscalation } from "./discord.js";
+
+const webhookUrl = "https://discord.test/support-webhook";
+const adminConversationUrl =
+	"https://admin.example.test/chat-support-logs?chat=conversation-123";
+
+describe("chat support Discord notifications", () => {
+	const fetchMock = vi.fn(
+		async (_url: string | URL | Request, _init?: RequestInit) =>
+			new Response(null, { status: 204 }),
+	);
+
+	beforeEach(() => {
+		process.env.DISCORD_SUPPORT_NOTIFICATION_URL = webhookUrl;
+		vi.stubGlobal("fetch", fetchMock);
+	});
+
+	afterEach(() => {
+		delete process.env.DISCORD_SUPPORT_NOTIFICATION_URL;
+		vi.unstubAllGlobals();
+		fetchMock.mockClear();
+	});
+
+	it("links directly to the support ticket", async () => {
+		await notifyChatSupportEscalation({
+			conversationId: "conversation-123",
+			adminConversationUrl,
+		});
+
+		expect(fetchMock).toHaveBeenCalledOnce();
+		expect(fetchMock).toHaveBeenCalledWith(
+			webhookUrl,
+			expect.objectContaining({
+				body: expect.any(String),
+			}),
+		);
+
+		const request = fetchMock.mock.calls[0][1];
+		const payload = JSON.parse(String(request?.body)) as {
+			embeds: Array<{
+				url?: string;
+				fields?: Array<{ name: string; value: string }>;
+			}>;
+		};
+
+		expect(payload.embeds[0].url).toBe(adminConversationUrl);
+		expect(payload.embeds[0].fields).toContainEqual({
+			name: "Admin dashboard",
+			value: `[View support ticket](${adminConversationUrl})`,
+			inline: false,
+		});
+	});
+});

--- a/apps/api/src/utils/discord.ts
+++ b/apps/api/src/utils/discord.ts
@@ -4,6 +4,7 @@ const discordWebhookUrl = process.env.DISCORD_NOTIFICATION_URL;
 
 interface DiscordEmbed {
 	title: string;
+	url?: string;
 	description?: string;
 	color?: number;
 	fields?: Array<{
@@ -397,10 +398,18 @@ export async function notifyChatSupportEscalation(args: {
 	name?: string;
 	email?: string;
 	conversationId: string;
+	adminConversationUrl: string;
 	ipAddress?: string;
 	lastMessage?: string;
 }): Promise<void> {
-	const { name, email, conversationId, ipAddress, lastMessage } = args;
+	const {
+		name,
+		email,
+		conversationId,
+		adminConversationUrl,
+		ipAddress,
+		lastMessage,
+	} = args;
 	const truncatedMessage =
 		lastMessage && lastMessage.length > 1000
 			? `${lastMessage.slice(0, 1000)}…`
@@ -412,6 +421,7 @@ export async function notifyChatSupportEscalation(args: {
 			embeds: [
 				{
 					title: "Chat Support Escalation",
+					url: adminConversationUrl,
 					color: 0xf59e0b, // Amber
 					fields: [
 						{ name: "Name", value: name || "Not provided", inline: true },
@@ -419,6 +429,11 @@ export async function notifyChatSupportEscalation(args: {
 						{
 							name: "Conversation ID",
 							value: conversationId,
+							inline: false,
+						},
+						{
+							name: "Admin dashboard",
+							value: `[View support ticket](${adminConversationUrl})`,
 							inline: false,
 						},
 						...(ipAddress


### PR DESCRIPTION
## Summary

Chat support escalation notifications in Discord showed the conversation ID but did not link to the admin ticket.

- pass the existing admin conversation URL to the Discord notification
- make the embed title and an explicit field link to the ticket
- add a regression test for the webhook payload

## Verification

- `pnpm exec vitest run apps/api/src/utils/discord.spec.ts --no-file-parallelism`
- `pnpm format`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat support escalation notifications now include a direct link to the related admin conversation.
  * Discord notifications include an “Admin dashboard” link for faster access.

* **Bug Fixes**
  * Improved escalation notifications so support staff can open the relevant conversation directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->