### PR TITLE
fix(worker): keep plan overflow off personal credits

### DIFF
--- a/apps/worker/src/log-processing.spec.ts
+++ b/apps/worker/src/log-processing.spec.ts
@@ -1078,6 +1078,48 @@ describe("Log Processing", () => {
 			expect(Number(updatedOrg!.credits)).toBe(0);
 		});
 
+		test("should carry debt for a planless personal org that holds a balance", async () => {
+			// No plan, but a real top-up/gift balance: getAvailableCredits admits
+			// this traffic on the balance alone, so the balance — not a plan — is
+			// what authorized it. The overage must be carried as debt exactly like
+			// a default org, otherwise the org gets more usage than it paid for.
+			await db
+				.update(organization)
+				.set({
+					kind: "chat",
+					credits: "0.01",
+					chatPlan: "none",
+					devPlan: "none",
+					devPlanPaygEnabled: false,
+				})
+				.where(eq(organization.id, testOrg.id));
+
+			await db.insert(log).values({
+				requestId: "test-request-planless-balance-debt",
+				organizationId: testOrg.id,
+				projectId: testProject.id,
+				apiKeyId: testApiKey.id,
+				cost: 0.05,
+				cached: false,
+				usedMode: "credits",
+				duration: 1000,
+				requestedModel: "openai/gpt-4o-mini",
+				requestedProvider: "openai",
+				usedModel: "gpt-4o-mini",
+				usedProvider: "openai",
+				responseSize: 100,
+				mode: "credits",
+			});
+
+			await batchProcessLogs();
+
+			const updatedOrg = await db.query.organization.findFirst({
+				where: { id: { eq: testOrg.id } },
+			});
+
+			expect(Number(updatedOrg!.credits)).toBeCloseTo(-0.04, 8);
+		});
+
 		test("should still let a default org go negative on overage", async () => {
 			// Pay-as-you-go orgs are invoiced and reconciled on the next top-up,
 			// so flooring them would lose genuinely incurred usage.

--- a/apps/worker/src/log-processing.spec.ts
+++ b/apps/worker/src/log-processing.spec.ts
@@ -950,6 +950,208 @@ describe("Log Processing", () => {
 
 			expect(Number(updatedOrg!.credits)).toBe(initialCredits);
 		});
+
+		test("should keep chat plan overflow off an empty credit balance", async () => {
+			// A chat-plan subscriber holds no pay-as-you-go balance. Requests
+			// admitted while the pool still had room can overshoot it, and
+			// getAvailableCredits adds `credits` to the plan allowance — so a
+			// negative balance would silently dock next cycle's allowance. The
+			// excess stays recorded as chat plan usage instead.
+			await db
+				.update(organization)
+				.set({
+					kind: "chat",
+					credits: "0.00",
+					chatPlan: "starter",
+					chatPlanCreditsLimit: "0.02",
+					chatPlanCreditsUsed: "0.00",
+				})
+				.where(eq(organization.id, testOrg.id));
+
+			await db.insert(log).values({
+				requestId: "test-request-chat-overflow-no-balance",
+				organizationId: testOrg.id,
+				projectId: testProject.id,
+				apiKeyId: testApiKey.id,
+				cost: 0.05,
+				cached: false,
+				usedMode: "credits",
+				duration: 1000,
+				requestedModel: "openai/gpt-4o-mini",
+				requestedProvider: "openai",
+				usedModel: "gpt-4o-mini",
+				usedProvider: "openai",
+				responseSize: 100,
+				mode: "credits",
+			});
+
+			await batchProcessLogs();
+
+			const updatedOrg = await db.query.organization.findFirst({
+				where: { id: { eq: testOrg.id } },
+			});
+
+			expect(Number(updatedOrg!.credits)).toBe(0);
+			expect(Number(updatedOrg!.chatPlanCreditsUsed)).toBeCloseTo(0.05, 8);
+		});
+
+		test("should spend a chat org balance before parking the rest on the pool", async () => {
+			// A partial balance must still be spent — flooring the whole charge
+			// would hand the org free usage. Only the part the balance cannot
+			// cover stays on the plan pool.
+			await db
+				.update(organization)
+				.set({
+					kind: "chat",
+					credits: "0.02",
+					chatPlan: "starter",
+					chatPlanCreditsLimit: "0.01",
+					chatPlanCreditsUsed: "0.01",
+				})
+				.where(eq(organization.id, testOrg.id));
+
+			await db.insert(log).values({
+				requestId: "test-request-chat-partial-balance",
+				organizationId: testOrg.id,
+				projectId: testProject.id,
+				apiKeyId: testApiKey.id,
+				cost: 0.05,
+				cached: false,
+				usedMode: "credits",
+				duration: 1000,
+				requestedModel: "openai/gpt-4o-mini",
+				requestedProvider: "openai",
+				usedModel: "gpt-4o-mini",
+				usedProvider: "openai",
+				responseSize: 100,
+				mode: "credits",
+			});
+
+			await batchProcessLogs();
+
+			const updatedOrg = await db.query.organization.findFirst({
+				where: { id: { eq: testOrg.id } },
+			});
+
+			// Balance fully spent, never negative; the $0.03 excess is plan usage.
+			expect(Number(updatedOrg!.credits)).toBe(0);
+			expect(Number(updatedOrg!.chatPlanCreditsUsed)).toBeCloseTo(0.04, 8);
+		});
+
+		test("should write off residual usage after the plan was cancelled", async () => {
+			// The plan pool is torn down on cancellation, so late-arriving usage
+			// it had already authorized has nowhere to go. Writing it off keeps
+			// the org out of phantom debt that a later top-up would silently pay.
+			await db
+				.update(organization)
+				.set({
+					kind: "devpass",
+					credits: "0.00",
+					devPlan: "none",
+					devPlanPaygEnabled: false,
+				})
+				.where(eq(organization.id, testOrg.id));
+
+			await db.insert(log).values({
+				requestId: "test-request-cancelled-plan-residual",
+				organizationId: testOrg.id,
+				projectId: testProject.id,
+				apiKeyId: testApiKey.id,
+				cost: 0.05,
+				cached: false,
+				usedMode: "credits",
+				duration: 1000,
+				requestedModel: "openai/gpt-4o-mini",
+				requestedProvider: "openai",
+				usedModel: "gpt-4o-mini",
+				usedProvider: "openai",
+				responseSize: 100,
+				mode: "credits",
+			});
+
+			await batchProcessLogs();
+
+			const updatedOrg = await db.query.organization.findFirst({
+				where: { id: { eq: testOrg.id } },
+			});
+
+			expect(Number(updatedOrg!.credits)).toBe(0);
+		});
+
+		test("should still let a default org go negative on overage", async () => {
+			// Pay-as-you-go orgs are invoiced and reconciled on the next top-up,
+			// so flooring them would lose genuinely incurred usage.
+			await db
+				.update(organization)
+				.set({ kind: "default", credits: "0.01" })
+				.where(eq(organization.id, testOrg.id));
+
+			await db.insert(log).values({
+				requestId: "test-request-default-still-negative",
+				organizationId: testOrg.id,
+				projectId: testProject.id,
+				apiKeyId: testApiKey.id,
+				cost: 0.05,
+				cached: false,
+				usedMode: "credits",
+				duration: 1000,
+				requestedModel: "openai/gpt-4o-mini",
+				requestedProvider: "openai",
+				usedModel: "gpt-4o-mini",
+				usedProvider: "openai",
+				responseSize: 100,
+				mode: "credits",
+			});
+
+			await batchProcessLogs();
+
+			const updatedOrg = await db.query.organization.findFirst({
+				where: { id: { eq: testOrg.id } },
+			});
+
+			expect(Number(updatedOrg!.credits)).toBeCloseTo(-0.04, 8);
+		});
+
+		test("should still let a PAYG-enabled devpass org go negative", async () => {
+			// Opting into pay-as-you-go overflow is an explicit request to bill
+			// real money past the allowance, with auto top-up to reconcile it.
+			await db
+				.update(organization)
+				.set({
+					kind: "devpass",
+					credits: "0.01",
+					devPlan: "pro",
+					devPlanCreditsLimit: "0.01",
+					devPlanCreditsUsed: "0.01",
+					devPlanPaygEnabled: true,
+				})
+				.where(eq(organization.id, testOrg.id));
+
+			await db.insert(log).values({
+				requestId: "test-request-payg-on-still-negative",
+				organizationId: testOrg.id,
+				projectId: testProject.id,
+				apiKeyId: testApiKey.id,
+				cost: 0.05,
+				cached: false,
+				usedMode: "credits",
+				duration: 1000,
+				requestedModel: "openai/gpt-4o-mini",
+				requestedProvider: "openai",
+				usedModel: "gpt-4o-mini",
+				usedProvider: "openai",
+				responseSize: 100,
+				mode: "credits",
+			});
+
+			await batchProcessLogs();
+
+			const updatedOrg = await db.query.organization.findFirst({
+				where: { id: { eq: testOrg.id } },
+			});
+
+			expect(Number(updatedOrg!.credits)).toBeCloseTo(-0.04, 8);
+		});
 	});
 
 	describe("provider key spend limits", () => {

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -1512,20 +1512,24 @@ export async function batchProcessLogs(): Promise<number> {
 						`Kept ${remainingCost.toString()} on the dev plan pool for organization ${orgId} (pay-as-you-go overflow disabled)`,
 					);
 				} else if (remainingCost.greaterThan(0)) {
-					// Personal (chat/devpass) orgs that never opted into pay-as-you-go
-					// must not be driven below zero. They are billed per plan cycle
-					// rather than invoiced, and getAvailableCredits sums `credits` with
-					// the plan allowance, so a negative balance silently docks the
-					// *next* cycle's allowance — a chat-plan subscriber ends up paying
-					// for overshoot out of the plan they already bought. Charge what
-					// the balance can actually cover and route the rest to an active
-					// plan pool, so the usage stays accounted for. `default` orgs and
-					// pay-as-you-go opt-ins keep today's behaviour: they may go
-					// negative and are reconciled on the next top-up.
-					const planFundedOrg =
-						org && org.kind !== "default" && !org.devPlanPaygEnabled;
+					// Overshoot is held off real credits only when a *plan* authorized
+					// the spend, never on org kind alone. getAvailableCredits sums
+					// `credits` with the plan allowance, so a negative balance silently
+					// docks the next cycle's allowance — a chat-plan subscriber would
+					// end up paying for overshoot out of the plan they already bought.
+					// That reasoning needs a plan pool behind it: either one still
+					// active to park the excess on, or a cancelled plan that left no
+					// balance to draw on. A personal org that still holds a balance is
+					// funded by that balance exactly like a `default` org, so it
+					// carries the overage as debt instead of having it forgiven.
+					const overflowPool = chatPool ?? devPool;
 					const balance = Decimal.max(0, new Decimal(org?.credits ?? "0"));
-					const chargeToCredits = planFundedOrg
+					const planAuthorized =
+						org &&
+						org.kind !== "default" &&
+						!org.devPlanPaygEnabled &&
+						(overflowPool !== null || balance.lessThanOrEqualTo(0));
+					const chargeToCredits = planAuthorized
 						? Decimal.min(remainingCost, balance)
 						: remainingCost;
 					const overflow = remainingCost.minus(chargeToCredits);
@@ -1550,7 +1554,6 @@ export async function batchProcessLogs(): Promise<number> {
 						// Prefer the pool that authorized the spend. With the plan
 						// already cancelled there is no pool left to hold it, so the
 						// residual is written off rather than turned into phantom debt.
-						const overflowPool = chatPool ?? devPool;
 						if (overflowPool) {
 							await deductFromPlanPool(
 								orgId,

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -1512,19 +1512,64 @@ export async function batchProcessLogs(): Promise<number> {
 						`Kept ${remainingCost.toString()} on the dev plan pool for organization ${orgId} (pay-as-you-go overflow disabled)`,
 					);
 				} else if (remainingCost.greaterThan(0)) {
-					const costStr = remainingCost.toString();
-					await tx
-						.update(organization)
-						.set({
-							credits: sql`${organization.credits} - ${costStr}`,
-						})
-						.where(eq(organization.id, orgId));
+					// Personal (chat/devpass) orgs that never opted into pay-as-you-go
+					// must not be driven below zero. They are billed per plan cycle
+					// rather than invoiced, and getAvailableCredits sums `credits` with
+					// the plan allowance, so a negative balance silently docks the
+					// *next* cycle's allowance — a chat-plan subscriber ends up paying
+					// for overshoot out of the plan they already bought. Charge what
+					// the balance can actually cover and route the rest to an active
+					// plan pool, so the usage stays accounted for. `default` orgs and
+					// pay-as-you-go opt-ins keep today's behaviour: they may go
+					// negative and are reconciled on the next top-up.
+					const planFundedOrg =
+						org && org.kind !== "default" && !org.devPlanPaygEnabled;
+					const balance = Decimal.max(0, new Decimal(org?.credits ?? "0"));
+					const chargeToCredits = planFundedOrg
+						? Decimal.min(remainingCost, balance)
+						: remainingCost;
+					const overflow = remainingCost.minus(chargeToCredits);
 
-					deductedOrgIds.push(orgId);
+					if (chargeToCredits.greaterThan(0)) {
+						const costStr = chargeToCredits.toString();
+						await tx
+							.update(organization)
+							.set({
+								credits: sql`${organization.credits} - ${costStr}`,
+							})
+							.where(eq(organization.id, orgId));
 
-					logger.debug(
-						`Deducted ${costStr} regular credits from organization ${orgId}`,
-					);
+						deductedOrgIds.push(orgId);
+
+						logger.debug(
+							`Deducted ${costStr} regular credits from organization ${orgId}`,
+						);
+					}
+
+					if (overflow.greaterThan(0)) {
+						// Prefer the pool that authorized the spend. With the plan
+						// already cancelled there is no pool left to hold it, so the
+						// residual is written off rather than turned into phantom debt.
+						const overflowPool = chatPool ?? devPool;
+						if (overflowPool) {
+							await deductFromPlanPool(
+								orgId,
+								overflowPool,
+								overflow,
+								Decimal.min(
+									fromChat.remainingPremium.plus(fromOther.remainingPremium),
+									overflow,
+								),
+							);
+							logger.debug(
+								`Kept ${overflow.toString()} on the ${overflowPool.kind} plan pool for organization ${orgId} (credit balance exhausted)`,
+							);
+						} else {
+							logger.debug(
+								`Wrote off ${overflow.toString()} for organization ${orgId} (no plan pool and no credit balance)`,
+							);
+						}
+					}
 				}
 
 				// 1% referral earnings on the full charge regardless of which pool paid.


### PR DESCRIPTION
## Problem

Requests are admitted while a plan pool still has room, so a burst can collectively cost more than was left. Today that overshoot falls through to the org's real `credits` balance and drives it negative for two cases `plannedOverflowOnly` doesn't cover:

- **Chat plans** — the guard requires `devPlan !== "none"`, so a chat-plan subscriber's overshoot always hits real credits.
- **Cancelled plans** — the pool is torn down on cancellation, so usage it had already authorized lands on `credits` afterwards.

For chat/devpass orgs that never opted into pay-as-you-go this is a real charge, not just cosmetic bookkeeping. `getAvailableCredits` computes `regularCredits + devPlanRemaining + chatPlanRemaining`, so a negative balance **silently docks the next cycle's plan allowance** — the subscriber ends up paying for overshoot out of the plan they already bought.

## Fix

In the residual branch of `batchProcessLogs`, for non-`default` orgs that have not enabled PAYG overflow:

- charge only what the real balance can actually cover (a partial balance is still fully spent — no free usage),
- route the remainder to an active chat/dev plan pool so the usage stays accounted for,
- write it off when the plan is already gone and there is no pool left to hold it.

Deliberately unchanged: `default` (pay-as-you-go) orgs and `devPlanPaygEnabled` opt-ins may still go negative and are reconciled on the next top-up. Opting into PAYG is an explicit request to bill real money past the allowance, and auto top-up exists to settle it — flooring those would lose genuinely incurred usage.

## Scope note

Once a plan is cancelled its pool is gone, so late-arriving usage it authorized can only be written off rather than billed precisely. Attributing it exactly would require recording which pool admitted each request at log time — a schema change well outside this diff.

## Tests

Five tests in `log-processing.spec.ts`; suite is 32/32 green.

Verified the tests actually catch the bug: with `worker.ts` reverted, the three bug-targeting tests fail, while the two regression guards (`default` org goes negative, PAYG-enabled devpass goes negative) pass either way — they pin behavior this PR intentionally leaves alone.

`pnpm format` clean, `pnpm build` green (17/17). The 9 failures in `sync-models.spec.ts` are pre-existing on `main` and unrelated.

## Supersedes

Replaces #2658, which was built on the premise that chat/devpass orgs hold no real credits. That premise no longer holds after #3430/#3473/#3560 — devpass gifting is deliberate and the admin UI exposes it — so that branch is best closed rather than rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented eligible plan-funded accounts without pay-as-you-go billing from reaching negative credit balances.
  * Usage now deducts available credits first, then applies remaining usage to the appropriate plan allowance.
  * Cancelled-plan residual usage is written off when no applicable allowance remains.
  * Planless personal accounts and pay-as-you-go-enabled accounts can retain negative balances after overage.
  * Default billing behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->