### PR TITLE
chore(models): deactivate NanoGPT mappings

### DIFF
--- a/packages/models/src/models/bytedance.ts
+++ b/packages/models/src/models/bytedance.ts
@@ -114,6 +114,7 @@ export const bytedanceModels = [
 		releasedAt: new Date("2026-08-10"),
 		providers: [
 			{
+				deactivatedAt: new Date("2026-08-20"),
 				providerId: "nanogpt",
 				externalId: "bytedance-seed/seed-2-1-turbo",
 				inputPrice: "0.5e-6",

--- a/packages/models/src/models/openai.ts
+++ b/packages/models/src/models/openai.ts
@@ -732,6 +732,7 @@ export const openaiModels = [
 			},
 			{
 				test: "skip",
+				deactivatedAt: new Date("2026-08-20"),
 				providerId: "nanogpt",
 				externalId: "openai/gpt-oss-120b",
 				inputPrice: "0.05e-6",
@@ -872,6 +873,7 @@ export const openaiModels = [
 			},
 			{
 				test: "skip",
+				deactivatedAt: new Date("2026-08-20"),
 				providerId: "nanogpt",
 				externalId: "openai/gpt-oss-20b",
 				inputPrice: "0.04e-6",


### PR DESCRIPTION
Deactivates every NanoGPT model mapping while preserving its catalogue history.

Verification: pnpm format; pnpm build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated availability information for ByteDance Seed 2.1 Turbo.
  * Updated availability information for NanoGPT’s GPT-OSS 120B and GPT-OSS 20B models.
  * These models are scheduled for deactivation on August 20, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->