### PR TITLE
fix(typo): InclusionAI Ling Flash 3.0

### DIFF
--- a/packages/models/src/models/inclusionai.ts
+++ b/packages/models/src/models/inclusionai.ts
@@ -3,7 +3,7 @@ import type { ModelDefinition } from "@/models.js";
 export const inclusionaiModels = [
 	{
 		id: "ling-3.0-flash",
-		name: "InclusionAI Ling 3.0 Flash",
+		name: "Ling 3.0 Flash",
 		description:
 			"InclusionAI's native hybrid-reasoning MoE model (124B total, 5.1B active) with strong agentic and coding performance.",
 		family: "inclusionai",


### PR DESCRIPTION
## Summary

The model definition `ling-3.0-flash` in `packages/models/src/models/inclusionai.ts` carried the provider name in its `name` field (`"InclusionAI Ling 3.0 Flash"`), which breaks the convention used by every other model in the catalog (e.g. `"Kimi K2"` not `"Moonshot Kimi K2"`, `"Qwen Max"` not `"Alibaba Qwen Max"`). The brand is tracked in the `family` field (`"inclusionai"`), so the display name should be the bare model name.

## Change

- `packages/models/src/models/inclusionai.ts`: `name: "Ling 3.0 Flash"` (was `"InclusionAI Ling 3.0 Flash"`)

## Validation

- [x] No spec references the old name string — verified (`grep` across tree for `InclusionAI Ling 3.0 Flash` in tests returns nothing)
- [x] Diff is one line, scoped to the name field
- [x] `pnpm install` + `turbo build --filter=@llmgateway/models` running in background (will confirm once done)

## Notes

The model id (`ling-3.0-flash`), family (`inclusionai`), and external provider ids (`inclusionAI/Ling-3.0-flash`, `inclusionai/ling-3.0-flash`) are unchanged — only the display `name` field is fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the InclusionAI Ling 3.0 Flash model’s display name to “Ling 3.0 Flash.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->