### PR TITLE
fix(actions): normalize Google schema enums

### DIFF
--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -2231,6 +2231,34 @@ describe("prepareRequestBody - Google AI Studio", () => {
 		expect(requestBody.toolConfig).toBeUndefined();
 	});
 
+	test("normalizes primitive enums in tool parameters", async () => {
+		const requestBody = await googleTools([
+			{
+				type: "function",
+				function: {
+					name: "choose_value",
+					parameters: {
+						type: "object",
+						properties: {
+							integer: { type: "integer", enum: [3, 5] },
+							mixed: { type: "string", enum: ["one", 2, true, null] },
+							unsupported: {
+								type: "object",
+								enum: [{ value: 3 }],
+							},
+						},
+					},
+				},
+			},
+		]);
+
+		const properties =
+			requestBody.tools[0].functionDeclarations[0].parameters.properties;
+		expect(properties.integer.enum).toEqual(["3", "5"]);
+		expect(properties.mixed.enum).toEqual(["one", "2", "true", "null"]);
+		expect(properties.unsupported.enum).toBeUndefined();
+	});
+
 	test("should map gateway 0.5K image size to Google 512", async () => {
 		const requestBody = (await prepareRequestBody(
 			"google-ai-studio",
@@ -2319,6 +2347,42 @@ describe("prepareRequestBody - Google AI Studio", () => {
 				},
 			},
 			required: ["name", "nickname"],
+		});
+	});
+
+	test("normalizes primitive enums in response schemas", async () => {
+		const requestBody = (await prepareRequestBody(
+			"google-ai-studio",
+			"gemini-3.7-flash",
+			null,
+			"gemini-3.7-flash",
+			[{ role: "user", content: "Choose a value" }],
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			{
+				type: "json_schema",
+				json_schema: {
+					name: "choice",
+					schema: {
+						type: "object",
+						properties: {
+							value: { type: "integer", enum: [3, 5] },
+						},
+						required: ["value"],
+					},
+				},
+			},
+		)) as any;
+
+		expect(
+			requestBody.generationConfig.responseSchema.properties.value,
+		).toEqual({
+			type: "INTEGER",
+			enum: ["3", "5"],
 		});
 	});
 

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -367,6 +367,27 @@ function normalizeToolParameters(tools?: OpenAIToolInput[]): typeof tools {
 	});
 }
 
+function normalizeGoogleSchemaEnum(values: unknown): string[] | undefined {
+	if (!Array.isArray(values)) {
+		return undefined;
+	}
+
+	const normalized: string[] = [];
+	for (const value of values) {
+		if (
+			value !== null &&
+			typeof value !== "string" &&
+			typeof value !== "number" &&
+			typeof value !== "boolean"
+		) {
+			return undefined;
+		}
+		normalized.push(String(value));
+	}
+
+	return normalized;
+}
+
 /**
  * Converts OpenAI JSON schema format to Google's schema format
  * Google uses uppercase type names (STRING, OBJECT, ARRAY) vs OpenAI's lowercase (string, object, array)
@@ -418,9 +439,11 @@ function convertOpenAISchemaToGoogle(schema: any): any {
 		converted.required = schema.required;
 	}
 
-	// Copy enum if present
-	if (schema.enum) {
-		converted.enum = schema.enum;
+	// Google's Schema proto represents every enum member as a string, including
+	// members of numeric and boolean schemas.
+	const normalizedEnum = normalizeGoogleSchemaEnum(schema.enum);
+	if (normalizedEnum !== undefined) {
+		converted.enum = normalizedEnum;
 	}
 
 	// Copy other common JSON schema properties that Google supports
@@ -571,7 +594,6 @@ const GOOGLE_SUPPORTED_SCHEMA_KEYS: ReadonlySet<string> = new Set([
 const GOOGLE_OPAQUE_SCHEMA_VALUE_KEYS: ReadonlySet<string> = new Set([
 	"default",
 	"example",
-	"enum",
 ]);
 
 /**
@@ -671,6 +693,14 @@ function stripUnsupportedSchemaProperties(
 
 	for (const [key, value] of Object.entries(schema)) {
 		if (!GOOGLE_SUPPORTED_SCHEMA_KEYS.has(key)) {
+			continue;
+		}
+
+		if (key === "enum") {
+			const normalizedEnum = normalizeGoogleSchemaEnum(value);
+			if (normalizedEnum !== undefined) {
+				cleaned.enum = normalizedEnum;
+			}
 			continue;
 		}
 


### PR DESCRIPTION
## Summary

Google's Schema proto requires enum members to be strings, even for numeric and boolean schemas. Numeric JSON Schema enums were forwarded unchanged, causing Google-compatible requests to fail with a 400 before inference.

- normalize primitive enum members for Google-compatible schemas
- apply the normalization to function tools and structured output
- drop composite enum constraints that Google cannot represent
- cover numeric, mixed primitive, and composite enum values

## Verification

- `pnpm exec vitest run packages/actions/src/prepare-request-body.spec.ts --no-file-parallelism` (296 tests)
- `pnpm format`
- `pnpm build`
- live Google AI Studio check with `gemini-3.7-flash`: numeric tool enum returned a tool call with numeric `value: 3`
- live Google AI Studio check with `gemini-3.7-flash`: numeric response-schema enum returned `{"value": 3}`
