### PR TITLE
fix(models): schedule ByteDance V4 pricing

### DIFF
--- a/apps/gateway/src/aisdk/convert.spec.ts
+++ b/apps/gateway/src/aisdk/convert.spec.ts
@@ -853,4 +853,29 @@ describe("config model listing", () => {
 		const future = new Date("2999-01-01");
 		expect(buildConfigModels(future).length).toBeLessThan(entries.length);
 	});
+
+	test.each([
+		{
+			at: "2026-08-20T15:59:59Z",
+			input: "0.14e-6",
+			output: "0.28e-6",
+			inputCacheRead: "0.028e-6",
+		},
+		{
+			at: "2026-08-20T16:00:00Z",
+			input: "0.44e-6",
+			output: "1.32e-6",
+			inputCacheRead: "0.014e-6",
+		},
+	])("publishes scheduled prices at $at", (expected) => {
+		const entry = buildConfigModels(new Date(expected.at)).find(
+			(candidate) => candidate.id === "bytedance/deepseek-v4-flash",
+		);
+
+		expect(entry?.pricing).toMatchObject({
+			input: expected.input,
+			output: expected.output,
+			input_cache_read: expected.inputCacheRead,
+		});
+	});
 });

--- a/apps/gateway/src/aisdk/tools/build-config-models.ts
+++ b/apps/gateway/src/aisdk/tools/build-config-models.ts
@@ -1,5 +1,6 @@
 import {
 	models as modelsList,
+	resolveTimeBasedPricing,
 	type ModelDefinition,
 	type ProviderModelMapping,
 } from "@llmgateway/models";
@@ -57,15 +58,16 @@ function resolveModelType(model: ModelDefinition): KnownModelType {
 	return "language";
 }
 
