### PR TITLE
feat(ui): og images + rankings bar chart

### DIFF
--- a/apps/api/src/routes/public-model-stats.ts
+++ b/apps/api/src/routes/public-model-stats.ts
@@ -239,6 +239,11 @@ publicModelStats.openapi(listRoute, async (c) => {
 			window === "30d"
 				? sql<Date>`date_trunc('day', ${mhTs})`
 				: sql<Date>`date_trunc('hour', ${mhTs})`;
+		// The 24h totals use an exact rolling lower bound, which would leave the
+		// leading hourly bucket artificially partial in the chart; floor it for
+		// the series only. The trailing in-progress bucket stays — the chart is
+		// live. 7d/30d startDate is already hour-floored.
+		const seriesStartDate = hourly ? startDate : floorToHourStart(startDate);
 
 		const seriesRows = await cdb
 			.select({
@@ -247,7 +252,7 @@ publicModelStats.openapi(listRoute, async (c) => {
 				totalTokens: sql<string>`COALESCE(SUM(${mh.totalTokens}), 0)`,
 			})
 			.from(mh)
-			.where(and(gte(mhTs, startDate), inArray(mh.modelId, topModelIds)))
+			.where(and(gte(mhTs, seriesStartDate), inArray(mh.modelId, topModelIds)))
 			.groupBy(mh.modelId, seriesBucket)
 			.orderBy(seriesBucket)
 			// The top-model set can shift within the TTL, so a tag keyed on the

--- a/apps/api/src/routes/public-model-stats.ts
+++ b/apps/api/src/routes/public-model-stats.ts
@@ -223,8 +223,8 @@ publicModelStats.openapi(listRoute, async (c) => {
 		totalRequests: models.reduce((sum, m) => sum + m.totalRequests, 0),
 	};
 
-	// Chart series for the top models only, bucketed by hour for the 24h
-	// window and by day otherwise.
+	// Chart series for the top models only, bucketed by hour for the 24h and
+	// 7d windows (24 / 168 dense chart bars) and by day for 30d.
 	const topModelIds = models
 		.slice(0, SERIES_MODEL_LIMIT)
 		.map((row) => row.modelId);
@@ -235,9 +235,10 @@ publicModelStats.openapi(listRoute, async (c) => {
 	}> = [];
 
 	if (topModelIds.length > 0) {
-		const seriesBucket = hourly
-			? sql<Date>`date_trunc('day', ${mhTs})`
-			: sql<Date>`date_trunc('hour', ${mhTs})`;
+		const seriesBucket =
+			window === "30d"
+				? sql<Date>`date_trunc('day', ${mhTs})`
+				: sql<Date>`date_trunc('hour', ${mhTs})`;
 
 		const seriesRows = await cdb
 			.select({
@@ -254,7 +255,7 @@ publicModelStats.openapi(listRoute, async (c) => {
 			// self-heals when the TTL lapses and is invisible in practice because
 			// the ranked list above it comes from the same cached snapshot.
 			.$withCache({
-				tag: `publicModelStats:series:v1:${window}`,
+				tag: `publicModelStats:series:v2:${window}`,
 				autoInvalidate: false,
 				config: { ex: STATS_CACHE_TTL_SECONDS },
 			});

--- a/apps/ui/src/app/add-provider/opengraph-image.tsx
+++ b/apps/ui/src/app/add-provider/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const alt = "LLM Gateway — List Your AI Provider";
+
+export default function Image() {
+	return ogImage({
+		eyebrow: "Providers",
+		title: "List Your AI Provider",
+		subtitle:
+			"Get your models in front of developers on LLM Gateway — share your details and our team will get in touch.",
+	});
+}

--- a/apps/ui/src/app/apps/opengraph-image.tsx
+++ b/apps/ui/src/app/apps/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const alt = "LLM Gateway — Apps";
+
+export default function Image() {
+	return ogImage({
+		eyebrow: "Apps",
+		title: "Apps Using LLM Gateway",
+		subtitle:
+			"Coding agents and tools ranked by real token volume — Claude Code, Cursor, Cline, OpenCode, Aider, and more.",
+	});
+}

--- a/apps/ui/src/app/blog/category/[category]/opengraph-image.tsx
+++ b/apps/ui/src/app/blog/category/[category]/opengraph-image.tsx
@@ -12,6 +12,9 @@ export const dynamicParams = false;
 export function generateStaticParams() {
 	const slugs = new Set<string>();
 	for (const post of allBlogs) {
+		if (post.draft) {
+			continue;
+		}
 		(post.categories ?? []).forEach((c: string) => slugs.add(slugify(c)));
 	}
 	return Array.from(slugs).map((category) => ({ category }));

--- a/apps/ui/src/app/blog/category/[category]/opengraph-image.tsx
+++ b/apps/ui/src/app/blog/category/[category]/opengraph-image.tsx
@@ -1,0 +1,46 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+import { slugify } from "@/lib/slugify";
+
+import { allBlogs } from "content-collections";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+
+// Satori cannot run at request time in production; prerender every category.
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+	const slugs = new Set<string>();
+	for (const post of allBlogs) {
+		(post.categories ?? []).forEach((c: string) => slugs.add(slugify(c)));
+	}
+	return Array.from(slugs).map((category) => ({ category }));
+}
+
+function findCategoryLabel(slug: string) {
+	for (const post of allBlogs) {
+		if (post.draft) {
+			continue;
+		}
+		for (const category of post.categories ?? []) {
+			if (slugify(category) === slug) {
+				return category;
+			}
+		}
+	}
+	return null;
+}
+
+export default async function BlogCategoryOgImage({
+	params,
+}: {
+	params: Promise<{ category: string }>;
+}) {
+	const { category } = await params;
+	const label = findCategoryLabel(category) ?? "Blog";
+	return ogImage({
+		eyebrow: "Blog",
+		title: label,
+		subtitle: `Articles in the ${label} category — news, tutorials, and product updates from the LLM Gateway team.`,
+	});
+}

--- a/apps/ui/src/app/blog/category/[category]/page.tsx
+++ b/apps/ui/src/app/blog/category/[category]/page.tsx
@@ -99,7 +99,6 @@ export async function generateMetadata({
 			description,
 			url: `https://llmgateway.io/blog/category/${slug}`,
 			type: "website",
-			images: ["/opengraph.png?v=2"],
 		},
 	};
 }

--- a/apps/ui/src/app/blog/category/opengraph-image.tsx
+++ b/apps/ui/src/app/blog/category/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const alt = "LLM Gateway — Blog Categories";
+
+export default function Image() {
+	return ogImage({
+		eyebrow: "Blog",
+		title: "Browse by Category",
+		subtitle:
+			"LLM Gateway blog posts by category — product updates, tutorials, deep-dives, and more.",
+	});
+}

--- a/apps/ui/src/app/blog/category/page.tsx
+++ b/apps/ui/src/app/blog/category/page.tsx
@@ -18,7 +18,6 @@ export const metadata: Metadata = {
 			"Browse LLM Gateway blog posts by category — product updates, tutorials, deep-dives, and more.",
 		url: "https://llmgateway.io/blog/category",
 		type: "website",
-		images: ["/opengraph.png?v=2"],
 	},
 };
 

--- a/apps/ui/src/app/blog/opengraph-image.tsx
+++ b/apps/ui/src/app/blog/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const alt = "LLM Gateway — Blog";
+
+export default function Image() {
+	return ogImage({
+		eyebrow: "Blog",
+		title: "News, Tutorials & Deep-Dives",
+		subtitle:
+			"From the LLM Gateway team: AI gateways, model routing, LLM costs, model comparisons, and shipping production AI apps.",
+	});
+}

--- a/apps/ui/src/app/brand/opengraph-image.tsx
+++ b/apps/ui/src/app/brand/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const alt = "LLM Gateway — Brand Assets";
+
+export default function Image() {
+	return ogImage({
+		eyebrow: "Brand",
+		title: "Brand Assets",
+		subtitle:
+			"Official LLM Gateway logos, marks, and usage guidelines — SVG files in light and dark variants.",
+	});
+}

--- a/apps/ui/src/app/brand/page.tsx
+++ b/apps/ui/src/app/brand/page.tsx
@@ -11,7 +11,6 @@ export const metadata: Metadata = {
 		"Download official LLM Gateway logos, marks, and brand assets. SVG files in light and dark variants, plus usage guidelines for partners.",
 	openGraph: {
 		title: "Brand Assets — Logos & Guidelines | LLM Gateway",
-		images: ["/opengraph.png?v=2"],
 		description:
 			"Download official LLM Gateway logos, marks, and brand assets. SVG files in light and dark variants.",
 		type: "website",

--- a/apps/ui/src/app/changelog/opengraph-image.tsx
+++ b/apps/ui/src/app/changelog/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const alt = "LLM Gateway — Changelog";
+
+export default function Image() {
+	return ogImage({
+		eyebrow: "Changelog",
+		title: "What's New in LLM Gateway",
+		subtitle:
+			"The latest features, improvements, and fixes across the gateway, dashboard, and APIs.",
+	});
+}

--- a/apps/ui/src/app/copilot-cost-calculator/opengraph-image.tsx
+++ b/apps/ui/src/app/copilot-cost-calculator/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const alt = "LLM Gateway — GitHub Copilot Cost Calculator";
+
+export default function Image() {
+	return ogImage({
+		eyebrow: "Free Tool",
+		title: "Copilot Cost Calculator",
+		subtitle:
+			"Estimate your team's monthly GitHub Copilot AI-credits bill and compare the same workload at pass-through token prices.",
+	});
+}

--- a/apps/ui/src/app/copilot-cost-calculator/page.tsx
+++ b/apps/ui/src/app/copilot-cost-calculator/page.tsx
@@ -32,14 +32,12 @@ export const metadata: Metadata = {
 		title: "GitHub Copilot Cost Calculator (2026 AI Credits) | LLM Gateway",
 		description:
 			"Model your team's Copilot AI Credits bill after the June 2026 change and compare the same workload routed through LLM Gateway.",
-		images: [{ url: "/opengraph.png?v=1" }],
 	},
 	twitter: {
 		card: "summary_large_image",
 		title: "GitHub Copilot Cost Calculator (2026 AI Credits) | LLM Gateway",
 		description:
 			"Estimate your team's Copilot AI Credits bill and see what the same usage costs at pass-through token prices with caching.",
-		images: ["/opengraph.png?v=1"],
 	},
 };
 

--- a/apps/ui/src/app/enterprise/[slug]/opengraph-image.tsx
+++ b/apps/ui/src/app/enterprise/[slug]/opengraph-image.tsx
@@ -1,0 +1,31 @@
+import {
+	enterpriseFeatures,
+	getEnterpriseFeatureBySlug,
+} from "@/lib/enterprise-features";
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+
+// Satori cannot run at request time in production; prerender every slug.
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+	return enterpriseFeatures.map((feature) => ({ slug: feature.slug }));
+}
+
+export default async function EnterpriseFeatureOgImage({
+	params,
+}: {
+	params: Promise<{ slug: string }>;
+}) {
+	const { slug } = await params;
+	const feature = getEnterpriseFeatureBySlug(slug);
+	return ogImage({
+		eyebrow: "Enterprise",
+		title: feature?.title ?? "Enterprise",
+		subtitle:
+			feature?.subtitle ??
+			"Enterprise-grade controls for teams running LLMs in production.",
+	});
+}

--- a/apps/ui/src/app/legal/[slug]/opengraph-image.tsx
+++ b/apps/ui/src/app/legal/[slug]/opengraph-image.tsx
@@ -1,0 +1,28 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+import { allLegals } from "content-collections";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+
+// Satori cannot run at request time in production; prerender every slug.
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+	return allLegals.map((entry) => ({ slug: entry.slug }));
+}
+
+export default async function LegalOgImage({
+	params,
+}: {
+	params: Promise<{ slug: string }>;
+}) {
+	const { slug } = await params;
+	const entry = allLegals.find((e) => e.slug === slug);
+	return ogImage({
+		eyebrow: "Legal",
+		title: entry?.title ?? "Legal & Policies",
+		subtitle:
+			entry?.description ?? "Legal information and policies for LLM Gateway.",
+	});
+}

--- a/apps/ui/src/app/legal/opengraph-image.tsx
+++ b/apps/ui/src/app/legal/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const alt = "LLM Gateway — Legal";
+
+export default function Image() {
+	return ogImage({
+		eyebrow: "Legal",
+		title: "Legal & Policies",
+		subtitle:
+			"Terms of Use, Privacy Policy, sub-processors, and AI provider legal and compliance information.",
+	});
+}

--- a/apps/ui/src/app/legal/providers/opengraph-image.tsx
+++ b/apps/ui/src/app/legal/providers/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const alt = "LLM Gateway — AI Provider Legal Information";
+
+export default function Image() {
+	return ogImage({
+		eyebrow: "Legal",
+		title: "AI Provider Legal Info",
+		subtitle:
+			"Privacy, data retention, training, location, and compliance details for every provider on LLM Gateway.",
+	});
+}

--- a/apps/ui/src/app/migration/opengraph-image.tsx
+++ b/apps/ui/src/app/migration/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const alt = "LLM Gateway — Migration Guides";
+
+export default function Image() {
+	return ogImage({
+		eyebrow: "Migration Guides",
+		title: "Switch to LLM Gateway",
+		subtitle:
+			"Step-by-step guides to migrate from GitHub Copilot, OpenRouter, Vercel AI Gateway, LiteLLM, Portkey, and more.",
+	});
+}

--- a/apps/ui/src/app/models/compare/opengraph-image.tsx
+++ b/apps/ui/src/app/models/compare/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const alt = "LLM Gateway — Compare AI Models";
+
+export default function Image() {
+	return ogImage({
+		eyebrow: "Models",
+		title: "Compare Models Side by Side",
+		subtitle:
+			"Pick any two AI models to compare pricing, context window, and capabilities.",
+	});
+}

--- a/apps/ui/src/app/models/premium/opengraph-image.tsx
+++ b/apps/ui/src/app/models/premium/opengraph-image.tsx
@@ -1,0 +1,12 @@
+import {
+	generateCategoryOgImage,
+	ogContentType,
+	ogSize,
+} from "@/components/models/category-og-image";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default async function PremiumModelsOgImage() {
+	return await generateCategoryOgImage("premium");
+}

--- a/apps/ui/src/app/models/premium/opengraph-image.tsx
+++ b/apps/ui/src/app/models/premium/opengraph-image.tsx
@@ -6,6 +6,7 @@ import {
 
 export const size = ogSize;
 export const contentType = ogContentType;
+export const alt = "LLM Gateway — Premium Models";
 
 export default async function PremiumModelsOgImage() {
 	return await generateCategoryOgImage("premium");

--- a/apps/ui/src/app/open-source/opengraph-image.tsx
+++ b/apps/ui/src/app/open-source/opengraph-image.tsx
@@ -1,0 +1,15 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+import { MARKETING_STATS } from "@llmgateway/shared";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const alt = "LLM Gateway — Open Source";
+
+export default function Image() {
+	return ogImage({
+		eyebrow: "Open Source",
+		title: "Self-Host Your AI Gateway",
+		subtitle: `Open source under AGPLv3. Route ${MARKETING_STATS.models} models across ${MARKETING_STATS.providers} providers through one OpenAI-compatible endpoint.`,
+	});
+}

--- a/apps/ui/src/app/pricing/opengraph-image.tsx
+++ b/apps/ui/src/app/pricing/opengraph-image.tsx
@@ -1,0 +1,15 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+import { MARKETING_STATS } from "@llmgateway/shared";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const alt = "LLM Gateway — Pricing";
+
+export default function Image() {
+	return ogImage({
+		eyebrow: "Pricing",
+		title: "Provider Rates. One Bill.",
+		subtitle: `Pay per-token at provider rates with a flat ${MARKETING_STATS.platformFee} platform fee on credits — or free with your own keys across ${MARKETING_STATS.providers} providers.`,
+	});
+}

--- a/apps/ui/src/app/products/ai-gateway/opengraph-image.tsx
+++ b/apps/ui/src/app/products/ai-gateway/opengraph-image.tsx
@@ -1,0 +1,15 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+import { MARKETING_STATS } from "@llmgateway/shared";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const alt = "LLM Gateway — AI Gateway";
+
+export default function Image() {
+	return ogImage({
+		eyebrow: "AI Gateway",
+		title: "One API for Every LLM",
+		subtitle: `Route ${MARKETING_STATS.models} models across ${MARKETING_STATS.providers} providers with smart routing, automatic fallback, caching, and guardrails.`,
+	});
+}

--- a/apps/ui/src/app/products/devpass/opengraph-image.tsx
+++ b/apps/ui/src/app/products/devpass/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const alt = "LLM Gateway — DevPass";
+
+export default function Image() {
+	return ogImage({
+		eyebrow: "DevPass",
+		title: "Flat-Price Dev Plans",
+		subtitle:
+			"Every dollar becomes $3 of model usage at provider rates — for Claude Code, Cursor, Cline, and any OpenAI-compatible coding tool.",
+	});
+}

--- a/apps/ui/src/app/products/lounge/opengraph-image.tsx
+++ b/apps/ui/src/app/products/lounge/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const alt = "LLM Gateway — Lounge";
+
+export default function Image() {
+	return ogImage({
+		eyebrow: "Lounge",
+		title: "Every Frontier Model, One Membership",
+		subtitle:
+			"Chat with GPT, Claude, and Gemini, generate images, video, and audio, and run multi-model group chats — from $9/mo.",
+	});
+}

--- a/apps/ui/src/app/products/observability/opengraph-image.tsx
+++ b/apps/ui/src/app/products/observability/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const alt = "LLM Gateway — Observability";
+
+export default function Image() {
+	return ogImage({
+		eyebrow: "Observability",
+		title: "See Every LLM Request",
+		subtitle:
+			"Real-time cost analytics, per-model and per-provider breakdowns, error and cache rates, latency, and full request logs.",
+	});
+}

--- a/apps/ui/src/app/providers/country/[country]/opengraph-image.tsx
+++ b/apps/ui/src/app/providers/country/[country]/opengraph-image.tsx
@@ -1,0 +1,37 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+import { listedProviders } from "@/lib/providers-catalog";
+
+import { getProviderCountries } from "@llmgateway/models";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+
+// Satori cannot run at request time in production; prerender every country.
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+	return getProviderCountries().map((country) => ({
+		country: country.code.toLowerCase(),
+	}));
+}
+
+export default async function ProviderCountryOgImage({
+	params,
+}: {
+	params: Promise<{ country: string }>;
+}) {
+	const { country } = await params;
+	const match = getProviderCountries().find(
+		(c) => c.code.toLowerCase() === country.toLowerCase(),
+	);
+	const providerCount = match
+		? listedProviders.filter((p) => p.headquarters === match.code).length
+		: 0;
+	return ogImage({
+		eyebrow: "Providers",
+		title: match ? `AI Providers in ${match.name}` : "AI Providers",
+		subtitle: match
+			? `${providerCount} AI ${providerCount === 1 ? "provider" : "providers"} headquartered in ${match.name}, available through one OpenAI-compatible API.`
+			: "Browse AI providers by headquarters country on LLM Gateway.",
+	});
+}

--- a/apps/ui/src/app/rankings/opengraph-image.tsx
+++ b/apps/ui/src/app/rankings/opengraph-image.tsx
@@ -1,0 +1,201 @@
+import { ImageResponse } from "next/og";
+
+import Logo from "@/lib/icons/Logo";
+
+export const size = {
+	width: 1200,
+	height: 630,
+};
+
+export const contentType = "image/png";
+
+export const alt = "LLM Rankings — Top Models by Real Usage";
+
+// Illustrative stacked-bar motif echoing the live rankings chart; the palette
+// matches SERIES_PALETTE (dark) in rankings-content.tsx.
+const BAR_COLORS = [
+	"#0284c7",
+	"#8b5cf6",
+	"#0d9488",
+	"#d97706",
+	"#ec4899",
+	"#6366f1",
+];
+
+// Per-column segment heights (px), bottom segment first.
+const BARS: number[][] = [
+	[52, 26, 18, 12, 8, 6],
+	[64, 30, 22, 14, 10, 6],
+	[58, 34, 20, 16, 8, 8],
+	[76, 38, 26, 16, 12, 8],
+	[88, 42, 28, 20, 12, 10],
+	[82, 48, 30, 18, 14, 10],
+	[104, 52, 34, 22, 16, 12],
+	[122, 58, 38, 26, 18, 12],
+];
+
+export default function RankingsOgImage() {
+	return new ImageResponse(
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				display: "flex",
+				flexDirection: "column",
+				justifyContent: "space-between",
+				position: "relative",
+				background: "#000000",
+				backgroundImage:
+					"radial-gradient(1100px 620px at 82% -12%, rgba(56,189,248,0.22), transparent 60%), radial-gradient(900px 620px at -8% 112%, rgba(139,92,246,0.20), transparent 55%)",
+				color: "#ffffff",
+				fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+				padding: 72,
+				boxSizing: "border-box",
+			}}
+		>
+			{/* Header */}
+			<div
+				style={{
+					display: "flex",
+					flexDirection: "row",
+					alignItems: "center",
+					gap: 14,
+				}}
+			>
+				<div style={{ display: "flex", color: "#ffffff" }}>
+					<Logo style={{ width: 44, height: 44 }} />
+				</div>
+				<div
+					style={{
+						display: "flex",
+						flexDirection: "row",
+						alignItems: "center",
+						gap: 10,
+						fontSize: 24,
+					}}
+				>
+					<span style={{ color: "#ffffff", fontWeight: 600 }}>LLM Gateway</span>
+					<span style={{ color: "#4B5563" }}>/</span>
+					<span style={{ color: "#9CA3AF" }}>Rankings</span>
+				</div>
+			</div>
+
+			{/* Title + stacked-bar motif */}
+			<div
+				style={{
+					display: "flex",
+					flexDirection: "row",
+					alignItems: "flex-end",
+					justifyContent: "space-between",
+					gap: 48,
+				}}
+			>
+				<div
+					style={{
+						display: "flex",
+						flexDirection: "column",
+						gap: 24,
+						maxWidth: 640,
+					}}
+				>
+					<div
+						style={{
+							display: "flex",
+							flexDirection: "row",
+							alignItems: "center",
+							gap: 10,
+							fontSize: 22,
+							color: "#4ade80",
+						}}
+					>
+						<div
+							style={{
+								display: "flex",
+								width: 10,
+								height: 10,
+								borderRadius: 999,
+								background: "#4ade80",
+							}}
+						/>
+						<span>Live gateway traffic</span>
+					</div>
+					<h1
+						style={{
+							fontSize: 84,
+							fontWeight: 800,
+							letterSpacing: "-0.03em",
+							lineHeight: 1.02,
+							margin: 0,
+						}}
+					>
+						LLM Rankings
+					</h1>
+					<p
+						style={{
+							fontSize: 30,
+							lineHeight: 1.35,
+							margin: 0,
+							color: "#9CA3AF",
+						}}
+					>
+						Top models by real token volume routed through LLM Gateway — not
+						benchmarks, not vibes.
+					</p>
+				</div>
+
+				<div
+					style={{
+						display: "flex",
+						flexDirection: "row",
+						alignItems: "flex-end",
+						gap: 14,
+					}}
+				>
+					{BARS.map((segments, columnIndex) => (
+						<div
+							key={columnIndex}
+							style={{
+								display: "flex",
+								flexDirection: "column-reverse",
+								gap: 3,
+								width: 34,
+							}}
+						>
+							{segments.map((height, segmentIndex) => (
+								<div
+									key={segmentIndex}
+									style={{
+										display: "flex",
+										height,
+										width: "100%",
+										borderRadius: 2,
+										background: BAR_COLORS[segmentIndex],
+										opacity: segmentIndex === 0 ? 1 : 0.85,
+									}}
+								/>
+							))}
+						</div>
+					))}
+				</div>
+			</div>
+
+			{/* Footer */}
+			<div
+				style={{
+					display: "flex",
+					flexDirection: "row",
+					alignItems: "center",
+					justifyContent: "space-between",
+					fontSize: 22,
+					color: "#9CA3AF",
+				}}
+			>
+				<span style={{ color: "#ffffff", fontWeight: 600 }}>
+					llmgateway.io/rankings
+				</span>
+				<span>Updated every few minutes</span>
+			</div>
+		</div>,
+		size,
+	);
+}

--- a/apps/ui/src/app/referrals/opengraph-image.tsx
+++ b/apps/ui/src/app/referrals/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const alt = "LLM Gateway — Referral Program";
+
+export default function Image() {
+	return ogImage({
+		eyebrow: "Referrals",
+		title: "Earn 1% of Referred Spend",
+		subtitle:
+			"Refer developers to LLM Gateway and earn 1% of their LLM spending as credits, added directly to your balance.",
+	});
+}

--- a/apps/ui/src/app/reliability/opengraph-image.tsx
+++ b/apps/ui/src/app/reliability/opengraph-image.tsx
@@ -1,0 +1,16 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+import { MARKETING_STATS } from "@llmgateway/shared";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const alt = "LLM Gateway — Reliability";
+
+export default function Image() {
+	return ogImage({
+		eyebrow: "Reliability",
+		title: `${MARKETING_STATS.effectiveUptime} Effective Uptime`,
+		subtitle:
+			"Automatic failover across providers, real-time health monitoring, and intelligent routing. Never go down, even when your providers do.",
+	});
+}

--- a/apps/ui/src/app/reliability/page.tsx
+++ b/apps/ui/src/app/reliability/page.tsx
@@ -15,7 +15,6 @@ export const metadata: Metadata = {
 	alternates: { canonical: "/reliability" },
 	openGraph: {
 		title: "Reliability & 99.9999% Uptime | LLM Gateway",
-		images: ["/opengraph.png?v=2"],
 		description:
 			"Automatic failover across providers, real-time health monitoring, and intelligent routing. Never go down, even when your providers do.",
 		url: "https://llmgateway.io/reliability",

--- a/apps/ui/src/app/token-cost-calculator/opengraph-image.tsx
+++ b/apps/ui/src/app/token-cost-calculator/opengraph-image.tsx
@@ -1,0 +1,15 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+import { MARKETING_STATS } from "@llmgateway/shared";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const alt = "LLM Gateway — Token Cost Calculator";
+
+export default function Image() {
+	return ogImage({
+		eyebrow: "Free Tool",
+		title: "LLM Token Cost Calculator",
+		subtitle: `Count tokens with a real tokenizer, then compare the same workload on GPT-5, Claude, Gemini, and ${MARKETING_STATS.models} models.`,
+	});
+}

--- a/apps/ui/src/app/token-cost-calculator/page.tsx
+++ b/apps/ui/src/app/token-cost-calculator/page.tsx
@@ -35,14 +35,12 @@ export const metadata: Metadata = {
 		title: "LLM Token Cost Calculator & Tokenizer | LLM Gateway",
 		description:
 			"Paste a prompt to count tokens, then compare cost across GPT-5, Claude, Gemini, and 200+ models at zero markup.",
-		images: [{ url: "/opengraph.png?v=1" }],
 	},
 	twitter: {
 		card: "summary_large_image",
 		title: "LLM Token Cost Calculator & Tokenizer | LLM Gateway",
 		description:
 			"Count your prompt's exact tokens and compare the cost across 200+ LLMs with LLM Gateway.",
-		images: ["/opengraph.png?v=1"],
 	},
 };
 

--- a/apps/ui/src/app/use-cases/[slug]/opengraph-image.tsx
+++ b/apps/ui/src/app/use-cases/[slug]/opengraph-image.tsx
@@ -1,0 +1,31 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+import { allUseCases } from "content-collections";
+
+import type { UseCase } from "content-collections";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+
+// Satori cannot run at request time in production; prerender every slug.
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+	return allUseCases
+		.filter((entry: UseCase) => !entry.draft)
+		.map((entry: UseCase) => ({ slug: entry.slug }));
+}
+
+export default async function UseCaseOgImage({
+	params,
+}: {
+	params: Promise<{ slug: string }>;
+}) {
+	const { slug } = await params;
+	const entry = allUseCases.find((e: UseCase) => e.slug === slug);
+	return ogImage({
+		eyebrow: "Use Cases",
+		title: entry?.title ?? "Use Cases",
+		subtitle: entry?.description ?? "What you can build with LLM Gateway.",
+	});
+}

--- a/apps/ui/src/app/use-cases/[slug]/page.tsx
+++ b/apps/ui/src/app/use-cases/[slug]/page.tsx
@@ -46,7 +46,6 @@ export async function generateMetadata({
 			description: entry.description,
 			type: "article",
 			url: `${BASE_URL}/use-cases/${entry.slug}`,
-			images: ["/opengraph.png"],
 		},
 		twitter: {
 			card: "summary_large_image",

--- a/apps/ui/src/app/use-cases/opengraph-image.tsx
+++ b/apps/ui/src/app/use-cases/opengraph-image.tsx
@@ -1,0 +1,15 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+import { MARKETING_STATS } from "@llmgateway/shared";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const alt = "LLM Gateway — Use Cases";
+
+export default function Image() {
+	return ogImage({
+		eyebrow: "Use Cases",
+		title: "What You Can Build",
+		subtitle: `Coding agents, AI support, RAG, and cost optimization — one API for ${MARKETING_STATS.models} models with fallback, caching, and analytics.`,
+	});
+}

--- a/apps/ui/src/app/use-cases/page.tsx
+++ b/apps/ui/src/app/use-cases/page.tsx
@@ -20,7 +20,6 @@ export const metadata: Metadata = {
 			"Coding agents, AI support, RAG, and cost optimization on one API for 200+ models with fallback, caching, and analytics.",
 		type: "website",
 		url: "https://llmgateway.io/use-cases",
-		images: ["/opengraph.png"],
 	},
 };
 

--- a/apps/ui/src/components/models/category-og-image.tsx
+++ b/apps/ui/src/components/models/category-og-image.tsx
@@ -17,6 +17,7 @@ import {
 	type ModelDefinition,
 	type ProviderModelMapping,
 } from "@llmgateway/models";
+import { isPremiumModel } from "@llmgateway/shared";
 
 export const ogSize = {
 	width: 1200,
@@ -238,6 +239,15 @@ export const categoryConfigs: Record<string, CategoryOgConfig> = {
 		countFilter: (m) =>
 			isTextOutput(m.output) &&
 			(OPEN_SOURCE_FAMILIES.has(m.family) || OPEN_SOURCE_MODEL_IDS.has(m.id)),
+	},
+	premium: {
+		title: "Premium Models",
+		subtitle: "High-cost frontier models, classified by price",
+		accentColor: "#F59E0B",
+		accentColorDim: "#78350F",
+		// Lucide "Gem" icon path
+		iconSvgPath: "M6 3h12l4 6-10 13L2 9Z M11 3 8 9l4 13 4-13-3-6 M2 9h20",
+		countFilter: (m) => isPremiumModel(m.id),
 	},
 };
 

--- a/apps/ui/src/components/rankings/rankings-content.tsx
+++ b/apps/ui/src/components/rankings/rankings-content.tsx
@@ -4,7 +4,7 @@ import { format } from "date-fns";
 import { ChevronDown, Server, TrendingDown, TrendingUp } from "lucide-react";
 import Link from "next/link";
 import { useMemo, useState } from "react";
-import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 
 import { Badge } from "@/lib/components/badge";
 import { Button } from "@/lib/components/button";
@@ -46,17 +46,18 @@ const WINDOW_OPTIONS: Array<{ value: StatsWindow; label: string }> = [
 	{ value: "30d", label: "30 days" },
 ];
 
-// Validated categorical palette (adjacent-pair CVD-safe in both modes); the
-// slot order is the safety mechanism, so series take slots in ranking order.
+// Validated categorical palette (adjacent-pair CVD-safe in both modes,
+// brand-anchored sky/violet with muted supports); the slot order is the
+// safety mechanism, so series take slots in ranking order.
 const SERIES_PALETTE: Array<{ light: string; dark: string }> = [
-	{ light: "#2a78d6", dark: "#3987e5" },
-	{ light: "#eb6834", dark: "#d95926" },
-	{ light: "#1baf7a", dark: "#199e70" },
-	{ light: "#eda100", dark: "#c98500" },
-	{ light: "#e87ba4", dark: "#d55181" },
-	{ light: "#008300", dark: "#008300" },
-	{ light: "#4a3aa7", dark: "#9085e9" },
-	{ light: "#e34948", dark: "#e66767" },
+	{ light: "#0284c7", dark: "#0284c7" },
+	{ light: "#7c3aed", dark: "#8b5cf6" },
+	{ light: "#0d9488", dark: "#0d9488" },
+	{ light: "#d97706", dark: "#d97706" },
+	{ light: "#db2777", dark: "#ec4899" },
+	{ light: "#4f46e5", dark: "#6366f1" },
+	{ light: "#65a30d", dark: "#65a30d" },
+	{ light: "#0891b2", dark: "#0891b2" },
 ];
 
 // The chart plots at most one series per palette slot; the ranked list below
@@ -180,6 +181,18 @@ export function RankingsContent({
 			.sort((a, b) => String(a.timestamp).localeCompare(String(b.timestamp)));
 	}, [series]);
 
+	// Hourly buckets in the 7d window are too dense for per-bucket ticks, so
+	// the axis only marks local midnights.
+	const dayTicks = useMemo(
+		() =>
+			statsWindow === "7d"
+				? chartData
+						.map((row) => String(row.timestamp))
+						.filter((ts) => new Date(ts).getHours() === 0)
+				: undefined,
+		[chartData, statsWindow],
+	);
+
 	const visibleModels = showAllModels
 		? models
 		: models.slice(0, LEADERBOARD_PREVIEW_COUNT);
@@ -199,7 +212,10 @@ export function RankingsContent({
 			: format(new Date(value), "MMM d");
 
 	return (
-		<div className="space-y-8">
+		// data-chart mirrors the ChartContainer id so the series color variables
+		// emitted by ChartStyle also reach the legend chips and leaderboard bars
+		// outside the chart itself.
+		<div className="space-y-8" data-chart="chart-rankings">
 			{/* Window selector + freshness note */}
 			<div className="flex flex-wrap items-center justify-between gap-4">
 				<div
@@ -283,15 +299,25 @@ export function RankingsContent({
 						</div>
 					) : (
 						<>
-							<ChartContainer config={chartConfig} className="h-72 w-full">
-								<AreaChart data={chartData} accessibilityLayer>
-									<CartesianGrid vertical={false} strokeOpacity={0.3} />
+							<ChartContainer
+								id="rankings"
+								config={chartConfig}
+								className="h-72 w-full"
+							>
+								<BarChart
+									data={chartData}
+									accessibilityLayer
+									margin={{ left: 12, right: 12 }}
+								>
+									<CartesianGrid vertical={false} />
 									<XAxis
 										dataKey="timestamp"
 										tickFormatter={tickFormatter}
 										tickLine={false}
 										axisLine={false}
+										tickMargin={8}
 										minTickGap={32}
+										ticks={dayTicks}
 									/>
 									<YAxis
 										tickFormatter={(value: number) => formatCompact(value)}
@@ -304,14 +330,28 @@ export function RankingsContent({
 											<ChartTooltipContent
 												labelFormatter={(_label, payload) => {
 													const ts = payload?.[0]?.payload?.timestamp;
-													return ts
-														? format(
-																new Date(ts),
-																statsWindow === "24h"
-																	? "MMM d, HH:mm"
-																	: "MMM d",
-															)
-														: "";
+													if (!ts) {
+														return "";
+													}
+													const total = (payload ?? []).reduce(
+														(sum, item) => sum + Number(item.value ?? 0),
+														0,
+													);
+													return (
+														<div className="flex w-full items-center justify-between gap-6">
+															<span>
+																{format(
+																	new Date(ts),
+																	statsWindow === "30d"
+																		? "MMM d"
+																		: "MMM d, HH:mm",
+																)}
+															</span>
+															<span className="font-mono font-normal tabular-nums text-muted-foreground">
+																{formatCompact(total)} total
+															</span>
+														</div>
+													);
 												}}
 												formatter={(value, name, item) => (
 													<div className="flex w-full items-center justify-between gap-4">
@@ -335,19 +375,15 @@ export function RankingsContent({
 									{series.map((entry) => {
 										const key = chartKey(entry.modelId);
 										return (
-											<Area
+											<Bar
 												key={key}
 												dataKey={key}
-												type="monotone"
 												stackId="models"
-												stroke={`var(--color-${key})`}
 												fill={`var(--color-${key})`}
-												fillOpacity={0.32}
-												strokeWidth={1.5}
 											/>
 										);
 									})}
-								</AreaChart>
+								</BarChart>
 							</ChartContainer>
 							<div className="mt-4 flex flex-wrap gap-x-4 gap-y-2">
 								{series.map((entry, index) => (

--- a/apps/ui/src/components/rankings/rankings-content.tsx
+++ b/apps/ui/src/components/rankings/rankings-content.tsx
@@ -182,16 +182,24 @@ export function RankingsContent({
 	}, [series]);
 
 	// Hourly buckets in the 7d window are too dense for per-bucket ticks, so
-	// the axis only marks local midnights.
-	const dayTicks = useMemo(
-		() =>
-			statsWindow === "7d"
-				? chartData
-						.map((row) => String(row.timestamp))
-						.filter((ts) => new Date(ts).getHours() === 0)
-				: undefined,
-		[chartData, statsWindow],
-	);
+	// the axis marks the first bucket of each local calendar day — robust to
+	// data gaps and DST days without a midnight bucket.
+	const dayTicks = useMemo(() => {
+		if (statsWindow !== "7d") {
+			return undefined;
+		}
+		const seenDays = new Set<string>();
+		const ticks: string[] = [];
+		for (const row of chartData) {
+			const ts = String(row.timestamp);
+			const day = format(new Date(ts), "yyyy-MM-dd");
+			if (!seenDays.has(day)) {
+				seenDays.add(day);
+				ticks.push(ts);
+			}
+		}
+		return ticks;
+	}, [chartData, statsWindow]);
 
 	const visibleModels = showAllModels
 		? models


### PR DESCRIPTION
## Problem

Most public marketing pages either fell back to the generic `/opengraph.png` card or — worse — had **no** OG image at all: any page that declares its own `openGraph` metadata block without `images` drops the layout default entirely (Next shallow-merges metadata). That included /pricing, /rankings, all four /products pages, /open-source, /referrals, /blog, /changelog and more.

Separately, the /rankings token-volume chart was a stacked area chart over just 7 daily points, and its legend chips and leaderboard bars silently rendered transparent.

## What changed

**OG images**
- New `opengraph-image.tsx` routes (shared `ogImage()` template) for: pricing, open-source, products/{ai-gateway,devpass,lounge,observability}, referrals, reliability, token-cost-calculator, copilot-cost-calculator, use-cases, migration, apps, blog, blog/category, changelog, legal, legal/providers, add-provider, brand, models/compare.
- A custom /rankings OG card with a stacked-bar motif matching the new chart palette.
- Dynamic-segment OG routes for use-cases/[slug], legal/[slug], enterprise/[slug], blog/category/[category], and providers/country/[country] — each with `generateStaticParams` + `dynamicParams = false` so satori prerenders them (on-demand satori 503s in prod).
- Added a `premium` config to the category OG generator (models/premium was the only category page without one) with a price-computed model count.
- Removed the generic `/opengraph.png` metadata entries that would shadow the new file-based routes.
- Counts in OG copy come from `MARKETING_STATS`, never hardcoded.

**Rankings chart (shadcn interactive-bar style)**
- Stacked area → dense stacked `BarChart` using the existing shadcn chart primitives, with `CartesianGrid vertical={false}`, midnight-only day ticks for the 7d window, and a tooltip showing the bucket's per-model breakdown plus total.
- `/public/models/stats` now buckets the chart series hourly for the 7d window (168 points instead of 7; 30d stays daily). Series cache tag bumped to v2.
- New CVD-validated, brand-anchored series palette (sky/violet/teal/amber/pink/indigo/lime/cyan; validated for both themes with the dataviz palette validator).
- Fixed a scoping bug: shadcn `ChartStyle` emits `--color-*` vars under `[data-chart=<id>]`, so the legend chips and leaderboard share bars outside `ChartContainer` were transparent. The container now gets a stable `id` and the page wrapper mirrors `data-chart`, so all three surfaces share the palette.

## Verification

- `pnpm build` passes; all new OG routes prerender as static in the build output (no `ƒ` markers).
- `pnpm test:unit` passes against an isolated stack.
- All 24h/7d/30d windows exercised locally with seeded data in both themes; sample OG images rendered below.

## Screenshots

Rankings chart — before (production) vs after (local, seeded data):

| Before (dark) | After (dark) |
| --- | --- |
| <img alt="before dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/c076ad7c6fa945b70537f9971444ad1758753dcc/chart-before-dark.png" /> | <img alt="after dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/c076ad7c6fa945b70537f9971444ad1758753dcc/chart-after-dark.png" /> |

| Before (light) | After (light) |
| --- | --- |
| <img alt="before light" src="https://raw.githubusercontent.com/theopenco/llmgateway/c076ad7c6fa945b70537f9971444ad1758753dcc/chart-before-light.png" /> | <img alt="after light" src="https://raw.githubusercontent.com/theopenco/llmgateway/c076ad7c6fa945b70537f9971444ad1758753dcc/chart-after-light.png" /> |

Tooltip with per-bucket breakdown + total, and the leaderboard now sharing the series palette:

| Tooltip | Leaderboard |
| --- | --- |
| <img alt="tooltip" src="https://raw.githubusercontent.com/theopenco/llmgateway/c076ad7c6fa945b70537f9971444ad1758753dcc/chart-tooltip-dark.png" /> | <img alt="leaderboard" src="https://raw.githubusercontent.com/theopenco/llmgateway/c076ad7c6fa945b70537f9971444ad1758753dcc/leaderboard-dark.png" /> |

Sample generated OG images:

| /rankings | /pricing |
| --- | --- |
| <img alt="rankings og" src="https://raw.githubusercontent.com/theopenco/llmgateway/c076ad7c6fa945b70537f9971444ad1758753dcc/og-rankings.png" /> | <img alt="pricing og" src="https://raw.githubusercontent.com/theopenco/llmgateway/c076ad7c6fa945b70537f9971444ad1758753dcc/og-pricing.png" /> |

| /products/devpass | /models/premium |
| --- | --- |
| <img alt="devpass og" src="https://raw.githubusercontent.com/theopenco/llmgateway/c076ad7c6fa945b70537f9971444ad1758753dcc/og-devpass.png" /> | <img alt="premium og" src="https://raw.githubusercontent.com/theopenco/llmgateway/c076ad7c6fa945b70537f9971444ad1758753dcc/og-premium.png" /> |

| /providers/country/us | /use-cases/coding-agents |
| --- | --- |
| <img alt="country og" src="https://raw.githubusercontent.com/theopenco/llmgateway/c076ad7c6fa945b70537f9971444ad1758753dcc/og-country-us.png" /> | <img alt="use case og" src="https://raw.githubusercontent.com/theopenco/llmgateway/c076ad7c6fa945b70537f9971444ad1758753dcc/og-use-case.png" /> |

https://claude.ai/code/session_018aDkAsZnJejEty8hGCE34h


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added branded Open Graph previews across marketing, blog, legal, product, provider, and calculator pages.
  - Added dynamic social preview images for categories, enterprise features, countries, and use cases.
  - Added a premium model category for high-cost frontier models.

- **Bug Fixes**
  - Improved public model statistics chart time ranges with more appropriate hourly and daily intervals.
  - Updated rankings charts with stacked bars, refreshed colors, clearer tooltips, and improved seven-day axis labels.
  - Prevented partial leading hourly buckets in 24-hour statistics series.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->