### PR TITLE
fix(routing): show custom models

### DIFF
--- a/apps/api/src/routes/dynamic-routes.spec.ts
+++ b/apps/api/src/routes/dynamic-routes.spec.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { app } from "@/index.js";
 import { createTestUser, deleteAll } from "@/testing.js";
 
-import { db, tables } from "@llmgateway/db";
+import { db, eq, tables } from "@llmgateway/db";
 
 import type { DynamicRouteGraph } from "@llmgateway/shared/dynamic-route";
 
@@ -218,6 +218,27 @@ describe("dynamic routes API", () => {
 			],
 		});
 		expect(missing.status).toBe(400);
+
+		await db
+			.update(tables.customModel)
+			.set({ status: "inactive" })
+			.where(eq(tables.customModel.id, "custom-model-id"));
+		const inactiveModel = await createRoute("inactive-custom-model", graph);
+		expect(inactiveModel.status).toBe(400);
+
+		await db
+			.update(tables.customModel)
+			.set({ status: "active" })
+			.where(eq(tables.customModel.id, "custom-model-id"));
+		await db
+			.update(tables.providerKey)
+			.set({ status: "inactive" })
+			.where(eq(tables.providerKey.id, "custom-provider-key"));
+		const inactiveProvider = await createRoute(
+			"inactive-custom-provider",
+			graph,
+		);
+		expect(inactiveProvider.status).toBe(400);
 	});
 
 	test("duplicate names conflict with 409", async () => {

--- a/apps/api/src/routes/dynamic-routes.spec.ts
+++ b/apps/api/src/routes/dynamic-routes.spec.ts
@@ -171,6 +171,55 @@ describe("dynamic routes API", () => {
 		expect(badName.status).toBe(400);
 	});
 
+	test("creates and publishes routes with organization custom models", async () => {
+		await db.insert(tables.providerKey).values({
+			id: "custom-provider-key",
+			token: "custom-provider-token",
+			provider: "custom",
+			name: "private-provider",
+			baseUrl: "https://example.com/v1",
+			organizationId: "test-org-id",
+		});
+		await db.insert(tables.customModel).values({
+			id: "custom-model-id",
+			providerKeyId: "custom-provider-key",
+			organizationId: "test-org-id",
+			modelName: "private-model",
+		});
+
+		const graph = {
+			entry: "m",
+			nodes: [
+				{
+					id: "m",
+					type: "model",
+					model: "private-provider/private-model",
+				},
+			],
+		};
+		const created = await createRoute("custom-route", graph);
+		expect(created.status).toBe(201);
+
+		const published = await authed(
+			"/dynamic-routes/test-project-id/custom-route/publish",
+			{ method: "POST" },
+		);
+		expect(published.status).toBe(200);
+		expect((await published.json()).publishedVersion.graph).toEqual(graph);
+
+		const missing = await createRoute("missing-custom", {
+			entry: "m",
+			nodes: [
+				{
+					id: "m",
+					type: "model",
+					model: "private-provider/missing-model",
+				},
+			],
+		});
+		expect(missing.status).toBe(400);
+	});
+
 	test("duplicate names conflict with 409", async () => {
 		expect((await createRoute()).status).toBe(201);
 		expect((await createRoute()).status).toBe(409);

--- a/apps/api/src/routes/dynamic-routes.ts
+++ b/apps/api/src/routes/dynamic-routes.ts
@@ -111,10 +111,10 @@ async function assertCustomModelsAvailable(
 		where: {
 			organizationId: { eq: organizationId },
 			provider: { eq: "custom" },
-			status: { ne: "deleted" },
+			status: { eq: "active" },
 		},
 		with: {
-			customModels: { where: { status: { ne: "deleted" } } },
+			customModels: { where: { status: { eq: "active" } } },
 		},
 	});
 	const available = new Set(

--- a/apps/api/src/routes/dynamic-routes.ts
+++ b/apps/api/src/routes/dynamic-routes.ts
@@ -7,6 +7,7 @@ import {
 	DYNAMIC_ROUTE_NAME_MESSAGE,
 	DYNAMIC_ROUTE_NAME_REGEX,
 	dynamicRouteGraphSchema,
+	parseCustomDynamicRouteModelRef,
 } from "@llmgateway/shared/dynamic-route";
 
 import { checkProjectEnterpriseAccess } from "./routing-config.js";
@@ -91,6 +92,51 @@ async function routeDetail(routeId: string) {
 	};
 }
 
+async function assertCustomModelsAvailable(
+	organizationId: string,
+	graph: DynamicRouteGraph,
+) {
+	const references = graph.nodes.flatMap((node) => {
+		if (node.type !== "model") {
+			return [];
+		}
+		const reference = parseCustomDynamicRouteModelRef(node.model);
+		return reference ? [reference] : [];
+	});
+	if (references.length === 0) {
+		return;
+	}
+
+	const customProviders = await db.query.providerKey.findMany({
+		where: {
+			organizationId: { eq: organizationId },
+			provider: { eq: "custom" },
+			status: { ne: "deleted" },
+		},
+		with: {
+			customModels: { where: { status: { ne: "deleted" } } },
+		},
+	});
+	const available = new Set(
+		customProviders.flatMap((provider) =>
+			provider.name
+				? provider.customModels.map(
+						(model) => `${provider.name}/${model.modelName}`,
+					)
+				: [],
+		),
+	);
+	const missing = references.find(
+		(reference) =>
+			!available.has(`${reference.providerName}/${reference.modelName}`),
+	);
+	if (missing) {
+		throw new HTTPException(400, {
+			message: `Custom model "${missing.providerName}/${missing.modelName}" is not available in this organization`,
+		});
+	}
+}
+
 const listRoutes = createRoute({
 	method: "get",
 	path: "/{projectId}",
@@ -172,8 +218,11 @@ dynamicRoutes.openapi(createRouteEndpoint, async (c) => {
 		throw new HTTPException(401, { message: "Unauthorized" });
 	}
 	const { projectId } = c.req.param();
-	await checkProjectEnterpriseAccess(user.id, projectId);
+	const { project } = await checkProjectEnterpriseAccess(user.id, projectId);
 	const body = c.req.valid("json");
+	if (body.graph) {
+		await assertCustomModelsAvailable(project.organizationId, body.graph);
+	}
 
 	// The insert itself is the authoritative duplicate check: concurrent
 	// creates race past any pre-read, so let the unique (projectId, name)
@@ -336,9 +385,10 @@ dynamicRoutes.openapi(updateDraft, async (c) => {
 		throw new HTTPException(401, { message: "Unauthorized" });
 	}
 	const { projectId, name } = c.req.param();
-	await checkProjectEnterpriseAccess(user.id, projectId);
+	const { project } = await checkProjectEnterpriseAccess(user.id, projectId);
 	const route = await findRouteOrThrow(projectId, name);
 	const body = c.req.valid("json");
+	await assertCustomModelsAvailable(project.organizationId, body.graph);
 
 	await cdb
 		.update(tables.dynamicRoute)
@@ -368,7 +418,7 @@ dynamicRoutes.openapi(publishRoute, async (c) => {
 		throw new HTTPException(401, { message: "Unauthorized" });
 	}
 	const { projectId, name } = c.req.param();
-	await checkProjectEnterpriseAccess(user.id, projectId);
+	const { project } = await checkProjectEnterpriseAccess(user.id, projectId);
 	const route = await findRouteOrThrow(projectId, name);
 
 	if (!route.draftGraph) {
@@ -384,6 +434,7 @@ dynamicRoutes.openapi(publishRoute, async (c) => {
 			message: `Draft graph is no longer valid: ${parsed.error.issues[0]?.message}`,
 		});
 	}
+	await assertCustomModelsAvailable(project.organizationId, parsed.data);
 
 	// Version insert and pointer re-point must land together (no orphan
 	// version rows), and the next version number is derived inside the
@@ -443,7 +494,7 @@ dynamicRoutes.openapi(rollbackRoute, async (c) => {
 		throw new HTTPException(401, { message: "Unauthorized" });
 	}
 	const { projectId, name } = c.req.param();
-	await checkProjectEnterpriseAccess(user.id, projectId);
+	const { project } = await checkProjectEnterpriseAccess(user.id, projectId);
 	const route = await findRouteOrThrow(projectId, name);
 	const body = c.req.valid("json");
 
@@ -465,6 +516,7 @@ dynamicRoutes.openapi(rollbackRoute, async (c) => {
 			message: `Version ${version.version} is no longer valid: ${parsed.error.issues[0]?.message}`,
 		});
 	}
+	await assertCustomModelsAvailable(project.organizationId, parsed.data);
 
 	await cdb
 		.update(tables.dynamicRoute)

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -165,6 +165,7 @@ import {
 	hasMaxTokens,
 	hasRegionSpecificEnvKey,
 	type ModelDefinition,
+	type Model,
 	models,
 	type Provider,
 	type ProviderDefinition,
@@ -188,6 +189,7 @@ import {
 	isRecognizedCodingAgent,
 	normalizeSourceToAgentId,
 } from "@llmgateway/shared";
+import { parseCustomDynamicRouteModelRef } from "@llmgateway/shared/dynamic-route";
 import {
 	applyRoutingPreference,
 	type ResolvedRoutingConfig,
@@ -211,6 +213,7 @@ import { createLogEntry } from "./tools/create-log-entry.js";
 import { estimateTokensFromContent } from "./tools/estimate-tokens-from-content.js";
 import { estimateTokens } from "./tools/estimate-tokens.js";
 import {
+	DynamicRouteEvaluationError,
 	type DynamicRouteEvaluation,
 	evaluateDynamicRoute,
 } from "./tools/evaluate-dynamic-route.js";
@@ -3008,6 +3011,9 @@ chat.openapi(completions, async (c) => {
 				splitKey: sessionId ?? requestId,
 			});
 		} catch (error) {
+			if (!(error instanceof DynamicRouteEvaluationError)) {
+				throw error;
+			}
 			throw new HTTPException(400, {
 				message: `Dynamic route "${dynamicRouteName}" evaluation failed: ${toError(error).message}`,
 			});
@@ -3025,20 +3031,17 @@ chat.openapi(completions, async (c) => {
 			path: evaluation.path,
 		};
 
-		const target = parseModelInput(evaluation.model);
-		if (target.requestedProvider === "custom") {
+		const customTarget = parseCustomDynamicRouteModelRef(evaluation.model);
+		if (customTarget) {
 			if (effectiveFreeModelsOnly) {
 				throw new HTTPException(400, {
 					message: `Dynamic route "${publishedRoute.name}" resolved to model "${evaluation.model}" which is not available with free_models_only`,
 				});
 			}
-			requestedModel = target.requestedModel;
-			customProviderName = target.customProviderName;
-			requestedRegion = target.requestedRegion;
-			const targetModelInfo = resolveModelInfo(
-				requestedModel,
-				target.requestedProvider,
-			);
+			requestedModel = customTarget.modelName as Model;
+			customProviderName = customTarget.providerName;
+			requestedRegion = undefined;
+			const targetModelInfo = resolveModelInfo(requestedModel, "custom");
 			routingExpandedModelProviders = expandAllProviderRegions(
 				targetModelInfo.modelInfo.providers,
 			);

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1907,9 +1907,9 @@ chat.openapi(completions, async (c) => {
 
 	// Parse model input to resolve model, provider, and custom provider name
 	const parseResult = parseModelInput(modelInput);
-	const requestedModel = parseResult.requestedModel;
-	const customProviderName = parseResult.customProviderName;
-	const requestedRegion = parseResult.requestedRegion;
+	let requestedModel = parseResult.requestedModel;
+	let customProviderName = parseResult.customProviderName;
+	let requestedRegion = parseResult.requestedRegion;
 
 	// Count input images from messages for cost calculation
 	const inputImageCount =
@@ -2964,6 +2964,94 @@ chat.openapi(completions, async (c) => {
 	let usedRegion: string | undefined = requestedRegion;
 	let routingMetadata: RoutingMetadata | undefined;
 
+	// Resolve a named dynamic route ("dynamic/<name>") to its target model and
+	// optional provider restriction. Official models continue through the auto
+	// candidate path below. A custom target is parsed here so the ordinary custom
+	// provider validation, catalog pricing, IAM and compliance paths can handle it.
+	let dynamicRouteSelection:
+		| {
+				name: string;
+				version: number;
+				model: string;
+				providers?: string[];
+				path: string[];
+		  }
+		| undefined;
+	if (parseResult.dynamicRouteName) {
+		const dynamicRouteName = parseResult.dynamicRouteName;
+		if (organization.plan !== "enterprise") {
+			throw new HTTPException(403, {
+				message:
+					"Dynamic routes are only available on the enterprise plan. Contact us at contact@llmgateway.io to upgrade.",
+			});
+		}
+		const publishedRoute = await getPublishedDynamicRoute(
+			project.id,
+			dynamicRouteName,
+		);
+		if (!publishedRoute) {
+			throw new HTTPException(404, {
+				message: `Dynamic route "${dynamicRouteName}" not found, disabled, or has no published version`,
+			});
+		}
+		let evaluation: DynamicRouteEvaluation;
+		try {
+			evaluation = evaluateDynamicRoute(publishedRoute.graph, {
+				getHeader: (name) => c.req.header(name),
+				body: rawBody as Record<string, unknown>,
+				metadata: {
+					orgId: project.organizationId,
+					projectId: project.id,
+					apiKeyId: apiKey.id,
+					plan: organization.plan,
+				},
+				splitKey: sessionId ?? requestId,
+			});
+		} catch (error) {
+			throw new HTTPException(400, {
+				message: `Dynamic route "${dynamicRouteName}" evaluation failed: ${toError(error).message}`,
+			});
+		}
+		if (evaluation.status === "end") {
+			throw new HTTPException(400, {
+				message: `Dynamic route "${dynamicRouteName}" ended without resolving to a model`,
+			});
+		}
+		dynamicRouteSelection = {
+			name: publishedRoute.name,
+			version: publishedRoute.version,
+			model: evaluation.model,
+			providers: evaluation.providers,
+			path: evaluation.path,
+		};
+
+		const target = parseModelInput(evaluation.model);
+		if (target.requestedProvider === "custom") {
+			if (effectiveFreeModelsOnly) {
+				throw new HTTPException(400, {
+					message: `Dynamic route "${publishedRoute.name}" resolved to model "${evaluation.model}" which is not available with free_models_only`,
+				});
+			}
+			requestedModel = target.requestedModel;
+			customProviderName = target.customProviderName;
+			requestedRegion = target.requestedRegion;
+			const targetModelInfo = resolveModelInfo(
+				requestedModel,
+				target.requestedProvider,
+			);
+			routingExpandedModelProviders = expandAllProviderRegions(
+				targetModelInfo.modelInfo.providers,
+			);
+			modelInfo = targetModelInfo.modelInfo;
+			allModelProviders = targetModelInfo.allModelProviders;
+			requestedProvider = targetModelInfo.requestedProvider;
+			usedProvider = requestedProvider;
+			usedInternalModel = requestedModel;
+			usedExternalId = requestedModel;
+			usedRegion = requestedRegion;
+		}
+	}
+
 	// Get image size limits from environment variables or use defaults
 	const freeLimitMB = imageSizeLimitMB(
 		process.env.IMAGE_SIZE_LIMIT_FREE_MB,
@@ -3314,75 +3402,6 @@ chat.openapi(completions, async (c) => {
 				}
 			}
 		}
-	}
-
-	// Resolve a named dynamic route ("dynamic/<name>") to its target model and
-	// optional provider restriction. The route was tagged in parseModelInput and
-	// piggybacks the "auto" placeholder model until here, where project/org
-	// context needed by conditional and percentage nodes is available. The
-	// resolved target then flows through the auto-routing block below, which
-	// narrows candidates to the route's model/providers instead of the auto
-	// allowlist.
-	let dynamicRouteSelection:
-		| {
-				name: string;
-				version: number;
-				model: string;
-				providers?: string[];
-				path: string[];
-		  }
-		| undefined;
-	if (parseResult.dynamicRouteName) {
-		const dynamicRouteName = parseResult.dynamicRouteName;
-		if (organization.plan !== "enterprise") {
-			throw new HTTPException(403, {
-				message:
-					"Dynamic routes are only available on the enterprise plan. Contact us at contact@llmgateway.io to upgrade.",
-			});
-		}
-		const publishedRoute = await getPublishedDynamicRoute(
-			project.id,
-			dynamicRouteName,
-		);
-		if (!publishedRoute) {
-			throw new HTTPException(404, {
-				message: `Dynamic route "${dynamicRouteName}" not found, disabled, or has no published version`,
-			});
-		}
-		let evaluation: DynamicRouteEvaluation;
-		try {
-			evaluation = evaluateDynamicRoute(publishedRoute.graph, {
-				getHeader: (name) => c.req.header(name),
-				// The RAW request body, not validationResult.data: the completions
-				// schema strips unknown keys, which would make body conditions on
-				// caller-defined fields (e.g. "metadata.segment") silently never
-				// match.
-				body: rawBody as Record<string, unknown>,
-				metadata: {
-					orgId: project.organizationId,
-					projectId: project.id,
-					apiKeyId: apiKey.id,
-					plan: organization.plan,
-				},
-				splitKey: sessionId ?? requestId,
-			});
-		} catch (error) {
-			throw new HTTPException(400, {
-				message: `Dynamic route "${dynamicRouteName}" evaluation failed: ${toError(error).message}`,
-			});
-		}
-		if (evaluation.status === "end") {
-			throw new HTTPException(400, {
-				message: `Dynamic route "${dynamicRouteName}" ended without resolving to a model`,
-			});
-		}
-		dynamicRouteSelection = {
-			name: publishedRoute.name,
-			version: publishedRoute.version,
-			model: evaluation.model,
-			providers: evaluation.providers,
-			path: evaluation.path,
-		};
 	}
 
 	// Apply routing logic after apiKey and project are available
@@ -3775,13 +3794,6 @@ chat.openapi(completions, async (c) => {
 			usedInternalModel = "claude-haiku-4-5";
 			usedExternalId = "claude-haiku-4-5";
 			usedProvider = "anthropic";
-		}
-		if (dynamicRouteSelection && routingMetadata) {
-			routingMetadata.dynamicRoute = {
-				name: dynamicRouteSelection.name,
-				version: dynamicRouteSelection.version,
-				path: dynamicRouteSelection.path,
-			};
 		}
 		// Update modelInfo to the selected model so retry/fallback logic can find
 		// alternative providers. Without this, modelInfo still points to the "auto"
@@ -5078,6 +5090,14 @@ chat.openapi(completions, async (c) => {
 			project.organizationId,
 			providerDiscountResolver,
 		);
+	}
+
+	if (dynamicRouteSelection && routingMetadata) {
+		routingMetadata.dynamicRoute = {
+			name: dynamicRouteSelection.name,
+			version: dynamicRouteSelection.version,
+			path: dynamicRouteSelection.path,
+		};
 	}
 
 	// Record where the processing tier came from. A dev-plan (DevPass) org's

--- a/apps/gateway/src/chat/tools/evaluate-dynamic-route.spec.ts
+++ b/apps/gateway/src/chat/tools/evaluate-dynamic-route.spec.ts
@@ -372,6 +372,34 @@ describe("dynamicRouteGraphSchema", () => {
 		expect(result.success).toBe(true);
 	});
 
+	it("accepts custom model references without provider overrides", () => {
+		expect(
+			dynamicRouteGraphSchema.safeParse({
+				entry: "m",
+				nodes: [
+					{
+						id: "m",
+						type: "model",
+						model: "private-provider/private-model",
+					},
+				],
+			}).success,
+		).toBe(true);
+		expect(
+			dynamicRouteGraphSchema.safeParse({
+				entry: "m",
+				nodes: [
+					{
+						id: "m",
+						type: "model",
+						model: "private-provider/private-model",
+						providers: ["openai"],
+					},
+				],
+			}).success,
+		).toBe(false);
+	});
+
 	it("rejects unknown models and providers", () => {
 		expect(
 			dynamicRouteGraphSchema.safeParse({

--- a/apps/gateway/src/chat/tools/evaluate-dynamic-route.spec.ts
+++ b/apps/gateway/src/chat/tools/evaluate-dynamic-route.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { dynamicRouteGraphSchema } from "@llmgateway/shared/dynamic-route";
 
 import {
+	DynamicRouteEvaluationError,
 	type DynamicRouteEvaluationContext,
 	evaluateDynamicRoute,
 } from "./evaluate-dynamic-route.js";
@@ -333,6 +334,9 @@ describe("evaluateDynamicRoute", () => {
 				},
 			],
 		} as DynamicRouteGraph;
+		expect(() => evaluateDynamicRoute(graph, makeContext())).toThrow(
+			DynamicRouteEvaluationError,
+		);
 		expect(() => evaluateDynamicRoute(graph, makeContext())).toThrow(/maximum/);
 	});
 
@@ -341,6 +345,9 @@ describe("evaluateDynamicRoute", () => {
 			entry: "missing",
 			nodes: [{ id: "m", type: "model", model: "gpt-5-nano" }],
 		} as DynamicRouteGraph;
+		expect(() => evaluateDynamicRoute(graph, makeContext())).toThrow(
+			DynamicRouteEvaluationError,
+		);
 		expect(() => evaluateDynamicRoute(graph, makeContext())).toThrow(
 			/unknown node/,
 		);

--- a/apps/gateway/src/chat/tools/evaluate-dynamic-route.ts
+++ b/apps/gateway/src/chat/tools/evaluate-dynamic-route.ts
@@ -37,6 +37,13 @@ export type DynamicRouteEvaluation =
 	  }
 	| { status: "end"; path: string[] };
 
+export class DynamicRouteEvaluationError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "DynamicRouteEvaluationError";
+	}
+}
+
 /**
  * FNV-1a 32-bit hash. Deterministic and dependency-free; used to bucket the
  * split key into percentage branches. The node id is mixed in so multiple
@@ -142,8 +149,8 @@ function pickPercentageBranch(
  * Walks a validated dynamic-route graph and resolves it to a target model
  * (with an optional provider restriction) or an explicit end.
  *
- * @throws Error when the graph references an unknown node or exceeds the hop
- * bound — both indicate a graph that bypassed save-time validation.
+ * @throws DynamicRouteEvaluationError when the graph references an unknown
+ * node or exceeds the hop bound.
  */
 export function evaluateDynamicRoute(
 	graph: DynamicRouteGraph,
@@ -156,7 +163,9 @@ export function evaluateDynamicRoute(
 	for (let hops = 0; hops < DYNAMIC_ROUTE_MAX_HOPS; hops++) {
 		const node = nodesById.get(currentId);
 		if (!node) {
-			throw new Error(`references unknown node "${currentId}"`);
+			throw new DynamicRouteEvaluationError(
+				`references unknown node "${currentId}"`,
+			);
 		}
 		path.push(node.id);
 		switch (node.type) {
@@ -181,7 +190,7 @@ export function evaluateDynamicRoute(
 				break;
 		}
 	}
-	throw new Error(
+	throw new DynamicRouteEvaluationError(
 		`exceeded the maximum of ${DYNAMIC_ROUTE_MAX_HOPS} nodes per evaluation`,
 	);
 }

--- a/apps/gateway/src/dynamic-routes.spec.ts
+++ b/apps/gateway/src/dynamic-routes.spec.ts
@@ -278,6 +278,52 @@ describe("dynamic routes request path", () => {
 		expect((await pinned.json()).metadata.used_provider).toBe("openai");
 	});
 
+	test("routes to a custom-provider catalog model", async () => {
+		const token = await seedBase("custom", []);
+		await db.insert(tables.providerKey).values({
+			id: "pk-dyn-custom",
+			token: "sk-custom-test-key",
+			provider: "custom",
+			name: "private-provider",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+		await db.insert(tables.customModel).values({
+			id: "cm-dyn-custom",
+			providerKeyId: "pk-dyn-custom",
+			organizationId: "org-id",
+			modelName: "private-model",
+			inputPrice: "1e-6",
+			outputPrice: "2e-6",
+		});
+		const routeName = await seedRoute("custom", {
+			entry: "m",
+			nodes: [modelNode("m", "private-provider/private-model")],
+		} as DynamicRouteGraph);
+
+		const response = await chatCompletion(token, {
+			model: `dynamic/${routeName}`,
+			messages: [{ role: "user", content: "hi custom dynamic route" }],
+		});
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.metadata).toMatchObject({
+			requested_model: `dynamic/${routeName}`,
+			used_model: "private-model",
+			used_provider: "custom",
+		});
+
+		await waitForLogs(1);
+		const log = await db.query.log.findFirst({});
+		expect(
+			(
+				log?.routingMetadata as {
+					dynamicRoute?: { name: string; path: string[] };
+				} | null
+			)?.dynamicRoute,
+		).toMatchObject({ name: routeName, path: ["m"] });
+	});
+
 	test("percentage splits stay sticky per session", async () => {
 		const token = await seedBase("split");
 		const routeName = await seedRoute("split", {

--- a/apps/gateway/src/dynamic-routes.spec.ts
+++ b/apps/gateway/src/dynamic-routes.spec.ts
@@ -35,20 +35,22 @@ describe("dynamic routes request path", () => {
 			createdBy: "user-id",
 		});
 
-		await db.insert(tables.providerKey).values(
-			providers.map((provider) => ({
-				id: `pk-dyn-${provider}-${suffix}`,
-				token: `sk-${provider}-test-key`,
-				provider,
-				organizationId: "org-id",
-				baseUrl: mockServerUrl,
-				// Azure requests must stay on the mock server's /openai/v1/*
-				// aliases regardless of local LLM_AZURE_DEPLOYMENT_TYPE values.
-				...(provider === "azure"
-					? { options: { azure_deployment_type: "ai-foundry" as const } }
-					: {}),
-			})),
-		);
+		if (providers.length > 0) {
+			await db.insert(tables.providerKey).values(
+				providers.map((provider) => ({
+					id: `pk-dyn-${provider}-${suffix}`,
+					token: `sk-${provider}-test-key`,
+					provider,
+					organizationId: "org-id",
+					baseUrl: mockServerUrl,
+					// Azure requests must stay on the mock server's /openai/v1/*
+					// aliases regardless of local LLM_AZURE_DEPLOYMENT_TYPE values.
+					...(provider === "azure"
+						? { options: { azure_deployment_type: "ai-foundry" as const } }
+						: {}),
+				})),
+			);
+		}
 
 		return `real-token-dyn-${suffix}`;
 	}
@@ -292,13 +294,13 @@ describe("dynamic routes request path", () => {
 			id: "cm-dyn-custom",
 			providerKeyId: "pk-dyn-custom",
 			organizationId: "org-id",
-			modelName: "private-model",
+			modelName: "private-model:revision",
 			inputPrice: "1e-6",
 			outputPrice: "2e-6",
 		});
 		const routeName = await seedRoute("custom", {
 			entry: "m",
-			nodes: [modelNode("m", "private-provider/private-model")],
+			nodes: [modelNode("m", "private-provider/private-model:revision")],
 		} as DynamicRouteGraph);
 
 		const response = await chatCompletion(token, {
@@ -309,7 +311,7 @@ describe("dynamic routes request path", () => {
 		const body = await response.json();
 		expect(body.metadata).toMatchObject({
 			requested_model: `dynamic/${routeName}`,
-			used_model: "private-model",
+			used_model: "private-model:revision",
 			used_provider: "custom",
 		});
 

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/settings/dynamic-routes/_components/route-flow-editor.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/settings/dynamic-routes/_components/route-flow-editor.tsx
@@ -678,16 +678,17 @@ function ModelInspector({
 					onValueChange={(value) => {
 						// The selector emits "provider/model[:region]" even in rootOnly
 						// mode; a model node stores the root catalog id — the provider
-						// restriction lives in the fallback list below. (model.id never
-						// contains ":", so stripping after the last colon is safe.)
+						// restriction lives in the fallback list below. Preserve exact
+						// catalog ids because custom model names may contain colons.
 						const withoutProvider = value.includes("/")
 							? value.slice(value.indexOf("/") + 1)
 							: value;
 						const lastColon = withoutProvider.lastIndexOf(":");
 						const modelId =
-							lastColon > -1
-								? withoutProvider.slice(0, lastColon)
-								: withoutProvider;
+							selectableModels.some((model) => model.id === withoutProvider) ||
+							lastColon === -1
+								? withoutProvider
+								: withoutProvider.slice(0, lastColon);
 						onChange((n) =>
 							n.type === "model"
 								? { ...n, model: modelId, providers: undefined }

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/settings/dynamic-routes/_components/route-flow-editor.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/settings/dynamic-routes/_components/route-flow-editor.tsx
@@ -15,6 +15,7 @@ import { useTheme } from "next-themes";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { ModelSelector } from "@/components/models/playground-model-selector";
+import { useCustomProviderSelection } from "@/hooks/useCustomProviders";
 import { Button } from "@/lib/components/button";
 import { Input } from "@/lib/components/input";
 import { Label } from "@/lib/components/label";
@@ -648,23 +649,30 @@ function ModelInspector({
 	node: Extract<DynamicRouteNode, { type: "model" }>;
 	onChange: (updater: (node: DynamicRouteNode) => DynamicRouteNode) => void;
 }) {
-	const modelDef = models.find((m) => m.id === node.model);
+	const { customModelOptions } = useCustomProviderSelection();
+	const selectableModels = useMemo(
+		() => [...SELECTABLE_MODELS, ...customModelOptions],
+		[customModelOptions],
+	);
+	const modelDef = selectableModels.find((model) => model.id === node.model);
+	const isCustomModel = modelDef?.family === "custom";
 	// Only providers actually serving the chosen model are selectable; selection
 	// order in MultiProviderSelector is the fallback order.
-	const selectableProviders: SelectableProviderOption[] = modelDef
-		? Array.from(new Set(modelDef.providers.map((p) => p.providerId))).map(
-				(id) => {
-					const def = providerDefinitions.find((p) => p.id === id);
-					return { id, name: def?.name ?? id, color: def?.color };
-				},
-			)
-		: [];
+	const selectableProviders: SelectableProviderOption[] =
+		modelDef && !isCustomModel
+			? Array.from(new Set(modelDef.providers.map((p) => p.providerId))).map(
+					(id) => {
+						const def = providerDefinitions.find((p) => p.id === id);
+						return { id, name: def?.name ?? id, color: def?.color };
+					},
+				)
+			: [];
 	return (
 		<div className="space-y-2">
 			<div className="space-y-1">
 				<Label className="text-xs">Model</Label>
 				<ModelSelector
-					models={SELECTABLE_MODELS as ModelDefinition[]}
+					models={selectableModels as ModelDefinition[]}
 					providers={providerDefinitions as unknown as ProviderDefinition[]}
 					value={node.model}
 					onValueChange={(value) => {
@@ -692,7 +700,11 @@ function ModelInspector({
 			</div>
 			<div className="space-y-1">
 				<Label className="text-xs">Provider fallback order (optional)</Label>
-				{modelDef ? (
+				{isCustomModel ? (
+					<p className="text-[10px] text-muted-foreground">
+						The custom provider is fixed by this model.
+					</p>
+				) : modelDef ? (
 					<MultiProviderSelector
 						providers={selectableProviders}
 						selectedProviders={node.providers ?? []}

--- a/apps/ui/src/components/models/playground-model-selector.tsx
+++ b/apps/ui/src/components/models/playground-model-selector.tsx
@@ -88,21 +88,30 @@ export function ModelSelector({
 		priceRange: "all",
 	});
 
-	// Parse value as provider/model-id (preferred). Fallback to model id only.
-	// Supports region suffix: "alibaba/deepseek-v3.2:cn-beijing" or
-	// "aws-bedrock/claude-haiku-4-5:global". The region is the substring after
-	// the last ":" (model.id never contains ":"; upstream modelNames may).
+	// Parse value as provider/model-id (preferred), while preserving root model
+	// ids that contain a slash (custom-provider models use `<name>/<model>`).
+	// A provider-prefixed exact model match wins before interpreting a trailing
+	// colon as a region because custom model names may contain colons.
 	const raw = value ?? "";
-	const [selectedProviderId, selectedModelIdRaw] = raw.includes("/")
-		? (raw.split("/") as [string, string])
-		: ["", raw];
-	const lastColonIdx = selectedModelIdRaw.lastIndexOf(":");
+	const separator = raw.indexOf("/");
+	const providerCandidate = separator > -1 ? raw.slice(0, separator) : "";
+	const hasProviderPrefix = providers.some(
+		(provider) => provider.id === providerCandidate,
+	);
+	const providerModelId = hasProviderPrefix ? raw.slice(separator + 1) : raw;
+	const exactProviderModel = hasProviderPrefix
+		? models.find((model) => model.id === providerModelId)
+		: undefined;
+	const lastColonIdx = exactProviderModel
+		? -1
+		: providerModelId.lastIndexOf(":");
+	const selectedProviderId = hasProviderPrefix ? providerCandidate : "";
 	const selectedRegion =
-		lastColonIdx > -1 ? selectedModelIdRaw.slice(lastColonIdx + 1) : undefined;
+		lastColonIdx > -1 ? providerModelId.slice(lastColonIdx + 1) : undefined;
 	const selectedModelId =
 		lastColonIdx > -1
-			? selectedModelIdRaw.slice(0, lastColonIdx)
-			: selectedModelIdRaw;
+			? providerModelId.slice(0, lastColonIdx)
+			: providerModelId;
 	const selectedModel = models.find((m) => m.id === selectedModelId);
 	const selectedProviderDef = providers.find(
 		(p) => p.id === selectedProviderId,

--- a/packages/shared/src/dynamic-route.ts
+++ b/packages/shared/src/dynamic-route.ts
@@ -2,6 +2,11 @@ import { z } from "zod";
 
 import { models, providers } from "@llmgateway/models";
 
+import {
+	CUSTOM_PROVIDER_NAME_REGEX,
+	RESERVED_CUSTOM_PROVIDER_NAMES,
+} from "./custom-providers.js";
+
 /**
  * Reserved model-string prefix that invokes a named dynamic route instead of a
  * concrete model, e.g. `"model": "dynamic/support"`. The prefix is also a
@@ -21,6 +26,36 @@ export const DYNAMIC_ROUTE_NAME_MESSAGE =
 export const DYNAMIC_ROUTE_MAX_HOPS = 50;
 
 export const DYNAMIC_ROUTE_MAX_NODES = 100;
+
+export interface CustomDynamicRouteModelRef {
+	providerName: string;
+	modelName: string;
+}
+
+/**
+ * Parses the `<custom-provider>/<model>` reference stored by a model node.
+ * Official provider-prefixed model strings are intentionally excluded: model
+ * nodes store official root model ids and use `providers` for restrictions.
+ */
+export function parseCustomDynamicRouteModelRef(
+	model: string,
+): CustomDynamicRouteModelRef | undefined {
+	const separator = model.indexOf("/");
+	if (separator <= 0 || separator === model.length - 1) {
+		return undefined;
+	}
+	const providerName = model.slice(0, separator);
+	if (
+		!CUSTOM_PROVIDER_NAME_REGEX.test(providerName) ||
+		(RESERVED_CUSTOM_PROVIDER_NAMES as readonly string[]).includes(
+			providerName,
+		) ||
+		providers.some((provider) => provider.id === providerName)
+	) {
+		return undefined;
+	}
+	return { providerName, modelName: model.slice(separator + 1) };
+}
 
 // Restricted so ids stay safe to embed in composite identifiers (the visual
 // editor derives edge ids as `<nodeId>:<handle>`).
@@ -229,11 +264,19 @@ export const dynamicRouteGraphSchema = z
 			if (node.type === "model") {
 				const modelDef = models.find((m) => m.id === node.model);
 				if (!modelDef) {
-					ctx.addIssue({
-						code: z.ZodIssueCode.custom,
-						message: `Node "${node.id}": unknown model "${node.model}"`,
-						path: ["nodes", index, "model"],
-					});
+					if (!parseCustomDynamicRouteModelRef(node.model)) {
+						ctx.addIssue({
+							code: z.ZodIssueCode.custom,
+							message: `Node "${node.id}": unknown model "${node.model}"`,
+							path: ["nodes", index, "model"],
+						});
+					} else if (node.providers) {
+						ctx.addIssue({
+							code: z.ZodIssueCode.custom,
+							message: `Node "${node.id}": custom model "${node.model}" already fixes its provider`,
+							path: ["nodes", index, "providers"],
+						});
+					}
 					continue;
 				}
 				for (const providerId of node.providers ?? []) {


### PR DESCRIPTION
## Problem

Dynamic route model nodes only offered official catalogue models, so models configured on custom providers could not be selected or routed.

## Changes

- include active custom-provider catalogue models in the dynamic route picker
- validate custom model references against active organization resources
- resolve custom route targets through existing pricing, IAM, compliance, and request paths
- preserve custom model IDs containing slashes or colons in selectors and gateway routing
- keep malformed route graphs as client errors while unexpected evaluator failures propagate
- add API, schema, and gateway regression coverage

## Screenshots

### Light

| Before | After |
| --- | --- |
| <img width="600" alt="Before: custom model search returns no results in light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/baa93707e5dba35adeb553d7e0b8cd52f3ed91ef/before-light.png" /> | <img width="600" alt="After: custom provider model appears in the dynamic route picker in light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/baa93707e5dba35adeb553d7e0b8cd52f3ed91ef/after-light.png" /> |

### Dark

| Before | After |
| --- | --- |
| <img width="600" alt="Before: custom model search returns no results in dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/baa93707e5dba35adeb553d7e0b8cd52f3ed91ef/before-dark.png" /> | <img width="600" alt="After: custom provider model appears in the dynamic route picker in dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/baa93707e5dba35adeb553d7e0b8cd52f3ed91ef/after-dark.png" /> |

## Verification

- `pnpm format`
- `pnpm build`
- `pnpm exec vitest run apps/api/src/routes/dynamic-routes.spec.ts apps/gateway/src/chat/tools/evaluate-dynamic-route.spec.ts apps/gateway/src/dynamic-routes.spec.ts --no-file-parallelism` (43 passed)
- verified the custom model picker against seeded local data in light and dark themes
