### PR TITLE
fix(models): update ByteDance V4 pricing

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -743,13 +743,11 @@ export const deepseekModels = [
 			{
 				providerId: "bytedance",
 				// The GA deployment; `deepseek-v4-flash-260425` is the superseded
-				// preview. Both currently bill at the rates below, but BytePlus raises
-				// the GA deployment to 0.44/0.014/1.32 on 2026-08-21 00:00 UTC+8 —
-				// these three fields have to move on that date.
+				// preview.
 				externalId: "deepseek-v4-flash-ga-260731",
-				inputPrice: "0.14e-6",
-				cachedInputPrice: "0.028e-6",
-				outputPrice: "0.28e-6",
+				inputPrice: "0.44e-6",
+				cachedInputPrice: "0.014e-6",
+				outputPrice: "1.32e-6",
 				requestPrice: "0",
 				contextSize: 1048576,
 				maxOutput: 393216,


### PR DESCRIPTION
## Problem

BytePlus changes the online inference prices for `deepseek-v4-flash-ga-260731` at 2026-08-21 00:00 UTC+8.

**Do not merge before `2026-08-20T16:00:00Z`.** The catalogue applies these prices immediately when this PR is merged.

## Approach

Update only the ByteDance mapping's current per-token prices. No scheduling logic is included.

## Mapping evidence

- Mapping: `deepseek-v4-flash` / `bytedance` / default region
- External ID: `deepseek-v4-flash-ga-260731`
- Input: $0.44 per million tokens
- Cache-hit input: $0.014 per million tokens
- Output: $1.32 per million tokens
- Batch pricing is out of scope because the gateway serves online inference
- Source: [BytePlus ModelArk pricing](https://docs.byteplus.com/en/docs/ModelArk/1544106)

Capabilities, context limits, and token semantics are unchanged.

## Verification

- `pnpm format`
- `pnpm build`
- `pnpm exec vitest run --no-file-parallelism packages/models/src/model-metadata.spec.ts packages/models/src/providers.spec.ts packages/models/src/realtime-models.spec.ts apps/gateway/src/lib/costs.spec.ts` (142 passed)
- `TEST_MODELS=bytedance/deepseek-v4-flash FULL_MODE=true pnpm test:e2e` (previously verified: 29 files passed, 2 skipped; 106 tests passed, 95 skipped)
