### PR TITLE
fix(gateway): correct reasoning token accounting

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -9034,6 +9034,90 @@ describe("api", () => {
 			);
 		});
 
+		test("final stream usage aligns total with an estimated completion", async () => {
+			await db.insert(tables.apiKey).values({
+				id: "token-id",
+				token: "real-token",
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+			await db.insert(tables.providerKey).values({
+				id: "provider-key-id",
+				token: "sk-test-key",
+				provider: "openai",
+				organizationId: "org-id",
+				baseUrl: mockServerUrl,
+			});
+
+			const sse = [
+				`data: ${JSON.stringify({
+					id: "chatcmpl-zero-usage",
+					object: "chat.completion.chunk",
+					created: 1,
+					model: "gpt-4o-mini",
+					choices: [
+						{
+							index: 0,
+							delta: {
+								role: "assistant",
+								content: "Estimated completion output",
+							},
+							finish_reason: null,
+						},
+					],
+				})}\n\n`,
+				`data: ${JSON.stringify({
+					id: "chatcmpl-zero-usage",
+					object: "chat.completion.chunk",
+					created: 1,
+					model: "gpt-4o-mini",
+					choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+					usage: {
+						prompt_tokens: 10,
+						completion_tokens: 0,
+						total_tokens: 10,
+					},
+				})}\n\n`,
+				"data: [DONE]\n\n",
+			].join("");
+
+			const fetchSpy = spyUpstreamResponse(
+				`${mockServerUrl}/v1/chat/completions`,
+				sse,
+				"text/event-stream",
+			);
+
+			try {
+				const res = await app.request("/v1/chat/completions", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: "Bearer real-token",
+						"x-no-fallback": "true",
+					},
+					body: JSON.stringify({
+						model: "openai/gpt-4o-mini",
+						messages: [{ role: "user", content: "Return an answer" }],
+						stream: true,
+					}),
+				});
+
+				expect(res.status).toBe(200);
+				const streamResult = await readAll(res.body);
+				const adjustedUsage = streamResult.chunks.find(
+					(chunk) => (chunk.usage?.completion_tokens ?? 0) > 0,
+				)?.usage;
+
+				expect(adjustedUsage).toBeDefined();
+				expect(adjustedUsage.total_tokens).toBe(
+					adjustedUsage.prompt_tokens + adjustedUsage.completion_tokens,
+				);
+			} finally {
+				fetchSpy.mockRestore();
+			}
+		});
+
 		test("empty non-streaming response is not billed", async () => {
 			await db.insert(tables.apiKey).values({
 				id: "token-id",

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -9867,17 +9867,35 @@ chat.openapi(completions, async (c) => {
 										reasoningTokens,
 										fullReasoningContent,
 									);
+									const finalStreamPromptTokens = Math.max(
+										1,
+										streamingCosts.promptTokens ?? finalPromptTokens ?? 1,
+									);
+									const finalStreamCompletionTokens =
+										streamingCosts.completionTokens ??
+										finalCompletionTokens ??
+										0;
+									const canonicalCountsChanged =
+										finalStreamPromptTokens !== promptTokens ||
+										finalStreamCompletionTokens !== completionTokens;
+									const finalStreamTotalTokens =
+										finalTotalTokens !== null && !canonicalCountsChanged
+											? finalTotalTokens
+											: sumTotalTokens(
+													usedProvider,
+													finalStreamPromptTokens,
+													finalStreamCompletionTokens,
+													reasoningTokens,
+													{
+														model: usedInternalModel,
+														streamed: true,
+													},
+												);
 
 									const finalStreamUsage: Record<string, any> = {
-										prompt_tokens: Math.max(
-											1,
-											streamingCosts.promptTokens ?? finalPromptTokens ?? 1,
-										),
-										completion_tokens:
-											streamingCosts.completionTokens ??
-											finalCompletionTokens ??
-											0,
-										total_tokens: Math.max(1, finalTotalTokens ?? 0),
+										prompt_tokens: finalStreamPromptTokens,
+										completion_tokens: finalStreamCompletionTokens,
+										total_tokens: Math.max(1, finalStreamTotalTokens),
 										...(calculatedReasoningTokens !== null &&
 											calculatedReasoningTokens > 0 && {
 												reasoning_tokens: calculatedReasoningTokens,

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -10235,6 +10235,7 @@ chat.openapi(completions, async (c) => {
 									serverToolUseIndices,
 									supportsReasoning,
 									toolSearchState,
+									fullContent,
 								);
 
 								// Skip null events (some providers have non-data events)

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -6414,6 +6414,7 @@ chat.openapi(completions, async (c) => {
 						audioInputTokens,
 						explicitCacheUsed,
 						customPricing: customPricingMapping,
+						streamed: true,
 					},
 				);
 
@@ -6437,6 +6438,10 @@ chat.openapi(completions, async (c) => {
 								costs.promptTokens ?? promptTokens,
 								completionTokens,
 								reasoningTokens,
+								{
+									model: usedInternalModel,
+									streamed: true,
+								},
 							).toString()
 						: (totalTokens?.toString() ?? null),
 					reasoningTokens: reasoningTokens?.toString() ?? null,
@@ -9796,6 +9801,10 @@ chat.openapi(completions, async (c) => {
 										finalPromptTokens,
 										finalCompletionTokens,
 										reasoningTokens,
+										{
+											model: usedInternalModel,
+											streamed: true,
+										},
 									);
 								}
 
@@ -9837,6 +9846,7 @@ chat.openapi(completions, async (c) => {
 											explicitCacheUsed,
 											servedServiceTier,
 											customPricing: customPricingMapping,
+											streamed: true,
 										},
 									);
 									streamingCosts.dataStorageCost = toDataStorageCostNumber(
@@ -9867,16 +9877,7 @@ chat.openapi(completions, async (c) => {
 											streamingCosts.completionTokens ??
 											finalCompletionTokens ??
 											0,
-										total_tokens: Math.max(
-											1,
-											sumTotalTokens(
-												usedProvider,
-												streamingCosts.promptTokens ?? finalPromptTokens,
-												streamingCosts.completionTokens ??
-													finalCompletionTokens,
-												reasoningTokens,
-											),
-										),
+										total_tokens: Math.max(1, finalTotalTokens ?? 0),
 										...(calculatedReasoningTokens !== null &&
 											calculatedReasoningTokens > 0 && {
 												reasoning_tokens: calculatedReasoningTokens,
@@ -10235,7 +10236,6 @@ chat.openapi(completions, async (c) => {
 									serverToolUseIndices,
 									supportsReasoning,
 									toolSearchState,
-									fullContent,
 								);
 
 								// Skip null events (some providers have non-data events)
@@ -11384,6 +11384,7 @@ chat.openapi(completions, async (c) => {
 											explicitCacheUsed,
 											servedServiceTier,
 											customPricing: customPricingMapping,
+											streamed: true,
 										},
 										finishReason === "content_filter",
 									);
@@ -11727,6 +11728,7 @@ chat.openapi(completions, async (c) => {
 										explicitCacheUsed,
 										servedServiceTier,
 										customPricing: customPricingMapping,
+										streamed: true,
 										// A stream that died never delivered a usage frame, so
 										// there is nothing to estimate from but the partial text
 										// and tool-call JSON that happened to arrive. Don't guess.

--- a/apps/gateway/src/chat/tools/extract-token-usage.spec.ts
+++ b/apps/gateway/src/chat/tools/extract-token-usage.spec.ts
@@ -685,12 +685,7 @@ describe("extractTokenUsage", () => {
 	});
 
 	describe("canopywave", () => {
-		// Canopywave's streaming usage shape varies BY MODEL: deepseek-v4-pro
-		// streams reasoning-exclusive counts while deepseek-v4-flash streams
-		// inclusive ones. The extractor detects the shape per payload from the
-		// visible content and folds only the exclusive shape, since the cost
-		// engine treats the provider as inclusive (COMPLETION_INCLUDES_REASONING).
-		it("folds an exclusive-shape payload (deepseek-v4-pro probe)", () => {
+		it("preserves an exclusive-shape payload", () => {
 			const data = {
 				usage: {
 					prompt_tokens: 40,
@@ -700,15 +695,15 @@ describe("extractTokenUsage", () => {
 				},
 			};
 
-			const result = extractTokenUsage(data, "canopywave", "9");
+			const result = extractTokenUsage(data, "canopywave");
 
 			expect(result.promptTokens).toBe(40);
-			expect(result.completionTokens).toBe(123); // 1 + 122
+			expect(result.completionTokens).toBe(1);
 			expect(result.reasoningTokens).toBe(122);
-			expect(result.totalTokens).toBe(163); // 40 + 123
+			expect(result.totalTokens).toBe(41);
 		});
 
-		it("does not fold an inclusive-shape payload (deepseek-v4-flash probe)", () => {
+		it("preserves an inclusive-shape payload", () => {
 			const data = {
 				usage: {
 					prompt_tokens: 37,
@@ -718,75 +713,11 @@ describe("extractTokenUsage", () => {
 				},
 			};
 
-			const result = extractTokenUsage(data, "canopywave", "The answer is 42.");
+			const result = extractTokenUsage(data, "canopywave");
 
-			expect(result.completionTokens).toBe(131); // already contains reasoning
+			expect(result.completionTokens).toBe(131);
 			expect(result.reasoningTokens).toBe(128);
 			expect(result.totalTokens).toBe(168);
-		});
-
-		it("folds an exclusive payload with a long visible answer", () => {
-			// completion ≈ visible estimate → reasoning lives outside it, even
-			// though completion > reasoning (where a bare size guard would fail).
-			const data = {
-				usage: {
-					prompt_tokens: 30,
-					completion_tokens: 200,
-					total_tokens: 230,
-					completion_tokens_details: { reasoning_tokens: 50 },
-				},
-			};
-
-			const result = extractTokenUsage(data, "canopywave", "x".repeat(800));
-
-			expect(result.completionTokens).toBe(250); // 200 + 50
-			expect(result.totalTokens).toBe(280);
-		});
-
-		it("does not fold a thinking-only inclusive payload", () => {
-			// No visible content and completion == reasoning: inclusive shape
-			// (the whole output was reasoning); folding would double-bill it.
-			const data = {
-				usage: {
-					prompt_tokens: 40,
-					completion_tokens: 128,
-					total_tokens: 168,
-					completion_tokens_details: { reasoning_tokens: 128 },
-				},
-			};
-
-			const result = extractTokenUsage(data, "canopywave", "");
-
-			expect(result.completionTokens).toBe(128);
-			expect(result.totalTokens).toBe(168);
-		});
-
-		it("falls back to a size comparison without visible content", () => {
-			const exclusive = extractTokenUsage(
-				{
-					usage: {
-						prompt_tokens: 40,
-						completion_tokens: 1,
-						total_tokens: 41,
-						reasoning_tokens: 122,
-					},
-				},
-				"canopywave",
-			);
-			expect(exclusive.completionTokens).toBe(123);
-
-			const inclusive = extractTokenUsage(
-				{
-					usage: {
-						prompt_tokens: 37,
-						completion_tokens: 131,
-						total_tokens: 168,
-						reasoning_tokens: 128,
-					},
-				},
-				"canopywave",
-			);
-			expect(inclusive.completionTokens).toBe(131);
 		});
 
 		it("leaves non-reasoning usage unchanged", () => {

--- a/apps/gateway/src/chat/tools/extract-token-usage.spec.ts
+++ b/apps/gateway/src/chat/tools/extract-token-usage.spec.ts
@@ -684,6 +684,140 @@ describe("extractTokenUsage", () => {
 		});
 	});
 
+	describe("canopywave", () => {
+		// Canopywave's streaming usage shape varies BY MODEL: deepseek-v4-pro
+		// streams reasoning-exclusive counts while deepseek-v4-flash streams
+		// inclusive ones. The extractor detects the shape per payload from the
+		// visible content and folds only the exclusive shape, since the cost
+		// engine treats the provider as inclusive (COMPLETION_INCLUDES_REASONING).
+		it("folds an exclusive-shape payload (deepseek-v4-pro probe)", () => {
+			const data = {
+				usage: {
+					prompt_tokens: 40,
+					completion_tokens: 1,
+					total_tokens: 41,
+					completion_tokens_details: { reasoning_tokens: 122 },
+				},
+			};
+
+			const result = extractTokenUsage(data, "canopywave", "9");
+
+			expect(result.promptTokens).toBe(40);
+			expect(result.completionTokens).toBe(123); // 1 + 122
+			expect(result.reasoningTokens).toBe(122);
+			expect(result.totalTokens).toBe(163); // 40 + 123
+		});
+
+		it("does not fold an inclusive-shape payload (deepseek-v4-flash probe)", () => {
+			const data = {
+				usage: {
+					prompt_tokens: 37,
+					completion_tokens: 131,
+					total_tokens: 168,
+					completion_tokens_details: { reasoning_tokens: 128 },
+				},
+			};
+
+			const result = extractTokenUsage(data, "canopywave", "The answer is 42.");
+
+			expect(result.completionTokens).toBe(131); // already contains reasoning
+			expect(result.reasoningTokens).toBe(128);
+			expect(result.totalTokens).toBe(168);
+		});
+
+		it("folds an exclusive payload with a long visible answer", () => {
+			// completion ≈ visible estimate → reasoning lives outside it, even
+			// though completion > reasoning (where a bare size guard would fail).
+			const data = {
+				usage: {
+					prompt_tokens: 30,
+					completion_tokens: 200,
+					total_tokens: 230,
+					completion_tokens_details: { reasoning_tokens: 50 },
+				},
+			};
+
+			const result = extractTokenUsage(data, "canopywave", "x".repeat(800));
+
+			expect(result.completionTokens).toBe(250); // 200 + 50
+			expect(result.totalTokens).toBe(280);
+		});
+
+		it("does not fold a thinking-only inclusive payload", () => {
+			// No visible content and completion == reasoning: inclusive shape
+			// (the whole output was reasoning); folding would double-bill it.
+			const data = {
+				usage: {
+					prompt_tokens: 40,
+					completion_tokens: 128,
+					total_tokens: 168,
+					completion_tokens_details: { reasoning_tokens: 128 },
+				},
+			};
+
+			const result = extractTokenUsage(data, "canopywave", "");
+
+			expect(result.completionTokens).toBe(128);
+			expect(result.totalTokens).toBe(168);
+		});
+
+		it("falls back to a size comparison without visible content", () => {
+			const exclusive = extractTokenUsage(
+				{
+					usage: {
+						prompt_tokens: 40,
+						completion_tokens: 1,
+						total_tokens: 41,
+						reasoning_tokens: 122,
+					},
+				},
+				"canopywave",
+			);
+			expect(exclusive.completionTokens).toBe(123);
+
+			const inclusive = extractTokenUsage(
+				{
+					usage: {
+						prompt_tokens: 37,
+						completion_tokens: 131,
+						total_tokens: 168,
+						reasoning_tokens: 128,
+					},
+				},
+				"canopywave",
+			);
+			expect(inclusive.completionTokens).toBe(131);
+		});
+
+		it("leaves non-reasoning usage unchanged", () => {
+			const data = {
+				usage: {
+					prompt_tokens: 20,
+					completion_tokens: 8,
+					total_tokens: 28,
+					prompt_tokens_details: { cached_tokens: 5 },
+				},
+			};
+
+			const result = extractTokenUsage(data, "canopywave");
+
+			expect(result.promptTokens).toBe(20);
+			expect(result.completionTokens).toBe(8);
+			expect(result.reasoningTokens).toBeNull();
+			expect(result.totalTokens).toBe(28);
+			expect(result.cachedTokens).toBe(5);
+		});
+
+		it("returns null for all fields when usage is missing", () => {
+			const result = extractTokenUsage({}, "canopywave");
+
+			expect(result.promptTokens).toBeNull();
+			expect(result.completionTokens).toBeNull();
+			expect(result.reasoningTokens).toBeNull();
+			expect(result.totalTokens).toBeNull();
+		});
+	});
+
 	describe("xai", () => {
 		it("reads reasoning tokens from completion_tokens_details", () => {
 			// Real grok-4.6 usage payload. xAI reports reasoning only in the nested

--- a/apps/gateway/src/chat/tools/extract-token-usage.ts
+++ b/apps/gateway/src/chat/tools/extract-token-usage.ts
@@ -1,6 +1,39 @@
+import { estimateTokensFromContent } from "./estimate-tokens-from-content.js";
 import { estimateTokens } from "./estimate-tokens.js";
 
 import type { Provider } from "@llmgateway/models";
+
+/**
+ * Decide whether a Canopywave streaming usage payload already includes
+ * reasoning in `completion_tokens`. The shape varies BY MODEL on the same
+ * provider and transport: deepseek-v4-pro streams exclusive counts
+ * (completion 1 / reasoning 122) while deepseek-v4-flash streams inclusive
+ * ones (completion 131 containing reasoning 128). `total_tokens` is
+ * prompt + completion in both shapes, so only the payload itself can
+ * discriminate: test the completion count against the visible-content
+ * estimate under each hypothesis and pick the closer one. Without content
+ * to estimate from, fall back to a size comparison. Ties prefer inclusive
+ * so an ambiguous payload underbills rather than double-bills (a
+ * thinking-only inclusive reply reports completion == reasoning).
+ */
+export function canopywaveCompletionIncludesReasoning(
+	completionTokens: number,
+	reasoningTokens: number,
+	visibleContent: string | undefined,
+): boolean {
+	if (reasoningTokens <= 0) {
+		return true;
+	}
+	if (visibleContent !== undefined) {
+		const visibleEstimate = estimateTokensFromContent(visibleContent);
+		const exclusiveDistance = Math.abs(completionTokens - visibleEstimate);
+		const inclusiveDistance = Math.abs(
+			completionTokens - (visibleEstimate + reasoningTokens),
+		);
+		return inclusiveDistance <= exclusiveDistance;
+	}
+	return completionTokens >= reasoningTokens;
+}
 
 /**
  * Adjust Google candidatesTokenCount for inconsistent API behavior.
@@ -275,6 +308,41 @@ export function extractTokenUsage(
 					(promptDetails.orchestration_input_cached_tokens ?? 0);
 				totalTokens =
 					data.usage.total_tokens ?? promptTokens + completionTokens;
+			}
+			break;
+		case "canopywave":
+			// Canopywave non-streaming folds reasoning into `completion_tokens`
+			// (why the provider is in COMPLETION_INCLUDES_REASONING), but its
+			// streaming usage varies BY MODEL — some models stream exclusive
+			// counts, others inclusive ones (see
+			// canopywaveCompletionIncludesReasoning). This extractor only runs
+			// on streaming chunks: detect the shape per payload and fold the
+			// reasoning back into the completion count only when it is
+			// excluded, so the cost engine always sees the inclusive shape.
+			if (data.usage) {
+				promptTokens = data.usage.prompt_tokens ?? null;
+				reasoningTokens =
+					data.usage.reasoning_tokens ??
+					data.usage.completion_tokens_details?.reasoning_tokens ??
+					null;
+				const rawCompletion = data.usage.completion_tokens ?? null;
+				const shouldFold =
+					rawCompletion !== null &&
+					reasoningTokens !== null &&
+					!canopywaveCompletionIncludesReasoning(
+						rawCompletion,
+						reasoningTokens,
+						fullContent,
+					);
+				completionTokens =
+					rawCompletion !== null
+						? rawCompletion + (shouldFold ? (reasoningTokens ?? 0) : 0)
+						: null;
+				totalTokens =
+					promptTokens !== null && completionTokens !== null
+						? promptTokens + completionTokens
+						: (data.usage.total_tokens ?? null);
+				cachedTokens = data.usage.prompt_tokens_details?.cached_tokens ?? null;
 			}
 			break;
 		default: // OpenAI format

--- a/apps/gateway/src/chat/tools/extract-token-usage.ts
+++ b/apps/gateway/src/chat/tools/extract-token-usage.ts
@@ -1,39 +1,6 @@
-import { estimateTokensFromContent } from "./estimate-tokens-from-content.js";
 import { estimateTokens } from "./estimate-tokens.js";
 
 import type { Provider } from "@llmgateway/models";
-
-/**
- * Decide whether a Canopywave streaming usage payload already includes
- * reasoning in `completion_tokens`. The shape varies BY MODEL on the same
- * provider and transport: deepseek-v4-pro streams exclusive counts
- * (completion 1 / reasoning 122) while deepseek-v4-flash streams inclusive
- * ones (completion 131 containing reasoning 128). `total_tokens` is
- * prompt + completion in both shapes, so only the payload itself can
- * discriminate: test the completion count against the visible-content
- * estimate under each hypothesis and pick the closer one. Without content
- * to estimate from, fall back to a size comparison. Ties prefer inclusive
- * so an ambiguous payload underbills rather than double-bills (a
- * thinking-only inclusive reply reports completion == reasoning).
- */
-export function canopywaveCompletionIncludesReasoning(
-	completionTokens: number,
-	reasoningTokens: number,
-	visibleContent: string | undefined,
-): boolean {
-	if (reasoningTokens <= 0) {
-		return true;
-	}
-	if (visibleContent !== undefined) {
-		const visibleEstimate = estimateTokensFromContent(visibleContent);
-		const exclusiveDistance = Math.abs(completionTokens - visibleEstimate);
-		const inclusiveDistance = Math.abs(
-			completionTokens - (visibleEstimate + reasoningTokens),
-		);
-		return inclusiveDistance <= exclusiveDistance;
-	}
-	return completionTokens >= reasoningTokens;
-}
 
 /**
  * Adjust Google candidatesTokenCount for inconsistent API behavior.
@@ -311,37 +278,16 @@ export function extractTokenUsage(
 			}
 			break;
 		case "canopywave":
-			// Canopywave non-streaming folds reasoning into `completion_tokens`
-			// (why the provider is in COMPLETION_INCLUDES_REASONING), but its
-			// streaming usage varies BY MODEL — some models stream exclusive
-			// counts, others inclusive ones (see
-			// canopywaveCompletionIncludesReasoning). This extractor only runs
-			// on streaming chunks: detect the shape per payload and fold the
-			// reasoning back into the completion count only when it is
-			// excluded, so the cost engine always sees the inclusive shape.
+			// Preserve Canopywave's reported usage. Whether completion includes
+			// reasoning is model- and transport-specific and is handled by billing.
 			if (data.usage) {
 				promptTokens = data.usage.prompt_tokens ?? null;
+				completionTokens = data.usage.completion_tokens ?? null;
+				totalTokens = data.usage.total_tokens ?? null;
 				reasoningTokens =
 					data.usage.reasoning_tokens ??
 					data.usage.completion_tokens_details?.reasoning_tokens ??
 					null;
-				const rawCompletion = data.usage.completion_tokens ?? null;
-				const shouldFold =
-					rawCompletion !== null &&
-					reasoningTokens !== null &&
-					!canopywaveCompletionIncludesReasoning(
-						rawCompletion,
-						reasoningTokens,
-						fullContent,
-					);
-				completionTokens =
-					rawCompletion !== null
-						? rawCompletion + (shouldFold ? (reasoningTokens ?? 0) : 0)
-						: null;
-				totalTokens =
-					promptTokens !== null && completionTokens !== null
-						? promptTokens + completionTokens
-						: (data.usage.total_tokens ?? null);
 				cachedTokens = data.usage.prompt_tokens_details?.cached_tokens ?? null;
 			}
 			break;

--- a/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
@@ -1380,6 +1380,24 @@ describe("parseProviderResponse", () => {
 			expect(result.totalTokens).toBe(110);
 		});
 
+		it("reads canopywave's nested reasoning count without re-adding it", () => {
+			// Canopywave only ever nests reasoning_tokens under
+			// completion_tokens_details; non-streaming completion_tokens already
+			// includes it, so the read is display-only and total stays inclusive.
+			const result = parseProviderResponse(
+				"canopywave",
+				"deepseek-v4-pro",
+				chatJson({
+					prompt_tokens: 116,
+					completion_tokens: 109,
+					completion_tokens_details: { reasoning_tokens: 107 },
+				}),
+			);
+
+			expect(result.reasoningTokens).toBe(107);
+			expect(result.totalTokens).toBe(225);
+		});
+
 		it("adds reasoning for an additive provider (default branch)", () => {
 			const result = parseProviderResponse(
 				"xai",

--- a/apps/gateway/src/chat/tools/parse-provider-response.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.ts
@@ -1179,12 +1179,16 @@ export function parseProviderResponse(
 				// `completion_tokens` EXCLUDES reasoning (total_tokens = prompt +
 				// completion + reasoning) and the count only ever appears nested
 				// under `completion_tokens_details`. Reading it here is what makes
-				// reasoning billable at all. Providers that fold reasoning into
-				// `completion_tokens` must keep reading the top-level field only,
-				// or the same tokens would be billed a second time.
+				// reasoning billable at all. Canopywave also only nests the count,
+				// but its non-streaming `completion_tokens` already includes
+				// reasoning, so the nested read is display/log accuracy only —
+				// the cost engine skips re-adding it (completionIncludesReasoning).
+				// For other providers that fold reasoning into `completion_tokens`
+				// but are treated as additive by the cost engine, reading the
+				// nested count would bill the same tokens a second time.
 				reasoningTokens =
 					json.usage?.reasoning_tokens ??
-					(usedProvider === "xai"
+					(usedProvider === "xai" || usedProvider === "canopywave"
 						? (json.usage?.completion_tokens_details?.reasoning_tokens ?? null)
 						: null);
 				cachedTokens = json.usage?.prompt_tokens_details?.cached_tokens ?? null;

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.spec.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.spec.ts
@@ -730,6 +730,99 @@ describe("transformStreamingToOpenai", () => {
 		expect(error).not.toHaveBeenCalled();
 	});
 
+	it("folds canopywave streamed reasoning into completion and total tokens", () => {
+		// Exclusive-shape canopywave stream (deepseek-v4-pro probe): reasoning
+		// is outside completion_tokens and total_tokens. Forwarded chunks must
+		// carry the inclusive shape so they match the final usage chunk.
+		const result = transformStreamingToOpenai(
+			"canopywave",
+			"deepseek-v4-pro",
+			{
+				id: "chatcmpl_456",
+				object: "chat.completion.chunk",
+				model: "deepseek-v4-pro",
+				choices: [],
+				usage: {
+					prompt_tokens: 40,
+					completion_tokens: 1,
+					total_tokens: 41,
+					completion_tokens_details: { reasoning_tokens: 122 },
+				},
+			},
+			[],
+			undefined,
+			true,
+			undefined,
+			"9",
+		);
+
+		expect(result.usage).toMatchObject({
+			prompt_tokens: 40,
+			completion_tokens: 123,
+			total_tokens: 163,
+			reasoning_tokens: 122,
+		});
+	});
+
+	it("does not fold canopywave usage that already includes reasoning", () => {
+		// Inclusive-shape canopywave stream (deepseek-v4-flash probe):
+		// completion_tokens already contains the reasoning; folding here would
+		// double-count it.
+		const result = transformStreamingToOpenai(
+			"canopywave",
+			"deepseek-v4-flash",
+			{
+				id: "chatcmpl_457",
+				object: "chat.completion.chunk",
+				model: "deepseek-v4-flash",
+				choices: [],
+				usage: {
+					prompt_tokens: 37,
+					completion_tokens: 131,
+					total_tokens: 168,
+					completion_tokens_details: { reasoning_tokens: 128 },
+				},
+			},
+			[],
+			undefined,
+			true,
+			undefined,
+			"The answer is 42.",
+		);
+
+		expect(result.usage).toMatchObject({
+			prompt_tokens: 37,
+			completion_tokens: 131,
+			total_tokens: 168,
+			reasoning_tokens: 128,
+		});
+	});
+
+	it("does not alter canopywave usage without reasoning", () => {
+		const result = transformStreamingToOpenai(
+			"canopywave",
+			"kimi-k2.6",
+			{
+				id: "chatcmpl_789",
+				object: "chat.completion.chunk",
+				model: "kimi-k2.6",
+				choices: [],
+				usage: {
+					prompt_tokens: 20,
+					completion_tokens: 8,
+					total_tokens: 28,
+				},
+			},
+			[],
+		);
+
+		expect(result.usage).toMatchObject({
+			prompt_tokens: 20,
+			completion_tokens: 8,
+			total_tokens: 28,
+		});
+	});
+
 	it("logs error for Google chunk with no candidates and no usage", () => {
 		warn.mockClear();
 		error.mockClear();

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.spec.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.spec.ts
@@ -730,10 +730,7 @@ describe("transformStreamingToOpenai", () => {
 		expect(error).not.toHaveBeenCalled();
 	});
 
-	it("folds canopywave streamed reasoning into completion and total tokens", () => {
-		// Exclusive-shape canopywave stream (deepseek-v4-pro probe): reasoning
-		// is outside completion_tokens and total_tokens. Forwarded chunks must
-		// carry the inclusive shape so they match the final usage chunk.
+	it("preserves canopywave usage that reports reasoning separately", () => {
 		const result = transformStreamingToOpenai(
 			"canopywave",
 			"deepseek-v4-pro",
@@ -750,24 +747,17 @@ describe("transformStreamingToOpenai", () => {
 				},
 			},
 			[],
-			undefined,
-			true,
-			undefined,
-			"9",
 		);
 
 		expect(result.usage).toMatchObject({
 			prompt_tokens: 40,
-			completion_tokens: 123,
-			total_tokens: 163,
+			completion_tokens: 1,
+			total_tokens: 41,
 			reasoning_tokens: 122,
 		});
 	});
 
-	it("does not fold canopywave usage that already includes reasoning", () => {
-		// Inclusive-shape canopywave stream (deepseek-v4-flash probe):
-		// completion_tokens already contains the reasoning; folding here would
-		// double-count it.
+	it("preserves canopywave usage that includes reasoning in completion", () => {
 		const result = transformStreamingToOpenai(
 			"canopywave",
 			"deepseek-v4-flash",
@@ -784,10 +774,6 @@ describe("transformStreamingToOpenai", () => {
 				},
 			},
 			[],
-			undefined,
-			true,
-			undefined,
-			"The answer is 42.",
 		);
 
 		expect(result.usage).toMatchObject({

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -7,6 +7,7 @@ import { calculatePromptTokensFromMessages } from "./calculate-prompt-tokens.js"
 import { extractImages } from "./extract-images.js";
 import {
 	adjustGoogleCandidateTokens,
+	canopywaveCompletionIncludesReasoning,
 	extractBedrockCacheCreationDetails,
 } from "./extract-token-usage.js";
 import { mapFinishReasonToOpenai } from "./map-finish-reason-to-openai.js";
@@ -78,6 +79,9 @@ export function transformStreamingToOpenai(
 	serverToolUseIndices?: Set<number>,
 	supportsReasoning = true,
 	toolSearchState?: AnthropicToolSearchState,
+	// Visible content streamed so far; used to detect whether a Canopywave
+	// usage payload already includes reasoning in its completion count.
+	fullContent?: string,
 ): any {
 	let transformedData = data;
 
@@ -1565,6 +1569,30 @@ export function transformStreamingToOpenai(
 				usedModel,
 				supportsReasoning,
 			);
+
+			// Some Canopywave models stream usage that excludes reasoning from
+			// completion_tokens and total_tokens while others stream inclusive
+			// counts (see canopywaveCompletionIncludesReasoning). Fold reasoning
+			// back in only for the exclusive shape so forwarded chunks match the
+			// final usage chunk; billing applies the same detection in
+			// extract-token-usage.
+			if (usedProvider === "canopywave" && transformedData?.usage) {
+				const usage = transformedData.usage;
+				if (
+					typeof usage.completion_tokens === "number" &&
+					typeof usage.reasoning_tokens === "number" &&
+					usage.reasoning_tokens > 0 &&
+					!canopywaveCompletionIncludesReasoning(
+						usage.completion_tokens,
+						usage.reasoning_tokens,
+						fullContent,
+					)
+				) {
+					usage.completion_tokens += usage.reasoning_tokens;
+					usage.total_tokens =
+						(usage.prompt_tokens ?? 0) + usage.completion_tokens;
+				}
+			}
 
 			// Map non-standard finish reasons to OpenAI-compatible values
 			if (transformedData?.choices?.[0]?.finish_reason === "end_turn") {

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -7,7 +7,6 @@ import { calculatePromptTokensFromMessages } from "./calculate-prompt-tokens.js"
 import { extractImages } from "./extract-images.js";
 import {
 	adjustGoogleCandidateTokens,
-	canopywaveCompletionIncludesReasoning,
 	extractBedrockCacheCreationDetails,
 } from "./extract-token-usage.js";
 import { mapFinishReasonToOpenai } from "./map-finish-reason-to-openai.js";
@@ -79,9 +78,6 @@ export function transformStreamingToOpenai(
 	serverToolUseIndices?: Set<number>,
 	supportsReasoning = true,
 	toolSearchState?: AnthropicToolSearchState,
-	// Visible content streamed so far; used to detect whether a Canopywave
-	// usage payload already includes reasoning in its completion count.
-	fullContent?: string,
 ): any {
 	let transformedData = data;
 
@@ -1569,30 +1565,6 @@ export function transformStreamingToOpenai(
 				usedModel,
 				supportsReasoning,
 			);
-
-			// Some Canopywave models stream usage that excludes reasoning from
-			// completion_tokens and total_tokens while others stream inclusive
-			// counts (see canopywaveCompletionIncludesReasoning). Fold reasoning
-			// back in only for the exclusive shape so forwarded chunks match the
-			// final usage chunk; billing applies the same detection in
-			// extract-token-usage.
-			if (usedProvider === "canopywave" && transformedData?.usage) {
-				const usage = transformedData.usage;
-				if (
-					typeof usage.completion_tokens === "number" &&
-					typeof usage.reasoning_tokens === "number" &&
-					usage.reasoning_tokens > 0 &&
-					!canopywaveCompletionIncludesReasoning(
-						usage.completion_tokens,
-						usage.reasoning_tokens,
-						fullContent,
-					)
-				) {
-					usage.completion_tokens += usage.reasoning_tokens;
-					usage.total_tokens =
-						(usage.prompt_tokens ?? 0) + usage.completion_tokens;
-				}
-			}
 
 			// Map non-standard finish reasons to OpenAI-compatible values
 			if (transformedData?.choices?.[0]?.finish_reason === "end_turn") {

--- a/apps/gateway/src/lib/costs.spec.ts
+++ b/apps/gateway/src/lib/costs.spec.ts
@@ -804,6 +804,32 @@ describe("calculateCosts", () => {
 		expect(result.completionTokens).toBe(82);
 	});
 
+	it("adds separately reported Canopywave streaming reasoning", async () => {
+		const result = await calculateCosts(
+			"deepseek-v4-pro",
+			"canopywave",
+			null,
+			40,
+			1,
+			0,
+			undefined,
+			122,
+			0,
+			undefined,
+			0,
+			null,
+			null,
+			undefined,
+			null,
+			null,
+			{ streamed: true },
+		);
+
+		expect(result.inputCost).toBeCloseTo(0.0000696, 10);
+		expect(result.outputCost).toBeCloseTo(0.00042804, 10);
+		expect(result.completionTokens).toBe(1);
+	});
+
 	it("should still add reasoning tokens for xAI", async () => {
 		// xAI is the verified exception: grok-4 answering "9" reports
 		// completion_tokens 1, reasoning_tokens 118 and total_tokens 324, so its
@@ -2451,6 +2477,27 @@ describe("sumTotalTokens", () => {
 			expect(sumTotalTokens(provider, 51, 136, 31)).toBe(218);
 			expect(completionIncludesReasoning(provider)).toBe(false);
 		}
+	});
+
+	it("uses Canopywave model and transport semantics", () => {
+		const streamingPro = {
+			model: "deepseek-v4-pro",
+			streamed: true,
+		};
+
+		expect(completionIncludesReasoning("canopywave", streamingPro)).toBe(false);
+		expect(sumTotalTokens("canopywave", 40, 1, 122, streamingPro)).toBe(163);
+		expect(
+			completionIncludesReasoning("canopywave", {
+				model: "deepseek-v4-pro",
+			}),
+		).toBe(true);
+		expect(
+			completionIncludesReasoning("canopywave", {
+				model: "deepseek-v4-flash",
+				streamed: true,
+			}),
+		).toBe(true);
 	});
 
 	it("treats null and undefined token counts as zero", () => {

--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -238,24 +238,16 @@ function getPricingForTokenCount(
  * resolve-reasoning-tokens derives from that text must not be added on top.
  *
  * Adding reasoning on top for a provider on this list would roughly double the
- * billed output — and the reported `total_tokens` — on reasoning requests.
+ * billed output on reasoning requests.
  *
  * xAI is the notable exception and must stay off this list: `grok-4` reports
  * `completion_tokens: 1` alongside `reasoning_tokens: 118` and
  * `total_tokens: 324` for a one-token answer, i.e. its completion count
  * genuinely excludes reasoning and its own total adds it back.
  *
- * Note that only a *top-level* `usage.reasoning_tokens` reaches the cost path
- * for OpenAI-format providers (extract-token-usage reads the raw upstream
- * chunk, not the normalized one), so most of these providers are latent rather
- * than actively mis-billed today.
- *
- * Canopywave is inclusive when non-streaming, but its streaming shape varies
- * BY MODEL — some models stream reasoning-exclusive counts, others inclusive
- * ones. extract-token-usage (streaming-only) detects the shape per payload
- * (canopywaveCompletionIncludesReasoning) and folds the reasoning back into
- * the completion count only when excluded, so by the time counts reach this
- * flag both modes are inclusive.
+ * Canopywave is inclusive except for its deepseek-v4-pro streaming endpoint,
+ * which reports reasoning separately. That stable model/transport exception
+ * is handled below without changing the provider-reported usage fields.
  */
 const COMPLETION_INCLUDES_REASONING = new Set([
 	"alibaba",
@@ -290,7 +282,22 @@ const COMPLETION_INCLUDES_REASONING = new Set([
 	"zai",
 ]);
 
-export function completionIncludesReasoning(provider: string): boolean {
+interface CompletionUsageContext {
+	model?: string;
+	streamed?: boolean;
+}
+
+export function completionIncludesReasoning(
+	provider: string,
+	context?: CompletionUsageContext,
+): boolean {
+	if (
+		provider === "canopywave" &&
+		context?.streamed &&
+		context.model === "deepseek-v4-pro"
+	) {
+		return false;
+	}
 	return COMPLETION_INCLUDES_REASONING.has(provider);
 }
 
@@ -305,11 +312,14 @@ export function sumTotalTokens(
 	promptTokens: number | null | undefined,
 	completionTokens: number | null | undefined,
 	reasoningTokens: number | null | undefined,
+	context?: CompletionUsageContext,
 ): number {
 	return (
 		(promptTokens ?? 0) +
 		(completionTokens ?? 0) +
-		(completionIncludesReasoning(provider) ? 0 : (reasoningTokens ?? 0))
+		(completionIncludesReasoning(provider, context)
+			? 0
+			: (reasoningTokens ?? 0))
 	);
 }
 
@@ -394,6 +404,8 @@ export async function calculateCosts(
 		 * up charged for 1.17M of them.
 		 */
 		allowOutputEstimate?: boolean;
+		/** Whether these counts came from a streaming response. */
+		streamed?: boolean;
 	},
 	contentFilterTriggered = false,
 ) {
@@ -833,7 +845,10 @@ export async function calculateCosts(
 		.plus(imageInputCost ?? 0)
 		.plus(audioInputCost ?? 0);
 
-	const totalOutputTokens = completionIncludesReasoning(provider)
+	const totalOutputTokens = completionIncludesReasoning(provider, {
+		model,
+		streamed: options?.streamed,
+	})
 		? calculatedCompletionTokens
 		: calculatedCompletionTokens + (reasoningTokens ?? 0);
 

--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -248,8 +248,14 @@ function getPricingForTokenCount(
  * Note that only a *top-level* `usage.reasoning_tokens` reaches the cost path
  * for OpenAI-format providers (extract-token-usage reads the raw upstream
  * chunk, not the normalized one), so most of these providers are latent rather
- * than actively mis-billed today. Canopywave is the exception that is not:
- * it reports `reasoning_tokens` at the top level.
+ * than actively mis-billed today.
+ *
+ * Canopywave is inclusive when non-streaming, but its streaming shape varies
+ * BY MODEL — some models stream reasoning-exclusive counts, others inclusive
+ * ones. extract-token-usage (streaming-only) detects the shape per payload
+ * (canopywaveCompletionIncludesReasoning) and folds the reasoning back into
+ * the completion count only when excluded, so by the time counts reach this
+ * flag both modes are inclusive.
  */
 const COMPLETION_INCLUDES_REASONING = new Set([
 	"alibaba",


### PR DESCRIPTION
Reasoning tokens can be double-counted in billed output and derived totals when a provider already includes them in its completion count. Streamed responses can also expose inconsistent final usage when cost calculation replaces zero or missing counts with estimates but retains the raw upstream total.

This centralizes provider-aware token summation across cost calculation, parsing, response normalization, cache, and log paths. Raw upstream usage remains intact; synthesized final usage preserves a raw total only while canonical prompt and completion counts are unchanged, otherwise recomputing it with provider, model, and transport semantics. Canopywave inclusion is resolved from canonical model and transport metadata: streaming deepseek-v4-pro reports reasoning separately, while the other verified Canopywave shapes include it in completion.

Verified with pnpm format, pnpm build, and focused unit coverage for provider accounting and adjusted stream totals. Paid provider E2E was not triggered.