### PR TITLE
fix(models): retire Nebius models

### DIFF
--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -752,6 +752,7 @@ export const alibabaModels = [
 			{
 				providerId: "nebius",
 				externalId: "Qwen/Qwen3-32B",
+				deactivatedAt: new Date("2026-08-31"),
 				inputPrice: "0.1e-6",
 				outputPrice: "0.3e-6",
 				requestPrice: "0",
@@ -929,6 +930,7 @@ export const alibabaModels = [
 			{
 				providerId: "nebius",
 				externalId: "Qwen/Qwen2.5-VL-72B-Instruct",
+				deactivatedAt: new Date("2026-08-31"),
 				inputPrice: "0.25e-6",
 				outputPrice: "0.75e-6",
 				requestPrice: "0",
@@ -1255,6 +1257,7 @@ export const alibabaModels = [
 			{
 				providerId: "nebius",
 				externalId: "Qwen/Qwen3-Next-80B-A3B-Thinking",
+				deactivatedAt: new Date("2026-08-31"),
 				inputPrice: "0.15e-6",
 				outputPrice: "1.2e-6",
 				requestPrice: "0",

--- a/packages/models/src/models/meta.ts
+++ b/packages/models/src/models/meta.ts
@@ -235,6 +235,7 @@ export const metaModels = [
 			{
 				providerId: "nebius",
 				externalId: "nvidia/Llama-3_1-Nemotron-Ultra-253B-v1",
+				deactivatedAt: new Date("2026-08-31"),
 				inputPrice: "0.6e-6",
 				outputPrice: "1.8e-6",
 				requestPrice: "0",
@@ -282,6 +283,7 @@ export const metaModels = [
 			{
 				providerId: "nebius",
 				externalId: "meta-llama/Llama-3.3-70B-Instruct",
+				deactivatedAt: new Date("2026-08-31"),
 				inputPrice: "0.13e-6",
 				outputPrice: "0.4e-6",
 				requestPrice: "0",

--- a/packages/models/src/models/minimax.ts
+++ b/packages/models/src/models/minimax.ts
@@ -300,6 +300,7 @@ export const minimaxModels = [
 				// Streaming tool calls and response_format: json_object are unreliable on Nebius
 				stability: "unstable",
 				externalId: "MiniMaxAI/MiniMax-M2.5",
+				deactivatedAt: new Date("2026-08-31"),
 				inputPrice: "0.3e-6",
 				outputPrice: "1.2e-6",
 				requestPrice: "0",

--- a/packages/models/src/models/nousresearch.ts
+++ b/packages/models/src/models/nousresearch.ts
@@ -44,6 +44,7 @@ export const nousresearchModels = [
 			{
 				providerId: "nebius",
 				externalId: "NousResearch/Hermes-4-70B",
+				deactivatedAt: new Date("2026-08-31"),
 				inputPrice: "0.13e-6",
 				outputPrice: "0.4e-6",
 				requestPrice: "0",

--- a/packages/models/src/models/nvidia.ts
+++ b/packages/models/src/models/nvidia.ts
@@ -28,6 +28,7 @@ export const nvidiaModels = [
 			{
 				providerId: "nebius",
 				externalId: "nvidia/Nemotron-3-Ultra-550b-a55b",
+				deactivatedAt: new Date("2026-08-31"),
 				inputPrice: "1.0e-6",
 				outputPrice: "3.0e-6",
 				requestPrice: "0",
@@ -81,6 +82,7 @@ export const nvidiaModels = [
 			{
 				providerId: "nebius",
 				externalId: "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B",
+				deactivatedAt: new Date("2026-08-31"),
 				inputPrice: "0.06e-6",
 				outputPrice: "0.24e-6",
 				requestPrice: "0",
@@ -106,6 +108,7 @@ export const nvidiaModels = [
 			{
 				providerId: "nebius",
 				externalId: "nvidia/Nemotron-3-Nano-Omni",
+				deactivatedAt: new Date("2026-08-31"),
 				inputPrice: "0.06e-6",
 				outputPrice: "0.24e-6",
 				requestPrice: "0",
@@ -131,6 +134,7 @@ export const nvidiaModels = [
 			{
 				providerId: "nebius",
 				externalId: "nvidia/Cosmos3-Super-Reasoner",
+				deactivatedAt: new Date("2026-08-31"),
 				inputPrice: "0.1e-6",
 				outputPrice: "0.3e-6",
 				requestPrice: "0",


### PR DESCRIPTION
## Summary

Nebius will retire 11 catalogue mappings on 2026-08-31. This preserves each mapping for historical lookups while removing it from future routing.

The announced DeepSeek V4 Flash deployment has no Nebius mapping in the current catalogue, so no change was needed for that item.

## Verification

- `pnpm format`
- `pnpm build`
- `pnpm exec vitest run --no-file-parallelism packages/models/src/model-metadata.spec.ts packages/models/src/providers.spec.ts packages/models/src/realtime-models.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Added August 31, 2026 deactivation dates for several Nebius-hosted AI models from Alibaba, Meta, MiniMax, Nous Research, and NVIDIA.
  * Model availability information is now more accurately reflected for affected providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->