### PR TITLE
fix(devpass): expose cache write toggle

### DIFF
--- a/apps/api/src/routes/dev-plans-payg.spec.ts
+++ b/apps/api/src/routes/dev-plans-payg.spec.ts
@@ -153,6 +153,40 @@ describe("dev-plan PAYG settings", () => {
 		expect(body.regularCredits).toBe("42.50");
 	});
 
+	it("updates provider cache writes on the DevPass project", async () => {
+		await insertOrg();
+		await db.insert(tables.project).values({
+			id: "test-payg-project",
+			name: "Default Project",
+			organizationId: ORG_ID,
+		});
+		const initialStatus = await app.request("/dev-plans/status", {
+			headers: { Cookie: token },
+		});
+		expect(initialStatus.status).toBe(200);
+		expect((await initialStatus.json()).providerCacheControlEnabled).toBe(true);
+
+		const update = await settingsRequest(
+			{ providerCacheControlEnabled: false },
+			token,
+		);
+		expect(update.status).toBe(200);
+		expect(await update.json()).toMatchObject({
+			providerCacheControlEnabled: false,
+		});
+
+		const project = await db.query.project.findFirst({
+			where: { id: { eq: "test-payg-project" } },
+		});
+		expect(project?.providerCacheControlEnabled).toBe(false);
+
+		const status = await app.request("/dev-plans/status", {
+			headers: { Cookie: token },
+		});
+		expect(status.status).toBe(200);
+		expect((await status.json()).providerCacheControlEnabled).toBe(false);
+	});
+
 	it("configures auto-reload with threshold and amount", async () => {
 		await insertOrg({ devPlanPaygEnabled: true });
 

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -1782,6 +1782,7 @@ const getStatus = createRoute({
 							"throughput",
 							"latency",
 						]),
+						providerCacheControlEnabled: z.boolean(),
 					}),
 				},
 			},
@@ -1842,6 +1843,7 @@ devPlans.openapi(getStatus, async (c) => {
 			apiKey: null,
 			devPlanServiceTier: "default" as const,
 			defaultRoutingStrategy: "auto" as const,
+			providerCacheControlEnabled: true,
 		});
 	}
 
