### PR TITLE
chore(anthropic): drop stale beta headers

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -7276,7 +7276,6 @@ chat.openapi(completions, async (c) => {
 				userPlan,
 				hasExistingToolCalls,
 				customProviderName,
-				webSearchEnabled: !!webSearchTool,
 				excludedEnvKeyIndices: failedKeys.envKeyIndicesFor(
 					providerMapping.providerId,
 					providerMapping.region,
@@ -7933,7 +7932,6 @@ chat.openapi(completions, async (c) => {
 						servedServiceTier = null;
 						const headers = getProviderHeaders(usedProvider, usedToken, {
 							requestId,
-							webSearchEnabled: !!webSearchTool,
 							// Same resolved token type as the endpoint so header auth and
 							// the `?key=` query param never disagree.
 							tokenType: resolveActiveVertexTokenType(),
@@ -12349,7 +12347,6 @@ chat.openapi(completions, async (c) => {
 		try {
 			const headers = getProviderHeaders(usedProvider, usedToken, {
 				requestId,
-				webSearchEnabled: !!webSearchTool,
 				// Same resolved token type as the endpoint so header auth and the
 				// `?key=` query param never disagree.
 				tokenType: resolveActiveVertexTokenType(),

--- a/apps/gateway/src/chat/tools/resolve-provider-context.ts
+++ b/apps/gateway/src/chat/tools/resolve-provider-context.ts
@@ -171,7 +171,6 @@ export interface ProviderContextOptions {
 	userPlan: "free" | "pro" | "enterprise" | null;
 	hasExistingToolCalls: boolean;
 	customProviderName: string | undefined;
-	webSearchEnabled: boolean;
 	excludedEnvKeyIndices?: ReadonlySet<number>;
 	excludedProviderKeyIds?: ReadonlySet<string>;
 	n?: number;
@@ -1032,7 +1031,6 @@ export async function resolveProviderContext(
 	// --- Headers ---
 	const headers = getProviderHeaders(usedProvider as Provider, usedToken, {
 		requestId: options.requestId,
-		webSearchEnabled: options.webSearchEnabled,
 		tokenType: vertexTokenType,
 	});
 	headers["Content-Type"] = "application/json";

--- a/packages/actions/src/get-provider-headers.spec.ts
+++ b/packages/actions/src/get-provider-headers.spec.ts
@@ -13,6 +13,27 @@ afterEach(() => {
 });
 
 describe("getProviderHeaders", () => {
+	describe("anthropic", () => {
+		it("sends no anthropic-beta header", () => {
+			const headers = getProviderHeaders("anthropic", "sk-ant-example");
+			expect(headers).toEqual({
+				"x-api-key": "sk-ant-example",
+				"anthropic-version": "2023-06-01",
+			});
+			expect(headers["anthropic-beta"]).toBeUndefined();
+		});
+
+		it("leaves anthropic-beta free for per-request betas to claim", () => {
+			// Callers build the header from scratch via `currentBeta ? ... : ...`,
+			// so a stale default here would prefix every request's betas.
+			expect(
+				getProviderHeaders("anthropic", "sk-ant-example", {
+					requestId: "req-1",
+				})["anthropic-beta"],
+			).toBeUndefined();
+		});
+	});
+
 	describe("google-vertex", () => {
 		it("returns no auth header by default (api-key mode)", () => {
 			expect(

--- a/packages/actions/src/get-provider-headers.ts
+++ b/packages/actions/src/get-provider-headers.ts
@@ -47,11 +47,6 @@ export function getProviderHeaders(
 	}
 
 	switch (provider) {
-		// No `anthropic-beta` here: tool use, prompt caching and web search are
-		// all GA and need no beta opt-in. Anthropic 400s on an unrecognized beta
-		// name, so a retired one would fail every request, not just the ones
-		// using the feature. Callers add the betas they actually need
-		// (`effort-2025-11-24`, `structured-outputs-2025-11-13`) per request.
 		case "anthropic":
 			return {
 				...requestIdHeader,

--- a/packages/actions/src/get-provider-headers.ts
+++ b/packages/actions/src/get-provider-headers.ts
@@ -7,10 +7,6 @@ import {
 import type { ProviderKeyOptions } from "@llmgateway/db";
 
 export interface ProviderHeaderOptions {
-	/**
-	 * Enable web search beta header for Anthropic
-	 */
-	webSearchEnabled?: boolean;
 	requestId?: string;
 	providerKeyOptions?: ProviderKeyOptions;
 	configIndex?: number;
@@ -51,18 +47,17 @@ export function getProviderHeaders(
 	}
 
 	switch (provider) {
-		case "anthropic": {
-			const betaFeatures = ["tools-2024-04-04", "prompt-caching-2024-07-31"];
-			if (options?.webSearchEnabled) {
-				betaFeatures.push("web-search-2025-03-05");
-			}
+		// No `anthropic-beta` here: tool use, prompt caching and web search are
+		// all GA and need no beta opt-in. Anthropic 400s on an unrecognized beta
+		// name, so a retired one would fail every request, not just the ones
+		// using the feature. Callers add the betas they actually need
+		// (`effort-2025-11-24`, `structured-outputs-2025-11-13`) per request.
+		case "anthropic":
 			return {
 				...requestIdHeader,
 				"x-api-key": token,
 				"anthropic-version": "2023-06-01",
-				"anthropic-beta": betaFeatures.join(","),
 			};
-		}
 		case "google-ai-studio":
 		case "glacier":
 		case "iceberg":


### PR DESCRIPTION
`getProviderHeaders` sent `tools-2024-04-04,prompt-caching-2024-07-31` on every Anthropic request, plus `web-search-2025-03-05` when web search was in play. All three features are GA and none of the names is declared in Anthropic's current OpenAPI spec, so they are grandfathered values the API still accepts — and since Anthropic returns 400 for an unrecognized beta name, retiring any one of them would fail *every* Anthropic request rather than only those using the feature.

Verified against the live API that tool calling, prompt caching (3643 tokens written, then read back) and web search all behave identically without their headers, using a deliberately invalid beta name as a control to confirm the endpoint validates rather than ignoring the header wholesale. The beta name is also not part of the cache key, so existing prompt-cache entries survive the deploy.

The conditional `effort-2025-11-24` and `structured-outputs-2025-11-13` betas are deliberately left in place: they look similarly redundant, but they only apply to requests already using those features, and the comment in `anthropic-effort-beta.ts` claims effort silently breaks without its header — so they warrant their own scoped verification rather than riding along here. This also adds the first spec coverage for the Anthropic header shape and drops the `webSearchEnabled` option, which had no remaining consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed obsolete web search configuration from provider requests.
  * Simplified Anthropic request headers to include only supported authentication and version information.
  * Improved consistency across streaming, retry, and standard requests.

* **Tests**
  * Added coverage confirming Anthropic headers are generated correctly, with or without a request ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->