### PR TITLE
fix(gateway): route custom models on auto

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -25,6 +25,7 @@ import {
 	findOrganizationById,
 	findCustomProviderKey,
 	findCustomModel,
+	findActiveCustomModels,
 	findEffectiveDiscount,
 	findEffectiveRoutingScoreMultiplier,
 	findProviderKey,
@@ -412,6 +413,28 @@ function customModelToProviderMapping(cm: CustomModel): ProviderModelMapping {
 		supportedParameters: cm.supportedParameters ?? undefined,
 		streaming,
 	};
+}
+
+type CustomAutoRoutingMapping = ProviderModelMapping & {
+	customProviderKeyId: string;
+	customProviderName: string;
+};
+
+function customModelHasRoutingPrice(customModel: CustomModel): boolean {
+	return (
+		(customModel.inputPrice !== null && customModel.outputPrice !== null) ||
+		customModel.requestPrice !== null
+	);
+}
+
+function isCustomAutoRoutingMapping(
+	mapping: ProviderModelMapping,
+): mapping is CustomAutoRoutingMapping {
+	return (
+		mapping.providerId === "custom" &&
+		"customProviderKeyId" in mapping &&
+		"customProviderName" in mapping
+	);
 }
 
 function filterRegionsByAvailableKeys(
@@ -1908,7 +1931,7 @@ chat.openapi(completions, async (c) => {
 	// Parse model input to resolve model, provider, and custom provider name
 	const parseResult = parseModelInput(modelInput);
 	const requestedModel = parseResult.requestedModel;
-	const customProviderName = parseResult.customProviderName;
+	let customProviderName = parseResult.customProviderName;
 	const requestedRegion = parseResult.requestedRegion;
 
 	// Count input images from messages for cost calculation
@@ -3026,7 +3049,7 @@ chat.openapi(completions, async (c) => {
 	// Do not move the compliance gate above this block. Relies on
 	// unique(organizationId, name) on provider_key: this row is the same one the
 	// request-execution path resolves later.
-	const customProviderKey =
+	let customProviderKey =
 		requestedProvider === "custom" && customProviderName
 			? await findCustomProviderKey(project.organizationId, customProviderName)
 			: undefined;
@@ -3039,7 +3062,7 @@ chat.openapi(completions, async (c) => {
 			message: `Provider '${customProviderName}' not found.`,
 		});
 	}
-	const complianceContext: ComplianceCheckContext = {
+	let complianceContext: ComplianceCheckContext = {
 		customAttestation: customProviderKey?.complianceAttestation ?? null,
 		customProviderName,
 	};
@@ -3430,6 +3453,22 @@ chat.openapi(completions, async (c) => {
 		// configured region (e.g. aws_bedrock_region: "eu") instead of being
 		// collapsed to the pinned default by applyPinnedDefaultRegions.
 		const autoProviderLockedRegions = buildProviderLockedRegions(providerKeys);
+		const customProviderKeysById = new Map(
+			providerKeys
+				.filter((key) => key.provider === "custom" && key.name !== null)
+				.map((key) => [key.id, key]),
+		);
+		const activeCustomModels =
+			project.mode !== "credits" && !isDevPlan
+				? await findActiveCustomModels(project.organizationId)
+				: [];
+		const activeCustomModelsByName = new Map<string, CustomModel[]>();
+		for (const customModel of activeCustomModels) {
+			const matchingModels =
+				activeCustomModelsByName.get(customModel.modelName) ?? [];
+			matchingModels.push(customModel);
+			activeCustomModelsByName.set(customModel.modelName, matchingModels);
+		}
 
 		// Find the cheapest model that meets our context size requirements
 		// Only consider hardcoded models for auto selection
@@ -3542,9 +3581,6 @@ chat.openapi(completions, async (c) => {
 				clientIp,
 				autoRouting: true,
 			});
-			if (!candidateIam.allowed) {
-				continue;
-			}
 			const candidateAllowedProviders = candidateIam.allowedProviders;
 
 			const { availableProviders, providersWithKeys } =
@@ -3576,13 +3612,73 @@ chat.openapi(completions, async (c) => {
 				),
 			);
 			// Check if any of the model's providers are available
-			const availableModelProviders = candidateProviders.filter(
-				(provider) =>
-					availableProviders.includes(provider.providerId) &&
-					(!candidateAllowedProviders ||
-						candidateAllowedProviders.includes(provider.providerId)) &&
-					(!dynamicRouteSelection?.providers ||
-						dynamicRouteSelection.providers.includes(provider.providerId)),
+			const availableModelProviders = candidateIam.allowed
+				? candidateProviders.filter(
+						(provider) =>
+							availableProviders.includes(provider.providerId) &&
+							(!candidateAllowedProviders ||
+								candidateAllowedProviders.includes(provider.providerId)) &&
+							(!dynamicRouteSelection?.providers ||
+								dynamicRouteSelection.providers.includes(provider.providerId)),
+					)
+				: [];
+			const customAvailableProviders = (
+				await Promise.all(
+					(activeCustomModelsByName.get(modelDef.id) ?? [])
+						.filter(customModelHasRoutingPrice)
+						.map(async (customModel) => {
+							const providerKey = customProviderKeysById.get(
+								customModel.providerKeyId,
+							);
+							if (!providerKey?.name) {
+								return undefined;
+							}
+							if (
+								effectiveFreeModelsOnly &&
+								[
+									customModel.inputPrice,
+									customModel.outputPrice,
+									customModel.requestPrice,
+								]
+									.filter((price): price is string => price !== null)
+									.some((price) => Number(price) !== 0)
+							) {
+								return undefined;
+							}
+							if (
+								dynamicRouteSelection?.providers &&
+								!dynamicRouteSelection.providers.some((provider) =>
+									[
+										"custom",
+										providerKey.name,
+										`custom:${providerKey.name}`,
+									].includes(provider),
+								)
+							) {
+								return undefined;
+							}
+
+							const mapping: CustomAutoRoutingMapping = {
+								...customModelToProviderMapping(customModel),
+								customProviderKeyId: providerKey.id,
+								customProviderName: providerKey.name,
+							};
+							const customIam = await validateRequestModelAccess({
+								apiKey,
+								organizationId: project.organizationId,
+								requestedModel: modelDef.id,
+								requestedProvider: "custom",
+								customProviderName: providerKey.name,
+								activeModelInfo: { ...modelDef, providers: [mapping] },
+								clientIp,
+								autoRouting: true,
+							});
+							return customIam.allowed ? mapping : undefined;
+						}),
+				)
+			).filter(
+				(provider): provider is CustomAutoRoutingMapping =>
+					provider !== undefined,
 			);
 			const cachedFilteredProviders = isDevPlan
 				? availableModelProviders.filter(providerSupportsCachedInput)
@@ -3591,11 +3687,34 @@ chat.openapi(completions, async (c) => {
 			// Drop providers that don't meet the org's compliance policy so auto
 			// routing picks a compliant provider instead of being blocked later. A
 			// model excluded by the policy's model lists loses all its providers.
-			const complianceFilteredProviders =
+			const catalogueComplianceFilteredProviders =
 				compliancePolicy && !isModelIdCompliant(modelDef.id, compliancePolicy)
 					? []
 					: applyCompliancePolicy(cachedFilteredProviders);
-			if (cachedFilteredProviders.length > 0) {
+			const customComplianceFilteredProviders = compliancePolicy
+				? customAvailableProviders.filter((provider) => {
+						const providerKey = customProviderKeysById.get(
+							provider.customProviderKeyId,
+						);
+						const context: ComplianceCheckContext = {
+							customAttestation: providerKey?.complianceAttestation ?? null,
+							customProviderName: provider.customProviderName,
+						};
+						return (
+							isModelIdCompliant(modelDef.id, compliancePolicy, context) &&
+							isProviderIdCompliant("custom", compliancePolicy, context)
+						);
+					})
+				: customAvailableProviders;
+			const preComplianceProviders = [
+				...cachedFilteredProviders,
+				...customAvailableProviders,
+			];
+			const complianceFilteredProviders = [
+				...catalogueComplianceFilteredProviders,
+				...customComplianceFilteredProviders,
+			];
+			if (preComplianceProviders.length > 0) {
 				anyPreComplianceCandidate = true;
 				if (complianceFilteredProviders.length > 0) {
 					anyPostComplianceCandidate = true;
@@ -3603,11 +3722,9 @@ chat.openapi(completions, async (c) => {
 			}
 			// Filter by context size requirement, reasoning capability, and deprecation status
 			const filteredOutForModel: FilteredProvider[] = [];
-			const compliantProviderIds = new Set(
-				complianceFilteredProviders.map((provider) => provider.providerId),
-			);
-			for (const provider of cachedFilteredProviders) {
-				if (!compliantProviderIds.has(provider.providerId)) {
+			const compliantProviders = new Set(complianceFilteredProviders);
+			for (const provider of preComplianceProviders) {
+				if (!compliantProviders.has(provider)) {
 					recordFilteredProvider(filteredOutForModel, provider.providerId, [
 						exclusionReason("compliance"),
 					]);
@@ -3645,9 +3762,34 @@ chat.openapi(completions, async (c) => {
 					return true;
 				},
 			);
+			let cheapestCustomProvider: ProviderModelMapping | undefined;
+			let cheapestCustomPrice = Number.MAX_VALUE;
+			for (const provider of suitableProviders) {
+				if (!isCustomAutoRoutingMapping(provider)) {
+					continue;
+				}
+				const { price } = await getDiscountedProviderSelectionPrice(
+					provider,
+					modelDef.id,
+					{
+						organizationId: project.organizationId,
+						providerDiscountResolver,
+					},
+				);
+				if (price.toNumber() < cheapestCustomPrice) {
+					cheapestCustomPrice = price.toNumber();
+					cheapestCustomProvider = provider;
+				}
+			}
+			const deduplicatedSuitableProviders = [
+				...suitableProviders.filter(
+					(provider) => !isCustomAutoRoutingMapping(provider),
+				),
+				...(cheapestCustomProvider ? [cheapestCustomProvider] : []),
+			];
 			const preferredSuitableProviders = preferProvidersWithKeys(
 				project.mode,
-				suitableProviders,
+				deduplicatedSuitableProviders,
 				providersWithKeys,
 			);
 
@@ -3666,7 +3808,10 @@ chat.openapi(completions, async (c) => {
 
 					if (totalPrice < lowestPrice) {
 						lowestPrice = totalPrice;
-						selectedModel = modelDef;
+						selectedModel = {
+							...modelDef,
+							providers: preferredSuitableProviders,
+						};
 						selectedProviders = preferredSuitableProviders;
 						selectedFilteredProviders = filteredOutForModel;
 					}
@@ -3675,6 +3820,21 @@ chat.openapi(completions, async (c) => {
 		}
 
 		let providerAgnosticSelectedProviders = selectedProviders;
+		const applySelectedCustomProvider = (provider: ProviderModelMapping) => {
+			if (!isCustomAutoRoutingMapping(provider)) {
+				return;
+			}
+			const providerKey = customProviderKeysById.get(
+				provider.customProviderKeyId,
+			);
+			customProviderName = provider.customProviderName;
+			customProviderKey = providerKey;
+			customPricingMapping = provider;
+			complianceContext = {
+				customAttestation: providerKey?.complianceAttestation ?? null,
+				customProviderName: provider.customProviderName,
+			};
+		};
 
 		// If we found a suitable model, use the cheapest provider from it
 		if (selectedModel && selectedProviders.length > 0) {
@@ -3721,6 +3881,7 @@ chat.openapi(completions, async (c) => {
 				usedInternalModel = selectedModel.id;
 				usedExternalId = cheapestResult.provider.externalId;
 				usedRegion = cheapestResult.provider.region;
+				applySelectedCustomProvider(cheapestResult.provider);
 				routingMetadata = {
 					...cheapestResult.metadata,
 					...getNoFallbackRoutingMetadata(noFallback, xNoFallbackHeaderSet),
@@ -3731,6 +3892,22 @@ chat.openapi(completions, async (c) => {
 				usedProvider = selectedProviders[0].providerId;
 				usedInternalModel = selectedModel.id;
 				usedExternalId = selectedProviders[0].externalId;
+				applySelectedCustomProvider(selectedProviders[0]);
+			}
+
+			if (usedProvider === "custom") {
+				providerAgnosticSelectedProviders =
+					providerAgnosticSelectedProviders.filter(
+						(provider) =>
+							provider.providerId !== "custom" ||
+							(isCustomAutoRoutingMapping(provider) &&
+								provider.customProviderName === customProviderName),
+					);
+			} else {
+				providerAgnosticSelectedProviders =
+					providerAgnosticSelectedProviders.filter(
+						(provider) => provider.providerId !== "custom",
+					);
 			}
 		} else {
 			// Compliance removed every otherwise-available candidate: fail closed
@@ -3813,6 +3990,9 @@ chat.openapi(completions, async (c) => {
 			apiKey,
 			organizationId: project.organizationId,
 			requestedModel: modelInfo.id,
+			requestedProvider: usedProvider === "custom" ? "custom" : undefined,
+			customProviderName:
+				usedProvider === "custom" ? customProviderName : undefined,
 			activeModelInfo: modelInfo,
 			clientIp,
 			autoRouting: true,

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -409,6 +409,7 @@ function customModelToProviderMapping(cm: CustomModel): ProviderModelMapping {
 		tools: cm.tools ?? undefined,
 		reasoning: cm.reasoning ?? undefined,
 		jsonOutput: cm.jsonOutput ?? undefined,
+		jsonOutputSchema: cm.jsonOutput ?? undefined,
 		audio: cm.audio ?? undefined,
 		supportedParameters: cm.supportedParameters ?? undefined,
 		streaming,
@@ -3268,11 +3269,7 @@ chat.openapi(completions, async (c) => {
 					message: `Model '${requestedModel}' is not configured to support tool calls. Remove the tools/tool_choice parameter or enable tools for this custom model.`,
 				});
 			}
-			// Custom models are soft-JSON-only by data model: org-model records
-			// carry jsonOutput but no jsonOutputSchema, so both json_object and
-			// json_schema are gated on jsonOutput (a custom model can still reach
-			// an upstream that enforces schema via a catalog mapping; extending
-			// custom models with jsonOutputSchema is a follow-up).
+			// Custom model records use jsonOutput for both JSON modes.
 			if (
 				customModelEntry.jsonOutput === false &&
 				(response_format?.type === "json_object" ||

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -7278,6 +7278,11 @@ chat.openapi(completions, async (c) => {
 		ctx: Awaited<ReturnType<typeof resolveProviderContext>>,
 	): void {
 		usedProvider = ctx.usedProvider;
+		if (usedProvider !== "custom") {
+			customProviderName = undefined;
+			customProviderKey = undefined;
+			customPricingMapping = undefined;
+		}
 		usedInternalModel = ctx.usedInternalModel;
 		usedExternalId = ctx.usedExternalId;
 		usedModelFormatted = ctx.usedModelFormatted;

--- a/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
@@ -94,10 +94,20 @@ describe("shouldRetryRequest", () => {
 		);
 	});
 
-	it("does not retry for custom provider", () => {
+	it("retries for an auto-selected custom provider", () => {
 		expect(shouldRetryRequest({ ...defaultOpts, usedProvider: "custom" })).toBe(
-			false,
+			true,
 		);
+	});
+
+	it("does not retry for a pinned custom provider", () => {
+		expect(
+			shouldRetryRequest({
+				...defaultOpts,
+				requestedProvider: "custom",
+				usedProvider: "custom",
+			}),
+		).toBe(false);
 	});
 
 	it("does not retry for llmgateway provider", () => {

--- a/apps/gateway/src/chat/tools/retry-with-fallback.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.ts
@@ -228,7 +228,7 @@ export function shouldRetryRequest(opts: {
 	if (opts.remainingProviders <= 0) {
 		return false;
 	}
-	if (opts.usedProvider === "custom" || opts.usedProvider === "llmgateway") {
+	if (opts.usedProvider === "llmgateway") {
 		return false;
 	}
 	return true;

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -428,6 +428,7 @@ describe("fallback and error status code handling", () => {
 			inputPrice: "0.1e-6",
 			outputPrice: "0.2e-6",
 			contextSize: 200_000,
+			jsonOutput: true,
 			streaming: "true",
 		});
 	}
@@ -454,6 +455,35 @@ describe("fallback and error status code handling", () => {
 			expect(logs[0].usedProvider).toBe("custom");
 			expect(logs[0].usedModel).toBe("my-custom/claude-haiku-4-5");
 			expect(Number(logs[0].cost)).toBeGreaterThan(0);
+		});
+
+		test("routes JSON schema requests to capable custom models", async () => {
+			await setupCustomAutoRouting();
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer auto-custom-token",
+				},
+				body: JSON.stringify({
+					model: "auto",
+					messages: [{ role: "user", content: "Return JSON" }],
+					response_format: {
+						type: "json_schema",
+						json_schema: {
+							name: "response",
+							schema: { type: "object" },
+						},
+					},
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			const logs = await waitForLogs(1);
+			expect(logs).toHaveLength(1);
+			expect(logs[0].usedProvider).toBe("custom");
+			expect(logs[0].usedModel).toBe("my-custom/claude-haiku-4-5");
 		});
 
 		test("falls back after an auto-selected custom provider fails", async () => {

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -390,6 +390,69 @@ describe("fallback and error status code handling", () => {
 		);
 	}
 
+	describe("custom provider auto routing", () => {
+		test("routes to a priced custom model with a matching catalog id", async () => {
+			await db
+				.update(tables.organization)
+				.set({ plan: "enterprise" })
+				.where(eq(tables.organization.id, "org-id"));
+			await db.insert(tables.apiKey).values({
+				id: "auto-custom-token-id",
+				token: "auto-custom-token",
+				projectId: "project-id",
+				description: "Custom auto-routing key",
+				createdBy: "user-id",
+			});
+			await db.insert(tables.providerKey).values([
+				{
+					id: "auto-custom-provider-key",
+					token: "sk-custom-auto",
+					provider: "custom",
+					name: "my-custom",
+					baseUrl: mockServerUrl,
+					organizationId: "org-id",
+					customModelsOnly: true,
+				},
+				{
+					id: "auto-anthropic-provider-key",
+					token: "sk-anthropic-auto",
+					provider: "anthropic",
+					baseUrl: mockServerUrl,
+					organizationId: "org-id",
+				},
+			]);
+			await db.insert(tables.customModel).values({
+				id: "auto-custom-model",
+				providerKeyId: "auto-custom-provider-key",
+				organizationId: "org-id",
+				modelName: "claude-haiku-4-5",
+				inputPrice: "0.1e-6",
+				outputPrice: "0.2e-6",
+				contextSize: 200_000,
+				streaming: "true",
+			});
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer auto-custom-token",
+				},
+				body: JSON.stringify({
+					model: "auto",
+					messages: [{ role: "user", content: "Hello custom auto!" }],
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			const logs = await waitForLogs(1);
+			expect(logs).toHaveLength(1);
+			expect(logs[0].usedProvider).toBe("custom");
+			expect(logs[0].usedModel).toBe("my-custom/claude-haiku-4-5");
+			expect(Number(logs[0].cost)).toBeGreaterThan(0);
+		});
+	});
+
 	describe("error status code classification", () => {
 		test("500 upstream error is classified as upstream_error with correct metadata in response and DB log", async () => {
 			await setupCustomKeys();

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -390,47 +390,51 @@ describe("fallback and error status code handling", () => {
 		);
 	}
 
+	async function setupCustomAutoRouting() {
+		await db
+			.update(tables.organization)
+			.set({ plan: "enterprise" })
+			.where(eq(tables.organization.id, "org-id"));
+		await db.insert(tables.apiKey).values({
+			id: "auto-custom-token-id",
+			token: "auto-custom-token",
+			projectId: "project-id",
+			description: "Custom auto-routing key",
+			createdBy: "user-id",
+		});
+		await db.insert(tables.providerKey).values([
+			{
+				id: "auto-custom-provider-key",
+				token: "sk-custom-auto",
+				provider: "custom",
+				name: "my-custom",
+				baseUrl: mockServerUrl,
+				organizationId: "org-id",
+				customModelsOnly: true,
+			},
+			{
+				id: "auto-anthropic-provider-key",
+				token: "sk-anthropic-auto",
+				provider: "anthropic",
+				baseUrl: mockServerUrl,
+				organizationId: "org-id",
+			},
+		]);
+		await db.insert(tables.customModel).values({
+			id: "auto-custom-model",
+			providerKeyId: "auto-custom-provider-key",
+			organizationId: "org-id",
+			modelName: "claude-haiku-4-5",
+			inputPrice: "0.1e-6",
+			outputPrice: "0.2e-6",
+			contextSize: 200_000,
+			streaming: "true",
+		});
+	}
+
 	describe("custom provider auto routing", () => {
 		test("routes to a priced custom model with a matching catalog id", async () => {
-			await db
-				.update(tables.organization)
-				.set({ plan: "enterprise" })
-				.where(eq(tables.organization.id, "org-id"));
-			await db.insert(tables.apiKey).values({
-				id: "auto-custom-token-id",
-				token: "auto-custom-token",
-				projectId: "project-id",
-				description: "Custom auto-routing key",
-				createdBy: "user-id",
-			});
-			await db.insert(tables.providerKey).values([
-				{
-					id: "auto-custom-provider-key",
-					token: "sk-custom-auto",
-					provider: "custom",
-					name: "my-custom",
-					baseUrl: mockServerUrl,
-					organizationId: "org-id",
-					customModelsOnly: true,
-				},
-				{
-					id: "auto-anthropic-provider-key",
-					token: "sk-anthropic-auto",
-					provider: "anthropic",
-					baseUrl: mockServerUrl,
-					organizationId: "org-id",
-				},
-			]);
-			await db.insert(tables.customModel).values({
-				id: "auto-custom-model",
-				providerKeyId: "auto-custom-provider-key",
-				organizationId: "org-id",
-				modelName: "claude-haiku-4-5",
-				inputPrice: "0.1e-6",
-				outputPrice: "0.2e-6",
-				contextSize: 200_000,
-				streaming: "true",
-			});
+			await setupCustomAutoRouting();
 
 			const res = await app.request("/v1/chat/completions", {
 				method: "POST",
@@ -450,6 +454,34 @@ describe("fallback and error status code handling", () => {
 			expect(logs[0].usedProvider).toBe("custom");
 			expect(logs[0].usedModel).toBe("my-custom/claude-haiku-4-5");
 			expect(Number(logs[0].cost)).toBeGreaterThan(0);
+		});
+
+		test("falls back after an auto-selected custom provider fails", async () => {
+			await setupCustomAutoRouting();
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer auto-custom-token",
+				},
+				body: JSON.stringify({
+					model: "auto",
+					messages: [
+						{ role: "user", content: "TRIGGER_FAIL_ONCE custom auto" },
+					],
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			const logs = await waitForLogs(2);
+			const failedLog = logs.find((log: Log) => log.hasError);
+			const successLog = logs.find((log: Log) => !log.hasError);
+			expect(failedLog?.usedProvider).toBe("custom");
+			expect(failedLog?.retried).toBe(true);
+			expect(successLog?.usedProvider).toBe("anthropic");
+			expect(successLog?.usedModel).toBe("anthropic/claude-haiku-4-5");
+			expect(failedLog?.retriedByLogId).toBe(successLog?.id);
 		});
 	});
 

--- a/apps/gateway/src/lib/cached-queries.spec.ts
+++ b/apps/gateway/src/lib/cached-queries.spec.ts
@@ -7,6 +7,7 @@ import {
 	eq,
 	apiKey,
 	apiKeyIamRule,
+	customModel,
 	organization,
 	project,
 	providerKey,
@@ -24,6 +25,7 @@ import {
 	findProjectById,
 	findOrganizationById,
 	findCustomProviderKey,
+	findActiveCustomModels,
 	findProviderKey,
 	findActiveProviderKeys,
 	findProviderKeysByProviders,
@@ -125,6 +127,24 @@ describe("Cached Queries - Gateway Database Access", () => {
 			organizationId: testOrgId,
 			status: "active",
 		});
+
+		await db.insert(customModel).values([
+			{
+				id: "test-active-custom-model",
+				providerKeyId: "test-custom-provider-key",
+				organizationId: testOrgId,
+				modelName: "claude-haiku-4-5",
+				inputPrice: "1e-6",
+				outputPrice: "2e-6",
+			},
+			{
+				id: "test-inactive-custom-model",
+				providerKeyId: "test-custom-provider-key",
+				organizationId: testOrgId,
+				modelName: "inactive-model",
+				status: "inactive",
+			},
+		]);
 
 		await db.insert(apiKeyIamRule).values({
 			id: testIamRuleId,
@@ -233,6 +253,20 @@ describe("Cached Queries - Gateway Database Access", () => {
 			const result = await findCustomProviderKey(testOrgId, "nonexistent");
 
 			expect(result).toBeUndefined();
+		});
+	});
+
+	describe("findActiveCustomModels", () => {
+		it("finds active custom models for an organization", async () => {
+			const result = await findActiveCustomModels(testOrgId);
+
+			expect(result.map((model) => model.id)).toEqual([
+				"test-active-custom-model",
+			]);
+		});
+
+		it("returns an empty array for another organization", async () => {
+			expect(await findActiveCustomModels("nonexistent-org")).toEqual([]);
 		});
 	});
 

--- a/apps/gateway/src/lib/cached-queries.ts
+++ b/apps/gateway/src/lib/cached-queries.ts
@@ -489,6 +489,26 @@ export async function findCustomModel(
 	return results[0];
 }
 
+/** Find every active custom model catalog entry for an organization. */
+export async function findActiveCustomModels(
+	organizationId: string,
+): Promise<CustomModel[]> {
+	return await swrWrap(
+		`customModel:active:${organizationId}`,
+		[customModelTableName],
+		async () =>
+			await db
+				.select()
+				.from(customModelTable)
+				.where(
+					and(
+						eq(customModelTable.status, "active"),
+						eq(customModelTable.organizationId, organizationId),
+					),
+				),
+	);
+}
+
 /**
  * The organization's own keys for a provider that can serve this request, in
  * selection order (index 0 is the primary). This is exactly the candidate set

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -807,6 +807,28 @@ mockOpenAIServer.post("/v1/responses", async (c) => {
 	return c.json(response);
 });
 
+mockOpenAIServer.post("/v1/messages", async (c) => {
+	const body = await c.req.json();
+	return c.json({
+		id: "msg-123",
+		type: "message",
+		role: "assistant",
+		model: body.model ?? "claude-haiku-4-5",
+		content: [
+			{
+				type: "text",
+				text: "Hello! I'm a mock response from the test server.",
+			},
+		],
+		stop_reason: "end_turn",
+		stop_sequence: null,
+		usage: {
+			input_tokens: 10,
+			output_tokens: 20,
+		},
+	});
+});
+
 // Handle chat completions endpoint
 mockOpenAIServer.post("/v1/chat/completions", async (c) => {
 	const body = await c.req.json();


### PR DESCRIPTION
## Problem

Auto-routing only built candidates from static catalogue provider mappings. A custom provider model with the same canonical model ID and configured pricing was therefore ignored.

## Approach

- load active custom model entries through the gateway cache
- add fully priced, matching custom models to auto-routing candidates
- apply project-mode, IAM, compliance, capability, context, and free-model filters before selection
- map the custom JSON output flag to both JSON object and JSON schema capabilities during auto filtering
- carry the selected custom provider name, key, and pricing through billing, logging, and retry setup
- preserve catalogue fallback after retryable failures from an auto-selected custom provider while keeping explicitly pinned custom requests pinned
- clear custom pricing context when fallback switches to a catalogue provider
- keep unpriced custom models out of automatic selection

## Verification

- `pnpm format`
- `pnpm build`
- `pnpm exec vitest run --no-file-parallelism apps/gateway/src/chat/tools/retry-with-fallback.spec.ts apps/gateway/src/fallback.spec.ts` (120 tests passed)
- `pnpm test:unit apps/gateway/src/fallback.spec.ts` (61 tests passed)
- custom-provider auto-routing regressions for priced models, JSON schema requests, and catalogue fallback after retryable failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-routing now supports eligible custom-provider models.
  * Selects the lowest-cost qualifying custom model while respecting pricing, access, compliance, and provider constraints.
  * Custom provider details and pricing carry through execution, retries, and usage records.
  * Active custom models are discovered automatically for routing.

* **Bug Fixes**
  * Improved fallback handling when routed custom-provider requests fail.
  * Prevented outdated provider details from affecting fallback attempts.

* **Tests**
  * Added coverage for routing, fallback behavior, active models, and cost tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->