### PR TITLE
fix(billing): cap top-up choices

### DIFF
--- a/apps/api/src/lib/topup-velocity.ts
+++ b/apps/api/src/lib/topup-velocity.ts
@@ -70,4 +70,12 @@ export async function assertTopUpVelocityAllowed(
 	}
 }
 
+export async function getTopUpVelocityAllowance(org: TopUpVelocityOrg) {
+	return await checkAndReserveTopUp({
+		org,
+		amountUsd: 0,
+		reserve: false,
+	});
+}
+
 export { releaseTopUpReservation };

--- a/apps/api/src/routes/payments-topup-velocity.spec.ts
+++ b/apps/api/src/routes/payments-topup-velocity.spec.ts
@@ -58,6 +58,22 @@ describe("top-up velocity limits", () => {
 		});
 	}
 
+	test("reports fee-aware maxima from the remaining tier allowance", async () => {
+		await seedWindowTopUps("20");
+
+		const res = await app.request(
+			"/payments/top-up-limit?organizationId=test-org-id",
+			{ headers: { Cookie: token } },
+		);
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			remainingGrossAmount: 80,
+			maxCardAmount: 75,
+			maxCheckoutAmount: 76,
+		});
+	});
+
 	test("create-payment-intent returns 429 when the 24h cap is filled", async () => {
 		await seedWindowTopUps("95");
 

--- a/apps/api/src/routes/payments.ts
+++ b/apps/api/src/routes/payments.ts
@@ -9,6 +9,7 @@ import { computeReferralBonus } from "@/lib/referral-bonus.js";
 import { forcedThreeDSecureOptions } from "@/lib/three-d-secure.js";
 import {
 	assertTopUpVelocityAllowed,
+	getTopUpVelocityAllowance,
 	releaseTopUpReservation,
 } from "@/lib/topup-velocity.js";
 import { ensureStripeCustomer } from "@/stripe.js";
@@ -20,6 +21,7 @@ import {
 	calculateFees,
 	CREDIT_TOP_UP_MAX_AMOUNT,
 	CREDIT_TOP_UP_MIN_AMOUNT,
+	getMaxCreditTopUpAmount,
 } from "@llmgateway/shared";
 
 import type { ServerTypes } from "@/vars.js";
@@ -91,6 +93,57 @@ async function findUserOrganization(userId: string, organizationId?: string) {
 		},
 	});
 }
