### PR TITLE
feat(models): support a base URL for Anthropic

### DIFF
--- a/packages/actions/src/get-provider-endpoint.spec.ts
+++ b/packages/actions/src/get-provider-endpoint.spec.ts
@@ -582,6 +582,44 @@ describe("getProviderEndpoint", () => {
 			);
 		});
 
+		it("honors an anthropic credential base URL override", () => {
+			const endpoint = getProviderEndpoint(
+				"anthropic",
+				undefined,
+				"claude-opus-5",
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				{ env_config: { baseUrl: "https://anthropic.example" } },
+				undefined,
+				undefined,
+				undefined,
+				true, // skipEnvVars
+			);
+
+			expect(endpoint).toBe("https://anthropic.example/v1/messages");
+		});
+
+		it("falls back to the anthropic default when no base URL is configured", () => {
+			const endpoint = getProviderEndpoint(
+				"anthropic",
+				undefined,
+				"claude-opus-5",
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				true, // skipEnvVars
+			);
+
+			expect(endpoint).toBe("https://api.anthropic.com/v1/messages");
+		});
+
 		it("still uses explicit baseUrl even when skipEnvVars is true", () => {
 			const endpoint = getProviderEndpoint(
 				"google-ai-studio",

--- a/packages/actions/src/get-provider-endpoint.ts
+++ b/packages/actions/src/get-provider-endpoint.ts
@@ -293,6 +293,7 @@ export function getProviderEndpoint(
 					throw new Error(`Provider ${provider} requires a baseUrl`);
 				}
 				break;
+			case "anthropic":
 			case "openai":
 			case "google-ai-studio":
 			case "google-vertex":

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -329,6 +329,9 @@ export const providers: ProviderDefinition[] = [
 			required: {
 				apiKey: "LLM_ANTHROPIC_API_KEY",
 			},
+			optional: {
+				baseUrl: "LLM_ANTHROPIC_BASE_URL",
+			},
 		},
 		streaming: true,
 		cancellation: true,


### PR DESCRIPTION
Anthropic was the only major provider with no `baseUrl` option. Its `env` block declared `apiKey` and nothing else, so the endpoint always resolved to `api.anthropic.com` and there was no way to point a credential at an alternate endpoint.

Every neighbouring provider already supports this — OpenAI, Azure, AWS Bedrock, Google Vertex and Google AI Studio all expose `baseUrl` — so the gap looks accidental rather than deliberate.

## Changes

- `packages/models/src/providers.ts` — add `optional: { baseUrl: "LLM_ANTHROPIC_BASE_URL" }` to the `anthropic` provider.
- `packages/actions/src/get-provider-endpoint.ts` — move `anthropic` onto the shared base-URL case alongside `openai` / `google-ai-studio` / `google-vertex` / `xiaomi`. That branch already resolves credential config → env var → static default via `envValueOrDefault`, so no new resolution logic is needed. Previously `anthropic` fell through to `default:`, which reads only the static default and ignores a configured base URL.

Without the second change the env key alone would have no effect, since the default branch never consults it.

## Behaviour

| Config | Endpoint |
| --- | --- |
| none | `https://api.anthropic.com/v1/messages` (unchanged) |
| `LLM_ANTHROPIC_BASE_URL` | `<value>/v1/messages` |
| credential `baseUrl` | `<value>/v1/messages` (wins over env) |

Purely additive — with nothing configured the resolved endpoint is byte-identical to before, which the second new test pins.

## Tests

Two cases added to `get-provider-endpoint.spec.ts`: a credential-config override, and the unchanged default. `pnpm vitest run packages/actions packages/models` → 219 passing. `pnpm build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)