### PR TITLE
fix(models): limit deactivation warnings

### DIFF
--- a/apps/ui/src/components/models/model-provider-card.tsx
+++ b/apps/ui/src/components/models/model-provider-card.tsx
@@ -40,7 +40,10 @@ import { XIcon } from "@/lib/icons/XIcon";
 import { getLoungeStudioPath } from "@/lib/model-utils";
 import { formatContextSize, formatDeprecationDate } from "@/lib/utils";
 
-import { getProviderIcon } from "@llmgateway/shared/components";
+import {
+	getProviderIcon,
+	shouldShowDeactivationNotice,
+} from "@llmgateway/shared/components";
 
 import type {
 	ProviderModelMapping,
@@ -72,6 +75,7 @@ export function ModelProviderCard({
 	const providerModelName = `${provider.providerId}/${modelName}`;
 	const ProviderIcon = getProviderIcon(provider.providerId);
 	const providerStability = provider.stability ?? modelStability;
+	const showDeactivationNotice = shouldShowDeactivationNotice(provider);
 
 	const shareUrl = `${config.appUrl}/models/${encodeURIComponent(modelName)}/${encodeURIComponent(provider.providerId)}`;
 	const shareTitle = `${provider.providerInfo?.name ?? provider.providerId} - ${modelName} on LLM Gateway`;
@@ -250,7 +254,7 @@ export function ModelProviderCard({
 					</div>
 				</div>
 
-				{(provider.deprecatedAt ?? provider.deactivatedAt) && (
+				{(provider.deprecatedAt || showDeactivationNotice) && (
 					<div className="flex flex-wrap gap-2 mb-4">
 						{provider.deprecatedAt && (
 							<Badge
@@ -261,13 +265,13 @@ export function ModelProviderCard({
 								{formatDeprecationDate(provider.deprecatedAt, "deprecated")}
 							</Badge>
 						)}
-						{provider.deactivatedAt && (
+						{showDeactivationNotice && (
 							<Badge
 								variant="outline"
 								className="text-xs px-2.5 py-1 gap-1.5 bg-red-50 dark:bg-red-500/5 text-red-700 dark:text-red-400 border-red-200 dark:border-red-500/20"
 							>
 								<AlertCircle className="h-3 w-3" />
-								{formatDeprecationDate(provider.deactivatedAt, "deactivated")}
+								{formatDeprecationDate(provider.deactivatedAt!, "deactivated")}
 							</Badge>
 						)}
 					</div>

--- a/apps/ui/src/components/models/model-status-badge-auto.tsx
+++ b/apps/ui/src/components/models/model-status-badge-auto.tsx
@@ -2,6 +2,8 @@
 
 import { ModelStatusBadge } from "@/components/models/model-status-badge";
 
+import { shouldShowDeactivationNotice } from "@llmgateway/shared/components";
+
 interface ProviderDateInfo {
 	deprecatedAt?: Date | string | null;
 	deactivatedAt?: Date | string | null;
@@ -19,9 +21,13 @@ export function ModelStatusBadgeAuto({ providers }: ModelStatusBadgeAutoProps) {
 	const now = new Date();
 
 	const allHaveDeactivatedAt = providers.every((p) => p.deactivatedAt);
-	const allHaveDeprecatedAt = providers.every((p) => p.deprecatedAt);
+	const showDeactivationStatus =
+		allHaveDeactivatedAt &&
+		providers.every((provider) => shouldShowDeactivationNotice(provider, now));
+	const allHaveDeprecatedAt =
+		!showDeactivationStatus && providers.every((p) => p.deprecatedAt);
 
-	if (allHaveDeactivatedAt) {
+	if (showDeactivationStatus) {
 		const allPast = providers.every((p) => new Date(p.deactivatedAt!) <= now);
 		return <ModelStatusBadge status="deactivated" isPast={allPast} />;
 	}

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -73,7 +73,10 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { isMappingDeactivated } from "@/deactivation";
+import {
+	isMappingDeactivated,
+	shouldShowDeactivationNotice,
+} from "@/deactivation";
 import { discountFraction } from "@/lib/discount";
 import { cn } from "@/lib/utils";
 
@@ -296,6 +299,7 @@ const ModelTableRow = React.memo(
 		const isCustom = row.model.source === "custom";
 		const blockedReasons = row.provider.blockedReasons ?? [];
 		const isBlocked = blockedReasons.length > 0;
+		const showDeactivationNotice = shouldShowDeactivationNotice(row.provider);
 
 		return (
 			<>
@@ -397,7 +401,7 @@ const ModelTableRow = React.memo(
 									</TooltipContent>
 								</Tooltip>
 							)}
-							{row.provider.deactivatedAt && (
+							{showDeactivationNotice && (
 								<Tooltip>
 									<TooltipTrigger asChild>
 										<span className="shrink-0 cursor-help">
@@ -407,14 +411,14 @@ const ModelTableRow = React.memo(
 									<TooltipContent>
 										<p className="text-xs">
 											{formatDeprecationDate(
-												row.provider.deactivatedAt,
+												row.provider.deactivatedAt!,
 												"deactivated",
 											)}
 										</p>
 									</TooltipContent>
 								</Tooltip>
 							)}
-							{!row.provider.deactivatedAt && row.provider.deprecatedAt && (
+							{!showDeactivationNotice && row.provider.deprecatedAt && (
 								<Tooltip>
 									<TooltipTrigger asChild>
 										<span className="shrink-0 cursor-help">

--- a/packages/shared/src/components/models-directory/model-card.tsx
+++ b/packages/shared/src/components/models-directory/model-card.tsx
@@ -32,6 +32,7 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { shouldShowDeactivationNotice } from "@/deactivation";
 import { cn } from "@/lib/utils";
 
 import { formatContextSize, formatDeprecationDate } from "./format";
@@ -175,8 +176,13 @@ export function ModelCard({
 	const allHaveDeactivatedAt =
 		model.providerDetails.length > 0 &&
 		model.providerDetails.every(({ provider }) => provider.deactivatedAt);
+	const showModelDeactivationStatus =
+		allHaveDeactivatedAt &&
+		model.providerDetails.every(({ provider }) =>
+			shouldShowDeactivationNotice(provider, now),
+		);
 	const allHaveDeprecatedAt =
-		!allHaveDeactivatedAt &&
+		!showModelDeactivationStatus &&
 		model.providerDetails.length > 0 &&
 		model.providerDetails.every(({ provider }) => provider.deprecatedAt);
 	const deactivationAllPast =
@@ -368,7 +374,7 @@ export function ModelCard({
 									</TooltipContent>
 								</Tooltip>
 							)}
-							{allHaveDeactivatedAt && (
+							{showModelDeactivationStatus && (
 								<ModelStatusBadge
 									status="deactivated"
 									isPast={deactivationAllPast}
@@ -609,6 +615,7 @@ export function ProviderSection({
 	const [selectedServiceTierId, setSelectedServiceTierId] =
 		useState("standard");
 	const activeMapping = mappings[activeRegionIdx] ?? mappings[0];
+	const showDeactivationNotice = shouldShowDeactivationNotice(activeMapping);
 	const hasMappingDetails =
 		(activeMapping.reasoningEfforts?.length ?? 0) > 0 ||
 		(activeMapping.supportedParameters?.length ?? 0) > 0;
@@ -802,7 +809,7 @@ export function ProviderSection({
 				</div>
 
 				{/* Deprecation/deactivation warnings */}
-				{(activeMapping.deprecatedAt ?? activeMapping.deactivatedAt) && (
+				{(activeMapping.deprecatedAt || showDeactivationNotice) && (
 					<div className="flex flex-wrap gap-1.5">
 						{activeMapping.deprecatedAt && (
 							<Badge
@@ -816,14 +823,14 @@ export function ProviderSection({
 								)}
 							</Badge>
 						)}
-						{activeMapping.deactivatedAt && (
+						{showDeactivationNotice && (
 							<Badge
 								variant="outline"
 								className="text-[10px] px-2 py-0.5 gap-1 bg-red-500/5 text-red-600 dark:text-red-400 border-red-500/20"
 							>
 								<AlertCircle className="h-2.5 w-2.5" />
 								{formatDeprecationDate(
-									activeMapping.deactivatedAt,
+									activeMapping.deactivatedAt!,
 									"deactivated",
 								)}
 							</Badge>

--- a/packages/shared/src/deactivation.spec.ts
+++ b/packages/shared/src/deactivation.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import {
 	isDeactivationScheduledSoon,
 	isMappingDeactivated,
+	shouldShowDeactivationNotice,
 } from "./deactivation";
 
 const now = new Date("2026-07-27T00:00:00.000Z");
@@ -55,7 +56,7 @@ describe("isDeactivationScheduledSoon", () => {
 	test("is false beyond the notice window", () => {
 		expect(
 			isDeactivationScheduledSoon(
-				{ deactivatedAt: new Date("2026-08-27T00:00:00.001Z") },
+				{ deactivatedAt: new Date("2026-08-26T00:00:00.001Z") },
 				now,
 			),
 		).toBe(false);
@@ -77,5 +78,22 @@ describe("isDeactivationScheduledSoon", () => {
 		expect(
 			isDeactivationScheduledSoon({ deactivatedAt: "2026-07-30" }, now, 7),
 		).toBe(true);
+	});
+});
+
+describe("shouldShowDeactivationNotice", () => {
+	test("is true for past and near-future dates", () => {
+		expect(
+			shouldShowDeactivationNotice({ deactivatedAt: "2026-07-26" }, now),
+		).toBe(true);
+		expect(
+			shouldShowDeactivationNotice({ deactivatedAt: "2026-10-25" }, now),
+		).toBe(true);
+	});
+
+	test("is false for distant dates", () => {
+		expect(
+			shouldShowDeactivationNotice({ deactivatedAt: "2027-07-27" }, now),
+		).toBe(false);
 	});
 });

--- a/packages/shared/src/deactivation.ts
+++ b/packages/shared/src/deactivation.ts
@@ -1,10 +1,10 @@
 /**
- * How close a scheduled deactivation has to be before it is worth surfacing.
- * A date further out than this is catalogue bookkeeping (providers routinely
- * publish retirement dates a year or more ahead) — the mapping routes normally
- * and nothing about it should read as "deactivated".
+ * How close a scheduled deactivation has to be for operational "soon" states.
  */
 export const DEACTIVATION_NOTICE_DAYS = 30;
+
+/** How close a deactivation has to be before the models directory warns. */
+export const MODEL_DEACTIVATION_NOTICE_DAYS = 90;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -39,5 +39,20 @@ export function isDeactivationScheduledSoon(
 	return (
 		deactivatedAt > now &&
 		deactivatedAt.getTime() - now.getTime() <= withinDays * DAY_MS
+	);
+}
+
+/**
+ * True when a deactivation deserves a warning: it has already happened or is
+ * scheduled inside the notice window.
+ */
+export function shouldShowDeactivationNotice(
+	mapping: { deactivatedAt?: Date | string | null },
+	now: Date = new Date(),
+	withinDays: number = MODEL_DEACTIVATION_NOTICE_DAYS,
+): boolean {
+	return (
+		isMappingDeactivated(mapping, now) ||
+		isDeactivationScheduledSoon(mapping, now, withinDays)
 	);
 }


### PR DESCRIPTION
## Summary

Scheduled deactivation dates can be known long before users need to act, so showing red warnings for every future date makes active models look unavailable.

- show model-directory deactivation warnings only after deactivation or within 90 days
- apply the rule to model headers, grid cards, provider cards, and table rows
- preserve applicable deprecation statuses when a distant deactivation warning is hidden
- keep the existing 30-day operational soon-state window unchanged

## Verification

- `pnpm format`
- `pnpm build`
- `pnpm exec vitest run packages/shared/src/deactivation.spec.ts --no-file-parallelism` (10 tests)
- UI mechanical detector (no findings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer deactivation notices for models and providers that are already deactivated or scheduled to deactivate within 90 days.
  * Improved status badges and model directory cards to prioritize deactivation information over deprecation notices.

* **Bug Fixes**
  * Corrected inconsistent display of deactivation and deprecation statuses across model views.

* **Tests**
  * Added coverage for past, near-future, and distant deactivation dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->