### PR TITLE
fix(gateway): normalize streaming chunks

### DIFF
--- a/apps/gateway/src/chat/tools/transform-openai-streaming.spec.ts
+++ b/apps/gateway/src/chat/tools/transform-openai-streaming.spec.ts
@@ -389,4 +389,58 @@ describe("transformOpenaiStreaming", () => {
 			"cache_creation_tokens",
 		);
 	});
+
+	test("adds empty choices to usage-only chunks", () => {
+		const input = {
+			service_tier: "default",
+			id: "chatcmpl-abc123",
+			object: "chat.completion.chunk",
+			created: 1786945815,
+			model: "deepseek-ai/DeepSeek-V4-Flash",
+			usage: {
+				prompt_tokens: 10,
+				completion_tokens: 2,
+				total_tokens: 12,
+			},
+		};
+
+		const result = transformOpenaiStreaming(input, "deepseek-v4-flash");
+
+		expect(result.choices).toEqual([]);
+		expect(result.usage).toEqual({
+			prompt_tokens: 10,
+			completion_tokens: 2,
+			total_tokens: 12,
+		});
+	});
+
+	test("adds an empty function to partial tool call deltas", () => {
+		const input = {
+			id: "chatcmpl-abc123",
+			object: "chat.completion.chunk",
+			created: 1786945815,
+			model: "deepseek-ai/DeepSeek-V4-Flash",
+			choices: [
+				{
+					index: 0,
+					delta: {
+						role: "assistant",
+						tool_calls: [{ index: 0, id: "call_1", type: "function" }],
+					},
+					finish_reason: null,
+				},
+			],
+		};
+
+		const result = transformOpenaiStreaming(input, "deepseek-v4-flash");
+
+		expect(result.choices[0].delta.tool_calls).toEqual([
+			{
+				index: 0,
+				id: "call_1",
+				type: "function",
+				function: {},
+			},
+		]);
+	});
 });

--- a/apps/gateway/src/chat/tools/transform-openai-streaming.ts
+++ b/apps/gateway/src/chat/tools/transform-openai-streaming.ts
@@ -99,6 +99,15 @@ export function transformOpenaiStreaming(
 			newDelta.tool_calls.length === 0
 		) {
 			delete newDelta.tool_calls;
+		} else if (Array.isArray(newDelta.tool_calls)) {
+			// Some upstreams announce a tool call before sending its function data.
+			// Strict OpenAI clients still require the function key on every frame.
+			newDelta.tool_calls = newDelta.tool_calls.map(
+				(toolCall: Record<string, unknown>) => ({
+					...toolCall,
+					function: toolCall.function ?? {},
+				}),
+			);
 		}
 
 		const normalizedReasoning =
@@ -154,12 +163,17 @@ export function transformOpenaiStreaming(
 	};
 
 	// Transform choices if they exist
-	const transformedChoices = data.choices
+	const normalizedUsage = normalizeUsage(data.usage);
+	// OpenAI usage-only chunks use an empty choices array. Strict clients reject
+	// the provider variant that omits the field entirely.
+	const transformedChoices = Array.isArray(data.choices)
 		? data.choices.map((choice: any) => ({
 				...choice,
 				delta: transformDelta(choice.delta),
 			}))
-		: null;
+		: normalizedUsage
+			? []
+			: null;
 
 	// If we don't have proper structure, build it
 	if (!data.id || !transformedChoices) {
@@ -182,7 +196,7 @@ export function transformOpenaiStreaming(
 					finish_reason: data.finish_reason ?? null,
 				},
 			],
-			usage: normalizeUsage(data.usage),
+			usage: normalizedUsage,
 		};
 	}
 
@@ -191,6 +205,6 @@ export function transformOpenaiStreaming(
 		...data,
 		object: "chat.completion.chunk",
 		choices: transformedChoices,
-		usage: normalizeUsage(data.usage),
+		usage: normalizedUsage,
 	};
 }


### PR DESCRIPTION
## Problem

Some OpenAI-compatible upstreams emit usage-only streaming chunks without `choices` and partial tool-call deltas without `function`. Strict clients reject either shape and terminate the stream.

## Changes

- emit `choices: []` for valid usage-only chunks
- add an empty `function` object to partial tool-call deltas when needed
- cover both reported payload shapes with regression tests

## Verification

- `pnpm format`
- `pnpm exec vitest run apps/gateway/src/chat/tools/transform-openai-streaming.spec.ts --no-file-parallelism`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming response handling for usage-only updates.
  * Preserved valid empty choice data in streaming responses.
  * Ensured tool-call updates consistently include function details, including announcement-only updates.
  * Standardized usage information across response formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->