### PR TITLE
fix(gateway): canonicalize response model ids

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -3017,6 +3017,7 @@ describe("api", () => {
 			},
 			body: JSON.stringify({
 				input: "I want to attack someone.",
+				model: "openai/openai-moderation",
 			}),
 		});
 

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -739,6 +739,7 @@ describe("api", () => {
 		expect(res.status).toBe(200);
 		const json = await res.json();
 		expect(json.id).toMatch(/^msg_/);
+		expect(json.model).toBe("llmgateway/custom");
 
 		const streamRes = await makeRequest(true);
 		expect(streamRes.status).toBe(200);
@@ -752,6 +753,7 @@ describe("api", () => {
 		const messageStart = events.find((e) => e.type === "message_start");
 		expect(messageStart).toBeTruthy();
 		expect(messageStart.message.id).toMatch(/^msg_/);
+		expect(messageStart.message.model).toBe("llmgateway/custom");
 	});
 
 	test("/v1/messages surfaces reasoning as thinking_delta events (streaming)", async () => {
@@ -1958,6 +1960,7 @@ describe("api", () => {
 		expect(res.status).toBe(200);
 		const json = await res.json();
 		expect(json.id).toMatch(/^resp_/);
+		expect(json.model).toBe("openai/gpt-4o-mini");
 		expect(json.output.length).toBeGreaterThan(0);
 
 		// The stored response is retrievable (state lives in responses storage).
@@ -1969,6 +1972,7 @@ describe("api", () => {
 		expect(getRes.status).toBe(200);
 		const stored = await getRes.json();
 		expect(stored.id).toBe(json.id);
+		expect(stored.model).toBe("openai/gpt-4o-mini");
 		expect(stored.output.length).toBeGreaterThan(0);
 
 		// The log row keeps metadata only — no payload, no responsesApiData.
@@ -2367,7 +2371,7 @@ describe("api", () => {
 				Authorization: "Bearer real-token-service-tier-stream",
 			},
 			body: JSON.stringify({
-				model: "openai/gpt-5.5",
+				model: "gpt-5.5",
 				service_tier: "priority",
 				stream: true,
 				stream_options: { include_usage: true },
@@ -2536,6 +2540,12 @@ describe("api", () => {
 
 		expect(res.status).toBe(200);
 		const raw = await res.text();
+		const createdLine = raw
+			.split("\n")
+			.find(
+				(line) =>
+					line.startsWith("data: ") && line.includes('"response.created"'),
+			);
 		const completedLine = raw
 			.split("\n")
 			.find(
@@ -2543,7 +2553,11 @@ describe("api", () => {
 					line.startsWith("data: ") && line.includes('"response.completed"'),
 			);
 		expect(completedLine).toBeDefined();
+		expect(createdLine).toBeDefined();
+		const created = JSON.parse(createdLine!.slice(6));
 		const completed = JSON.parse(completedLine!.slice(6));
+		expect(created.response.model).toBe("openai/gpt-5.5");
+		expect(completed.response.model).toBe("openai/gpt-5.5");
 		expect(completed.response.service_tier).toBe("priority");
 
 		const logs = await waitForLogs(1);
@@ -3010,7 +3024,7 @@ describe("api", () => {
 
 		const json = await res.json();
 		expect(json).toHaveProperty("id", "modr-123");
-		expect(json).toHaveProperty("model", "omni-moderation-latest");
+		expect(json).toHaveProperty("model", "openai/openai-moderation");
 		expect(json.results[0].flagged).toBe(true);
 
 		const logs = await waitForLogs(1);
@@ -3250,7 +3264,7 @@ describe("api", () => {
 
 		const json = await res.json();
 		expect(json).toHaveProperty("object", "list");
-		expect(json).toHaveProperty("model", "text-embedding-3-small");
+		expect(json).toHaveProperty("model", "openai/text-embedding-3-small");
 		expect(Array.isArray(json.data)).toBe(true);
 		expect(json.data[0]).toHaveProperty("embedding");
 		expect(Array.isArray(json.data[0].embedding)).toBe(true);
@@ -3557,7 +3571,10 @@ describe("api", () => {
 
 		const json = await res.json();
 		expect(json).toHaveProperty("object", "list");
-		expect(json).toHaveProperty("model", "gemini-embedding-001");
+		expect(json).toHaveProperty(
+			"model",
+			"google-ai-studio/gemini-embedding-001",
+		);
 		expect(Array.isArray(json.data)).toBe(true);
 		expect(json.data).toHaveLength(1);
 		expect(json.data[0]).toHaveProperty("object", "embedding");
@@ -3633,7 +3650,10 @@ describe("api", () => {
 			expect(res.status).toBe(200);
 			const json = await res.json();
 			expect(json).toHaveProperty("object", "list");
-			expect(json).toHaveProperty("model", "gemini-embedding-001");
+			expect(json).toHaveProperty(
+				"model",
+				"google-ai-studio/gemini-embedding-001",
+			);
 			expect(json.data).toHaveLength(1);
 			expect(json.data[0].embedding).toHaveLength(768);
 

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -9930,7 +9930,7 @@ chat.openapi(completions, async (c) => {
 										id: `chatcmpl-${Date.now()}`,
 										object: "chat.completion.chunk",
 										created: Math.floor(Date.now() / 1000),
-										model: usedInternalModel,
+										model: usedModelFormatted,
 										choices: [
 											{
 												index: 0,
@@ -9964,7 +9964,7 @@ chat.openapi(completions, async (c) => {
 													id: `chatcmpl-${Date.now()}`,
 													object: "chat.completion.chunk",
 													created: Math.floor(Date.now() / 1000),
-													model: usedInternalModel,
+													model: usedModelFormatted,
 													choices: [
 														{
 															index: 0,
@@ -10119,7 +10119,7 @@ chat.openapi(completions, async (c) => {
 											billingModel: usedInternalModel,
 											billingProvider: usedProvider,
 											billingRegion: usedRegion ?? null,
-											responseModel: data.model ?? usedInternalModel,
+											responseModel: usedModelFormatted,
 										});
 										handledTerminalProviderEvent = true;
 									} else {
@@ -10224,7 +10224,7 @@ chat.openapi(completions, async (c) => {
 								// Transform streaming responses to OpenAI format for all providers
 								const transformedData = transformStreamingToOpenai(
 									streamFormatProvider,
-									usedInternalModel,
+									usedModelFormatted,
 									data,
 									messages,
 									serverToolUseIndices,
@@ -11292,7 +11292,7 @@ chat.openapi(completions, async (c) => {
 									id: `chatcmpl-${Date.now()}`,
 									object: "chat.completion.chunk",
 									created: Math.floor(Date.now() / 1000),
-									model: usedInternalModel,
+									model: usedModelFormatted,
 									choices: [
 										{
 											index: 0,
@@ -11416,7 +11416,7 @@ chat.openapi(completions, async (c) => {
 								id: `chatcmpl-${Date.now()}`,
 								object: "chat.completion.chunk",
 								created: Math.floor(Date.now() / 1000),
-								model: usedInternalModel,
+								model: usedModelFormatted,
 								choices: [
 									{
 										index: 0,
@@ -11550,7 +11550,7 @@ chat.openapi(completions, async (c) => {
 									id: lastChunkId ?? `chatcmpl-${Date.now()}`,
 									object: "chat.completion.chunk",
 									created: lastChunkCreated ?? Math.floor(Date.now() / 1000),
-									model: lastChunkModel ?? usedInternalModel,
+									model: lastChunkModel ?? usedModelFormatted,
 									choices: [
 										{
 											index: 0,
@@ -11572,7 +11572,7 @@ chat.openapi(completions, async (c) => {
 									id: lastChunkId ?? `chatcmpl-${Date.now()}`,
 									object: "chat.completion.chunk",
 									created: lastChunkCreated ?? Math.floor(Date.now() / 1000),
-									model: lastChunkModel ?? usedInternalModel,
+									model: lastChunkModel ?? usedModelFormatted,
 									choices: [
 										{
 											index: 0,

--- a/apps/gateway/src/chat/managed-credentials.spec.ts
+++ b/apps/gateway/src/chat/managed-credentials.spec.ts
@@ -677,6 +677,7 @@ describe("managed provider credentials", () => {
 					}),
 				});
 				expect(res.status).toBe(200);
+				expect((await res.json()).model).toBe("openai/text-embedding-3-small");
 			} finally {
 				if (previousEnvKey !== undefined) {
 					process.env.LLM_OPENAI_API_KEY = previousEnvKey;
@@ -712,6 +713,7 @@ describe("managed provider credentials", () => {
 					body: JSON.stringify({ input: "hello" }),
 				});
 				expect(res.status).toBe(200);
+				expect((await res.json()).model).toBe("openai/openai-moderation");
 			} finally {
 				if (previousEnvKey !== undefined) {
 					process.env.LLM_OPENAI_API_KEY = previousEnvKey;
@@ -750,6 +752,7 @@ describe("managed provider credentials", () => {
 					}),
 				});
 				expect(res.status).toBe(200);
+				expect((await res.json()).model).toBe("deepinfra/qwen3-reranker-8b");
 			} finally {
 				if (previousEnvKey !== undefined) {
 					process.env.LLM_DEEPINFRA_API_KEY = previousEnvKey;

--- a/apps/gateway/src/chat/tools/resolve-provider-context.ts
+++ b/apps/gateway/src/chat/tools/resolve-provider-context.ts
@@ -6,6 +6,7 @@ import {
 	findProviderKey,
 	listEligibleProviderKeys,
 } from "@/lib/cached-queries.js";
+import { formatUsedModelForDisplay } from "@/lib/model-response-id.js";
 import { posthog } from "@/posthog.js";
 
 import {
@@ -465,20 +466,7 @@ function assertOrganizationHasCreditsForEnvFallback(
 	});
 }
 
-export function formatUsedModelForDisplay(
-	usedProvider: string,
-	usedInternalModel: string,
-	customProviderName?: string,
-	usedRegion?: string,
-): string {
-	const usedModelProviderPrefix =
-		usedProvider === "custom" && customProviderName
-			? customProviderName
-			: usedProvider;
-
-	const base = `${usedModelProviderPrefix}/${usedInternalModel}`;
-	return usedRegion ? `${base}:${usedRegion}` : base;
-}
+export { formatUsedModelForDisplay } from "@/lib/model-response-id.js";
 
 /**
  * Which of an organization's own keys may serve a given model.

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.spec.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.spec.ts
@@ -25,6 +25,29 @@ vi.mock("@llmgateway/logger", () => ({
 }));
 
 describe("transformStreamingToOpenai", () => {
+	it("replaces upstream model ids with the canonical mapping", () => {
+		const result = transformStreamingToOpenai(
+			"deepinfra",
+			"deepinfra/deepseek-v4-flash",
+			{
+				id: "chatcmpl-123",
+				object: "chat.completion.chunk",
+				created: 1234567890,
+				model: "deepseek-ai/DeepSeek-V4-Flash-0731",
+				choices: [
+					{
+						index: 0,
+						delta: { content: "Hello" },
+						finish_reason: null,
+					},
+				],
+			},
+			[],
+		);
+
+		expect(result.model).toBe("deepinfra/deepseek-v4-flash");
+	});
+
 	it("does not warn for Permafrost OpenAI streaming chunks", () => {
 		warn.mockClear();
 

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -1599,5 +1599,11 @@ export function transformStreamingToOpenai(
 		}
 	}
 
+	// Upstream model names are deployment identifiers. The client-facing stream
+	// must consistently expose the gateway's canonical provider/model mapping.
+	if (transformedData && typeof transformedData === "object") {
+		transformedData.model = usedModel;
+	}
+
 	return transformedData;
 }

--- a/apps/gateway/src/embeddings/embeddings.spec.ts
+++ b/apps/gateway/src/embeddings/embeddings.spec.ts
@@ -85,6 +85,7 @@ describe("embeddings", () => {
 		expect(res.status).toBe(200);
 		const json = await res.json();
 		expect(json).toHaveProperty("object", "list");
+		expect(json).toHaveProperty("model", "openai/text-embedding-3-small");
 		expect(Array.isArray(json.data)).toBe(true);
 
 		const logs = await waitForLogs(2);

--- a/apps/gateway/src/embeddings/embeddings.ts
+++ b/apps/gateway/src/embeddings/embeddings.ts
@@ -43,6 +43,7 @@ import { extractApiToken } from "@/lib/extract-api-token.js";
 import { createFailedKeyTracker } from "@/lib/failed-key-tracker.js";
 import { throwIamException, validateRequestModelAccess } from "@/lib/iam.js";
 import { calculateDataStorageCost, insertLog } from "@/lib/logs.js";
+import { formatUsedModelForDisplay } from "@/lib/model-response-id.js";
 import { assertOrganizationUsable } from "@/lib/organization-access.js";
 import { assertSpendLimit } from "@/lib/spend-limit.js";
 import {
@@ -524,6 +525,12 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 	const { mapping, modelDef, modelDefId, explicitProvider } = match;
 	const upstreamModel = mapping.externalId;
 	const providerId = mapping.providerId;
+	const responseModel = formatUsedModelForDisplay(
+		providerId,
+		modelDefId,
+		undefined,
+		mapping.region,
+	);
 
 	const isTokenIdInput = (() => {
 		if (!Array.isArray(input)) {
@@ -1511,7 +1518,7 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 				normalizedResponse = {
 					object: "list",
 					data,
-					model: requestedModel,
+					model: responseModel,
 					usage: {
 						prompt_tokens: promptTokens,
 						total_tokens: totalTokens,
@@ -1568,7 +1575,7 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 				normalizedResponse = {
 					object: "list",
 					data,
-					model: requestedModel,
+					model: responseModel,
 					usage: {
 						prompt_tokens: promptTokens,
 						total_tokens: totalTokens,
@@ -1596,6 +1603,8 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 					});
 				}
 			}
+
+			normalizedResponse.model = responseModel;
 
 			const inputPrice = Number(mapping.inputPrice ?? "0");
 			const inputCost = promptTokens !== null ? promptTokens * inputPrice : 0;

--- a/apps/gateway/src/lib/model-response-id.ts
+++ b/apps/gateway/src/lib/model-response-id.ts
@@ -1,0 +1,14 @@
+export function formatUsedModelForDisplay(
+	usedProvider: string,
+	usedInternalModel: string,
+	customProviderName?: string,
+	usedRegion?: string,
+): string {
+	const providerPrefix =
+		usedProvider === "custom" && customProviderName
+			? customProviderName
+			: usedProvider;
+
+	const base = `${providerPrefix}/${usedInternalModel}`;
+	return usedRegion ? `${base}:${usedRegion}` : base;
+}

--- a/apps/gateway/src/moderations/moderations.ts
+++ b/apps/gateway/src/moderations/moderations.ts
@@ -34,6 +34,7 @@ import { buildOpenAIErrorBody } from "@/lib/error-response.js";
 import { extractApiToken } from "@/lib/extract-api-token.js";
 import { throwIamException, validateRequestModelAccess } from "@/lib/iam.js";
 import { calculateDataStorageCost, insertLog } from "@/lib/logs.js";
+import { formatUsedModelForDisplay } from "@/lib/model-response-id.js";
 import { assertOrganizationUsable } from "@/lib/organization-access.js";
 import { assertSpendLimit } from "@/lib/spend-limit.js";
 import { createCombinedSignal, isTimeoutError } from "@/lib/timeout-config.js";
@@ -423,6 +424,10 @@ moderations.openapi(createModeration, async (c): Promise<any> => {
 	}
 
 	const { input, model: upstreamModel } = validationResult.data;
+	const responseModel = formatUsedModelForDisplay(
+		"openai",
+		"openai-moderation",
+	);
 	const startedAt = Date.now();
 	const source = validateSource(
 		c.req.header("x-source"),
@@ -1025,7 +1030,10 @@ moderations.openapi(createModeration, async (c): Promise<any> => {
 				{ retentionLevel },
 			);
 
-			return c.json(upstreamJson as any);
+			return c.json({
+				...(upstreamJson as Record<string, unknown>),
+				model: responseModel,
+			});
 		}
 	} finally {
 		c.req.raw.signal.removeEventListener("abort", onAbort);

--- a/apps/gateway/src/moderations/moderations.ts
+++ b/apps/gateway/src/moderations/moderations.ts
@@ -54,6 +54,12 @@ import type { Context } from "hono";
  * this fixed rate regardless of input size or moderation model.
  */
 export const MODERATION_REQUEST_PRICE = 0.00001;
+const MODERATION_MODEL_ID = "openai-moderation";
+const DEFAULT_UPSTREAM_MODERATION_MODEL = "omni-moderation-latest";
+const CANONICAL_MODERATION_MODEL = formatUsedModelForDisplay(
+	"openai",
+	MODERATION_MODEL_ID,
+);
 
 const moderationInputTextSchema = z.string().openapi({
 	description: "Plain text input to classify.",
@@ -144,7 +150,7 @@ const moderationResponseSchema = z
 		}),
 		model: z.string().optional().openapi({
 			description: "Moderation model used for the request.",
-			example: "omni-moderation-latest",
+			example: CANONICAL_MODERATION_MODEL,
 		}),
 		results: z.array(moderationResultSchema).optional().openapi({
 			description: "Moderation results for the submitted input.",
@@ -166,10 +172,15 @@ const moderationErrorSchema = z.object({
 
 const moderationRequestSchema = z.object({
 	input: moderationInputSchema,
-	model: z.string().optional().default("omni-moderation-latest").openapi({
-		description: "OpenAI moderation model. Defaults to omni-moderation-latest.",
-		example: "omni-moderation-latest",
-	}),
+	model: z
+		.string()
+		.optional()
+		.default(DEFAULT_UPSTREAM_MODERATION_MODEL)
+		.openapi({
+			description:
+				"OpenAI moderation model. Defaults to omni-moderation-latest.",
+			example: "omni-moderation-latest",
+		}),
 });
 
 function normalizeModerationInputToMessages(input: unknown) {
@@ -423,11 +434,12 @@ moderations.openapi(createModeration, async (c): Promise<any> => {
 		);
 	}
 
-	const { input, model: upstreamModel } = validationResult.data;
-	const responseModel = formatUsedModelForDisplay(
-		"openai",
-		"openai-moderation",
-	);
+	const { input, model: requestedModel } = validationResult.data;
+	const upstreamModel =
+		requestedModel === CANONICAL_MODERATION_MODEL ||
+		requestedModel === MODERATION_MODEL_ID
+			? DEFAULT_UPSTREAM_MODERATION_MODEL
+			: requestedModel;
 	const startedAt = Date.now();
 	const source = validateSource(
 		c.req.header("x-source"),
@@ -1032,7 +1044,7 @@ moderations.openapi(createModeration, async (c): Promise<any> => {
 
 			return c.json({
 				...(upstreamJson as Record<string, unknown>),
-				model: responseModel,
+				model: CANONICAL_MODERATION_MODEL,
 			});
 		}
 	} finally {

--- a/apps/gateway/src/ocr/ocr.spec.ts
+++ b/apps/gateway/src/ocr/ocr.spec.ts
@@ -100,6 +100,7 @@ describe("ocr", () => {
 
 		expect(res.status).toBe(200);
 		const json = await res.json();
+		expect(json.model).toBe("mistral/mistral-ocr-latest");
 		expect(Array.isArray(json.pages)).toBe(true);
 		expect(json.pages).toHaveLength(3);
 		expect(json.usage_info.pages_processed).toBe(3);

--- a/apps/gateway/src/ocr/ocr.ts
+++ b/apps/gateway/src/ocr/ocr.ts
@@ -42,6 +42,7 @@ import { extractApiToken } from "@/lib/extract-api-token.js";
 import { createFailedKeyTracker } from "@/lib/failed-key-tracker.js";
 import { throwIamException, validateRequestModelAccess } from "@/lib/iam.js";
 import { calculateDataStorageCost, insertLog } from "@/lib/logs.js";
+import { formatUsedModelForDisplay } from "@/lib/model-response-id.js";
 import { assertOrganizationUsable } from "@/lib/organization-access.js";
 import { assertSpendLimit } from "@/lib/spend-limit.js";
 import { createCombinedSignal, isTimeoutError } from "@/lib/timeout-config.js";
@@ -433,6 +434,12 @@ ocr.openapi(createOcr, async (c): Promise<any> => {
 	const { mapping, modelDef, modelDefId, explicitProvider } = match;
 	const upstreamModel = mapping.externalId;
 	const providerId = mapping.providerId;
+	const responseModel = formatUsedModelForDisplay(
+		providerId,
+		modelDefId,
+		undefined,
+		mapping.region,
+	);
 
 	const startedAt = Date.now();
 	const source = validateSource(
@@ -1210,7 +1217,10 @@ ocr.openapi(createOcr, async (c): Promise<any> => {
 				{ retentionLevel },
 			);
 
-			return c.json(upstreamJson as z.infer<typeof ocrResponseSchema>);
+			return c.json({
+				...(upstreamJson as z.infer<typeof ocrResponseSchema>),
+				model: responseModel,
+			});
 		}
 	} finally {
 		c.req.raw.signal.removeEventListener("abort", onAbort);

--- a/apps/gateway/src/realtime/client-secrets-route.spec.ts
+++ b/apps/gateway/src/realtime/client-secrets-route.spec.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { realtimeClientSecretsRoute } from "./client-secrets-route.js";
+
+const mocks = vi.hoisted(() => ({
+	createClientSecret: vi.fn(),
+	runRealtimePreflight: vi.fn(),
+}));
+
+vi.mock("@/lib/extract-api-token.js", () => ({
+	extractApiToken: () => "test-token",
+}));
+
+vi.mock("./client-secrets.js", () => ({
+	clampClientSecretTtl: () => 60,
+	createClientSecret: mocks.createClientSecret,
+}));
+
+vi.mock("./preflight.js", () => ({
+	runRealtimePreflight: mocks.runRealtimePreflight,
+}));
+
+describe("realtime client secrets route", () => {
+	const previousRealtimeEnabled = process.env.REALTIME_ENABLED;
+
+	beforeEach(() => {
+		process.env.REALTIME_ENABLED = "true";
+		mocks.createClientSecret.mockResolvedValue({
+			value: "ek_test",
+			expiresAt: 123,
+		});
+		mocks.runRealtimePreflight.mockResolvedValue({
+			match: {
+				modelId: "gpt-realtime-2.1-mini",
+				mapping: { providerId: "openai" },
+			},
+			allowedTranscriptionModelIds: [],
+			project: { organizationId: "org_test" },
+		});
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+		if (previousRealtimeEnabled === undefined) {
+			delete process.env.REALTIME_ENABLED;
+		} else {
+			process.env.REALTIME_ENABLED = previousRealtimeEnabled;
+		}
+	});
+
+	it("stores and returns the canonical model", async () => {
+		const response = await realtimeClientSecretsRoute.request(
+			"/client_secrets",
+			{
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({
+					session: { type: "realtime", model: "gpt-realtime-mini" },
+				}),
+			},
+		);
+
+		expect(response.status).toBe(200);
+		expect(mocks.createClientSecret).toHaveBeenCalledWith(
+			expect.objectContaining({ model: "openai/gpt-realtime-2.1-mini" }),
+		);
+		expect((await response.json()).session.model).toBe(
+			"openai/gpt-realtime-2.1-mini",
+		);
+	});
+});

--- a/apps/gateway/src/realtime/client-secrets-route.ts
+++ b/apps/gateway/src/realtime/client-secrets-route.ts
@@ -3,6 +3,7 @@ import { OpenAPIHono, z } from "@hono/zod-openapi";
 import { validateSource } from "@/chat/tools/validate-source.js";
 import { getClientIpFromRequest } from "@/lib/client-ip.js";
 import { extractApiToken } from "@/lib/extract-api-token.js";
+import { formatUsedModelForDisplay } from "@/lib/model-response-id.js";
 
 import { logger } from "@llmgateway/logger";
 
@@ -207,7 +208,12 @@ realtimeClientSecretsRoute.post("/client_secrets", async (c) => {
 		expires_at: secret.expiresAt,
 		session: {
 			type: "realtime" as const,
-			model: body.session.model,
+			model: formatUsedModelForDisplay(
+				preflight.match.mapping.providerId,
+				preflight.match.modelId,
+				undefined,
+				preflight.match.mapping.region,
+			),
 		},
 	});
 });

--- a/apps/gateway/src/realtime/client-secrets-route.ts
+++ b/apps/gateway/src/realtime/client-secrets-route.ts
@@ -176,16 +176,27 @@ realtimeClientSecretsRoute.post("/client_secrets", async (c) => {
 				`This API key is not allowed to use the transcription model ${match.modelId}.`,
 			);
 		}
-		transcriptionModel = requestedTranscription.model;
+		transcriptionModel = formatUsedModelForDisplay(
+			match.mapping.providerId,
+			match.modelId,
+			undefined,
+			match.mapping.region,
+		);
 	}
 
 	const ttlSeconds = clampClientSecretTtl(body.expires_after?.seconds);
+	const responseModel = formatUsedModelForDisplay(
+		preflight.match.mapping.providerId,
+		preflight.match.modelId,
+		undefined,
+		preflight.match.mapping.region,
+	);
 
 	let secret;
 	try {
 		secret = await createClientSecret({
 			token,
-			model: body.session.model,
+			model: responseModel,
 			transcriptionModel,
 			source,
 			ttlSeconds,
@@ -208,12 +219,7 @@ realtimeClientSecretsRoute.post("/client_secrets", async (c) => {
 		expires_at: secret.expiresAt,
 		session: {
 			type: "realtime" as const,
-			model: formatUsedModelForDisplay(
-				preflight.match.mapping.providerId,
-				preflight.match.modelId,
-				undefined,
-				preflight.match.mapping.region,
-			),
+			model: responseModel,
 		},
 	});
 });

--- a/apps/gateway/src/realtime/client-secrets.ts
+++ b/apps/gateway/src/realtime/client-secrets.ts
@@ -23,7 +23,7 @@ export interface RealtimeClientSecretRecord {
 	 */
 	token: string;
 	/**
-	 * Realtime model pinned at mint time (as requested by the caller).
+	 * Canonical realtime model pinned at mint time.
 	 */
 	model: string;
 	/**

--- a/apps/gateway/src/realtime/server.spec.ts
+++ b/apps/gateway/src/realtime/server.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { extractSubprotocolSecret } from "./server.js";
+import { extractSubprotocolSecret, realtimeModelIdsMatch } from "./server.js";
 
 describe("extractSubprotocolSecret", () => {
 	it("accepts the official OpenAI browser subprotocol", () => {
@@ -21,5 +21,28 @@ describe("extractSubprotocolSecret", () => {
 	it("ignores subprotocols that carry no credential", () => {
 		expect(extractSubprotocolSecret(["realtime"])).toBeUndefined();
 		expect(extractSubprotocolSecret([])).toBeUndefined();
+	});
+});
+
+describe("realtimeModelIdsMatch", () => {
+	it("accepts equivalent bare and canonical model ids", () => {
+		expect(
+			realtimeModelIdsMatch(
+				"gpt-realtime-2.1-mini",
+				"openai/gpt-realtime-2.1-mini",
+			),
+		).toBe(true);
+	});
+
+	it("rejects different or unknown model ids", () => {
+		expect(
+			realtimeModelIdsMatch(
+				"openai/gpt-realtime-2.1-mini",
+				"openai/gpt-realtime-2.1",
+			),
+		).toBe(false);
+		expect(
+			realtimeModelIdsMatch("unknown-model", "openai/gpt-realtime-2.1-mini"),
+		).toBe(false);
 	});
 });

--- a/apps/gateway/src/realtime/server.ts
+++ b/apps/gateway/src/realtime/server.ts
@@ -14,7 +14,10 @@ import {
 	closeRealtimeSessionRecord,
 	createRealtimeSessionRecord,
 } from "./billing.js";
-import { findRealtimeTranscriptionMapping } from "./catalog.js";
+import {
+	findRealtimeMapping,
+	findRealtimeTranscriptionMapping,
+} from "./catalog.js";
 import {
 	CLIENT_SECRET_PREFIX,
 	getClientSecretRecord,
@@ -46,6 +49,24 @@ interface ShutdownableSession {
 	 * charge the provider has already made.
 	 */
 	close: (code: number, reason: string) => void;
+}
+
+export function realtimeModelIdsMatch(
+	requestedModel: string,
+	pinnedModel: string,
+): boolean {
+	if (requestedModel === pinnedModel) {
+		return true;
+	}
+	const requestedMatch = findRealtimeMapping(requestedModel);
+	const pinnedMatch = findRealtimeMapping(pinnedModel);
+	return (
+		requestedMatch !== null &&
+		pinnedMatch !== null &&
+		requestedMatch.modelId === pinnedMatch.modelId &&
+		requestedMatch.mapping.providerId === pinnedMatch.mapping.providerId &&
+		requestedMatch.mapping.region === pinnedMatch.mapping.region
+	);
 }
 
 function writeHttpError(
@@ -303,7 +324,10 @@ export function attachRealtimeServer(server: Server): RealtimeServer {
 					);
 					return;
 				}
-				if (requestedModel && requestedModel !== record.model) {
+				if (
+					requestedModel &&
+					!realtimeModelIdsMatch(requestedModel, record.model)
+				) {
 					writeHttpError(
 						socket,
 						400,

--- a/apps/gateway/src/realtime/session.spec.ts
+++ b/apps/gateway/src/realtime/session.spec.ts
@@ -195,6 +195,26 @@ beforeEach(() => {
 });
 
 describe("RealtimeProxySession turn handling", () => {
+	it("canonicalizes model ids in upstream lifecycle events", async () => {
+		const { client, session, upstreamSends } = createSession();
+
+		upstreamSends({
+			type: "session.created",
+			session: { id: "sess_1", model: "upstream-deployment" },
+		});
+		upstreamSends({
+			type: "response.created",
+			response: { id: "resp_1", model: "upstream-deployment" },
+		});
+		await flush();
+
+		const events = client.sent.map((value) => JSON.parse(value));
+		expect(events[0].session.model).toBe("openai/gpt-realtime-2.1-mini");
+		expect(events[1].response.model).toBe("openai/gpt-realtime-2.1-mini");
+
+		session.shutdown(1000, "test_done");
+	});
+
 	it("starts the pending auto-response only after a commit-during-response's response.done is billed", async () => {
 		const { upstream, session, clientSends, upstreamSends } = createSession();
 

--- a/apps/gateway/src/realtime/session.spec.ts
+++ b/apps/gateway/src/realtime/session.spec.ts
@@ -13,6 +13,7 @@ import {
 } from "./billing.js";
 import { RealtimeProxySession } from "./session.js";
 
+import type { RealtimeMappingMatch } from "./catalog.js";
 import type { RealtimePreflightResult } from "./preflight.js";
 import type { WebSocket } from "ws";
 
@@ -162,7 +163,10 @@ async function flush(): Promise<void> {
 	}
 }
 
-function createSession(preflightOverrides: Record<string, unknown> = {}) {
+function createSession(
+	preflightOverrides: Record<string, unknown> = {},
+	allowedTranscription: RealtimeMappingMatch | null = null,
+) {
 	const client = new FakeSocket();
 	const upstream = new FakeSocket();
 	const session = new RealtimeProxySession({
@@ -178,7 +182,7 @@ function createSession(preflightOverrides: Record<string, unknown> = {}) {
 		lease: { sessionId: "rts_1", organizationId: "org_1", apiKeyId: "key_1" },
 		source: "lounge.llmgateway.io",
 		userAgent: "vitest",
-		allowedTranscription: null,
+		allowedTranscription,
 		onClosed: () => {},
 	});
 	const clientSends = (event: Record<string, unknown>) => {
@@ -196,11 +200,22 @@ beforeEach(() => {
 
 describe("RealtimeProxySession turn handling", () => {
 	it("canonicalizes model ids in upstream lifecycle events", async () => {
-		const { client, session, upstreamSends } = createSession();
+		const allowedTranscription = {
+			modelId: "gpt-4o-mini-transcribe",
+			mapping: { providerId: "openai" },
+		} as unknown as RealtimeMappingMatch;
+		const { client, session, upstreamSends } = createSession(
+			{},
+			allowedTranscription,
+		);
 
 		upstreamSends({
 			type: "session.created",
-			session: { id: "sess_1", model: "upstream-deployment" },
+			session: {
+				id: "sess_1",
+				model: "upstream-deployment",
+				input_audio_transcription: { model: "upstream-transcription" },
+			},
 		});
 		upstreamSends({
 			type: "response.created",
@@ -210,6 +225,9 @@ describe("RealtimeProxySession turn handling", () => {
 
 		const events = client.sent.map((value) => JSON.parse(value));
 		expect(events[0].session.model).toBe("openai/gpt-realtime-2.1-mini");
+		expect(events[0].session.input_audio_transcription.model).toBe(
+			"openai/gpt-4o-mini-transcribe",
+		);
 		expect(events[1].response.model).toBe("openai/gpt-realtime-2.1-mini");
 
 		session.shutdown(1000, "test_done");

--- a/apps/gateway/src/realtime/session.spec.ts
+++ b/apps/gateway/src/realtime/session.spec.ts
@@ -199,6 +199,34 @@ beforeEach(() => {
 });
 
 describe("RealtimeProxySession turn handling", () => {
+	it("accepts canonical model ids in session updates", async () => {
+		const preflight = buildPreflight();
+		const { client, upstream, session, clientSends } = createSession({
+			match: {
+				...preflight.match,
+				mapping: {
+					...preflight.match.mapping,
+					externalId: "upstream-deployment",
+				},
+			},
+		});
+
+		clientSends({
+			type: "session.update",
+			session: { model: "openai/gpt-realtime-2.1-mini" },
+		});
+		await flush();
+
+		expect(client.sent).toHaveLength(0);
+		expect(upstream.sent).toHaveLength(1);
+		const forwarded = JSON.parse(upstream.sent[0]) as {
+			session: { model: string };
+		};
+		expect(forwarded.session.model).toBe("upstream-deployment");
+
+		session.shutdown(1000, "test_done");
+	});
+
 	it("canonicalizes model ids in upstream lifecycle events", async () => {
 		const allowedTranscription = {
 			modelId: "gpt-4o-mini-transcribe",

--- a/apps/gateway/src/realtime/session.ts
+++ b/apps/gateway/src/realtime/session.ts
@@ -359,12 +359,15 @@ export class RealtimeProxySession {
 			message.session && typeof message.session === "object"
 				? (message.session as Record<string, unknown>)
 				: {};
+		const requestedSessionModel =
+			typeof session.model === "string" ? session.model : undefined;
 
 		// The model is pinned at connection time.
 		if (
-			typeof session.model === "string" &&
-			session.model !== this.preflight.match.mapping.externalId &&
-			session.model !== this.preflight.match.modelId
+			requestedSessionModel !== undefined &&
+			requestedSessionModel !== this.preflight.match.mapping.externalId &&
+			requestedSessionModel !== this.preflight.match.modelId &&
+			requestedSessionModel !== this.canonicalModelId(this.preflight.match)
 		) {
 			this.sendToClientRaw(
 				buildErrorEvent(
@@ -539,6 +542,10 @@ export class RealtimeProxySession {
 			}
 			return forwarded;
 		};
+		if (requestedSessionModel !== undefined) {
+			const fwdSession = cloneForwarded().session as Record<string, unknown>;
+			fwdSession.model = this.preflight.match.mapping.externalId;
+		}
 		if (turnDetection !== undefined) {
 			if (turnDetection === null) {
 				this.turnDetectionEnabled = false;

--- a/apps/gateway/src/realtime/session.ts
+++ b/apps/gateway/src/realtime/session.ts
@@ -855,14 +855,24 @@ export class RealtimeProxySession {
 			audio?.input && typeof audio.input === "object"
 				? (audio.input as Record<string, unknown>)
 				: undefined;
-		const transcription =
+		const nestedTranscription =
 			input?.transcription && typeof input.transcription === "object"
 				? (input.transcription as Record<string, unknown>)
 				: undefined;
+		const legacyTranscription =
+			session.input_audio_transcription &&
+			typeof session.input_audio_transcription === "object"
+				? (session.input_audio_transcription as Record<string, unknown>)
+				: undefined;
 		const transcriptionMatch =
 			this.transcription?.match ?? this.allowedTranscription;
-		if (transcription && transcriptionMatch) {
-			transcription.model = this.canonicalModelId(transcriptionMatch);
+		if (transcriptionMatch) {
+			if (nestedTranscription) {
+				nestedTranscription.model = this.canonicalModelId(transcriptionMatch);
+			}
+			if (legacyTranscription) {
+				legacyTranscription.model = this.canonicalModelId(transcriptionMatch);
+			}
 		}
 	}
 

--- a/apps/gateway/src/realtime/session.ts
+++ b/apps/gateway/src/realtime/session.ts
@@ -1,6 +1,7 @@
 import { Decimal } from "decimal.js";
 import { WebSocket } from "ws";
 
+import { formatUsedModelForDisplay } from "@/lib/model-response-id.js";
 import { checkProviderRateLimit } from "@/lib/provider-rate-limit.js";
 
 import { getEffectiveDiscount } from "@llmgateway/db";
@@ -835,6 +836,36 @@ export class RealtimeProxySession {
 		this.shutdown(1008, "insufficient_credits");
 	}
 
+	private canonicalModelId(match: RealtimeMappingMatch): string {
+		return formatUsedModelForDisplay(
+			match.mapping.providerId,
+			match.modelId,
+			undefined,
+			match.mapping.region,
+		);
+	}
+
+	private normalizeSessionModelIds(session: Record<string, unknown>): void {
+		session.model = this.canonicalModelId(this.preflight.match);
+		const audio =
+			session.audio && typeof session.audio === "object"
+				? (session.audio as Record<string, unknown>)
+				: undefined;
+		const input =
+			audio?.input && typeof audio.input === "object"
+				? (audio.input as Record<string, unknown>)
+				: undefined;
+		const transcription =
+			input?.transcription && typeof input.transcription === "object"
+				? (input.transcription as Record<string, unknown>)
+				: undefined;
+		const transcriptionMatch =
+			this.transcription?.match ?? this.allowedTranscription;
+		if (transcription && transcriptionMatch) {
+			transcription.model = this.canonicalModelId(transcriptionMatch);
+		}
+	}
+
 	// --- Upstream → client ---
 
 	private async handleUpstreamMessage(data: RawData): Promise<void> {
@@ -872,7 +903,8 @@ export class RealtimeProxySession {
 						);
 					});
 				}
-				this.sendToClientRaw(text);
+				this.normalizeSessionModelIds(session);
+				this.sendToClientRaw(JSON.stringify(event));
 				// Disable the provider's automatic VAD response so every generation
 				// passes the gateway's authorization gates. The echoed
 				// session.updated for this control message is suppressed below.
@@ -896,13 +928,19 @@ export class RealtimeProxySession {
 				);
 				return;
 			}
-			case "session.updated":
+			case "session.updated": {
 				if (this.suppressSessionUpdated > 0) {
 					this.suppressSessionUpdated -= 1;
 					return;
 				}
-				this.sendToClientRaw(text);
+				const session =
+					event.session && typeof event.session === "object"
+						? (event.session as Record<string, unknown>)
+						: {};
+				this.normalizeSessionModelIds(session);
+				this.sendToClientRaw(JSON.stringify(event));
 				return;
+			}
 			case "response.created": {
 				const response =
 					event.response && typeof event.response === "object"
@@ -911,12 +949,21 @@ export class RealtimeProxySession {
 				this.responseInFlight =
 					typeof response.id === "string" ? response.id : "pending";
 				this.responseStartedAt = this.responseStartedAt ?? Date.now();
-				this.sendToClientRaw(text);
+				response.model = this.canonicalModelId(this.preflight.match);
+				this.sendToClientRaw(JSON.stringify(event));
 				return;
 			}
-			case "response.done":
-				await this.handleResponseDone(event, text);
+			case "response.done": {
+				const response =
+					event.response && typeof event.response === "object"
+						? (event.response as Record<string, unknown>)
+						: undefined;
+				if (response) {
+					response.model = this.canonicalModelId(this.preflight.match);
+				}
+				await this.handleResponseDone(event, JSON.stringify(event));
 				return;
+			}
 			case "input_audio_buffer.committed": {
 				const itemId =
 					typeof event.item_id === "string" ? event.item_id : undefined;

--- a/apps/gateway/src/rerank/rerank.ts
+++ b/apps/gateway/src/rerank/rerank.ts
@@ -43,6 +43,7 @@ import { extractApiToken } from "@/lib/extract-api-token.js";
 import { createFailedKeyTracker } from "@/lib/failed-key-tracker.js";
 import { throwIamException, validateRequestModelAccess } from "@/lib/iam.js";
 import { calculateDataStorageCost, insertLog } from "@/lib/logs.js";
+import { formatUsedModelForDisplay } from "@/lib/model-response-id.js";
 import { assertOrganizationUsable } from "@/lib/organization-access.js";
 import { assertSpendLimit } from "@/lib/spend-limit.js";
 import {
@@ -140,6 +141,7 @@ const rerankMetaSchema = z
 const rerankResponseSchema = z
 	.object({
 		id: z.string().optional(),
+		model: z.string(),
 		results: z.array(rerankResultSchema),
 		meta: rerankMetaSchema.optional(),
 	})
@@ -507,6 +509,12 @@ rerank.openapi(createRerank, async (c): Promise<any> => {
 	} = result;
 	const providerId = rerankMapping.providerId;
 	const upstreamModel = rerankMapping.externalId;
+	const responseModel = formatUsedModelForDisplay(
+		providerId,
+		modelDefId,
+		undefined,
+		rerankMapping.region,
+	);
 
 	// 3. Validate model output includes "rerank"
 	validateModelOutput(modelDef, requestedModel, ["rerank"]);
@@ -1228,6 +1236,7 @@ rerank.openapi(createRerank, async (c): Promise<any> => {
 					normalizedResponse.id = requestId;
 				}
 			}
+			normalizedResponse.model = responseModel;
 
 			// Calculate cost from input tokens
 			const inputPrice = Number(rerankMapping.inputPrice ?? "0");

--- a/apps/gateway/src/responses/responses-route.spec.ts
+++ b/apps/gateway/src/responses/responses-route.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { responses } from "./responses.js";
+
+const mocks = vi.hoisted(() => ({
+	appRequest: vi.fn(),
+}));
+
+vi.mock("@/app.js", () => ({
+	app: { request: mocks.appRequest },
+}));
+
+vi.mock("@/lib/api-key-usage-limits.js", () => ({
+	assertApiKeyWithinUsageLimits: vi.fn(),
+	assertMemberWithinBudget: vi.fn(),
+}));
+
+vi.mock("@/lib/cached-queries.js", () => ({
+	findApiKeyByToken: vi.fn().mockResolvedValue({
+		id: "key_test",
+		projectId: "project_test",
+		createdBy: "user_test",
+		status: "active",
+	}),
+	findProjectById: vi.fn().mockResolvedValue({
+		id: "project_test",
+		organizationId: "org_test",
+	}),
+	findOrganizationById: vi.fn().mockResolvedValue({
+		id: "org_test",
+		status: "active",
+	}),
+}));
+
+vi.mock("@/lib/organization-access.js", () => ({
+	getOrganizationBlockReason: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("@/lib/responses-context.js", () => ({
+	deleteResponsesContext: vi.fn(),
+	setResponsesContext: vi.fn(),
+}));
+
+vi.mock("./tools/response-state.js", () => ({
+	getStoredResponse: vi.fn(),
+	resolveItemReferences: vi.fn(async (items) => items),
+	storeResponse: vi.fn(),
+}));
+
+describe("responses streaming lifecycle", () => {
+	it("emits response.created before an early response.failed", async () => {
+		mocks.appRequest.mockResolvedValue(
+			new Response(
+				new ReadableStream({
+					pull() {
+						throw new Error("stream failed before first chunk");
+					},
+				}),
+				{ status: 200 },
+			),
+		);
+
+		const response = await responses.request("/", {
+			method: "POST",
+			headers: {
+				authorization: "Bearer test-token",
+				"content-type": "application/json",
+			},
+			body: JSON.stringify({
+				model: "gpt-4o-mini",
+				input: "hello",
+				stream: true,
+				store: false,
+			}),
+		});
+
+		expect(response.status).toBe(200);
+		const eventTypes = (await response.text())
+			.split("\n")
+			.filter((line) => line.startsWith("event: "))
+			.map((line) => line.slice(7));
+		expect(eventTypes).toEqual(["response.created", "response.failed"]);
+	});
+});

--- a/apps/gateway/src/responses/responses.spec.ts
+++ b/apps/gateway/src/responses/responses.spec.ts
@@ -1289,6 +1289,21 @@ describe("streaming conversion", () => {
 		expect(data.response.status).toBe("in_progress");
 	});
 
+	it("uses the canonical model from streaming chat chunks", () => {
+		const state = createStreamingState("deepseek-v4-flash");
+		processStreamChunk(
+			{
+				model: "deepinfra/deepseek-v4-flash",
+				choices: [{ delta: { content: "Hello" } }],
+			},
+			state,
+		);
+
+		const completed = createCompletionEvents(state);
+		const data = JSON.parse(completed[completed.length - 1]!.data);
+		expect(data.response.model).toBe("deepinfra/deepseek-v4-flash");
+	});
+
 	it("processes content delta", () => {
 		const state = createStreamingState("gpt-4o-mini");
 		const chunk = {

--- a/apps/gateway/src/responses/responses.ts
+++ b/apps/gateway/src/responses/responses.ts
@@ -593,6 +593,7 @@ responses.post("/", async (c) => {
 						error,
 					});
 					try {
+						await sendCreated();
 						const failedEvent = createFailedEvent(state);
 						await stream.writeSSE({
 							event: failedEvent.event,

--- a/apps/gateway/src/responses/responses.ts
+++ b/apps/gateway/src/responses/responses.ts
@@ -453,6 +453,21 @@ responses.post("/", async (c) => {
 			const reader = streamBody.getReader();
 			const decoder = new TextDecoder();
 			let buffer = "";
+			let createdSent = false;
+			const sendCreated = async (chunk?: Record<string, unknown>) => {
+				if (createdSent) {
+					return;
+				}
+				if (typeof chunk?.model === "string" && chunk.model) {
+					state.model = chunk.model;
+				}
+				const createdEvent = createResponseCreatedEvent(state);
+				await stream.writeSSE({
+					event: createdEvent.event,
+					data: createdEvent.data,
+				});
+				createdSent = true;
+			};
 
 			// SSE keepalive to prevent proxy/load balancer and client idle
 			// timeouts from closing the connection during quiet gaps (slow
@@ -469,13 +484,6 @@ responses.post("/", async (c) => {
 				});
 			}, KEEPALIVE_INTERVAL_MS);
 
-			// Send response.created
-			const createdEvent = createResponseCreatedEvent(state);
-			await stream.writeSSE({
-				event: createdEvent.event,
-				data: createdEvent.data,
-			});
-
 			const processLine = async (line: string) => {
 				if (!line.startsWith("data: ")) {
 					return false;
@@ -483,6 +491,7 @@ responses.post("/", async (c) => {
 				const data = line.slice(6).trim();
 
 				if (data === "[DONE]") {
+					await sendCreated();
 					// Send completion events
 					const completionEvents = createCompletionEvents(
 						state,
@@ -510,7 +519,7 @@ responses.post("/", async (c) => {
 								input: inputItems,
 								output: buildFinalOutputItems(state),
 								instructions: req.instructions,
-								model: req.model,
+								model: state.model,
 								status: completedResponse?.status ?? "completed",
 								incomplete_details:
 									completedResponse?.incomplete_details ?? null,
@@ -535,6 +544,7 @@ responses.post("/", async (c) => {
 					return false;
 				}
 
+				await sendCreated(chunk);
 				const events = processStreamChunk(chunk, state);
 				for (const event of events) {
 					await stream.writeSSE({
@@ -622,7 +632,7 @@ responses.post("/", async (c) => {
 				input: inputItems,
 				output: responsesResponse.output,
 				instructions: req.instructions,
-				model: req.model,
+				model: responsesResponse.model,
 				status: responsesResponse.status as
 					"completed" | "incomplete" | "failed",
 				incomplete_details: responsesResponse.incomplete_details,
@@ -845,6 +855,13 @@ responses.post("/compact", async (c) => {
 		compactionId,
 		createdAt,
 	);
+	const responseModel =
+		chatJson &&
+		typeof chatJson === "object" &&
+		"model" in chatJson &&
+		typeof chatJson.model === "string"
+			? chatJson.model
+			: req.model;
 
 	await storeResponse(
 		compactionId,
@@ -853,7 +870,7 @@ responses.post("/compact", async (c) => {
 			input: inputItems,
 			output: compactionResponse.output,
 			instructions: req.instructions,
-			model: req.model,
+			model: responseModel,
 			status: "completed",
 			usage: compactionResponse.usage as unknown as Record<string, unknown>,
 			created_at: createdAt,

--- a/apps/gateway/src/responses/responses.ts
+++ b/apps/gateway/src/responses/responses.ts
@@ -860,7 +860,8 @@ responses.post("/compact", async (c) => {
 		chatJson &&
 		typeof chatJson === "object" &&
 		"model" in chatJson &&
-		typeof chatJson.model === "string"
+		typeof chatJson.model === "string" &&
+		chatJson.model.trim().length > 0
 			? chatJson.model
 			: req.model;
 

--- a/apps/gateway/src/responses/tools/convert-streaming-to-responses.ts
+++ b/apps/gateway/src/responses/tools/convert-streaming-to-responses.ts
@@ -240,6 +240,9 @@ export function processStreamChunk(
 	state: StreamingState,
 ): SSEEvent[] {
 	const events: SSEEvent[] = [];
+	if (typeof chunk.model === "string" && chunk.model) {
+		state.model = chunk.model;
+	}
 
 	// Capture the served processing tier so the completion events echo the tier
 	// the provider actually applied (e.g. a flex request downgraded to default)

--- a/apps/gateway/src/transcriptions/transcriptions.ts
+++ b/apps/gateway/src/transcriptions/transcriptions.ts
@@ -42,6 +42,7 @@ import { extractApiToken } from "@/lib/extract-api-token.js";
 import { createFailedKeyTracker } from "@/lib/failed-key-tracker.js";
 import { throwIamException, validateRequestModelAccess } from "@/lib/iam.js";
 import { calculateDataStorageCost, insertLog } from "@/lib/logs.js";
+import { formatUsedModelForDisplay } from "@/lib/model-response-id.js";
 import { assertOrganizationUsable } from "@/lib/organization-access.js";
 import { assertSpendLimit } from "@/lib/spend-limit.js";
 import { createCombinedSignal, isTimeoutError } from "@/lib/timeout-config.js";
@@ -437,6 +438,12 @@ transcriptions.openapi(createTranscription, async (c): Promise<any> => {
 	const { mapping, modelDef, modelDefId, explicitProvider } = match;
 	const upstreamModel = mapping.externalId;
 	const providerId = mapping.providerId;
+	const responseModel = formatUsedModelForDisplay(
+		providerId,
+		modelDefId,
+		undefined,
+		mapping.region,
+	);
 
 	const startedAt = Date.now();
 	const source = validateSource(
@@ -1250,7 +1257,9 @@ transcriptions.openapi(createTranscription, async (c): Promise<any> => {
 			});
 
 			return c.json(
-				upstreamJson as z.infer<typeof transcriptionResponseSchema>,
+				(responseObject && typeof responseObject.model === "string"
+					? { ...responseObject, model: responseModel }
+					: upstreamJson) as z.infer<typeof transcriptionResponseSchema>,
 			);
 		}
 	} finally {

--- a/apps/gateway/src/videos/videos.spec.ts
+++ b/apps/gateway/src/videos/videos.spec.ts
@@ -527,6 +527,7 @@ describe("videos", () => {
 
 		expect(createRes.status).toBe(200);
 		const created = await createRes.json();
+		expect(created.model).toBe("atlascloud/kling-v3-0");
 		const videoJob = await db.query.videoJob.findFirst({
 			where: { id: { eq: created.id } },
 		});
@@ -1289,6 +1290,9 @@ describe("videos", () => {
 				headers: { Authorization: "Bearer real-token" },
 			});
 			expect(statusRes.status).toBe(200);
+			expect((await statusRes.json()).model).toBe(
+				"google-vertex/veo-3.1-generate-preview",
+			);
 
 			setMockVideoStatus(videoJob!.upstreamId, "completed");
 			await processPendingVideoJobs();

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -2584,7 +2584,7 @@ async function serializeVideoJob(job: VideoJobRecord, logId?: string | null) {
 	return {
 		id: job.id,
 		object: "video" as const,
-		model: job.model,
+		model: getFormattedUsedVideoModel(job.usedProvider as Provider, job.model),
 		status: job.status,
 		progress: TERMINAL_VIDEO_STATUSES.has(job.status)
 			? job.status === "completed"

--- a/apps/worker/src/services/video-jobs.ts
+++ b/apps/worker/src/services/video-jobs.ts
@@ -813,7 +813,7 @@ async function serializeVideoJob(job: VideoJobRecord, logId?: string | null) {
 	return {
 		id: job.id,
 		object: "video" as const,
-		model: job.model,
+		model: getFormattedUsedVideoModel(job),
 		status: job.status,
 		progress:
 			job.status === "completed"


### PR DESCRIPTION
## Summary

- return canonical provider/model IDs from Chat Completions, Responses, Anthropic Messages, embeddings, moderation, OCR, rerank, video, and Realtime responses
- preserve the selected fallback provider and region in streaming and stored response IDs
- keep provider deployment IDs confined to upstream requests
- store canonical Realtime model pins, accept equivalent aliases on connect and canonical IDs in session updates, round-trip canonical moderation IDs, and preserve Responses streaming lifecycle order on early failures

Image generation/editing and speech responses do not expose a model field. Transcription responses preserve their standard shape and canonicalize a model field if an upstream includes one.

## Verification

- `pnpm format`
- targeted gateway tests: 388 passed, 2 skipped
- moderation route tests: 7 passed
- `pnpm build`
