### PR TITLE
fix(models): deactivate Cerebras Llama 3.3

### DIFF
--- a/packages/models/src/models/meta.ts
+++ b/packages/models/src/models/meta.ts
@@ -308,6 +308,8 @@ export const metaModels = [
 			{
 				providerId: "cerebras",
 				test: "skip",
+				// Removed from the Cerebras public API
+				deactivatedAt: new Date("2026-08-18"),
 				externalId: "llama-3.3-70b",
 				inputPrice: "0.85e-6",
 				outputPrice: "1.2e-6",


### PR DESCRIPTION
## Problem

Cerebras deprecated `llama-3.3-70b` on February 16, 2026, but the mapping remained active. The live Cerebras model list no longer contains it, and a pinned chat-completions request now returns `404 model_not_found`.

Official notice: https://inference-docs.cerebras.ai/support/deprecation

## Change

Deactivate the Cerebras mapping on August 18, 2026. The root `llama-3.3-70b-instruct` model remains available through its other providers.

Mapping details are otherwise unchanged: external ID `llama-3.3-70b`, 128K context, unspecified output cap, streaming/tool/JSON support, no vision, and historical rates of $0.85/M input and $1.20/M output tokens. Rates were not reverified because the deployment is unavailable and is being disabled.

## Verification

- Live `GET /v1/models`: mapping absent
- Live pinned chat completion: `404 model_not_found`
- `pnpm format`
- Catalogue/provider/realtime/cost suites: 142 tests passed
- `pnpm build`: 17/17 tasks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Marked the Cerebras `llama-3.3-70b-instruct` model as unavailable.
  * Documented its removal from the Cerebras public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->