@@ -1890,6 +1892,7 @@ devPlans.openapi(getStatus, async (c) => {
 	let projectId: string | null = null;
 	let defaultRoutingStrategy: "auto" | "price" | "throughput" | "latency" =
 		"auto";
+	let providerCacheControlEnabled = true;
 	if (personalOrg.devPlan !== "none") {
 		// Find the default project for this org. Order by createdAt asc so we
 		// always return the original "Default Project" rather than whichever
@@ -1908,6 +1911,7 @@ devPlans.openapi(getStatus, async (c) => {
 		if (project) {
 			projectId = project.id;
 			defaultRoutingStrategy = project.defaultRoutingStrategy;
+			providerCacheControlEnabled = project.providerCacheControlEnabled;
 			apiKey = await getOrCreatePersonalOrgApiKey(
 				personalOrg.id,
 				project.id,
@@ -1961,6 +1965,7 @@ devPlans.openapi(getStatus, async (c) => {
 		apiKey,
 		devPlanServiceTier: personalOrg.devPlanServiceTier,
 		defaultRoutingStrategy,
+		providerCacheControlEnabled,
 	});
 });
 
@@ -1980,6 +1985,9 @@ const updateSettings = createRoute({
 						// Coding plans optimize for prompt caching, so only the
 						// default weighted routing or the price strategy are allowed.
 						defaultRoutingStrategy: z.enum(["auto", "price"]).optional(),
+						// Control upstream prompt-cache writes for coding clients that
+						// send cache markers automatically.
+						providerCacheControlEnabled: z.boolean().optional(),
 						// Opt-in pay-as-you-go overflow past the monthly allowance.
 						devPlanPaygEnabled: z.boolean().optional(),
 						// Auto-reload: automatically top up when the credits balance
@@ -2009,6 +2017,7 @@ const updateSettings = createRoute({
 							"throughput",
 							"latency",
 						]),
+						providerCacheControlEnabled: z.boolean(),
 						devPlanPaygEnabled: z.boolean(),
 						autoTopUpEnabled: z.boolean(),
 						autoTopUpThreshold: z.string().nullable(),
@@ -2026,6 +2035,7 @@ devPlans.openapi(updateSettings, async (c) => {
 	const {
 		devPlanServiceTier,
 		defaultRoutingStrategy,
+		providerCacheControlEnabled,
 		devPlanPaygEnabled,
 		autoTopUpEnabled,
 		autoTopUpThreshold,
@@ -2159,10 +2169,10 @@ devPlans.openapi(updateSettings, async (c) => {
 		}
 	}
 
-	// The default routing strategy lives on the project, not the org. Apply it to
-	// the org's default project (the same one surfaced by the status endpoint).
+	// Project-scoped settings apply to the default project surfaced by status.
 	let effectiveRoutingStrategy: "auto" | "price" | "throughput" | "latency" =
 		"auto";
+	let effectiveProviderCacheControlEnabled = true;
 	const defaultProject = await db.query.project.findFirst({
 		where: {
 			organizationId: {
@@ -2175,22 +2185,52 @@ devPlans.openapi(updateSettings, async (c) => {
 	});
 	if (defaultProject) {
 		effectiveRoutingStrategy = defaultProject.defaultRoutingStrategy;
+		effectiveProviderCacheControlEnabled =
+			defaultProject.providerCacheControlEnabled;
+		const projectUpdateData: Partial<typeof tables.project.$inferInsert> = {};
 		if (
 			defaultRoutingStrategy !== undefined &&
 			defaultRoutingStrategy !== defaultProject.defaultRoutingStrategy
 		) {
+			projectUpdateData.defaultRoutingStrategy = defaultRoutingStrategy;
+		}
+		if (
+			providerCacheControlEnabled !== undefined &&
+			providerCacheControlEnabled !== defaultProject.providerCacheControlEnabled
+		) {
+			projectUpdateData.providerCacheControlEnabled =
+				providerCacheControlEnabled;
+		}
+		if (Object.keys(projectUpdateData).length > 0) {
 			// Cached client so the gateway's project-cache invalidates and the new
-			// default routing strategy takes effect immediately (see projects.ts).
+			// settings take effect immediately (see projects.ts).
 			await cdb
 				.update(tables.project)
-				.set({ defaultRoutingStrategy })
+				.set(projectUpdateData)
 				.where(eq(tables.project.id, defaultProject.id));
+		}
+		if (
+			defaultRoutingStrategy !== undefined &&
+			defaultRoutingStrategy !== defaultProject.defaultRoutingStrategy
+		) {
 			changes.defaultRoutingStrategy = {
 				old: defaultProject.defaultRoutingStrategy,
 				new: defaultRoutingStrategy,
 			};
-			effectiveRoutingStrategy = defaultRoutingStrategy;
 		}
+		if (
+			providerCacheControlEnabled !== undefined &&
+			providerCacheControlEnabled !== defaultProject.providerCacheControlEnabled
+		) {
+			changes.providerCacheControlEnabled = {
+				old: defaultProject.providerCacheControlEnabled,
+				new: providerCacheControlEnabled,
+			};
+		}
+		effectiveRoutingStrategy =
+			defaultRoutingStrategy ?? effectiveRoutingStrategy;
+		effectiveProviderCacheControlEnabled =
+			providerCacheControlEnabled ?? effectiveProviderCacheControlEnabled;
 	}
 
 	if (Object.keys(changes).length > 0) {
@@ -2207,6 +2247,7 @@ devPlans.openapi(updateSettings, async (c) => {
 		success: true,
 		devPlanServiceTier: devPlanServiceTier ?? personalOrg.devPlanServiceTier,
 		defaultRoutingStrategy: effectiveRoutingStrategy,
+		providerCacheControlEnabled: effectiveProviderCacheControlEnabled,
 		devPlanPaygEnabled: devPlanPaygEnabled ?? personalOrg.devPlanPaygEnabled,
 		autoTopUpEnabled:
 			updateData.autoTopUpEnabled ?? personalOrg.autoTopUpEnabled,

--- a/apps/code/src/app/dashboard/(main)/settings/page.tsx
+++ b/apps/code/src/app/dashboard/(main)/settings/page.tsx
@@ -51,6 +51,9 @@ export default function SettingsPage() {
 					defaultRoutingStrategy={
 						devPlanStatus.defaultRoutingStrategy ?? "auto"
 					}
+					providerCacheControlEnabled={
+						devPlanStatus.providerCacheControlEnabled ?? true
+					}
 				/>
 			)}
 

--- a/apps/code/src/app/dashboard/components/DevPlanSettings.tsx
+++ b/apps/code/src/app/dashboard/components/DevPlanSettings.tsx
@@ -11,6 +11,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import { useApi } from "@/lib/fetch-client";
 
 type RoutingStrategy = "auto" | "price" | "throughput" | "latency";
@@ -38,11 +39,13 @@ const SERVICE_TIER_OPTIONS: Array<{ value: ServiceTier; label: string }> = [
 interface DevPlanSettingsProps {
 	devPlanServiceTier: ServiceTier;
 	defaultRoutingStrategy: RoutingStrategy;
+	providerCacheControlEnabled: boolean;
 }
 
 export default function DevPlanSettings({
 	devPlanServiceTier: initialServiceTier,
 	defaultRoutingStrategy: initialRoutingStrategy,
+	providerCacheControlEnabled: initialProviderCacheControlEnabled,
 }: DevPlanSettingsProps) {
 	const api = useApi();
 
@@ -54,6 +57,9 @@ export default function DevPlanSettings({
 	const [serviceTier, setServiceTier] =
 		useState<ServiceTier>(initialServiceTier);
 	const [isUpdatingServiceTier, setIsUpdatingServiceTier] = useState(false);
+	const [providerCacheControlEnabled, setProviderCacheControlEnabled] =
+		useState(initialProviderCacheControlEnabled);
+	const [isUpdatingProviderCache, setIsUpdatingProviderCache] = useState(false);
 
 	const updateSettingsMutation = api.useMutation(
 		"patch",
@@ -106,6 +112,27 @@ export default function DevPlanSettings({
 		}
 	};
 
+	const handleProviderCacheChange = async (enabled: boolean) => {
+		const previous = providerCacheControlEnabled;
+		setProviderCacheControlEnabled(enabled);
+		setIsUpdatingProviderCache(true);
+		try {
+			await updateSettingsMutation.mutateAsync({
+				body: { providerCacheControlEnabled: enabled },
+			});
+			toast.success(
+				enabled
+					? "Provider cache writes enabled"
+					: "Provider cache writes disabled",
+			);
+		} catch {
+			setProviderCacheControlEnabled(previous);
+			toast.error("Failed to update provider cache writes");
+		} finally {
+			setIsUpdatingProviderCache(false);
+		}
+	};
+
 	return (
 		<div>
 			<h2 className="mb-4 font-semibold">Settings</h2>
@@ -155,6 +182,32 @@ export default function DevPlanSettings({
 								))}
 							</SelectContent>
 						</Select>
+					</div>
+				</div>
+
+				<div className="rounded-xl border p-5">
+					<div className="flex items-start justify-between gap-4">
+						<div className="space-y-0.5">
+							<Label
+								htmlFor="provider-cache-writes"
+								className="text-sm font-medium"
+							>
+								Provider cache writes
+							</Label>
+							<p className="text-xs text-muted-foreground">
+								Enabled by default. DevPass adds and forwards Claude cache
+								markers for reusable prompt prefixes. Cache writes cost 1.25×
+								for 5 minutes or 2× for 1 hour, while cache reads cost 0.1×.
+								Disable this for sporadic sessions that rarely reuse a prompt
+								within the cache lifetime.
+							</p>
+						</div>
+						<Switch
+							id="provider-cache-writes"
+							checked={providerCacheControlEnabled}
+							onCheckedChange={handleProviderCacheChange}
+							disabled={isUpdatingProviderCache}
+						/>
 					</div>
 				</div>
 

--- a/apps/docs/content/features/caching/provider-cache-control.mdx
+++ b/apps/docs/content/features/caching/provider-cache-control.mdx
@@ -28,7 +28,7 @@ Providers including OpenAI, Anthropic (when prompts cross the provider's minimum
 
 For **Anthropic** and **AWS Bedrock Claude**, prompt caching is strictly opt-in via `cache_control` / `cachePoint` markers on the request body. To get automatic cache benefits without rewriting your requests, LLM Gateway injects those markers for you on long system and user messages by default. If you send long prompts sporadically — with gaps wider than the 5-minute TTL — you may want to disable this entirely, since you would otherwise pay the cache-write premium (1.25× input for 5m, 2× for 1h) without ever benefiting from a cache read.
 
-To disable, open **Project Settings → Caching → Provider Cache Writes** and turn off "Allow provider cache writes". When disabled, the gateway strips **all** `cache_control` markers from outgoing requests for the project — both the ones it adds automatically and any markers your client sends. This covers callers that always emit markers regardless of the user's request cadence (e.g. Claude Code, Cursor, Cline). The change takes up to 5 minutes to take effect due to the project-settings cache.
+To disable, open **Project Settings → Caching → Provider Cache Writes** and turn off "Allow provider cache writes". On DevPass, use **Settings → Provider cache writes** instead. When disabled, the gateway strips **all** `cache_control` markers from outgoing requests for the project — both the ones it adds automatically and any markers your client sends. This covers callers that always emit markers regardless of the user's request cadence (e.g. Claude Code, Cursor, Cline). The change takes up to 5 minutes to take effect due to the project-settings cache.
 
 To take advantage of automatic caching:
 

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -320,77 +320,80 @@ describe("prepareRequestBody - Anthropic", () => {
 		expect(totalCacheControlBlocks).toBe(4);
 	});
 
-	test("strips caller-supplied cache_control when providerCacheControlEnabled is false", async () => {
-		const longContent = "A".repeat(5000);
-		const requestBody = (await prepareRequestBody(
-			"anthropic",
-			"claude-3-5-sonnet-20241022",
-			null,
-			"claude-3-5-sonnet-20241022",
-			[
-				{
-					role: "system",
-					content: [
-						{
-							type: "text",
-							text: longContent,
-							cache_control: { type: "ephemeral", ttl: "1h" },
-						},
-					],
-				},
-				{
-					role: "user",
-					content: [
-						{
-							type: "text",
-							text: longContent,
-							cache_control: { type: "ephemeral" },
-						},
-					],
-				},
-			],
-			false, // stream
-			undefined, // temperature
-			1024, // max_tokens
-			undefined, // top_p
-			undefined, // frequency_penalty
-			undefined, // presence_penalty
-			undefined, // response_format
-			undefined, // tools
-			undefined, // tool_choice
-			undefined, // reasoning_effort
-			undefined, // supportsReasoning
-			false, // isProd
-			20, // maxImageSizeMB
-			null, // userPlan
-			undefined, // sensitive_word_check
-			undefined, // image_config
-			undefined, // effort
-			undefined, // imageGenerations
-			undefined, // webSearchTool
-			undefined, // reasoning_max_tokens
-			undefined, // useResponsesApi
-			undefined, // prompt_cache_key
-			undefined, // prompt_cache_retention
-			false, // providerCacheControlEnabled
-		)) as AnthropicRequestBody;
+	test.each(["claude-fable-5", "claude-opus-5"])(
+		"strips cache_control for %s when provider cache writes are disabled",
+		async (model) => {
+			const longContent = "A".repeat(5000);
+			const requestBody = (await prepareRequestBody(
+				"anthropic",
+				model,
+				null,
+				model,
+				[
+					{
+						role: "system",
+						content: [
+							{
+								type: "text",
+								text: longContent,
+								cache_control: { type: "ephemeral", ttl: "1h" },
+							},
+						],
+					},
+					{
+						role: "user",
+						content: [
+							{
+								type: "text",
+								text: longContent,
+								cache_control: { type: "ephemeral" },
+							},
+						],
+					},
+				],
+				false, // stream
+				undefined, // temperature
+				1024, // max_tokens
+				undefined, // top_p
+				undefined, // frequency_penalty
+				undefined, // presence_penalty
+				undefined, // response_format
+				undefined, // tools
+				undefined, // tool_choice
+				undefined, // reasoning_effort
+				undefined, // supportsReasoning
+				false, // isProd
+				20, // maxImageSizeMB
+				null, // userPlan
+				undefined, // sensitive_word_check
+				undefined, // image_config
+				undefined, // effort
+				undefined, // imageGenerations
+				undefined, // webSearchTool
+				undefined, // reasoning_max_tokens
+				undefined, // useResponsesApi
+				undefined, // prompt_cache_key
+				undefined, // prompt_cache_retention
+				false, // providerCacheControlEnabled
+			)) as AnthropicRequestBody;
 
-		// System: no caller marker preserved, no heuristic-added marker.
-		if (requestBody.system && Array.isArray(requestBody.system)) {
-			for (const block of requestBody.system) {
-				expect(getCacheControl(block)).toBeUndefined();
-			}
-		}
-
-		// User content: no caller marker preserved, no heuristic-added marker.
-		for (const msg of requestBody.messages) {
-			if (Array.isArray(msg.content)) {
-				for (const block of msg.content) {
+			// System: no caller marker preserved, no heuristic-added marker.
+			if (requestBody.system && Array.isArray(requestBody.system)) {
+				for (const block of requestBody.system) {
 					expect(getCacheControl(block)).toBeUndefined();
 				}
 			}
-		}
-	});
+
+			// User content: no caller marker preserved, no heuristic-added marker.
+			for (const msg of requestBody.messages) {
+				if (Array.isArray(msg.content)) {
+					for (const block of msg.content) {
+						expect(getCacheControl(block)).toBeUndefined();
+					}
+				}
+			}
+		},
+	);
 
 	test("defers auto-injection when caller supplies a 1h ttl marker in messages", async () => {
 		const longContent = "A".repeat(5000);
@@ -3813,6 +3816,79 @@ describe("prepareRequestBody - AWS Bedrock", () => {
 			{ cachePoint: { type: "default", ttl: "5m" } },
 		]);
 	});
+
+	test.each(["claude-fable-5", "claude-opus-5"])(
+		"omits cache points for %s when provider cache writes are disabled",
+		async (model) => {
+			const mapping = models
+				.find((candidate) => candidate.id === model)
+				?.providers.find((candidate) => candidate.providerId === "aws-bedrock");
+			expect(mapping).toBeDefined();
+			const longContent = "A".repeat(20_000);
+			const requestBody = (await prepareRequestBody(
+				"aws-bedrock",
+				model,
+				null,
+				mapping!.externalId,
+				[
+					{
+						role: "system",
+						content: [
+							{
+								type: "text",
+								text: longContent,
+								cache_control: { type: "ephemeral", ttl: "1h" },
+							},
+						],
+					},
+					{
+						role: "user",
+						content: [
+							{
+								type: "text",
+								text: longContent,
+								cache_control: { type: "ephemeral" },
+							},
+						],
+					},
+				],
+				false,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				false,
+				false,
+				20,
+				null,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				false,
+			)) as {
+				system?: Array<Record<string, unknown>>;
+				messages: Array<{ content: Array<Record<string, unknown>> }>;
+			};
+
+			expect(requestBody.system).not.toContainEqual(
+				expect.objectContaining({ cachePoint: expect.anything() }),
+			);
+			expect(requestBody.messages[0].content).not.toContainEqual(
+				expect.objectContaining({ cachePoint: expect.anything() }),
+			);
+		},
+	);
 
 	test("forwards base64 image blocks as Bedrock image content", async () => {
 		const pngBase64 =


### PR DESCRIPTION
## Summary

- expose provider cache writes in DevPass settings
- keep cache writes enabled by default, matching regular projects
- strip Claude and Bedrock cache markers when disabled
- document the DevPass settings path

DevPass personal projects already carried the provider cache-control flag, but the DevPass status/settings API and dashboard did not expose it. This made the existing opt-out unreachable for DevPass users.

## Screenshots

### Light

| Before | After |
| --- | --- |
| ![DevPass settings before, light](https://raw.githubusercontent.com/theopenco/llmgateway/assets/pr-3696/devpass-settings-before-light.png) | ![DevPass settings after, light](https://raw.githubusercontent.com/theopenco/llmgateway/assets/pr-3696/devpass-settings-after-light.png) |

### Dark

| Before | After |
| --- | --- |
| ![DevPass settings before, dark](https://raw.githubusercontent.com/theopenco/llmgateway/assets/pr-3696/devpass-settings-before-dark.png) | ![DevPass settings after, dark](https://raw.githubusercontent.com/theopenco/llmgateway/assets/pr-3696/devpass-settings-after-dark.png) |

## Verification

- `pnpm exec vitest run --no-file-parallelism packages/actions/src/prepare-request-body.spec.ts`
- `direnv exec . pnpm exec vitest run --no-file-parallelism apps/api/src/routes/dev-plans-payg.spec.ts`
- `pnpm format`
- `pnpm build`
- verified enabled-by-default behavior and toggle persistence in light and dark themes