### PR TITLE
fix(routing): clarify multiplier behavior

### DIFF
--- a/apps/code/src/app/legal/terms/page.tsx
+++ b/apps/code/src/app/legal/terms/page.tsx
@@ -18,7 +18,7 @@ export default function TermsPage() {
 			<p>
 				<strong>Effective Date:</strong> April 26, 2026
 				<br />
-				<strong>Last Updated:</strong> August 2, 2026
+				<strong>Last Updated:</strong> August 18, 2026
 			</p>
 			<LegalSummary variant="terms" />
 			<p>
@@ -91,6 +91,15 @@ export default function TermsPage() {
 				application or for non-inference workloads (such as embeddings, image
 				generation, or video generation), use a standard LLM Gateway credits
 				plan under the Base Terms instead.
+			</p>
+			<p>
+				<strong>Automatic routing.</strong> When DevPass selects a provider
+				automatically, we may change internal routing scores, weights,
+				preferences, and similar routing parameters at any time and at our
+				discretion. As described in Section&nbsp;7 of the Base Terms, these
+				parameters affect provider selection but do not themselves change the
+				price used to measure usage. If you require a particular provider, you
+				must pin that provider where the Service supports provider pinning.
 			</p>
 			<hr />
 			<h2>2. Plans, Billing, and Fair Use</h2>

--- a/apps/ui/src/content/legal/terms.md
+++ b/apps/ui/src/content/legal/terms.md
@@ -1,7 +1,7 @@
 ---
 id: "1"
 slug: "terms"
-date: "2026-06-11"
+date: "2026-08-18"
 title: "Terms Of Use"
 description: "Review the Terms of Use for LLM Gateway. Learn about account eligibility, billing, credits, AI outputs, acceptable use, warranties, liability, and dispute resolution when using our multi-provider AI gateway platform."
 ---
@@ -9,7 +9,7 @@ description: "Review the Terms of Use for LLM Gateway. Learn about account eligi
 # Terms of Use
 
 **Effective Date:** June 11, 2026  
-**Last Updated:** June 11, 2026
+**Last Updated:** August 18, 2026
 
 Welcome to **LLM Gateway** (“we”, “our”, or “us”), operated by **Polar Lights LLC**, 16192 Coastal Highway, Lewes, DE 19958, United States. These Terms of Use (“Terms”) form a binding legal agreement between you (“you” or “Customer”) and LLM Gateway and govern your access to and use of the LLM Gateway platform, including our website **[llmgateway.io](https://llmgateway.io)**, APIs, SDKs, dashboards, and any related products or services (collectively, the “Service”).
 
@@ -116,6 +116,8 @@ When using AI models through LLM Gateway, you are also subject to the **terms, p
 - **AI outputs do not constitute professional advice** of any kind (including legal, medical, financial, or tax advice). You are responsible for independently reviewing, verifying, and validating any output before relying on or acting upon it.
 - We **do not control, endorse, or assume responsibility** for any AI model, provider, or output, including the accuracy of outputs, the intellectual-property status of outputs, or how providers process your data.
 - You bear all responsibility and risk for your use of AI outputs and for any decisions or actions taken based on them.
+
+**Automatic routing.** When you use automatic routing instead of pinning a provider, you authorize us to select among eligible providers. We may change internal routing scores, weights, preferences, and similar routing parameters at any time and at our discretion. These parameters affect provider selection but do not themselves change the price used to bill a request. If you require a particular provider, you must pin that provider in your request.
 
 **Stealth and undisclosed providers.** To improve availability, performance, and pricing, we may route some requests through **stealth providers** whose identity is not publicly disclosed (for example, providers offering preview or unreleased models under confidentiality). For these providers we **endeavor to obtain the same terms, privacy, and data-handling guarantees** that apply elsewhere on the Service, but because their identity and practices are not disclosed, **we cannot guarantee that they meet those standards**. If you require a known provider with a declared terms, privacy, and compliance posture, you can **pin your requests to specific providers** listed on our [Providers page](https://llmgateway.io/providers).
 

--- a/ee/admin/src/components/discount-form.tsx
+++ b/ee/admin/src/components/discount-form.tsx
@@ -91,6 +91,13 @@ function AdjustmentForm({
 	const isDiscount = kind === "discount";
 	const noun = isDiscount ? "Discount" : "Routing Multiplier";
 	const parsedValue = Number.parseFloat(value);
+	const routingPreview = !Number.isFinite(parsedValue)
+		? "Enter -10% to prioritize by 10%, or +10% to deprioritize by 10%."
+		: parsedValue < 0
+			? `Prioritized: routing compares at ${100 + parsedValue}% of the discounted price; billing is unchanged.`
+			: parsedValue > 0
+				? `Deprioritized: routing compares at ${100 + parsedValue}% of the discounted price; billing is unchanged.`
+				: "No change to routing preference or customer billing.";
 
 	const reset = () => {
 		setProvider("__all__");
@@ -161,7 +168,7 @@ function AdjustmentForm({
 					<DialogDescription>
 						{isDiscount
 							? "Create a customer discount for a provider, model, or combination."
-							: "Adjust internal routing preference without changing customer billing."}
+							: "Use a negative percentage to prioritize or a positive percentage to deprioritize. Customer billing is unchanged."}
 					</DialogDescription>
 				</DialogHeader>
 				<form onSubmit={handleSubmit} className="space-y-4">
@@ -241,7 +248,7 @@ function AdjustmentForm({
 								min={isDiscount ? 0 : -100}
 								max={isDiscount ? 100 : undefined}
 								step="0.1"
-								placeholder={isDiscount ? "30" : "-20 or 20"}
+								placeholder={isDiscount ? "30" : "-10"}
 								value={value}
 								onChange={(event) => setValue(event.target.value)}
 								required
@@ -253,7 +260,7 @@ function AdjustmentForm({
 						<p className="text-xs text-muted-foreground">
 							{isDiscount
 								? `Customer pays ${100 - (parsedValue || 0)}% of the original price`
-								: `Routes as ${100 + (parsedValue || 0)}% of the discounted price; billing is unchanged`}
+								: routingPreview}
 						</p>
 					</div>
 


### PR DESCRIPTION
## Problem

The routing multiplier dialog did not clearly explain whether positive or negative values prioritize a target. The Terms also did not explicitly reserve discretion to adjust internal automatic-routing parameters.

## Changes

- explain that `-10%` prioritizes a target and `+10%` deprioritizes it
- show whether the entered value prioritizes or deprioritizes and preview its effective routing price
- clarify in the base and DevPass Terms that automatic-routing scores, weights, preferences, and similar parameters may change without themselves changing billing or usage pricing
- update the legal documents' last-updated dates

## Verification

- `pnpm format`
- `pnpm build`

Screenshots omitted at the request of the reviewer.