+
+const getTopUpLimit = createRoute({
+	method: "get",
+	path: "/top-up-limit",
+	request: {
+		query: z.object({
+			organizationId: z.string().optional(),
+		}),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						remainingGrossAmount: z.number().nullable(),
+						maxCardAmount: z.number(),
+						maxCheckoutAmount: z.number(),
+					}),
+				},
+			},
+			description: "Current credit top-up limits",
+		},
+	},
+});
+
+payments.openapi(getTopUpLimit, async (c) => {
+	const user = c.get("user");
+	if (!user) {
+		throw new HTTPException(401, { message: "Unauthorized" });
+	}
+
+	const { organizationId } = c.req.valid("query");
+	const userOrganization = await findUserOrganization(user.id, organizationId);
+	if (!userOrganization?.organization) {
+		throw new HTTPException(404, { message: "Organization not found" });
+	}
+
+	const allowance = await getTopUpVelocityAllowance(
+		userOrganization.organization,
+	);
+	const remainingGrossAmount = Number.isFinite(allowance.capUsd)
+		? allowance.remainingUsd
+		: null;
+	const availableGrossAmount = remainingGrossAmount ?? Number.POSITIVE_INFINITY;
+
+	return c.json({
+		remainingGrossAmount,
+		maxCardAmount: getMaxCreditTopUpAmount(availableGrossAmount, true),
+		maxCheckoutAmount: getMaxCreditTopUpAmount(availableGrossAmount, false),
+	});
+});
 
 export async function isInternationalPaymentMethod(
 	stripePaymentMethodId: string,

--- a/apps/ui/src/components/credits/top-up-credits-dialog.tsx
+++ b/apps/ui/src/components/credits/top-up-credits-dialog.tsx
@@ -163,6 +163,7 @@ export function TopUpCreditsDialog({ children }: TopUpCreditsDialogProps) {
 						organizationId={organizationId}
 						maxCardAmount={maxCardAmount}
 						maxCheckoutAmount={maxCheckoutAmount}
+						topUpLimitLoaded={Boolean(topUpLimit)}
 						topUpLimitError={topUpLimitError}
 						topUpLimitPending={topUpLimitPending}
 						autoTopUpIntent={autoTopUpIntent}
@@ -239,6 +240,7 @@ function AmountStep({
 	organizationId,
 	maxCardAmount,
 	maxCheckoutAmount,
+	topUpLimitLoaded,
 	topUpLimitError,
 	topUpLimitPending,
 	autoTopUpIntent,
@@ -251,6 +253,7 @@ function AmountStep({
 	organizationId: string | undefined;
 	maxCardAmount: number;
 	maxCheckoutAmount: number;
+	topUpLimitLoaded: boolean;
 	topUpLimitError: boolean;
 	topUpLimitPending: boolean;
 	autoTopUpIntent: boolean;
@@ -280,9 +283,9 @@ function AmountStep({
 	const amountValidationMessage = topUpLimitError
 		? "Couldn't load your current top-up allowance"
 		: maxCheckoutAmount < CREDIT_TOP_UP_MIN_AMOUNT
-			? "Your 24-hour top-up allowance is currently used up"
+			? "Your account tier's 24-hour top-up allowance is currently used up"
 			: amount > maxCheckoutAmount
-				? `Maximum $${maxCheckoutAmount.toLocaleString("en-US")} for your current top-up allowance`
+				? `Maximum $${maxCheckoutAmount.toLocaleString("en-US")} from your account tier's remaining 24-hour allowance`
 				: amount < CREDIT_TOP_UP_MIN_AMOUNT
 					? `Minimum $${CREDIT_TOP_UP_MIN_AMOUNT}`
 					: !Number.isInteger(amount)
@@ -388,7 +391,11 @@ function AmountStep({
 							}}
 							className="w-[4ch] border-0 bg-transparent p-0 text-center text-5xl font-bold tabular-nums tracking-tight caret-primary placeholder:text-muted-foreground/40 focus:outline-none focus:ring-0"
 							aria-invalid={Boolean(amountValidationMessage)}
-							aria-describedby="amount-hint"
+							aria-describedby={
+								topUpLimitLoaded && !topUpLimitError
+									? "amount-hint amount-limit-reason"
+									: "amount-hint"
+							}
 							required
 						/>
 						<Pencil
@@ -407,9 +414,38 @@ function AmountStep({
 					>
 						{amountValidationMessage ??
 							(amount > maxCardAmount
-								? `Card top-ups allow up to $${maxCardAmount}; use checkout below for this amount`
+								? `Card maximum $${maxCardAmount} after processing fees; use checkout below for this amount`
 								: `Type any amount from $${CREDIT_TOP_UP_MIN_AMOUNT} to $${maxCheckoutAmount.toLocaleString("en-US")}`)}
 					</p>
+					{topUpLimitLoaded && !topUpLimitError ? (
+						<div
+							id="amount-limit-reason"
+							className="space-y-1 text-xs text-muted-foreground"
+						>
+							<p>
+								This maximum is based on your account tier&apos;s remaining
+								24-hour top-up allowance and processing fees.{" "}
+								{organizationId ? (
+									<Link
+										href={`/dashboard/${organizationId}/org/limits`}
+										className="font-medium text-foreground underline underline-offset-2"
+									>
+										View account limits
+									</Link>
+								) : null}
+							</p>
+							<p>
+								Need to top up more? Email{" "}
+								<a
+									href="mailto:contact@lmkp.io"
+									className="font-medium text-foreground underline underline-offset-2"
+								>
+									contact@lmkp.io
+								</a>{" "}
+								and we can unlock a higher tier.
+							</p>
+						</div>
+					) : null}
 				</div>
 
 				{/* Preset grid */}
@@ -423,6 +459,11 @@ function AmountStep({
 								type="button"
 								onClick={() => setAmount(p.value)}
 								disabled={isDisabled}
+								title={
+									isDisabled
+										? `Above your account tier's remaining 24-hour top-up allowance`
+										: undefined
+								}
 								className={cn(
 									"flex flex-col items-center justify-center rounded-lg border px-2 py-2.5 transition-colors focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-40",
 									isSelected

--- a/apps/ui/src/components/credits/top-up-credits-dialog.tsx
+++ b/apps/ui/src/components/credits/top-up-credits-dialog.tsx
@@ -69,7 +69,7 @@ export function TopUpCreditsDialog({ children }: TopUpCreditsDialogProps) {
 	const [step, setStep] = useState<
 		"amount" | "payment" | "select-payment" | "confirm-payment" | "success"
 	>("amount");
-	const [amount, setAmount] = useState<number>(100);
+	const [amount, setAmount] = useState<number>(50);
 	const [loading, setLoading] = useState(false);
 	const [selectedPaymentMethod, setSelectedPaymentMethod] = useState<
 		string | null
@@ -93,6 +93,21 @@ export function TopUpCreditsDialog({ children }: TopUpCreditsDialogProps) {
 				enabled: open, // Only fetch when dialog is open
 			},
 		);
+	const {
+		data: topUpLimit,
+		isError: topUpLimitError,
+		isFetching: topUpLimitFetching,
+		isLoading: topUpLimitLoading,
+	} = api.useQuery(
+		"get",
+		"/payments/top-up-limit",
+		{ params: { query: { organizationId } } },
+		{ enabled: open, staleTime: 0 },
+	);
+	const maxCardAmount = topUpLimit?.maxCardAmount ?? CREDIT_TOP_UP_MAX_AMOUNT;
+	const maxCheckoutAmount =
+		topUpLimit?.maxCheckoutAmount ?? CREDIT_TOP_UP_MAX_AMOUNT;
+	const topUpLimitPending = topUpLimitLoading || topUpLimitFetching;
 
 	const hasPaymentMethods =
 		paymentMethodsData?.paymentMethods &&
@@ -106,6 +121,14 @@ export function TopUpCreditsDialog({ children }: TopUpCreditsDialogProps) {
 			setSelectedPaymentMethod(defaultPaymentMethod.id);
 		}
 	}, [defaultPaymentMethod]);
+
+	useEffect(() => {
+		if (topUpLimit && amount > maxCheckoutAmount) {
+			setAmount(
+				maxCheckoutAmount >= CREDIT_TOP_UP_MIN_AMOUNT ? maxCheckoutAmount : 0,
+			);
+		}
+	}, [amount, maxCheckoutAmount, topUpLimit]);
 
 	const handleClose = () => {
 		setOpen(false);
@@ -138,6 +161,10 @@ export function TopUpCreditsDialog({ children }: TopUpCreditsDialogProps) {
 						amount={amount}
 						setAmount={setAmount}
 						organizationId={organizationId}
+						maxCardAmount={maxCardAmount}
+						maxCheckoutAmount={maxCheckoutAmount}
+						topUpLimitError={topUpLimitError}
+						topUpLimitPending={topUpLimitPending}
 						autoTopUpIntent={autoTopUpIntent}
 						setAutoTopUpIntent={setAutoTopUpIntent}
 						alreadyHasAutoTopUp={alreadyHasAutoTopUp}
@@ -210,6 +237,10 @@ function AmountStep({
 	amount,
 	setAmount,
 	organizationId,
+	maxCardAmount,
+	maxCheckoutAmount,
+	topUpLimitError,
+	topUpLimitPending,
 	autoTopUpIntent,
 	setAutoTopUpIntent,
 	alreadyHasAutoTopUp,
@@ -218,6 +249,10 @@ function AmountStep({
 	amount: number;
 	setAmount: (amount: number) => void;
 	organizationId: string | undefined;
+	maxCardAmount: number;
+	maxCheckoutAmount: number;
+	topUpLimitError: boolean;
+	topUpLimitPending: boolean;
 	autoTopUpIntent: boolean;
 	setAutoTopUpIntent: (v: boolean) => void;
 	alreadyHasAutoTopUp: boolean;
@@ -238,15 +273,21 @@ function AmountStep({
 		"post",
 		"/payments/create-checkout-session",
 	);
-	const isAmountValid = isCreditTopUpAmountInRange(amount);
-	const amountValidationMessage =
-		amount > CREDIT_TOP_UP_MAX_AMOUNT
-			? `Maximum $${CREDIT_TOP_UP_MAX_AMOUNT.toLocaleString("en-US")}`
-			: amount < CREDIT_TOP_UP_MIN_AMOUNT
-				? `Minimum $${CREDIT_TOP_UP_MIN_AMOUNT}`
-				: !Number.isInteger(amount)
-					? "Whole dollar amounts only"
-					: null;
+	const isAmountInGlobalRange = isCreditTopUpAmountInRange(amount);
+	const isCardAmountValid = isAmountInGlobalRange && amount <= maxCardAmount;
+	const isCheckoutAmountValid =
+		isAmountInGlobalRange && amount <= maxCheckoutAmount;
+	const amountValidationMessage = topUpLimitError
+		? "Couldn't load your current top-up allowance"
+		: maxCheckoutAmount < CREDIT_TOP_UP_MIN_AMOUNT
+			? "Your 24-hour top-up allowance is currently used up"
+			: amount > maxCheckoutAmount
+				? `Maximum $${maxCheckoutAmount.toLocaleString("en-US")} for your current top-up allowance`
+				: amount < CREDIT_TOP_UP_MIN_AMOUNT
+					? `Minimum $${CREDIT_TOP_UP_MIN_AMOUNT}`
+					: !Number.isInteger(amount)
+						? "Whole dollar amounts only"
+						: null;
 	const {
 		data: feeData,
 		isLoading: feeDataLoading,
@@ -258,12 +299,21 @@ function AmountStep({
 			body: { amount, organizationId },
 		},
 		{
-			enabled: isAmountValid,
+			enabled: isCheckoutAmountValid,
 			placeholderData: keepPreviousData,
 		},
 	);
-	const isActionDisabled =
-		!isAmountValid || Boolean(feeDataLoading) || checkoutLoading;
+	const isCardActionDisabled =
+		!isCardAmountValid ||
+		Boolean(feeDataLoading) ||
+		topUpLimitPending ||
+		topUpLimitError;
+	const isCheckoutActionDisabled =
+		!isCheckoutAmountValid ||
+		Boolean(feeDataLoading) ||
+		topUpLimitPending ||
+		topUpLimitError ||
+		checkoutLoading;
 
 	const hasBonus = feeData?.bonusAmount && feeData.bonusAmount > 0;
 
@@ -356,7 +406,9 @@ function AmountStep({
 						)}
 					>
 						{amountValidationMessage ??
-							`Type any amount from $${CREDIT_TOP_UP_MIN_AMOUNT} to $${CREDIT_TOP_UP_MAX_AMOUNT.toLocaleString("en-US")}`}
+							(amount > maxCardAmount
+								? `Card top-ups allow up to $${maxCardAmount}; use checkout below for this amount`
+								: `Type any amount from $${CREDIT_TOP_UP_MIN_AMOUNT} to $${maxCheckoutAmount.toLocaleString("en-US")}`)}
 					</p>
 				</div>
 
@@ -364,13 +416,15 @@ function AmountStep({
 				<div className="grid grid-cols-4 gap-2">
 					{presets.map((p) => {
 						const isSelected = amount === p.value;
+						const isDisabled = p.value > maxCheckoutAmount;
 						return (
 							<button
 								key={p.value}
 								type="button"
 								onClick={() => setAmount(p.value)}
+								disabled={isDisabled}
 								className={cn(
-									"flex flex-col items-center justify-center rounded-lg border px-2 py-2.5 transition-colors focus:outline-none focus:ring-2 focus:ring-ring/50",
+									"flex flex-col items-center justify-center rounded-lg border px-2 py-2.5 transition-colors focus:outline-none focus:ring-2 focus:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-40",
 									isSelected
 										? "border-primary bg-primary/10 text-primary"
 										: "border-border hover:bg-accent hover:text-accent-foreground",
@@ -391,7 +445,7 @@ function AmountStep({
 				</div>
 
 				{/* Total (collapsed) */}
-				{isAmountValid ? (
+				{isCheckoutAmountValid ? (
 					<div className="overflow-hidden rounded-lg border bg-muted/30">
 						<button
 							type="button"
@@ -495,15 +549,19 @@ function AmountStep({
 				<Button
 					type="button"
 					onClick={onNext}
-					disabled={isActionDisabled}
+					disabled={isCardActionDisabled}
 					className="w-full"
 					size="lg"
 				>
-					{feeDataLoading
-						? "Calculating…"
-						: isAmountValid
-							? `Add $${amount} credits →`
-							: "Add credits"}
+					{topUpLimitError
+						? "Top-up allowance unavailable"
+						: topUpLimitPending || feeDataLoading
+							? "Calculating…"
+							: isCardAmountValid
+								? `Add $${amount} credits →`
+								: amount > maxCardAmount && isCheckoutAmountValid
+									? `Card maximum $${maxCardAmount}`
+									: "Add credits"}
 				</Button>
 
 				<div className="relative flex items-center justify-center">
@@ -519,7 +577,7 @@ function AmountStep({
 				<button
 					type="button"
 					onClick={handleStripeCheckout}
-					disabled={isActionDisabled}
+					disabled={isCheckoutActionDisabled}
 					aria-label="Pay with Apple Pay, Google Pay, crypto, or another method"
 					className="flex w-full items-center justify-center gap-2.5 rounded-lg border px-4 py-2.5 transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60"
 				>

--- a/apps/ui/src/components/credits/top-up-credits-dialog.tsx
+++ b/apps/ui/src/components/credits/top-up-credits-dialog.tsx
@@ -437,10 +437,10 @@ function AmountStep({
 							<p>
 								Need to top up more? Email{" "}
 								<a
-									href="mailto:contact@lmkp.io"
+									href="mailto:contact@llmgateway.io"
 									className="font-medium text-foreground underline underline-offset-2"
 								>
-									contact@lmkp.io
+									contact@llmgateway.io
 								</a>{" "}
 								and we can unlock a higher tier.
 							</p>

--- a/packages/shared/src/fees.spec.ts
+++ b/packages/shared/src/fees.spec.ts
@@ -4,6 +4,7 @@ import {
 	calculateFees,
 	CREDIT_TOP_UP_MAX_AMOUNT,
 	CREDIT_TOP_UP_MIN_AMOUNT,
+	getMaxCreditTopUpAmount,
 	isCreditTopUpAmountInRange,
 } from "./fees.js";
 
@@ -56,5 +57,24 @@ describe("calculateFees", () => {
 			internationalFee: 0,
 			totalAmount: 105,
 		});
+	});
+});
+
+describe("getMaxCreditTopUpAmount", () => {
+	it("accounts for fees within the gross allowance", () => {
+		expect(getMaxCreditTopUpAmount(100, false)).toBe(95);
+		expect(getMaxCreditTopUpAmount(100, true)).toBe(93);
+	});
+
+	it("accounts for allowance already used", () => {
+		expect(getMaxCreditTopUpAmount(50, false)).toBe(47);
+		expect(getMaxCreditTopUpAmount(50, true)).toBe(46);
+		expect(getMaxCreditTopUpAmount(0, false)).toBe(0);
+	});
+
+	it("keeps the global ceiling for exempt organizations", () => {
+		expect(getMaxCreditTopUpAmount(Number.POSITIVE_INFINITY, true)).toBe(
+			CREDIT_TOP_UP_MAX_AMOUNT,
+		);
 	});
 });

--- a/packages/shared/src/fees.ts
+++ b/packages/shared/src/fees.ts
@@ -24,6 +24,31 @@ export function isCreditTopUpAmountInRange(amount: number): boolean {
 	);
 }
 
+export function getMaxCreditTopUpAmount(
+	grossAllowanceUsd: number,
+	isInternational: boolean,
+): number {
+	if (!Number.isFinite(grossAllowanceUsd)) {
+		return CREDIT_TOP_UP_MAX_AMOUNT;
+	}
+
+	let low = 0;
+	let high = CREDIT_TOP_UP_MAX_AMOUNT;
+	while (low < high) {
+		const candidate = Math.ceil((low + high) / 2);
+		if (
+			calculateFees({ amount: candidate, isInternational }).totalAmount <=
+			grossAllowanceUsd
+		) {
+			low = candidate;
+		} else {
+			high = candidate - 1;
+		}
+	}
+
+	return low;
+}
+
 const PLATFORM_FEE_PERCENTAGE = 0.05;
 export const INTERNATIONAL_CARD_FEE_PERCENTAGE = 0.015;
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -35,6 +35,7 @@ export {
 	calculateFees,
 	CREDIT_TOP_UP_MAX_AMOUNT,
 	CREDIT_TOP_UP_MIN_AMOUNT,
+	getMaxCreditTopUpAmount,
 	INTERNATIONAL_CARD_FEE_PERCENTAGE,
 	isCreditTopUpAmountInRange,
 	type FeeBreakdown,


### PR DESCRIPTION
## Problem

The top-up picker used the global ceiling even when an organization's rolling tier allowance was lower. Because the allowance applies to the gross charge, fees could also make an apparently valid base amount fail after selection.

## Changes

- expose the live remaining gross allowance with fee-aware card and hosted Checkout maxima
- cap presets and actions separately for the embedded card and hosted Checkout flows
- refresh the allowance whenever the dialog opens and handle exhausted or unavailable states
- explain that the maximum comes from the account tier's remaining 24-hour allowance and fees, with links to account limits and higher-tier support
- cover allowance calculations and the authenticated limit endpoint

## Verification

- `pnpm format`
- `pnpm exec vitest run packages/shared/src/fees.spec.ts apps/api/src/routes/payments-topup-velocity.spec.ts --no-file-parallelism`
- `pnpm build`
- verified the seeded dashboard flow, including the tier explanation, limits link, support email, separate card maximum, and disabled higher preset

## Screenshot

<img width="500" alt="Tier-aware top-up choices" src="https://raw.githubusercontent.com/theopenco/llmgateway/9eb26e42c6ddeca5fc4f567bcbd83dc5d712a3b6/top-up-tier-limit.png" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added top-up allowance visibility, including remaining gross allowance and fee-adjusted maximum amounts for card and Checkout payments.
  - Updated the top-up dialog with organization-specific limits, allowance-aware validation, and clearer unavailable or error states.
  - Top-up amounts now default to $50 and automatically adjust when they exceed available limits.

- **Bug Fixes**
  - Improved fee calculations to keep top-ups within available allowances, including international fees and global maximum limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->