-function buildPricing(mapping: ProviderModelMapping) {
+function buildPricing(mapping: ProviderModelMapping, now: Date) {
 	if (mapping.inputPrice === undefined && mapping.outputPrice === undefined) {
 		return undefined;
 	}
+	const pricing = resolveTimeBasedPricing(mapping, now);
 	return {
-		input: mapping.inputPrice ?? "0",
-		output: mapping.outputPrice ?? "0",
-		...(mapping.cachedInputPrice !== undefined && {
-			input_cache_read: mapping.cachedInputPrice,
+		input: pricing.inputPrice,
+		output: pricing.outputPrice,
+		...(pricing.cachedInputPrice !== undefined && {
+			input_cache_read: pricing.cachedInputPrice,
 		}),
 		...(mapping.cacheWriteInputPrice !== undefined && {
 			input_cache_write: mapping.cacheWriteInputPrice,
@@ -98,7 +100,7 @@ export function buildConfigModels(now = new Date()): ConfigModelEntry[] {
 				continue;
 			}
 
-			const pricing = buildPricing(mapping);
+			const pricing = buildPricing(mapping, now);
 
 			entries.push({
 				id: `${mapping.providerId}/${model.id}`,

--- a/apps/gateway/src/lib/costs.spec.ts
+++ b/apps/gateway/src/lib/costs.spec.ts
@@ -2438,3 +2438,47 @@ describe("peak / off-peak time-of-day pricing (DeepSeek)", () => {
 		expect(flash.cachedInputCost).toBeCloseTo(0.0028); // base: 0.0028e-6 * 1M
 	});
 });
+
+describe("scheduled pricing (ByteDance)", () => {
+	beforeEach(() => {
+		vi.mocked(mockGetEffectiveDiscount).mockImplementation(async () => ({
+			discount: "0",
+			source: "none",
+		}));
+		vi.useFakeTimers({ shouldAdvanceTime: true });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it.each([
+		{
+			at: "2026-08-20T15:59:59Z",
+			inputCost: 0.14,
+			outputCost: 0.28,
+			cachedInputCost: 0.028,
+		},
+		{
+			at: "2026-08-20T16:00:00Z",
+			inputCost: 0.44,
+			outputCost: 1.32,
+			cachedInputCost: 0.014,
+		},
+	])("bills the rates effective at $at", async (expected) => {
+		vi.setSystemTime(new Date(expected.at));
+
+		const costs = await calculateCosts(
+			"deepseek-v4-flash",
+			"bytedance",
+			null,
+			2_000_000,
+			1_000_000,
+			1_000_000,
+		);
+
+		expect(costs.inputCost).toBeCloseTo(expected.inputCost);
+		expect(costs.outputCost).toBeCloseTo(expected.outputCost);
+		expect(costs.cachedInputCost).toBeCloseTo(expected.cachedInputCost);
+	});
+});

--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -537,10 +537,7 @@ export async function calculateCosts(
 	// Set completion tokens to 0 if not available (but still calculate input costs)
 	calculatedCompletionTokens ??= 0;
 
-	// Resolve peak/off-peak time-of-day pricing (DeepSeek first-party): use the
-	// peak rates while the current UTC hour is inside the mapping's peak window,
-	// the off-peak base rates otherwise. Tier selection below then overrides by
-	// token count for mappings that price by context length.
+	// Resolve scheduled and peak/off-peak pricing before token-count tiers.
 	const timeBasedPricing = resolveTimeBasedPricing(providerInfo);
 	const pricing = getPricingForTokenCount(
 		providerInfo.pricingTiers,

--- a/apps/gateway/src/models/models.spec.ts
+++ b/apps/gateway/src/models/models.spec.ts
@@ -507,23 +507,39 @@ describe("Models API", () => {
 		vi.setSystemTime(new Date(expected.at));
 
 		try {
-			const res = await app.request("/v1/models?mapped=true");
-			expect(res.status).toBe(200);
+			const [modelsRes, mappedRes] = await Promise.all([
+				app.request("/v1/models"),
+				app.request("/v1/models?mapped=true"),
+			]);
+			expect(modelsRes.status).toBe(200);
+			expect(mappedRes.status).toBe(200);
 
-			const json = await res.json();
-			const mapping = json.data.find(
+			const modelsJson = await modelsRes.json();
+			const model = modelsJson.data.find(
+				(entry: { id: string }) => entry.id === "deepseek-v4-flash",
+			);
+			const provider = model.providers.find(
+				(entry: { providerId: string }) => entry.providerId === "bytedance",
+			);
+
+			const mappedJson = await mappedRes.json();
+			const mapping = mappedJson.data.find(
 				(model: { id: string }) => model.id === "bytedance/deepseek-v4-flash",
 			);
 
+			expect(provider).toBeDefined();
 			expect(mapping).toBeDefined();
-			expect(mapping.pricing.prompt).toBe(expected.prompt);
-			expect(mapping.pricing.completion).toBe(expected.completion);
-			expect(mapping.pricing.input_cache_read).toBe(expected.cacheRead);
-			expect(mapping.providers[0].pricing).toMatchObject({
-				prompt: expected.prompt,
-				completion: expected.completion,
-				input_cache_read: expected.cacheRead,
-			});
+			for (const pricing of [
+				provider.pricing,
+				mapping.pricing,
+				mapping.providers[0].pricing,
+			]) {
+				expect(pricing).toMatchObject({
+					prompt: expected.prompt,
+					completion: expected.completion,
+					input_cache_read: expected.cacheRead,
+				});
+			}
 		} finally {
 			vi.useRealTimers();
 		}

--- a/apps/gateway/src/models/models.spec.ts
+++ b/apps/gateway/src/models/models.spec.ts
@@ -2,7 +2,11 @@ import { describe, expect, test, vi } from "vitest";
 
 import { app } from "@/app.js";
 
-import { models as modelsList, providers } from "@llmgateway/models";
+import {
+	models as modelsList,
+	providers,
+	resolveTimeBasedPricing,
+} from "@llmgateway/models";
 
 import type { ProviderModelMapping } from "@llmgateway/models";
 
@@ -421,10 +425,11 @@ describe("Models API", () => {
 			p.perSecondPrice !== undefined ||
 			p.ocrPagePrice !== undefined;
 		const score = (p: ProviderModelMapping) => {
+			const pricing = resolveTimeBasedPricing(p, now);
 			const input =
-				p.inputPrice !== undefined ? Number(p.inputPrice) : undefined;
+				p.inputPrice !== undefined ? Number(pricing.inputPrice) : undefined;
 			const output =
-				p.outputPrice !== undefined ? Number(p.outputPrice) : undefined;
+				p.outputPrice !== undefined ? Number(pricing.outputPrice) : undefined;
 			if (input !== undefined || output !== undefined) {
 				return (input ?? 0) + (output ?? 0);
 			}
@@ -463,10 +468,12 @@ describe("Models API", () => {
 					: cheapest(mappings.filter((p) => hasPricing(p)));
 
 			expect(model.pricing.prompt).toBe(
-				expected?.inputPrice?.toString() ?? "0",
+				expected ? resolveTimeBasedPricing(expected, now).inputPrice : "0",
 			);
 			expect(model.pricing.input_cache_read).toBe(
-				expected?.cachedInputPrice?.toString() ?? "0",
+				expected
+					? (resolveTimeBasedPricing(expected, now).cachedInputPrice ?? "0")
+					: "0",
 			);
 		}
 
@@ -480,6 +487,46 @@ describe("Models API", () => {
 		expect(deepseek.pricing.prompt).toBe("0.26e-6");
 		expect(deepseek.pricing.completion).toBe("0.38e-6");
 		expect(deepseek.pricing.input_cache_read).toBe("0.13e-6");
+	});
+
+	test.each([
+		{
+			at: "2026-08-20T15:59:59Z",
+			prompt: "0.14e-6",
+			completion: "0.28e-6",
+			cacheRead: "0.028e-6",
+		},
+		{
+			at: "2026-08-20T16:00:00Z",
+			prompt: "0.44e-6",
+			completion: "1.32e-6",
+			cacheRead: "0.014e-6",
+		},
+	])("GET /v1/models publishes scheduled prices at $at", async (expected) => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date(expected.at));
+
+		try {
+			const res = await app.request("/v1/models?mapped=true");
+			expect(res.status).toBe(200);
+
+			const json = await res.json();
+			const mapping = json.data.find(
+				(model: { id: string }) => model.id === "bytedance/deepseek-v4-flash",
+			);
+
+			expect(mapping).toBeDefined();
+			expect(mapping.pricing.prompt).toBe(expected.prompt);
+			expect(mapping.pricing.completion).toBe(expected.completion);
+			expect(mapping.pricing.input_cache_read).toBe(expected.cacheRead);
+			expect(mapping.providers[0].pricing).toMatchObject({
+				prompt: expected.prompt,
+				completion: expected.completion,
+				input_cache_read: expected.cacheRead,
+			});
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	test("GET /v1/models reports JSON capabilities only from servable provider mappings", async () => {

--- a/apps/gateway/src/models/models.ts
+++ b/apps/gateway/src/models/models.ts
@@ -5,6 +5,7 @@ import { logger, toError } from "@llmgateway/logger";
 import {
 	models as modelsList,
 	providers,
+	resolveTimeBasedPricing,
 	type ProviderModelMapping,
 	type ModelDefinition,
 } from "@llmgateway/models";
@@ -320,10 +321,13 @@ modelsApi.openapi(listModels, async (c) => {
 							top_provider: {
 								is_moderated: true,
 							},
-							providers: [serializeProviderMapping(provider, model)],
+							providers: [
+								serializeProviderMapping(provider, model, currentDate),
+							],
 							pricing: {
 								...buildPricingFields(
 									hasPricing(provider) ? provider : undefined,
+									currentDate,
 								),
 								web_search: "0",
 								internal_reasoning: "0",
@@ -402,10 +406,10 @@ modelsApi.openapi(listModels, async (c) => {
 					is_moderated: true,
 				},
 				providers: model.providers.map((provider: ProviderModelMapping) =>
-					serializeProviderMapping(provider, model),
+					serializeProviderMapping(provider, model, currentDate),
 				),
 				pricing: {
-					...buildPricingFields(pricingProvider),
+					...buildPricingFields(pricingProvider, currentDate),
 					web_search: "0", // Not defined in model definitions yet
 					internal_reasoning: "0", // Not defined in model definitions yet
 				},
@@ -456,6 +460,7 @@ modelsApi.openapi(listModels, async (c) => {
 function serializeProviderMapping(
 	provider: ProviderModelMapping,
 	model: ModelDefinition,
+	currentDate: Date,
 ) {
 	// Find the provider definition to get cancellation support
 	const providerDef = providers.find((p) => p.id === provider.providerId);
@@ -466,7 +471,9 @@ function serializeProviderMapping(
 		supportedVideoSizes: provider.supportedVideoSizes,
 		supportsVideoAudio: provider.supportsVideoAudio,
 		supportsVideoWithoutAudio: provider.supportsVideoWithoutAudio,
-		pricing: hasPricing(provider) ? buildPricingFields(provider) : undefined,
+		pricing: hasPricing(provider)
+			? buildPricingFields(provider, currentDate)
+			: undefined,
 		streaming: provider.streaming,
 		vision: provider.vision ?? false,
 		realtime: provider.realtime === true ? true : undefined,
@@ -531,10 +538,17 @@ function hasPricing(p: ProviderModelMapping): boolean {
 // per-provider pricing and (with a representative mapping) the model-level
 // pricing, so the two expose the same level of detail. A missing mapping or
 // missing field defaults to "0".
-function buildPricingFields(p: ProviderModelMapping | undefined) {
+function buildPricingFields(
+	p: ProviderModelMapping | undefined,
+	currentDate: Date,
+) {
+	const timeBasedPricing = p
+		? resolveTimeBasedPricing(p, currentDate)
+		: undefined;
+
 	return {
-		prompt: p?.inputPrice?.toString() ?? "0",
-		completion: p?.outputPrice?.toString() ?? "0",
+		prompt: timeBasedPricing?.inputPrice ?? "0",
+		completion: timeBasedPricing?.outputPrice ?? "0",
 		image: p?.imageInputPrice?.toString() ?? "0",
 		input_audio: p?.inputAudioPrice?.toString(),
 		input_audio_cache_read: p?.cachedInputAudioPrice?.toString(),
@@ -556,7 +570,7 @@ function buildPricingFields(p: ProviderModelMapping | undefined) {
 				)
 			: undefined,
 		request: p?.requestPrice?.toString() ?? "0",
-		input_cache_read: p?.cachedInputPrice?.toString() ?? "0",
+		input_cache_read: timeBasedPricing?.cachedInputPrice ?? "0",
 		input_cache_write: p?.cacheWriteInputPrice?.toString() ?? "0",
 		input_cache_write_1h: p?.cacheWriteInputPrice1h?.toString() ?? "0",
 		ocr_page: p?.ocrPagePrice?.toString(),
@@ -568,10 +582,16 @@ function buildPricingFields(p: ProviderModelMapping | undefined) {
 // one. Token-priced models compare on input + output price; models priced by
 // other units (OCR per page, video per second, per request, image) fall back to
 // those. Lower is cheaper; a mapping with no comparable price sorts last.
-function pricingScore(p: ProviderModelMapping): number {
-	const input = p.inputPrice !== undefined ? Number(p.inputPrice) : undefined;
+function pricingScore(p: ProviderModelMapping, currentDate: Date): number {
+	const timeBasedPricing = resolveTimeBasedPricing(p, currentDate);
+	const input =
+		p.inputPrice !== undefined
+			? Number(timeBasedPricing.inputPrice)
+			: undefined;
 	const output =
-		p.outputPrice !== undefined ? Number(p.outputPrice) : undefined;
+		p.outputPrice !== undefined
+			? Number(timeBasedPricing.outputPrice)
+			: undefined;
 	const tokenScore =
 		input !== undefined || output !== undefined
 			? (input ?? 0) + (output ?? 0)
@@ -621,7 +641,10 @@ function pickPricingProvider(
 	const cheapest = (candidates: ProviderModelMapping[]) =>
 		candidates.reduce<ProviderModelMapping | undefined>(
 			(best, p) =>
-				best === undefined || pricingScore(p) < pricingScore(best) ? p : best,
+				best === undefined ||
+				pricingScore(p, currentDate) < pricingScore(best, currentDate)
+					? p
+					: best,
 			undefined,
 		);
 

--- a/packages/actions/src/get-cheapest-from-available-providers.ts
+++ b/packages/actions/src/get-cheapest-from-available-providers.ts
@@ -347,15 +347,19 @@ export function getProviderSelectionPrice(
 				| "perImagePrice"
 				| "requestPrice"
 		  > &
-				Partial<Pick<ProviderModelMapping, "peakPricing" | "cachedInputPrice">>)
+				Partial<
+					Pick<
+						ProviderModelMapping,
+						"peakPricing" | "scheduledPricing" | "cachedInputPrice"
+					>
+				>)
 		| undefined,
 	videoPricing?: VideoPricingContext,
 	now: Date = new Date(),
 ): Decimal {
 	const requestPrice = providerInfo?.requestPrice;
-	// Resolve peak/off-peak time-of-day pricing (DeepSeek first-party): token
-	// rates vary by UTC hour once the mapping's peakPricing is effective, so
-	// routing must rank with the same rates billing uses.
+	// Resolve scheduled and peak/off-peak pricing so routing ranks providers
+	// with the same rates billing uses.
 	const timeBasedPricing = providerInfo
 		? resolveTimeBasedPricing(providerInfo, now)
 		: undefined;

--- a/packages/actions/src/models.spec.ts
+++ b/packages/actions/src/models.spec.ts
@@ -1373,7 +1373,7 @@ describe("getCheapestFromAvailableProviders", () => {
 		).toBe(0.375 / 1e6);
 	});
 
-	describe("time-of-day pricing in provider selection", () => {
+	describe("time-based pricing in provider selection", () => {
 		// Mirrors the DeepSeek V4 Pro first-party mapping: peak 01:00-04:00 and
 		// 06:00-10:00 UTC at double the off-peak rates, base (regular) flat
 		// rates before effectiveAt.
@@ -1437,6 +1437,33 @@ describe("getCheapestFromAvailableProviders", () => {
 					outputPrice: "1.5e-6",
 				}).toNumber(),
 			).toBe(1e-6);
+		});
+
+		it("returns scheduled prices on and after effectiveAt", () => {
+			const mapping = {
+				inputPrice: "0.14e-6",
+				outputPrice: "0.28e-6",
+				scheduledPricing: {
+					effectiveAt: "2026-08-20T16:00:00Z",
+					inputPrice: "0.44e-6",
+					outputPrice: "1.32e-6",
+				},
+			};
+
+			expect(
+				getProviderSelectionPrice(
+					mapping,
+					undefined,
+					new Date("2026-08-20T15:59:59Z"),
+				).toNumber(),
+			).toBe((0.14e-6 + 0.28e-6) / 2);
+			expect(
+				getProviderSelectionPrice(
+					mapping,
+					undefined,
+					new Date("2026-08-20T16:00:00Z"),
+				).toNumber(),
+			).toBe((0.44e-6 + 1.32e-6) / 2);
 		});
 
 		it("ranks with peak rates through full provider selection", async () => {

--- a/packages/models/src/helpers.spec.ts
+++ b/packages/models/src/helpers.spec.ts
@@ -52,6 +52,38 @@ describe("resolveTimeBasedPricing", () => {
 		});
 	});
 
+	it("applies a scheduled permanent price change at effectiveAt", () => {
+		const mapping = {
+			inputPrice: "0.14e-6",
+			outputPrice: "0.28e-6",
+			cachedInputPrice: "0.028e-6",
+			scheduledPricing: {
+				effectiveAt: "2026-08-20T16:00:00Z",
+				inputPrice: "0.44e-6",
+				outputPrice: "1.32e-6",
+				cachedInputPrice: "0.014e-6",
+			},
+		} satisfies Pick<
+			ProviderModelMapping,
+			"inputPrice" | "outputPrice" | "cachedInputPrice" | "scheduledPricing"
+		>;
+
+		expect(
+			resolveTimeBasedPricing(mapping, at("2026-08-20T15:59:59Z")),
+		).toEqual({
+			inputPrice: "0.14e-6",
+			outputPrice: "0.28e-6",
+			cachedInputPrice: "0.028e-6",
+		});
+		expect(
+			resolveTimeBasedPricing(mapping, at("2026-08-20T16:00:00Z")),
+		).toEqual({
+			inputPrice: "0.44e-6",
+			outputPrice: "1.32e-6",
+			cachedInputPrice: "0.014e-6",
+		});
+	});
+
 	it.each([
 		["01:00", "2026-08-17T01:00:00Z"],
 		["03:59", "2026-08-17T03:59:00Z"],

--- a/packages/models/src/helpers.ts
+++ b/packages/models/src/helpers.ts
@@ -197,16 +197,18 @@ export function supportsOpenAIExplicitPromptCache(modelName: string): boolean {
 
 /**
  * Resolve the per-token rates that apply to a mapping at a given instant.
- * Without `peakPricing`, the mapping's base inputPrice/outputPrice/
- * cachedInputPrice are always returned. With `peakPricing`, the base fields
- * (the regular flat rates) apply before `effectiveAt`; on/after it, the
- * `peak` rates apply while `now` (UTC) falls inside a peak window and the
- * `offPeak` rates otherwise.
+ * A scheduled permanent change takes precedence once effective. Otherwise,
+ * peak/off-peak pricing applies after its effective date, falling back to the
+ * mapping's base prices before then.
  */
 export function resolveTimeBasedPricing(
 	mapping: Pick<
 		ProviderModelMapping,
-		"inputPrice" | "outputPrice" | "cachedInputPrice" | "peakPricing"
+		| "inputPrice"
+		| "outputPrice"
+		| "cachedInputPrice"
+		| "scheduledPricing"
+		| "peakPricing"
 	>,
 	now: Date = new Date(),
 ): {
@@ -214,6 +216,17 @@ export function resolveTimeBasedPricing(
 	outputPrice: string;
 	cachedInputPrice: string | undefined;
 } {
+	const scheduledPricing = mapping.scheduledPricing;
+	if (
+		scheduledPricing &&
+		now.getTime() >= Date.parse(scheduledPricing.effectiveAt)
+	) {
+		return {
+			inputPrice: scheduledPricing.inputPrice,
+			outputPrice: scheduledPricing.outputPrice,
+			cachedInputPrice: scheduledPricing.cachedInputPrice,
+		};
+	}
 	const peakPricing = mapping.peakPricing;
 	if (!peakPricing) {
 		return {

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -318,6 +318,30 @@ export interface ProviderModelMapping {
 	 */
 	pricingTiers?: PricingTier[];
 	/**
+	 * A permanent per-token price change that takes effect at a specific instant.
+	 * The mapping's base prices apply before `effectiveAt`; the scheduled prices
+	 * apply on and after it.
+	 */
+	scheduledPricing?: {
+		/**
+		 * ISO-8601 instant when the scheduled prices take effect.
+		 */
+		effectiveAt: string;
+		/**
+		 * Price per input token in USD after the change.
+		 */
+		inputPrice: Price;
+		/**
+		 * Price per output token in USD after the change.
+		 */
+		outputPrice: Price;
+		/**
+		 * Price per cached input token in USD after the change. When unset,
+		 * billing falls back to `inputPrice`, matching base-price behavior.
+		 */
+		cachedInputPrice?: Price;
+	};
+	/**
 	 * Peak/off-peak time-of-day pricing. The mapping's base
 	 * inputPrice/outputPrice/cachedInputPrice are the regular flat prices,
 	 * billed before `effectiveAt` (and always when `peakPricing` is absent).

--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -743,13 +743,17 @@ export const deepseekModels = [
 			{
 				providerId: "bytedance",
 				// The GA deployment; `deepseek-v4-flash-260425` is the superseded
-				// preview. Both currently bill at the rates below, but BytePlus raises
-				// the GA deployment to 0.44/0.014/1.32 on 2026-08-21 00:00 UTC+8 —
-				// these three fields have to move on that date.
+				// preview. The new rates start at 2026-08-21 00:00 UTC+8.
 				externalId: "deepseek-v4-flash-ga-260731",
 				inputPrice: "0.14e-6",
 				cachedInputPrice: "0.028e-6",
 				outputPrice: "0.28e-6",
+				scheduledPricing: {
+					effectiveAt: "2026-08-20T16:00:00Z",
+					inputPrice: "0.44e-6",
+					cachedInputPrice: "0.014e-6",
+					outputPrice: "1.32e-6",
+				},
 				requestPrice: "0",
 				contextSize: 1048576,
 				maxOutput: 393216,


### PR DESCRIPTION
## Problem

BytePlus changes the online inference rates for `deepseek-v4-flash-ga-260731` at 2026-08-21 00:00 UTC+8. Applying the new values directly before that deadline would misbill current traffic.

## Approach

- Add reusable scheduled per-token pricing with an exact effective instant.
- Resolve scheduled rates consistently in billing, provider selection, `/v1/models`, and the AI SDK `/config` response.
- Schedule the ByteDance mapping to switch at `2026-08-20T16:00:00Z`.
- Keep batch pricing out of scope because the gateway serves online inference.

## Mapping evidence

- Mapping: `deepseek-v4-flash` / `bytedance` / default region
- External ID: `deepseek-v4-flash-ga-260731`
- Before cutoff (USD/M tokens): input 0.14, cache-hit input 0.028, output 0.28
- After cutoff (USD/M tokens): input 0.44, cache-hit input 0.014, output 1.32
- Context: 1,048,576 tokens; max output: 393,216 tokens
- Capabilities unchanged: streaming, reasoning, and tools enabled; vision and JSON output disabled
- Source: [BytePlus ModelArk pricing](https://docs.byteplus.com/en/docs/ModelArk/1544106)

The future rates and effective time are from BytePlus's August 17 pricing notice. Live post-change billing cannot be reconciled until the cutoff; boundary cost and model-listing tests hand-check both rate sets, and the current deployment passes scoped live e2e.

## Verification

- `pnpm format`
- `pnpm build`
- `pnpm exec vitest run --no-file-parallelism packages/models/src/helpers.spec.ts packages/models/src/model-metadata.spec.ts packages/models/src/providers.spec.ts packages/models/src/realtime-models.spec.ts packages/actions/src/models.spec.ts apps/gateway/src/lib/costs.spec.ts` (215 passed)
- `pnpm exec vitest run --no-file-parallelism apps/gateway/src/models/models.spec.ts` (27 passed)
- `pnpm exec vitest run --no-file-parallelism apps/gateway/src/aisdk/convert.spec.ts` (31 passed)
- `TEST_MODELS=bytedance/deepseek-v4-flash FULL_MODE=true pnpm test:e2e` (29 files passed, 2 skipped; 106 tests passed, 95 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for scheduled, permanent pricing changes that activate at a specific time.
  * Updated ByteDance DeepSeek V4 Flash GA pricing with future input, output, and cached-input rates effective August 20, 2026.
  * Scheduled rates take precedence over peak and off-peak pricing once active.
  * Provider and model pricing now reflect rates applicable at the current time.

* **Bug Fixes**
  * Improved provider cost selection before and after scheduled pricing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
