### PR TITLE
feat(devpass): hide Flex for new users

### DIFF
--- a/apps/api/src/routes/user.spec.ts
+++ b/apps/api/src/routes/user.spec.ts
@@ -197,6 +197,10 @@ describe("user accounts and email editability", () => {
 		expect(json.user.accounts).toBeDefined();
 		expect(Array.isArray(json.user.accounts)).toBe(true);
 		expect(json.user.accounts).toContainEqual({ providerId: "credential" });
+		expect(json.user.createdAt).toEqual(expect.any(String));
+		expect(new Date(json.user.createdAt).toISOString()).toBe(
+			json.user.createdAt,
+		);
 	});
 
 	it("GET /user/me should return isSsoUser false for a non-SSO user", async () => {

--- a/apps/api/src/routes/user.ts
+++ b/apps/api/src/routes/user.ts
@@ -25,6 +25,7 @@ const USERNAME_REGEX = /^[a-z0-9_-]{3,30}$/;
 
 const publicUserSchema = z.object({
 	id: z.string(),
+	createdAt: z.string().datetime(),
 	email: z.string(),
 	name: z.string().nullable(),
 	onboardingCompleted: z.boolean(),
@@ -85,6 +86,7 @@ function toPublicUser(
 ): z.infer<typeof publicUserSchema> {
 	return {
 		id: userRecord.id,
+		createdAt: userRecord.createdAt.toISOString(),
 		email: userRecord.email,
 		name: userRecord.name,
 		onboardingCompleted: userRecord.onboardingCompleted,

--- a/apps/code/src/app/dashboard/(main)/settings/page.tsx
+++ b/apps/code/src/app/dashboard/(main)/settings/page.tsx
@@ -4,6 +4,7 @@ import dynamic from "next/dynamic";
 
 import { useDevPlanStatus } from "@/app/dashboard/useDevPlanStatus";
 import { useUser } from "@/hooks/useUser";
+import { canConfigureDevPlanServiceTier } from "@/lib/dev-plan-service-tier";
 
 const DevPlanSettings = dynamic(
 	() => import("@/app/dashboard/components/DevPlanSettings"),
@@ -47,6 +48,9 @@ export default function SettingsPage() {
 			    endpoint rejects updates once the subscription has ended. */}
 			{devPlanStatus.devPlan !== "none" && (
 				<DevPlanSettings
+					canConfigureServiceTier={
+						user !== null && canConfigureDevPlanServiceTier(user.createdAt)
+					}
 					devPlanServiceTier={devPlanStatus.devPlanServiceTier ?? "default"}
 					defaultRoutingStrategy={
 						devPlanStatus.defaultRoutingStrategy ?? "auto"

--- a/apps/code/src/app/dashboard/components/DevPlanSettings.tsx
+++ b/apps/code/src/app/dashboard/components/DevPlanSettings.tsx
@@ -37,12 +37,14 @@ const SERVICE_TIER_OPTIONS: Array<{ value: ServiceTier; label: string }> = [
 ];
 
 interface DevPlanSettingsProps {
+	canConfigureServiceTier: boolean;
 	devPlanServiceTier: ServiceTier;
 	defaultRoutingStrategy: RoutingStrategy;
 	providerCacheControlEnabled: boolean;
 }
 
 export default function DevPlanSettings({
+	canConfigureServiceTier,
 	devPlanServiceTier: initialServiceTier,
 	defaultRoutingStrategy: initialRoutingStrategy,
 	providerCacheControlEnabled: initialProviderCacheControlEnabled,
@@ -211,45 +213,51 @@ export default function DevPlanSettings({
 					</div>
 				</div>
 
-				<div className="rounded-xl border p-5 space-y-4">
-					<div className="flex items-center justify-between gap-4">
-						<div className="space-y-0.5">
-							<Label htmlFor="service-tier" className="text-sm font-medium">
-								Default service tier
-							</Label>
-							<p className="text-xs text-muted-foreground">
-								Flex processing costs less and saves your plan credits, but
-								responses may be slower during peak demand. Only applied for
-								models that support it — everything else stays on standard
-								processing.{" "}
-								<a
-									href="https://docs.llmgateway.io/features/service-tiers"
-									target="_blank"
-									rel="noreferrer"
-									className="underline underline-offset-2"
+				{canConfigureServiceTier && (
+					<div className="rounded-xl border p-5 space-y-4">
+						<div className="flex items-center justify-between gap-4">
+							<div className="space-y-0.5">
+								<Label htmlFor="service-tier" className="text-sm font-medium">
+									Default service tier
+								</Label>
+								<p className="text-xs text-muted-foreground">
+									Flex processing costs less and saves your plan credits, but
+									responses may be slower during peak demand. Only applied for
+									models that support it — everything else stays on standard
+									processing.{" "}
+									<a
+										href="https://docs.llmgateway.io/features/service-tiers"
+										target="_blank"
+										rel="noreferrer"
+										className="underline underline-offset-2"
+									>
+										Learn more
+									</a>
+								</p>
+							</div>
+							<Select
+								value={serviceTier}
+								onValueChange={handleServiceTierChange}
+								disabled={isUpdatingServiceTier}
+							>
+								<SelectTrigger
+									id="service-tier"
+									size="sm"
+									className="w-[180px]"
 								>
-									Learn more
-								</a>
-							</p>
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{SERVICE_TIER_OPTIONS.map((option) => (
+										<SelectItem key={option.value} value={option.value}>
+											{option.label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
 						</div>
-						<Select
-							value={serviceTier}
-							onValueChange={handleServiceTierChange}
-							disabled={isUpdatingServiceTier}
-						>
-							<SelectTrigger id="service-tier" size="sm" className="w-[180px]">
-								<SelectValue />
-							</SelectTrigger>
-							<SelectContent>
-								{SERVICE_TIER_OPTIONS.map((option) => (
-									<SelectItem key={option.value} value={option.value}>
-										{option.label}
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
 					</div>
-				</div>
+				)}
 			</div>
 		</div>
 	);

--- a/apps/code/src/lib/dev-plan-service-tier.spec.ts
+++ b/apps/code/src/lib/dev-plan-service-tier.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { canConfigureDevPlanServiceTier } from "./dev-plan-service-tier";
+
+describe("canConfigureDevPlanServiceTier", () => {
+	it("allows users created before August 20, 2026", () => {
+		expect(canConfigureDevPlanServiceTier("2026-08-19T23:59:59.999Z")).toBe(
+			true,
+		);
+	});
+
+	it("denies users created on or after August 20, 2026", () => {
+		expect(canConfigureDevPlanServiceTier("2026-08-20T00:00:00.000Z")).toBe(
+			false,
+		);
+		expect(canConfigureDevPlanServiceTier("2026-08-21T00:00:00.000Z")).toBe(
+			false,
+		);
+	});
+});

--- a/apps/code/src/lib/dev-plan-service-tier.ts
+++ b/apps/code/src/lib/dev-plan-service-tier.ts
@@ -1,0 +1,5 @@
+const DEV_PLAN_SERVICE_TIER_CUTOFF = Date.parse("2026-08-20T00:00:00Z");
+
+export function canConfigureDevPlanServiceTier(userCreatedAt: string): boolean {
+	return new Date(userCreatedAt).getTime() < DEV_PLAN_SERVICE_TIER_CUTOFF;
+}

--- a/apps/docs/content/features/service-tiers.mdx
+++ b/apps/docs/content/features/service-tiers.mdx
@@ -43,8 +43,11 @@ The parameter works the same on the OpenAI-compatible **Responses API**
 (`/v1/responses`): the tier is forwarded to the provider and the response's
 `service_tier` field echoes the tier that was actually served.
 
-Coding (dev) plans are limited to `default`/`auto` and `flex` — the premium
-`priority` tier is not part of the plan and a request that asks for it returns a 403.
+<Callout type="info">
+	Service-tier selection is available for pay-as-you-go requests. DevPass uses
+	Standard processing and does not expose a service-tier selector in the
+	dashboard.
+</Callout>
 
 ## Supported providers
 
@@ -111,12 +114,9 @@ carried through all of it.
   tier. If no eligible candidate is left, you get the upstream error instead of
   a silently downgraded response.
 
-This applies to a tier you requested yourself. The optional coding-plan default
-tier is a cost preference rather than a requirement, so a request that cannot be
-served at that tier runs at standard instead of failing; `used_service_tier` in
-the response metadata always reports what was actually served. A tier sent on
-the request always takes precedence over that default, within the tiers the plan
-allows.
+This behavior applies to explicit service-tier requests made with pay-as-you-go
+credits. The `used_service_tier` response metadata always reports the tier that
+was actually served.
 
 <Callout type="info">
 	Rotating to another key for the same provider is a separate upstream account


### PR DESCRIPTION
## Summary

New DevPass users should no longer be offered Flex as a default service tier, while existing users retain the setting.

- expose the authenticated account creation timestamp to the dashboard
- hide the service-tier setting for accounts created on or after August 20, 2026
- preserve routing strategy and provider cache settings for every cohort
- document service-tier selection as pay-as-you-go and DevPass as Standard processing without a dashboard selector
- leave the DevPass settings API and Gateway behavior unchanged

## Verification

- `pnpm exec vitest run apps/code/src/lib/dev-plan-service-tier.spec.ts apps/api/src/routes/user.spec.ts --no-file-parallelism`
- `pnpm format`
- `pnpm build`
- verified grandfathered and new account states locally in light and dark themes

## Screenshots

### Grandfathered account — light

<img width="1280" alt="Grandfathered DevPass account retaining the service tier selector in light mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/686785766a618437b7983c19c6b55f773178e4ea/grandfathered-light.png" />

### New account — light

<img width="1280" alt="New DevPass account without the service tier selector in light mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/686785766a618437b7983c19c6b55f773178e4ea/new-light.png" />

### Grandfathered account — dark

<img width="1280" alt="Grandfathered DevPass account retaining the service tier selector in dark mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/686785766a618437b7983c19c6b55f773178e4ea/grandfathered-dark.png" />

### New account — dark

<img width="1280" alt="New DevPass account without the service tier selector in dark mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/686785766a618437b7983c19c6b55f773178e4ea/new-dark.png" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added eligibility-based access to service-tier configuration in Dev Plan settings.
  * Service-tier controls are shown only to eligible users based on account creation date.
  * User responses now include the account creation timestamp.

* **Documentation**
  * Clarified how service tiers apply to pay-as-you-go requests, DevPass processing, retries, fallbacks, and reported service tiers.

* **Tests**
  * Added coverage for eligibility cutoff behavior and timestamp validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->