### PR TITLE
fix(gateway): normalize null tool call types

### DIFF
--- a/apps/gateway/src/chat/tools/transform-openai-streaming.spec.ts
+++ b/apps/gateway/src/chat/tools/transform-openai-streaming.spec.ts
@@ -443,4 +443,42 @@ describe("transformOpenaiStreaming", () => {
 			},
 		]);
 	});
+
+	test("normalizes null tool call types in partial deltas", () => {
+		const input = {
+			service_tier: "default",
+			id: "chatcmpl-abc123",
+			object: "chat.completion.chunk",
+			created: 1787205218,
+			model: "deepseek-ai/DeepSeek-V4-Flash-0731",
+			choices: [
+				{
+					index: 0,
+					delta: {
+						role: "assistant",
+						content: "",
+						reasoning_content: null,
+						tool_calls: [
+							{
+								index: 0,
+								id: null,
+								function: {
+									arguments: "",
+									name: null,
+								},
+								type: null,
+							},
+						],
+					},
+					logprobs: null,
+					finish_reason: null,
+				},
+			],
+			usage: null,
+		};
+
+		const result = transformOpenaiStreaming(input, "deepseek-v4-flash");
+
+		expect(result.choices[0].delta.tool_calls[0].type).toBe("function");
+	});
 });

--- a/apps/gateway/src/chat/tools/transform-openai-streaming.ts
+++ b/apps/gateway/src/chat/tools/transform-openai-streaming.ts
@@ -100,11 +100,13 @@ export function transformOpenaiStreaming(
 		) {
 			delete newDelta.tool_calls;
 		} else if (Array.isArray(newDelta.tool_calls)) {
-			// Some upstreams announce a tool call before sending its function data.
-			// Strict OpenAI clients still require the function key on every frame.
+			// Some upstreams announce a tool call with null placeholders before
+			// sending its function data. Strict OpenAI clients still require the
+			// function key and reject a present type unless it is "function".
 			newDelta.tool_calls = newDelta.tool_calls.map(
 				(toolCall: Record<string, unknown>) => ({
 					...toolCall,
+					type: toolCall.type ?? "function",
 					function: toolCall.function ?? {},
 				}),
 			);


### PR DESCRIPTION
## Problem

Some OpenAI-compatible upstreams emit partial streaming tool-call deltas with `type: null`. Strict clients reject the chunk because a present tool-call type must be `function`. The previous normalization covered missing function objects but left explicit null types unchanged.

## Changes

- normalize null partial tool-call types to `function`
- add regression coverage for the reported streaming payload shape

## Verification

- `pnpm format`
- `pnpm build`
- `pnpm exec vitest run apps/gateway/src/chat/tools/transform-openai-streaming.spec.ts --no-file-parallelism`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming tool-call handling when partial responses omit the tool type.
  * Ensured these responses are correctly recognized as function calls, preventing malformed or interrupted tool interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->