### PR TITLE
feat(devpass): confirm high-use resets

### DIFF
--- a/apps/api/src/routes/dev-plans-reset-passes.spec.ts
+++ b/apps/api/src/routes/dev-plans-reset-passes.spec.ts
@@ -100,14 +100,17 @@ async function getOrg() {
 	return org;
 }
 
-function redeemRequest(token?: string) {
+function redeemRequest(
+	token?: string,
+	body: { confirmHighCycleUsage?: boolean } = {},
+) {
 	return app.request("/dev-plans/reset-pass/redeem", {
 		method: "POST",
 		headers: {
 			...(token ? { Cookie: token } : {}),
 			"Content-Type": "application/json",
 		},
-		body: JSON.stringify({}),
+		body: JSON.stringify(body),
 	});
 }
 
@@ -216,9 +219,7 @@ describe("reset pass redeem", () => {
 		expect((await getOrg()).devPlanResetPassesPro).toBe(2);
 	});
 
-	it("rejects redeem above 90% of the monthly cycle allowance", async () => {
-		// The weekly cap would be restored against an almost-empty credit pool,
-		// wasting the pass — the redeem is held until the cycle renews.
+	it("requires confirmation above 90% of the monthly cycle allowance", async () => {
 		await insertOrg({
 			devPlanCreditsUsed: "91",
 			devPlanCreditsLimit: "100",
@@ -232,6 +233,20 @@ describe("reset pass redeem", () => {
 		const body = await res.json();
 		expect(body.message).toContain("90%");
 		expect((await getOrg()).devPlanResetPassesPro).toBe(2);
+	});
+
+	it("allows a confirmed redeem above 90% of the monthly cycle allowance", async () => {
+		await insertOrg({
+			devPlanCreditsUsed: "91",
+			devPlanCreditsLimit: "100",
+			devPlanPremiumCreditsUsed: "5",
+			devPlanPremiumWeekStart: new Date(),
+			devPlanResetPassesPro: 2,
+		});
+
+		const res = await redeemRequest(token, { confirmHighCycleUsage: true });
+		expect(res.status).toBe(200);
+		expect((await getOrg()).devPlanResetPassesPro).toBe(1);
 	});
 
 	it("allows redeem at exactly 90% of the monthly cycle allowance", async () => {

--- a/apps/api/src/routes/dev-plans-reset-passes.spec.ts
+++ b/apps/api/src/routes/dev-plans-reset-passes.spec.ts
@@ -246,7 +246,9 @@ describe("reset pass redeem", () => {
 
 		const res = await redeemRequest(token, { confirmHighCycleUsage: true });
 		expect(res.status).toBe(200);
-		expect((await getOrg()).devPlanResetPassesPro).toBe(1);
+		const org = await getOrg();
+		expect(org.devPlanIncludedResetPassesUsed).toBe(1);
+		expect(org.devPlanResetPassesPro).toBe(2);
 	});
 
 	it("rejects a confirmed redeem when the monthly cycle is exhausted", async () => {

--- a/apps/api/src/routes/dev-plans-reset-passes.spec.ts
+++ b/apps/api/src/routes/dev-plans-reset-passes.spec.ts
@@ -249,6 +249,22 @@ describe("reset pass redeem", () => {
 		expect((await getOrg()).devPlanResetPassesPro).toBe(1);
 	});
 
+	it("rejects a confirmed redeem when the monthly cycle is exhausted", async () => {
+		await insertOrg({
+			devPlanCreditsUsed: "100",
+			devPlanCreditsLimit: "100",
+			devPlanPremiumCreditsUsed: "5",
+			devPlanPremiumWeekStart: new Date(),
+			devPlanResetPassesPro: 2,
+		});
+
+		const res = await redeemRequest(token, { confirmHighCycleUsage: true });
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.message).toContain("fully used");
+		expect((await getOrg()).devPlanResetPassesPro).toBe(2);
+	});
+
 	it("allows redeem at exactly 90% of the monthly cycle allowance", async () => {
 		await insertOrg({
 			devPlanCreditsUsed: "90",

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -3593,13 +3593,21 @@ devPlans.openapi(redeemResetPass, async (c) => {
 		});
 	}
 
+	const cycleUsage = getDevPlanCycleUsageFraction(
+		personalOrg.devPlanCreditsUsed,
+		personalOrg.devPlanCreditsLimit,
+	);
+	if (cycleUsage >= 1) {
+		throw new HTTPException(400, {
+			message:
+				"Your monthly credit allowance is fully used, so a Reset Pass cannot unlock any remaining plan usage.",
+		});
+	}
+
 	// A reset remains available late in the cycle, but the caller must affirm
 	// that it understands the pass unlocks only the remaining monthly credits.
 	if (
-		getDevPlanCycleUsageFraction(
-			personalOrg.devPlanCreditsUsed,
-			personalOrg.devPlanCreditsLimit,
-		) > DEV_PLAN_RESET_PASS_REDEEM_MAX_CYCLE_USAGE &&
+		cycleUsage > DEV_PLAN_RESET_PASS_REDEEM_MAX_CYCLE_USAGE &&
 		!confirmHighCycleUsage
 	) {
 		throw new HTTPException(400, {

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -3535,7 +3535,17 @@ devPlans.openapi(topUpCredits, async (c) => {
 const redeemResetPass = createRoute({
 	method: "post",
 	path: "/reset-pass/redeem",
-	request: {},
+	request: {
+		body: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						confirmHighCycleUsage: z.boolean().optional(),
+					}),
+				},
+			},
+		},
+	},
 	responses: {
 		200: {
 			content: {
@@ -3555,6 +3565,7 @@ const redeemResetPass = createRoute({
 
 devPlans.openapi(redeemResetPass, async (c) => {
 	const user = c.get("user");
+	const { confirmHighCycleUsage = false } = c.req.valid("json");
 
 	if (!user) {
 		throw new HTTPException(401, {
@@ -3582,18 +3593,18 @@ devPlans.openapi(redeemResetPass, async (c) => {
 		});
 	}
 
-	// With the monthly credit pool nearly exhausted, a reset would restore a
-	// weekly cap the user can't actually spend against — burning the pass for
-	// almost nothing. The pass keeps until the cycle renews, so hold it.
+	// A reset remains available late in the cycle, but the caller must affirm
+	// that it understands the pass unlocks only the remaining monthly credits.
 	if (
 		getDevPlanCycleUsageFraction(
 			personalOrg.devPlanCreditsUsed,
 			personalOrg.devPlanCreditsLimit,
-		) > DEV_PLAN_RESET_PASS_REDEEM_MAX_CYCLE_USAGE
+		) > DEV_PLAN_RESET_PASS_REDEEM_MAX_CYCLE_USAGE &&
+		!confirmHighCycleUsage
 	) {
 		throw new HTTPException(400, {
 			message:
-				"You've used more than 90% of this cycle's credit allowance — redeeming now would waste the pass on usage you can't spend. Your pass stays available for when your credits renew.",
+				"You've used more than 90% of this cycle's credit allowance. Confirm that you want to use a Reset Pass with the remaining monthly allowance.",
 		});
 	}
 

--- a/apps/code/src/app/dashboard/components/ResetPassCard.tsx
+++ b/apps/code/src/app/dashboard/components/ResetPassCard.tsx
@@ -1,14 +1,11 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { ArrowUpRight, Loader2, Plane, Stamp } from "lucide-react";
+import { Loader2, Stamp } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import Link from "next/link";
-import { usePostHog } from "posthog-js/react";
 import { useState } from "react";
 import { toast } from "sonner";
 
-import { plans } from "@/app/dashboard/plans";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -21,7 +18,6 @@ import {
 	AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
-import { useAppConfig } from "@/lib/config";
 import { useApi } from "@/lib/fetch-client";
 
 import {
@@ -112,8 +108,6 @@ export default function ResetPassCard({
 }: ResetPassCardProps) {
 	const api = useApi();
 	const queryClient = useQueryClient();
-	const { uiUrl, posthogKey } = useAppConfig();
-	const posthog = usePostHog();
 	const [stampOverlay, setStampOverlay] = useState<
 		{ kind: "redeemed" } | { kind: "purchased"; amount: number } | null
 	>(null);
@@ -121,32 +115,18 @@ export default function ResetPassCard({
 
 	const available = includedRemaining + purchased;
 	const nothingToReset = premiumCreditsUsed <= 0;
-	// Mirrors the server-side gates: near the end of the monthly credit pool a
-	// pass restores a cap there's nothing left to spend against, so buying is
-	// blocked above 95% cycle usage and redeeming above 90%.
+	// Near the end of the monthly credit pool a pass may restore a cap with
+	// little remaining spend. Buying is blocked above 95%; redeeming remains
+	// available but requires an explicit acknowledgement above 90%.
 	const cycleUsage = getDevPlanCycleUsageFraction(
 		cycleCreditsUsed,
 		cycleCreditsLimit,
 	);
 	const purchaseBlocked =
 		cycleUsage > DEV_PLAN_RESET_PASS_PURCHASE_MAX_CYCLE_USAGE;
-	const redeemBlocked = cycleUsage > DEV_PLAN_RESET_PASS_REDEEM_MAX_CYCLE_USAGE;
+	const requiresHighUsageConfirmation =
+		cycleUsage > DEV_PLAN_RESET_PASS_REDEEM_MAX_CYCLE_USAGE;
 	const serial = (organizationId ?? "GATEWAY").slice(-6).toUpperCase();
-
-	// Once the gates kick in, passes are a dead end for the rest of the cycle —
-	// give the user the action that actually helps instead: a tier upgrade
-	// (fresh cycle, full allowance, immediately) or PAYG credits on the top
-	// tier, mirroring the promo shown at full exhaustion.
-	const currentIndex = plans.findIndex((p) => p.tier === tier);
-	const nextPlan = currentIndex >= 0 ? (plans[currentIndex + 1] ?? null) : null;
-	const trackGateUpgradeClick = () => {
-		if (posthogKey) {
-			posthog.capture("devpass_reset_gate_upgrade_clicked", {
-				tier,
-				promo: nextPlan ? "upgrade" : "payg",
-			});
-		}
-	};
 
 	const invalidateStatus = () =>
 		queryClient.invalidateQueries({
@@ -287,17 +267,14 @@ export default function ResetPassCard({
 									disabled={
 										available === 0 ||
 										nothingToReset ||
-										redeemBlocked ||
 										redeemMutation.isPending
 									}
 									title={
-										redeemBlocked
-											? "Over 90% of this cycle's credits are used — a reset would give you almost nothing. Your passes keep until your credits renew."
-											: available === 0
-												? "No passes held — buy one below"
-												: nothingToReset
-													? "Nothing to reset yet — your allowance is untouched"
-													: undefined
+										available === 0
+											? "No passes held — buy one below"
+											: nothingToReset
+												? "Nothing to reset yet — your allowance is untouched"
+												: undefined
 									}
 								>
 									{redeemMutation.isPending ? (
@@ -310,24 +287,48 @@ export default function ResetPassCard({
 							</AlertDialogTrigger>
 							<AlertDialogContent data-testid="redeem-pass-confirm">
 								<AlertDialogHeader>
-									<AlertDialogTitle>Stamp a Reset Pass now?</AlertDialogTitle>
+									<AlertDialogTitle>
+										{requiresHighUsageConfirmation
+											? "Use a Reset Pass with limited monthly allowance?"
+											: "Stamp a Reset Pass now?"}
+									</AlertDialogTitle>
 									<AlertDialogDescription>
-										This spends one of your{" "}
-										{`${available} pass${available === 1 ? "" : "es"}`} (
-										{includedRemaining > 0 ? "included" : "purchased"}) and
-										immediately lifts the weekly premium limit back to{" "}
-										{`$${premiumWeeklyLimit.toFixed(2)}`}. It doesn&apos;t add
-										credits — usage still draws from your monthly allowance, and
-										a spent pass can&apos;t be undone.
+										{requiresHighUsageConfirmation ? (
+											<>
+												More than 90% of this cycle&apos;s monthly allowance is
+												already used. This will reset your weekly premium limit,
+												but it doesn&apos;t add credits, so only the remaining
+												monthly allowance will be available. This spends one
+												pass and can&apos;t be undone.
+											</>
+										) : (
+											<>
+												This spends one of your{" "}
+												{`${available} pass${available === 1 ? "" : "es"}`} (
+												{includedRemaining > 0 ? "included" : "purchased"}) and
+												immediately lifts the weekly premium limit back to{" "}
+												{`$${premiumWeeklyLimit.toFixed(2)}`}. It doesn&apos;t
+												add credits — usage still draws from your monthly
+												allowance, and a spent pass can&apos;t be undone.
+											</>
+										)}
 									</AlertDialogDescription>
 								</AlertDialogHeader>
 								<AlertDialogFooter>
 									<AlertDialogCancel>Not now</AlertDialogCancel>
 									<AlertDialogAction
-										onClick={() => redeemMutation.mutate({})}
+										onClick={() =>
+											redeemMutation.mutate({
+												body: {
+													confirmHighCycleUsage: requiresHighUsageConfirmation,
+												},
+											})
+										}
 										data-testid="redeem-pass-confirm-action"
 									>
-										Stamp the pass
+										{requiresHighUsageConfirmation
+											? "Use pass anyway"
+											: "Stamp the pass"}
 									</AlertDialogAction>
 								</AlertDialogFooter>
 							</AlertDialogContent>
@@ -347,9 +348,7 @@ export default function ResetPassCard({
 								<AlertDialogTrigger asChild>
 									<Button
 										size="sm"
-										variant={
-											available === 0 && !redeemBlocked ? "default" : "outline"
-										}
+										variant={available === 0 ? "default" : "outline"}
 										disabled={purchaseMutation.isPending}
 									>
 										{purchaseMutation.isPending ? (
@@ -381,44 +380,7 @@ export default function ResetPassCard({
 								</AlertDialogContent>
 							</AlertDialog>
 						)}
-						{redeemBlocked &&
-							(nextPlan ? (
-								<Button size="sm" asChild onClick={trackGateUpgradeClick}>
-									<Link href="/dashboard/billing">
-										<Plane className="mr-1.5 h-4 w-4" />
-										Upgrade to {nextPlan.name} · ${nextPlan.price}/mo
-									</Link>
-								</Button>
-							) : (
-								<Button size="sm" asChild onClick={trackGateUpgradeClick}>
-									<a
-										href={`${uiUrl}/dashboard?from=devpass-payg`}
-										target="_blank"
-										rel="noopener noreferrer"
-									>
-										Get PAYG credits on llmgateway.io
-										<ArrowUpRight className="ml-1.5 h-4 w-4" />
-									</a>
-								</Button>
-							))}
 					</div>
-					{redeemBlocked && (
-						<p className="mt-2.5 max-w-md text-xs text-muted-foreground">
-							Over 90% of this cycle&apos;s credits are used, so passes are on
-							hold until your credits renew.{" "}
-							{nextPlan ? (
-								<>
-									Upgrading to {nextPlan.name} starts a fresh cycle instantly
-									with a {`$${nextPlan.usage} `}monthly allowance.
-								</>
-							) : (
-								<>
-									Pay-as-you-go credits on LLM Gateway work with the same coding
-									agents — just swap your API key.
-								</>
-							)}
-						</p>
-					)}
 				</div>
 
 				<div className="flex items-center gap-2">

--- a/apps/docs/content/learn/reset-passes.mdx
+++ b/apps/docs/content/learn/reset-passes.mdx
@@ -45,7 +45,7 @@ Two kinds of stamps appear on the card:
 
 ## Redeeming a pass
 
-Click **Use a pass** on the card. Your premium usage for the week is zeroed immediately and the 7-day window restarts with your next premium request. Redemption is deliberately explicit — a pass is never consumed automatically, and it is rejected while your allowance is untouched. Once you've used more than 90% of your monthly credit allowance, the dashboard also asks you to confirm: a reset restores the weekly cap, but only the remaining monthly allowance is available to spend.
+Click **Use a pass** on the card. Your premium usage for the week is zeroed immediately and the 7-day window restarts with your next premium request. Redemption is deliberately explicit — a pass is never consumed automatically, and it is rejected while your allowance is untouched. Once you've used more than 90% of your monthly credit allowance, the dashboard also asks you to confirm: a reset restores the weekly cap, but only the remaining monthly allowance is available to spend. Once the monthly allowance is fully used, Reset Passes cannot be redeemed.
 
 Standard models are unaffected either way: they never count against the weekly cap.
 

--- a/apps/docs/content/learn/reset-passes.mdx
+++ b/apps/docs/content/learn/reset-passes.mdx
@@ -45,7 +45,7 @@ Two kinds of stamps appear on the card:
 
 ## Redeeming a pass
 
-Click **Use a pass** on the card. Your premium usage for the week is zeroed immediately and the 7-day window restarts with your next premium request. Redemption is deliberately explicit — a pass is never consumed automatically, and two guards stop a pass from being wasted: a redeem is rejected while your allowance is untouched, and also once you've used more than 90% of your monthly credit allowance (a reset then would restore a cap you have almost nothing left to spend against — the pass keeps until your credits renew).
+Click **Use a pass** on the card. Your premium usage for the week is zeroed immediately and the 7-day window restarts with your next premium request. Redemption is deliberately explicit — a pass is never consumed automatically, and it is rejected while your allowance is untouched. Once you've used more than 90% of your monthly credit allowance, the dashboard also asks you to confirm: a reset restores the weekly cap, but only the remaining monthly allowance is available to spend.
 
 Standard models are unaffected either way: they never count against the weekly cap.
 


### PR DESCRIPTION
## Problem

Reset Pass redemption was unavailable after more than 90% of the monthly allowance had been used, even when a user intentionally wanted to spend a held pass. Fully exhausted monthly allowances must still keep passes non-redeemable.

## Approach

Keep the pass action available with a dedicated warning for usage above 90% and below 100%. The redemption API requires explicit acknowledgement in that range, and rejects exhausted cycles even when the confirmation flag is supplied.

## Verification

- `pnpm format`
- `pnpm build`
- Focused reset-pass API coverage, including confirmed 90–100% redemption and confirmed rejection at full exhaustion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reset Pass redemption above 90% monthly credit usage now requires explicit confirmation.
  * Updated redemption prompts and actions in the dashboard.

* **Bug Fixes**
  * Redemption is rejected when the monthly credit allowance is fully exhausted.
  * Removed outdated upgrade and pay-as-you-go fallback messaging.

* **Documentation**
  * Updated Reset Pass guidance to reflect the revised redemption rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->