### PR TITLE
fix(models): point Fireworks V4 Pro at 0813 GA

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -522,10 +522,13 @@ export const deepseekModels = [
 			},
 			{
 				providerId: "fireworks",
-				externalId: "accounts/fireworks/models/deepseek-v4-pro",
-				inputPrice: "1.74e-6",
-				cachedInputPrice: "0.145e-6",
-				outputPrice: "3.48e-6",
+				// Fireworks keeps the unversioned `deepseek-v4-pro` slug pointed at
+				// the original preview build, at its own rate card, even after the
+				// 0813 GA release; the GA build only serves under this dedicated slug.
+				externalId: "accounts/fireworks/models/deepseek-v4-pro-0813",
+				inputPrice: "1.32e-6",
+				cachedInputPrice: "0.044e-6",
+				outputPrice: "3.96e-6",
 				requestPrice: "0",
 				// Fireworks prices DeepSeek's Priority tier at 1.5x standard rather
 				// than the 1.25x that applies to the rest of its catalogue.


### PR DESCRIPTION
## Summary
- Fireworks' unversioned `deepseek-v4-pro` slug still serves the superseded preview build, at the preview's own rate card; the 0813 GA release only serves under the dedicated `deepseek-v4-pro-0813` slug, at a different price.
- Points the mapping's `externalId` at the versioned `-0813` slug and corrects `inputPrice`/`cachedInputPrice`/`outputPrice` to match, so the models page now clearly shows which build is served and bills at the right rate. Verified against Fireworks' live model catalogue API and a direct chat-completions call against both slugs.
- Same fix was already applied for DeepSeek V4 Flash on Fireworks; this brings V4 Pro in line with that precedent.

## Test plan
- [x] `pnpm format`
- [x] `turbo run build --filter=@llmgateway/models --filter=gateway --filter=api`
- [x] `vitest run packages/models/src` (150 passed)
- [x] Verified live against Fireworks' account model-list API and a direct `/chat/completions` call to both `deepseek-v4-pro` and `deepseek-v4-pro-0813`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the DeepSeek V4 Pro provider configuration to use the versioned deployment.
  * Updated input, cached-input, and output pricing to reflect the current rates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->