### PR TITLE
fix(anthropic): correct cache breakpoint handling

### DIFF
--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -27,7 +27,7 @@ import { buildAnthropicErrorEvent } from "./streaming-error-translation.js";
 import { mapAnthropicThinkingToReasoning } from "./thinking-to-reasoning.js";
 
 import type { ServerTypes } from "@/vars.js";
-import type { AnthropicNativeBlock } from "@llmgateway/models";
+import type { AnthropicNativeBlock, CacheControl } from "@llmgateway/models";
 
 // Most of the request schema is built from unions (content blocks, tool
 // variants), and a union issue's own message is a useless "Invalid input" —
@@ -139,6 +139,15 @@ const anthropicMessageSchema = z.object({
 					tool_use_id: z.string(),
 					content: z.union([z.string(), z.array(z.unknown())]).optional(),
 					is_error: z.boolean().optional(),
+					// Anthropic allows a breakpoint here, and in an agentic loop the
+					// stable prefix usually ends on a tool result — dropping it would
+					// cost the caller the cache hit they explicitly asked for.
+					cache_control: z
+						.object({
+							type: z.enum(["ephemeral"]),
+							ttl: z.enum(["5m", "1h"]).optional(),
+						})
+						.optional(),
 				}),
 				// Extended-thinking blocks echoed back in conversation history. They
 				// carry no value for the internal OpenAI-format request, so they're
@@ -765,12 +774,24 @@ anthropic.openapi(messages, async (c) => {
 						: [],
 				);
 
+				// A breakpoint on the tool_result block has no home in the OpenAI
+				// message shape, so carry it alongside. Blocks sharing a tool_use_id
+				// collapse into one message, so the last marker wins — it is the one
+				// that ends the prefix.
+				const toolResultCacheControl = blocks.reduce<CacheControl | undefined>(
+					(marker, block) => block.cache_control ?? marker,
+					undefined,
+				);
+
 				openaiMessages.push({
 					role: "tool",
 					content: combinedContent,
 					tool_call_id: toolUseId,
 					...(referenceBlocks.length > 0 && {
 						anthropic_native_blocks: referenceBlocks,
+					}),
+					...(toolResultCacheControl && {
+						tool_result_cache_control: toolResultCacheControl,
 					}),
 				});
 			}

--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -941,6 +941,10 @@ anthropic.openapi(messages, async (c) => {
 						// Carried through to Anthropic upstreams and stripped
 						// elsewhere, where the tool is simply loaded eagerly.
 						...(tool.defer_loading === true && { defer_loading: true }),
+						// Same deal for the caller's cache breakpoint: tools are the
+						// base of Anthropic's cache hierarchy, so dropping it here cost
+						// the caller the largest cacheable prefix they have.
+						...(tool.cache_control && { cache_control: tool.cache_control }),
 					};
 				}
 

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -607,6 +607,104 @@ describe("api", () => {
 		}
 	});
 
+	test("/v1/messages keeps a caller's tool cache_control on the wire", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-test-key",
+			provider: "anthropic",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const originalFetch = globalThis.fetch;
+		let upstreamBody: any = null;
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockImplementation(async (input, init) => {
+				const url =
+					typeof input === "string"
+						? input
+						: input instanceof URL
+							? input.toString()
+							: input.url;
+
+				if (url.includes(`${mockServerUrl}/v1/messages`)) {
+					const body =
+						input instanceof Request ? await input.text() : String(init?.body);
+					upstreamBody = JSON.parse(body);
+
+					return new Response(
+						JSON.stringify({
+							id: "msg_tool_cache",
+							type: "message",
+							role: "assistant",
+							model: "claude-opus-4-8",
+							content: [{ type: "text", text: "Sunny." }],
+							stop_reason: "end_turn",
+							stop_sequence: null,
+							usage: { input_tokens: 100, output_tokens: 5 },
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				return await originalFetch(input as RequestInfo | URL, init);
+			});
+
+		try {
+			const res = await app.request("/v1/messages", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer real-token`,
+					"x-no-fallback": "true",
+				},
+				body: JSON.stringify({
+					model: "anthropic/claude-opus-4-8",
+					max_tokens: 1024,
+					messages: [{ role: "user", content: "Weather in Paris?" }],
+					tools: [
+						{
+							name: "get_weather",
+							description: "Get the weather",
+							input_schema: { type: "object" },
+						},
+						{
+							name: "get_time",
+							description: "Get the time",
+							input_schema: { type: "object" },
+							cache_control: { type: "ephemeral" },
+						},
+					],
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			expect(upstreamBody).toBeTruthy();
+
+			// Tools are the base of Anthropic's cache hierarchy, so a breakpoint on
+			// the last tool caches the largest prefix a caller has. The schema
+			// accepted it and the tool conversion then dropped it, silently costing
+			// an agentic client its biggest cache hit.
+			expect(upstreamBody.tools).toHaveLength(2);
+			expect(upstreamBody.tools[0].cache_control).toBeUndefined();
+			expect(upstreamBody.tools[1].name).toBe("get_time");
+			expect(upstreamBody.tools[1].cache_control).toEqual({
+				type: "ephemeral",
+			});
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
 	test("/v1/messages surfaces reasoning as a thinking block (non-streaming)", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id",

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -493,6 +493,120 @@ describe("api", () => {
 		}
 	});
 
+	test("/v1/messages keeps a caller's tool_result cache_control on the wire", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			token: "real-token",
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			token: "sk-test-key",
+			provider: "anthropic",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const originalFetch = globalThis.fetch;
+		let upstreamBody: any = null;
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockImplementation(async (input, init) => {
+				const url =
+					typeof input === "string"
+						? input
+						: input instanceof URL
+							? input.toString()
+							: input.url;
+
+				if (url.includes(`${mockServerUrl}/v1/messages`)) {
+					const body =
+						input instanceof Request ? await input.text() : String(init?.body);
+					upstreamBody = JSON.parse(body);
+
+					return new Response(
+						JSON.stringify({
+							id: "msg_tool_result_cache",
+							type: "message",
+							role: "assistant",
+							model: "claude-opus-4-8",
+							content: [{ type: "text", text: "A raincoat." }],
+							stop_reason: "end_turn",
+							stop_sequence: null,
+							usage: { input_tokens: 100, output_tokens: 5 },
+						}),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+
+				return await originalFetch(input as RequestInfo | URL, init);
+			});
+
+		try {
+			const res = await app.request("/v1/messages", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer real-token`,
+					"x-no-fallback": "true",
+				},
+				body: JSON.stringify({
+					model: "anthropic/claude-opus-4-8",
+					max_tokens: 1024,
+					messages: [
+						{ role: "user", content: "Look up the weather." },
+						{
+							role: "assistant",
+							content: [
+								{
+									type: "tool_use",
+									id: "toolu_1",
+									name: "get_weather",
+									input: { city: "Paris" },
+								},
+							],
+						},
+						{
+							role: "user",
+							content: [
+								{
+									type: "tool_result",
+									tool_use_id: "toolu_1",
+									content: "sunny",
+									cache_control: { type: "ephemeral", ttl: "1h" },
+								},
+							],
+						},
+					],
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			expect(upstreamBody).toBeTruthy();
+
+			// Anthropic accepts a breakpoint on a tool_result block, and in an
+			// agentic loop that is exactly where the stable prefix ends. The request
+			// schema used to strip the marker and the OpenAI tool message it lowers
+			// to had nowhere to keep it, so the caller silently lost the cache hit
+			// they asked for.
+			const toolResultBlocks = upstreamBody.messages.flatMap((m: any) =>
+				Array.isArray(m.content)
+					? m.content.filter((b: any) => b.type === "tool_result")
+					: [],
+			);
+			expect(toolResultBlocks).toHaveLength(1);
+			expect(toolResultBlocks[0].cache_control).toEqual({
+				type: "ephemeral",
+				ttl: "1h",
+			});
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
+
 	test("/v1/messages surfaces reasoning as a thinking block (non-streaming)", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id",

--- a/apps/gateway/src/chat/schemas/completions.ts
+++ b/apps/gateway/src/chat/schemas/completions.ts
@@ -169,6 +169,16 @@ export const completionsRequestSchema = z.object({
 					description:
 						"Anthropic content blocks with no OpenAI-format equivalent. On an assistant message these are the server-side tool search blocks (`server_tool_use` + `tool_search_tool_result`), replayed ahead of the message's tool calls; on a tool message they are the `tool_result` content array, which is how a client-side tool search returns `tool_reference` blocks. Replayed on the Anthropic Messages API only and stripped for every other provider.",
 				}),
+			tool_result_cache_control: z
+				.object({
+					type: z.enum(["ephemeral"]),
+					ttl: z.enum(["5m", "1h"]).optional(),
+				})
+				.optional()
+				.openapi({
+					description:
+						"Prompt-cache breakpoint for the Anthropic `tool_result` block this tool message becomes. The OpenAI tool message shape has nowhere to carry it, so it rides here. Applied on the Anthropic Messages API only and stripped for every other provider.",
+				}),
 		}),
 	),
 	temperature: z

--- a/apps/gateway/src/chat/schemas/completions.ts
+++ b/apps/gateway/src/chat/schemas/completions.ts
@@ -310,6 +310,16 @@ export const completionsRequestSchema = z.object({
 						description:
 							"Anthropic only. Keeps the tool out of the rendered tools section so it never enters the cached prompt prefix, and loads it on demand once the tool search tool discovers it. Requires a `tool_search` tool in `tools`, and Anthropic rejects a request whose tools are all deferred. Stripped for every other provider, which receives the tool eagerly instead.",
 					}),
+					cache_control: z
+						.object({
+							type: z.enum(["ephemeral"]),
+							ttl: z.enum(["5m", "1h"]).optional(),
+						})
+						.optional()
+						.openapi({
+							description:
+								"Anthropic only. Cache breakpoint ending the tool-definitions prefix, which Anthropic renders before the system prompt and messages. Placed on the last tool it caches every tool up to and including that one, and counts toward Anthropic's limit of 4 breakpoints per request. Stripped for every other provider.",
+						}),
 				}),
 				z.object({
 					type: z.literal("tool_search"),

--- a/packages/actions/src/anthropic-tool-search.ts
+++ b/packages/actions/src/anthropic-tool-search.ts
@@ -74,8 +74,8 @@ export function toAnthropicToolSearchTool(
 
 /**
  * Removes the Anthropic-only tool extensions for upstreams that would reject
- * them (`defer_loading` is an unknown property, and the tool search tool has no
- * counterpart at all).
+ * them (`defer_loading` and `cache_control` are unknown properties, and the
+ * tool search tool has no counterpart at all).
  */
 export function stripAnthropicToolExtensions(
 	tools: OpenAIToolInput[] | undefined,
@@ -86,10 +86,17 @@ export function stripAnthropicToolExtensions(
 	return tools
 		.filter((tool) => !isToolSearchTool(tool))
 		.map((tool) => {
-			if (tool.type !== "function" || tool.defer_loading === undefined) {
+			if (
+				tool.type !== "function" ||
+				(tool.defer_loading === undefined && tool.cache_control === undefined)
+			) {
 				return tool;
 			}
-			const { defer_loading: _deferLoading, ...rest } = tool;
+			const {
+				defer_loading: _deferLoading,
+				cache_control: _cacheControl,
+				...rest
+			} = tool;
 			return rest;
 		});
 }

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -743,6 +743,159 @@ describe("prepareRequestBody - Anthropic", () => {
 		expect(toolMarkers + systemMarkers + messageMarkers).toBe(4);
 	});
 
+	test.each([
+		{
+			name: "a later 1h system marker",
+			messages: [
+				{
+					role: "system" as const,
+					content: [
+						{
+							type: "text" as const,
+							text: "A".repeat(5000),
+							cache_control: { type: "ephemeral" as const, ttl: "1h" as const },
+						},
+					],
+				},
+				{ role: "user" as const, content: "Hello!" },
+			],
+		},
+		{
+			name: "a later 1h message marker",
+			messages: [
+				{
+					role: "user" as const,
+					content: [
+						{
+							type: "text" as const,
+							text: "A".repeat(5000),
+							cache_control: { type: "ephemeral" as const, ttl: "1h" as const },
+						},
+					],
+				},
+			],
+		},
+	])(
+		"drops a 5m tool breakpoint that would precede $name",
+		async ({ messages }) => {
+			// Anthropic renders tools first, so a 5m tool marker would sit ahead of
+			// the caller's 1h marker and the whole request is rejected. Keep the 1h
+			// breakpoint and drop the 5m one rather than 400.
+			const requestBody = (await prepareRequestBody(
+				"anthropic",
+				"claude-3-5-sonnet-20241022",
+				null,
+				"claude-3-5-sonnet-20241022",
+				messages,
+				false, // stream
+				undefined, // temperature
+				1024, // max_tokens
+				undefined, // top_p
+				undefined, // frequency_penalty
+				undefined, // presence_penalty
+				undefined, // response_format
+				[
+					{
+						type: "function",
+						function: { name: "get_weather", parameters: { type: "object" } },
+						cache_control: { type: "ephemeral" },
+					},
+				], // tools
+			)) as AnthropicRequestBody;
+
+			for (const tool of requestBody.tools ?? []) {
+				expect(getCacheControl(tool)).toBeUndefined();
+			}
+
+			// The caller's 1h marker is untouched, and nothing 5m precedes it.
+			const oneHourMarkers = [
+				...(Array.isArray(requestBody.system) ? requestBody.system : []),
+				...requestBody.messages.flatMap((msg) =>
+					Array.isArray(msg.content) ? msg.content : [],
+				),
+			].filter(
+				(block) =>
+					(getCacheControl(block) as { ttl?: string } | undefined)?.ttl ===
+					"1h",
+			);
+			expect(oneHourMarkers).toHaveLength(1);
+		},
+	);
+
+	test("drops a 5m tool breakpoint that precedes a 1h tool breakpoint", async () => {
+		const requestBody = (await prepareRequestBody(
+			"anthropic",
+			"claude-3-5-sonnet-20241022",
+			null,
+			"claude-3-5-sonnet-20241022",
+			[{ role: "user", content: "Hello!" }],
+			false, // stream
+			undefined, // temperature
+			1024, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			[
+				{
+					type: "function",
+					function: { name: "get_weather", parameters: { type: "object" } },
+					cache_control: { type: "ephemeral" },
+				},
+				{
+					type: "function",
+					function: { name: "get_time", parameters: { type: "object" } },
+					cache_control: { type: "ephemeral", ttl: "1h" },
+				},
+			], // tools
+		)) as AnthropicRequestBody;
+
+		// Within the tools array the same ordering rule applies.
+		expect(getCacheControl(requestBody.tools![0])).toBeUndefined();
+		expect(getCacheControl(requestBody.tools![1])).toEqual({
+			type: "ephemeral",
+			ttl: "1h",
+		});
+	});
+
+	test("keeps a 1h tool breakpoint ahead of auto-injected 5m markers", async () => {
+		// The safe direction: the gateway only ever injects ttl-less (5m) markers,
+		// and they land after the tools, so a 1h tool marker stays valid.
+		const longContent = "A".repeat(5000);
+		const requestBody = (await prepareRequestBody(
+			"anthropic",
+			"claude-3-5-sonnet-20241022",
+			null,
+			"claude-3-5-sonnet-20241022",
+			[
+				{ role: "system", content: longContent },
+				{ role: "user", content: longContent },
+			],
+			false, // stream
+			undefined, // temperature
+			1024, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			[
+				{
+					type: "function",
+					function: { name: "get_weather", parameters: { type: "object" } },
+					cache_control: { type: "ephemeral", ttl: "1h" },
+				},
+			], // tools
+		)) as AnthropicRequestBody;
+
+		expect(getCacheControl(requestBody.tools![0])).toEqual({
+			type: "ephemeral",
+			ttl: "1h",
+		});
+		expect(getCacheControl((requestBody.system as unknown[])[0])).toEqual({
+			type: "ephemeral",
+		});
+	});
+
 	test("drops a tool breakpoint for a non-Anthropic provider", async () => {
 		const requestBody = (await prepareRequestBody(
 			"openai",

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import { models } from "@llmgateway/models";
 
@@ -393,6 +393,318 @@ describe("prepareRequestBody - Anthropic", () => {
 		// Both trailing user turns get a marker; without the fix the four tool
 		// results exhaust the budget and this is 0.
 		expect(totalCacheControlBlocks).toBe(2);
+	});
+
+	test("keeps a caller breakpoint on the tool_result block it was set on", async () => {
+		const requestBody = (await prepareRequestBody(
+			"anthropic",
+			"claude-3-5-sonnet-20241022",
+			null,
+			"claude-3-5-sonnet-20241022",
+			[
+				{ role: "user", content: "Look up the weather." },
+				{
+					role: "assistant",
+					content: "",
+					tool_calls: [
+						{
+							id: "call_1",
+							type: "function",
+							function: { name: "get_weather", arguments: "{}" },
+						},
+					],
+				},
+				{
+					role: "tool",
+					tool_call_id: "call_1",
+					content: "sunny",
+					tool_result_cache_control: { type: "ephemeral" },
+				},
+				{ role: "user", content: "What should I wear?" },
+			],
+			false, // stream
+			undefined, // temperature
+			1024, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+		)) as AnthropicRequestBody;
+
+		const marked = requestBody.messages.flatMap((msg) =>
+			Array.isArray(msg.content)
+				? msg.content.filter((block) => getCacheControl(block))
+				: [],
+		);
+
+		// Exactly one marker, on the tool_result block the caller chose — the
+		// turn boundary lands on that same message and leaves it alone.
+		expect(marked).toHaveLength(1);
+		expect((marked[0] as { type: string }).type).toBe("tool_result");
+		expect(getCacheControl(marked[0])).toEqual({ type: "ephemeral" });
+	});
+
+	test("suppresses auto-injection when a tool_result carries a 1h ttl", async () => {
+		// Anthropic processes tools, then system, then messages, and rejects a
+		// ttl:"1h" breakpoint that comes after a ttl:"5m" one. The gateway's
+		// heuristics only ever emit ttl-less (5m) markers, so a caller 1h marker
+		// anywhere in the messages has to disable them — including when it sits on
+		// a tool_result rather than a text block.
+		const longContent = "A".repeat(5000);
+		const requestBody = (await prepareRequestBody(
+			"anthropic",
+			"claude-3-5-sonnet-20241022",
+			null,
+			"claude-3-5-sonnet-20241022",
+			[
+				{ role: "system", content: longContent },
+				{ role: "user", content: longContent },
+				{
+					role: "assistant",
+					content: "",
+					tool_calls: [
+						{
+							id: "call_1",
+							type: "function",
+							function: { name: "get_weather", arguments: "{}" },
+						},
+					],
+				},
+				{
+					role: "tool",
+					tool_call_id: "call_1",
+					content: "sunny",
+					tool_result_cache_control: { type: "ephemeral", ttl: "1h" },
+				},
+				{ role: "user", content: "What should I wear?" },
+			],
+			false, // stream
+			undefined, // temperature
+			1024, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+		)) as AnthropicRequestBody;
+
+		// The long system prompt and the long user turn would both attract a 5m
+		// marker, and either would land before the caller's 1h one — a 400.
+		if (requestBody.system && Array.isArray(requestBody.system)) {
+			for (const block of requestBody.system) {
+				expect(getCacheControl(block)).toBeUndefined();
+			}
+		}
+		const marked = requestBody.messages.flatMap((msg) =>
+			Array.isArray(msg.content)
+				? msg.content.filter((block) => getCacheControl(block))
+				: [],
+		);
+		expect(marked).toHaveLength(1);
+		expect((marked[0] as { type: string }).type).toBe("tool_result");
+		expect(getCacheControl(marked[0])).toEqual({
+			type: "ephemeral",
+			ttl: "1h",
+		});
+	});
+
+	test("places the turn-boundary marker on a bare tool_result message", async () => {
+		// A native-format turn that mixes a tool result with new text arrives as
+		// two messages, so the boundary message holds only a tool_result block.
+		// Anthropic accepts a breakpoint there; skipping it caches nothing.
+		const requestBody = (await prepareRequestBody(
+			"anthropic",
+			"claude-3-5-sonnet-20241022",
+			null,
+			"claude-3-5-sonnet-20241022",
+			[
+				{ role: "user", content: "Look up the weather." },
+				{
+					role: "assistant",
+					content: "",
+					tool_calls: [
+						{
+							id: "call_1",
+							type: "function",
+							function: { name: "get_weather", arguments: "{}" },
+						},
+					],
+				},
+				{ role: "tool", tool_call_id: "call_1", content: "sunny" },
+				{ role: "user", content: "What should I wear?" },
+			],
+			false, // stream
+			undefined, // temperature
+			1024, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+		)) as AnthropicRequestBody;
+
+		const boundaryMsg = requestBody.messages[2]!;
+		const boundaryBlock = (boundaryMsg.content as unknown[])[0] as {
+			type: string;
+		};
+		expect(boundaryBlock.type).toBe("tool_result");
+		expect(getCacheControl(boundaryBlock)).toEqual({ type: "ephemeral" });
+	});
+
+	test("drops a tool_result breakpoint for a non-Anthropic provider", async () => {
+		const requestBody = (await prepareRequestBody(
+			"openai",
+			"gpt-4o-mini",
+			null,
+			"gpt-4o-mini",
+			[
+				{ role: "user", content: "Look up the weather." },
+				{
+					role: "assistant",
+					content: "",
+					tool_calls: [
+						{
+							id: "call_1",
+							type: "function",
+							function: { name: "get_weather", arguments: "{}" },
+						},
+					],
+				},
+				{
+					role: "tool",
+					tool_call_id: "call_1",
+					content: "sunny",
+					tool_result_cache_control: { type: "ephemeral" },
+				},
+			],
+			false, // stream
+			undefined, // temperature
+			1024, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+		)) as OpenAIRequestBody;
+
+		// OpenAI rejects unknown message fields, so the carrier must not survive.
+		for (const msg of requestBody.messages) {
+			expect(msg).not.toHaveProperty("tool_result_cache_control");
+		}
+	});
+
+	test("drops a tool_result breakpoint when provider cache writes are disabled", async () => {
+		const requestBody = (await prepareRequestBody(
+			"anthropic",
+			"claude-3-5-sonnet-20241022",
+			null,
+			"claude-3-5-sonnet-20241022",
+			[
+				{ role: "user", content: "Look up the weather." },
+				{
+					role: "assistant",
+					content: "",
+					tool_calls: [
+						{
+							id: "call_1",
+							type: "function",
+							function: { name: "get_weather", arguments: "{}" },
+						},
+					],
+				},
+				{
+					role: "tool",
+					tool_call_id: "call_1",
+					content: "sunny",
+					tool_result_cache_control: { type: "ephemeral" },
+				},
+				{ role: "user", content: "What should I wear?" },
+			],
+			false, // stream
+			undefined, // temperature
+			1024, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			undefined, // tools
+			undefined, // tool_choice
+			undefined, // reasoning_effort
+			undefined, // supportsReasoning
+			false, // isProd
+			20, // maxImageSizeMB
+			null, // userPlan
+			undefined, // sensitive_word_check
+			undefined, // image_config
+			undefined, // effort
+			undefined, // imageGenerations
+			undefined, // webSearchTool
+			undefined, // reasoning_max_tokens
+			undefined, // useResponsesApi
+			undefined, // prompt_cache_key
+			undefined, // prompt_cache_retention
+			false, // providerCacheControlEnabled
+		)) as AnthropicRequestBody;
+
+		for (const msg of requestBody.messages) {
+			expect(msg).not.toHaveProperty("tool_result_cache_control");
+			if (Array.isArray(msg.content)) {
+				for (const block of msg.content) {
+					expect(getCacheControl(block)).toBeUndefined();
+				}
+			}
+		}
+	});
+
+	test("does not fetch images inside a tool message's discarded content", async () => {
+		// The array content of a tool message is rebuilt into a tool_result block,
+		// so fetching its images buys nothing — and a size rejection would fail a
+		// request over bytes that never reach the provider.
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+		try {
+			const requestBody = (await prepareRequestBody(
+				"anthropic",
+				"claude-3-5-sonnet-20241022",
+				null,
+				"claude-3-5-sonnet-20241022",
+				[
+					{ role: "user", content: "Screenshot the page." },
+					{
+						role: "assistant",
+						content: "",
+						tool_calls: [
+							{
+								id: "call_1",
+								type: "function",
+								function: { name: "screenshot", arguments: "{}" },
+							},
+						],
+					},
+					{
+						role: "tool",
+						tool_call_id: "call_1",
+						content: [
+							{
+								type: "image_url",
+								image_url: { url: "https://example.com/huge.png" },
+							},
+						],
+					},
+				],
+				false, // stream
+				undefined, // temperature
+				1024, // max_tokens
+				undefined, // top_p
+				undefined, // frequency_penalty
+				undefined, // presence_penalty
+				undefined, // response_format
+			)) as AnthropicRequestBody;
+
+			expect(fetchSpy).not.toHaveBeenCalled();
+			const toolMsg = requestBody.messages[2]!;
+			expect(((toolMsg.content as unknown[])[0] as { type: string }).type).toBe(
+				"tool_result",
+			);
+		} finally {
+			fetchSpy.mockRestore();
+		}
 	});
 
 	test.each(["claude-fable-5", "claude-opus-5"])(

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -896,6 +896,56 @@ describe("prepareRequestBody - Anthropic", () => {
 		});
 	});
 
+	test("trims caller message markers against a retained tool marker", async () => {
+		// The tool marker seeds the budget at 1, so only 3 of the caller's 4
+		// message markers fit. Forwarding all of them ships 5 breakpoints and
+		// Anthropic rejects the request outright.
+		const marked = (text: string) => ({
+			role: "user" as const,
+			content: [
+				{
+					type: "text" as const,
+					text,
+					cache_control: { type: "ephemeral" as const },
+				},
+			],
+		});
+		const requestBody = (await prepareRequestBody(
+			"anthropic",
+			"claude-3-5-sonnet-20241022",
+			null,
+			"claude-3-5-sonnet-20241022",
+			[marked("one"), marked("two"), marked("three"), marked("four")],
+			false, // stream
+			undefined, // temperature
+			1024, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			[
+				{
+					type: "function",
+					function: { name: "get_weather", parameters: { type: "object" } },
+					cache_control: { type: "ephemeral" },
+				},
+			], // tools
+		)) as AnthropicRequestBody;
+
+		const toolMarkers = (requestBody.tools ?? []).filter((tool) =>
+			getCacheControl(tool),
+		).length;
+		const messageMarkers = requestBody.messages.flatMap((msg) =>
+			Array.isArray(msg.content)
+				? msg.content.filter((block) => getCacheControl(block))
+				: [],
+		).length;
+
+		expect(toolMarkers).toBe(1);
+		expect(messageMarkers).toBe(3);
+		expect(toolMarkers + messageMarkers).toBe(4);
+	});
+
 	test("drops a tool breakpoint for a non-Anthropic provider", async () => {
 		const requestBody = (await prepareRequestBody(
 			"openai",
@@ -973,7 +1023,11 @@ describe("prepareRequestBody - Anthropic", () => {
 		// The array content of a tool message is rebuilt into a tool_result block,
 		// so fetching its images buys nothing — and a size rejection would fail a
 		// request over bytes that never reach the provider.
-		const fetchSpy = vi.spyOn(globalThis, "fetch");
+		// The spy rejects rather than calling through, so a regression fails the
+		// assertion below instead of reaching the network.
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockRejectedValue(new Error("network access is not allowed here"));
 		try {
 			const requestBody = (await prepareRequestBody(
 				"anthropic",

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -653,6 +653,169 @@ describe("prepareRequestBody - Anthropic", () => {
 		}
 	});
 
+	test("forwards a caller breakpoint on the last tool definition", async () => {
+		const requestBody = (await prepareRequestBody(
+			"anthropic",
+			"claude-3-5-sonnet-20241022",
+			null,
+			"claude-3-5-sonnet-20241022",
+			[{ role: "user", content: "Hello!" }],
+			false, // stream
+			undefined, // temperature
+			1024, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			[
+				{
+					type: "function",
+					function: { name: "get_weather", parameters: { type: "object" } },
+				},
+				{
+					type: "function",
+					function: { name: "get_time", parameters: { type: "object" } },
+					cache_control: { type: "ephemeral", ttl: "1h" },
+				},
+			], // tools
+		)) as AnthropicRequestBody;
+
+		expect(requestBody.tools).toHaveLength(2);
+		expect(getCacheControl(requestBody.tools![0])).toBeUndefined();
+		expect(getCacheControl(requestBody.tools![1])).toEqual({
+			type: "ephemeral",
+			ttl: "1h",
+		});
+	});
+
+	test("counts a tool breakpoint before system and messages", async () => {
+		// Anthropic renders tools first, so the tool marker has to consume the
+		// first of the 4 slots — otherwise the system pass below spends all four
+		// and the request ships 5 breakpoints, which Anthropic rejects.
+		const longContent = "A".repeat(5000);
+		const requestBody = (await prepareRequestBody(
+			"anthropic",
+			"claude-3-5-sonnet-20241022",
+			null,
+			"claude-3-5-sonnet-20241022",
+			[
+				{ role: "system", content: longContent },
+				{ role: "system", content: longContent },
+				{ role: "system", content: longContent },
+				{ role: "system", content: longContent },
+				{ role: "user", content: longContent },
+				{ role: "assistant", content: "Hi!" },
+				{ role: "user", content: longContent },
+			],
+			false, // stream
+			undefined, // temperature
+			1024, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			[
+				{
+					type: "function",
+					function: { name: "get_weather", parameters: { type: "object" } },
+					cache_control: { type: "ephemeral" },
+				},
+			], // tools
+		)) as AnthropicRequestBody;
+
+		const toolMarkers = (requestBody.tools ?? []).filter((tool) =>
+			getCacheControl(tool),
+		).length;
+		const systemMarkers = Array.isArray(requestBody.system)
+			? requestBody.system.filter((block) => getCacheControl(block)).length
+			: 0;
+		const messageMarkers = requestBody.messages.flatMap((msg) =>
+			Array.isArray(msg.content)
+				? msg.content.filter((block) => getCacheControl(block))
+				: [],
+		).length;
+
+		expect(toolMarkers).toBe(1);
+		// The remaining 3 slots go to the system prompts; nothing is left for the
+		// messages or the turn boundary.
+		expect(systemMarkers).toBe(3);
+		expect(messageMarkers).toBe(0);
+		expect(toolMarkers + systemMarkers + messageMarkers).toBe(4);
+	});
+
+	test("drops a tool breakpoint for a non-Anthropic provider", async () => {
+		const requestBody = (await prepareRequestBody(
+			"openai",
+			"gpt-4o-mini",
+			null,
+			"gpt-4o-mini",
+			[{ role: "user", content: "Hello!" }],
+			false, // stream
+			undefined, // temperature
+			1024, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			[
+				{
+					type: "function",
+					function: { name: "get_weather", parameters: { type: "object" } },
+					cache_control: { type: "ephemeral" },
+				},
+			], // tools
+		)) as OpenAIRequestBody;
+
+		// OpenAI rejects unknown properties on a tool definition.
+		for (const tool of requestBody.tools ?? []) {
+			expect(tool).not.toHaveProperty("cache_control");
+		}
+	});
+
+	test("drops a tool breakpoint when provider cache writes are disabled", async () => {
+		const requestBody = (await prepareRequestBody(
+			"anthropic",
+			"claude-3-5-sonnet-20241022",
+			null,
+			"claude-3-5-sonnet-20241022",
+			[{ role: "user", content: "Hello!" }],
+			false, // stream
+			undefined, // temperature
+			1024, // max_tokens
+			undefined, // top_p
+			undefined, // frequency_penalty
+			undefined, // presence_penalty
+			undefined, // response_format
+			[
+				{
+					type: "function",
+					function: { name: "get_weather", parameters: { type: "object" } },
+					cache_control: { type: "ephemeral" },
+				},
+			], // tools
+			undefined, // tool_choice
+			undefined, // reasoning_effort
+			undefined, // supportsReasoning
+			false, // isProd
+			20, // maxImageSizeMB
+			null, // userPlan
+			undefined, // sensitive_word_check
+			undefined, // image_config
+			undefined, // effort
+			undefined, // imageGenerations
+			undefined, // webSearchTool
+			undefined, // reasoning_max_tokens
+			undefined, // useResponsesApi
+			undefined, // prompt_cache_key
+			undefined, // prompt_cache_retention
+			false, // providerCacheControlEnabled
+		)) as AnthropicRequestBody;
+
+		for (const tool of requestBody.tools ?? []) {
+			expect(getCacheControl(tool)).toBeUndefined();
+		}
+	});
+
 	test("does not fetch images inside a tool message's discarded content", async () => {
 		// The array content of a tool message is rebuilt into a tool_result block,
 		// so fetching its images buys nothing — and a size rejection would fail a

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -320,6 +320,81 @@ describe("prepareRequestBody - Anthropic", () => {
 		expect(totalCacheControlBlocks).toBe(4);
 	});
 
+	test("does not spend cache_control budget on tool-result messages", async () => {
+		// A tool-result message's text content is rebuilt into a tool_result
+		// block (which carries no cache_control), so the long tool outputs below
+		// must not consume any of the 4 cache_control slots — the real cacheable
+		// user turns after them should still receive markers.
+		const longContent = "A".repeat(5000);
+		const requestBody = (await prepareRequestBody(
+			"anthropic",
+			"claude-3-5-sonnet-20241022",
+			null,
+			"claude-3-5-sonnet-20241022",
+			[
+				{
+					role: "assistant",
+					content: "",
+					tool_calls: [
+						{
+							id: "call_1",
+							type: "function",
+							function: { name: "search", arguments: "{}" },
+						},
+						{
+							id: "call_2",
+							type: "function",
+							function: { name: "search", arguments: "{}" },
+						},
+						{
+							id: "call_3",
+							type: "function",
+							function: { name: "search", arguments: "{}" },
+						},
+						{
+							id: "call_4",
+							type: "function",
+							function: { name: "search", arguments: "{}" },
+						},
+					],
+				},
+				{ role: "tool", tool_call_id: "call_1", content: longContent },
+				{ role: "tool", tool_call_id: "call_2", content: longContent },
+				{ role: "tool", tool_call_id: "call_3", content: longContent },
+				{ role: "tool", tool_call_id: "call_4", content: longContent },
+				{ role: "user", content: longContent },
+				{ role: "user", content: longContent },
+			],
+			false,
+			undefined,
+			1024,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			false,
+			false,
+		)) as AnthropicRequestBody;
+
+		let totalCacheControlBlocks = 0;
+		for (const msg of requestBody.messages) {
+			if (Array.isArray(msg.content)) {
+				for (const block of msg.content) {
+					if (getCacheControl(block)) {
+						totalCacheControlBlocks++;
+					}
+				}
+			}
+		}
+
+		// Both trailing user turns get a marker; without the fix the four tool
+		// results exhaust the budget and this is 0.
+		expect(totalCacheControlBlocks).toBe(2);
+	});
+
 	test.each(["claude-fable-5", "claude-opus-5"])(
 		"strips cache_control for %s when provider cache writes are disabled",
 		async (model) => {

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -2943,8 +2943,24 @@ export async function prepareRequestBody(
 
 			// Build the system field with cache_control for long prompts
 			// Track cache_control usage across system and user messages (max 4 total per Anthropic's limit)
-			let systemCacheControlCount = 0;
 			const maxCacheControlBlocks = 4;
+
+			// Anthropic renders `tools` before `system` and `messages`, so a caller
+			// breakpoint on the last tool caches the largest prefix available — and
+			// it is the one an agentic client (Claude Code) reliably sets. Those
+			// markers are forwarded with the tools below, so seed the budget with
+			// them here: counting them after the fact would let the system and
+			// message passes spend slots the tools already took, and Anthropic
+			// rejects the fifth breakpoint outright.
+			const toolCacheControlCount = providerCacheControlEnabled
+				? Math.min(
+						(tools ?? []).filter(
+							(tool) => isFunctionTool(tool) && !!tool.cache_control,
+						).length,
+						maxCacheControlBlocks,
+					)
+				: 0;
+			let systemCacheControlCount = toolCacheControlCount;
 
 			// Get the minCacheableTokens from the model definition (default to 1024 if not specified)
 			const providerMapping = modelDef?.providers.find(
@@ -3075,15 +3091,30 @@ export async function prepareRequestBody(
 				// Filter to only function tools (web_search is handled separately)
 				const functionTools = tools.filter(isFunctionTool);
 				if (functionTools.length > 0) {
-					requestBody.tools = functionTools.map((tool) => ({
-						name: tool.function.name,
-						description: tool.function.description,
-						input_schema: tool.function.parameters,
-						// Anthropic strips deferred tools from the rendered tools
-						// section before the cache key is computed, so forwarding this
-						// is what keeps a large tool catalogue out of the cached prefix.
-						...(tool.defer_loading === true && { defer_loading: true }),
-					}));
+					// Forward at most the slots seeded into the budget above, so a
+					// caller that over-marks its tools loses the extras here instead of
+					// having the whole request rejected — the same way an over-budget
+					// system marker is dropped below.
+					let toolMarkersForwarded = 0;
+					requestBody.tools = functionTools.map((tool) => {
+						const keepCacheControl =
+							providerCacheControlEnabled &&
+							!!tool.cache_control &&
+							toolMarkersForwarded < maxCacheControlBlocks;
+						if (keepCacheControl) {
+							toolMarkersForwarded++;
+						}
+						return {
+							name: tool.function.name,
+							description: tool.function.description,
+							input_schema: tool.function.parameters,
+							// Anthropic strips deferred tools from the rendered tools
+							// section before the cache key is computed, so forwarding this
+							// is what keeps a large tool catalogue out of the cached prefix.
+							...(tool.defer_loading === true && { defer_loading: true }),
+							...(keepCacheControl && { cache_control: tool.cache_control }),
+						};
+					});
 				}
 				// The tool search tool has to come first: Anthropic rejects a request
 				// whose tools are all deferred, and it is the one tool that never is.

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -2947,20 +2947,57 @@ export async function prepareRequestBody(
 
 			// Anthropic renders `tools` before `system` and `messages`, so a caller
 			// breakpoint on the last tool caches the largest prefix available — and
-			// it is the one an agentic client (Claude Code) reliably sets. Those
-			// markers are forwarded with the tools below, so seed the budget with
-			// them here: counting them after the fact would let the system and
-			// message passes spend slots the tools already took, and Anthropic
-			// rejects the fifth breakpoint outright.
-			const toolCacheControlCount = providerCacheControlEnabled
-				? Math.min(
-						(tools ?? []).filter(
-							(tool) => isFunctionTool(tool) && !!tool.cache_control,
-						).length,
-						maxCacheControlBlocks,
-					)
-				: 0;
-			let systemCacheControlCount = toolCacheControlCount;
+			// it is the one an agentic client (Claude Code) reliably sets.
+			const anthropicFunctionTools = (tools ?? []).filter(isFunctionTool);
+
+			// Being first also makes a 5m tool marker the one thing that can strand
+			// a caller's later 1h marker on the wrong side of Anthropic's ordering
+			// rule ("a 1-hour cache entry must appear before any 5-minute cache
+			// entries"). Auto-injected markers are always ttl-less/5m and land after
+			// the tools, so they are safe; a caller mixing TTLs is not. Drop the 5m
+			// tool marker in that case rather than emit a request Anthropic rejects
+			// — the 1h breakpoint the caller paid the 2x write premium for is the
+			// one worth keeping.
+			const callerUses1hTtlAfterTools =
+				callerUses1hTtlInMessages ||
+				systemMessages.some(
+					(sysMsg) =>
+						Array.isArray(sysMsg.content) &&
+						sysMsg.content.some(
+							(part) => isTextContent(part) && part.cache_control?.ttl === "1h",
+						),
+				);
+			let lastOneHourToolIndex = -1;
+			anthropicFunctionTools.forEach((tool, index) => {
+				if (tool.cache_control?.ttl === "1h") {
+					lastOneHourToolIndex = index;
+				}
+			});
+
+			// Decide here which tool markers actually ship, so the budget seeded
+			// below matches them exactly. Counting them after the fact would let the
+			// system and message passes spend slots the tools already took, and
+			// Anthropic rejects the fifth breakpoint outright.
+			let toolMarkersKeptSoFar = 0;
+			const toolCacheControlKept = anthropicFunctionTools.map((tool, index) => {
+				const marker = tool.cache_control;
+				if (
+					!providerCacheControlEnabled ||
+					!marker ||
+					toolMarkersKeptSoFar >= maxCacheControlBlocks
+				) {
+					return false;
+				}
+				const orderingSafe =
+					marker.ttl === "1h" ||
+					(!callerUses1hTtlAfterTools && index > lastOneHourToolIndex);
+				if (!orderingSafe) {
+					return false;
+				}
+				toolMarkersKeptSoFar++;
+				return true;
+			});
+			let systemCacheControlCount = toolMarkersKeptSoFar;
 
 			// Get the minCacheableTokens from the model definition (default to 1024 if not specified)
 			const providerMapping = modelDef?.providers.find(
@@ -3089,32 +3126,22 @@ export async function prepareRequestBody(
 			// Transform tools from OpenAI format to Anthropic format
 			if (tools && tools.length > 0) {
 				// Filter to only function tools (web_search is handled separately)
-				const functionTools = tools.filter(isFunctionTool);
+				const functionTools = anthropicFunctionTools;
 				if (functionTools.length > 0) {
-					// Forward at most the slots seeded into the budget above, so a
-					// caller that over-marks its tools loses the extras here instead of
-					// having the whole request rejected — the same way an over-budget
-					// system marker is dropped below.
-					let toolMarkersForwarded = 0;
-					requestBody.tools = functionTools.map((tool) => {
-						const keepCacheControl =
-							providerCacheControlEnabled &&
-							!!tool.cache_control &&
-							toolMarkersForwarded < maxCacheControlBlocks;
-						if (keepCacheControl) {
-							toolMarkersForwarded++;
-						}
-						return {
-							name: tool.function.name,
-							description: tool.function.description,
-							input_schema: tool.function.parameters,
-							// Anthropic strips deferred tools from the rendered tools
-							// section before the cache key is computed, so forwarding this
-							// is what keeps a large tool catalogue out of the cached prefix.
-							...(tool.defer_loading === true && { defer_loading: true }),
-							...(keepCacheControl && { cache_control: tool.cache_control }),
-						};
-					});
+					requestBody.tools = functionTools.map((tool, index) => ({
+						name: tool.function.name,
+						description: tool.function.description,
+						input_schema: tool.function.parameters,
+						// Anthropic strips deferred tools from the rendered tools
+						// section before the cache key is computed, so forwarding this
+						// is what keeps a large tool catalogue out of the cached prefix.
+						...(tool.defer_loading === true && { defer_loading: true }),
+						// Budget and TTL ordering were both settled above, where the
+						// system pass needed the resulting count.
+						...(toolCacheControlKept[index] && {
+							cache_control: tool.cache_control,
+						}),
+					}));
 				}
 				// The tool search tool has to come first: Anthropic rejects a request
 				// whose tools are all deferred, and it is the one tool that never is.

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -1778,6 +1778,21 @@ export async function prepareRequestBody(
 		processedMessages = transformMessagesForNoSystemRole(processedMessages);
 	}
 
+	// A tool message's `tool_result_cache_control` only has a destination on the
+	// Anthropic Messages API, where it becomes a marker on the tool_result block
+	// the message is lowered to. Anywhere else it would reach the upstream as an
+	// unknown message field, and a project that opted out of provider cache
+	// writes must not emit it at all.
+	if (!anthropicMessagesApi || !providerCacheControlEnabled) {
+		processedMessages = processedMessages.map((m) => {
+			if (m.tool_result_cache_control === undefined) {
+				return m;
+			}
+			const { tool_result_cache_control: _dropped, ...rest } = m;
+			return rest;
+		});
+	}
+
 	// Strip Anthropic-style cache_control markers from caller-supplied content
 	// parts. We do this in two cases:
 	//   1) The resolved provider doesn't natively understand cache_control —
@@ -2903,20 +2918,25 @@ export async function prepareRequestBody(
 			);
 
 			// Anthropic requires longer-TTL cache breakpoints to come before
-			// shorter ones (processing order: tools, system, messages). The
-			// gateway's heuristics inject ttl-less markers (5m default), so when
-			// the caller placed an explicit ttl:"1h" marker in the messages, any
-			// auto-injected marker would land before it and Anthropic rejects the
-			// request ("a ttl='1h' cache_control block must not come after a
-			// ttl='5m' cache_control block"). Defer entirely to the caller's
-			// caching strategy in that case. A 1h marker only on system is safe:
+			// shorter ones ("a 1-hour cache entry must appear before any 5-minute
+			// cache entries" —
+			// platform.claude.com/docs/en/build-with-claude/prompt-caching;
+			// processing order: tools, system, messages). The gateway's heuristics
+			// inject ttl-less markers (5m default), so when the caller placed an
+			// explicit ttl:"1h" marker in the messages, any auto-injected marker
+			// would land before it and Anthropic rejects the request ("a ttl='1h'
+			// cache_control block must not come after a ttl='5m' cache_control
+			// block"). Defer entirely to the caller's caching strategy in that
+			// case — including when the 1h marker rides on a tool_result, which
+			// this check would otherwise miss. A 1h marker only on system is safe:
 			// message-level 5m markers after it satisfy the ordering.
 			const callerUses1hTtlInMessages = nonSystemMessages.some(
 				(m) =>
-					Array.isArray(m.content) &&
-					m.content.some(
-						(part) => isTextContent(part) && part.cache_control?.ttl === "1h",
-					),
+					m.tool_result_cache_control?.ttl === "1h" ||
+					(Array.isArray(m.content) &&
+						m.content.some(
+							(part) => isTextContent(part) && part.cache_control?.ttl === "1h",
+						)),
 			);
 			const autoCacheControlEnabled =
 				providerCacheControlEnabled && !callerUses1hTtlInMessages;

--- a/packages/actions/src/transform-anthropic-messages.ts
+++ b/packages/actions/src/transform-anthropic-messages.ts
@@ -94,6 +94,16 @@ export async function transformAnthropicMessages(
 	for (const m of groupedMessages) {
 		let content: MessageContent[] = [];
 
+		// A tool-result message has its content rebuilt into a tool_result block
+		// below, discarding whatever we assemble here. Skip cache_control
+		// accounting for it — otherwise auto-injecting (or counting a
+		// caller-supplied marker on) a text block that gets thrown away still
+		// consumes one of Anthropic's 4 cache_control slots, starving the real
+		// cacheable blocks (and the turn boundary) of markers.
+		const originalRole = m.role === "user" && m.tool_call_id ? "tool" : m.role;
+		const isDiscardedToolResult =
+			originalRole === "tool" && !!m.tool_call_id && m.content !== undefined;
+
 		// Handle existing content
 		if (Array.isArray(m.content)) {
 			// Process all images in parallel for better performance
@@ -132,7 +142,7 @@ export async function transformAnthropicMessages(
 							} as TextContent;
 						}
 					}
-					if (isTextContent(part) && part.text) {
+					if (!isDiscardedToolResult && isTextContent(part) && part.text) {
 						if (part.cache_control) {
 							// Count caller-supplied markers toward Anthropic's 4-block
 							// cap so subsequent auto-injection and the turn-boundary
@@ -160,6 +170,7 @@ export async function transformAnthropicMessages(
 		} else if (m.content && typeof m.content === "string") {
 			// Handle string content - automatically add cache_control for long prompts
 			const shouldCache =
+				!isDiscardedToolResult &&
 				shouldApplyCacheControl &&
 				m.content.length >= minCacheableChars &&
 				cacheControlCount < maxCacheControlBlocks;
@@ -218,8 +229,7 @@ export async function transformAnthropicMessages(
 		}
 
 		// Handle OpenAI-style tool role messages by converting them to Anthropic tool_result content blocks
-		// Use the original role since the mapped role will be "user"
-		const originalRole = m.role === "user" && m.tool_call_id ? "tool" : m.role;
+		// (originalRole was computed above, since the mapped role will be "user")
 		if (originalRole === "tool" && m.tool_call_id && m.content !== undefined) {
 			// For tool results, we need to check if content is JSON string and parse it appropriately
 			let toolResultContent: string;

--- a/packages/actions/src/transform-anthropic-messages.ts
+++ b/packages/actions/src/transform-anthropic-messages.ts
@@ -183,7 +183,16 @@ export async function transformAnthropicMessages(
 							// rejects with a 400). Without this, a coding agent like
 							// Claude Code that sends 4 markers itself would hit the
 							// "Found 5" error after we add our own.
-							cacheControlCount++;
+							if (cacheControlCount < maxCacheControlBlocks) {
+								cacheControlCount++;
+								return part;
+							}
+							// Past the cap the marker has to go: the budget may already
+							// be spent by the tools and system that render ahead of these
+							// messages, and the earlier markers cover the longer prefixes
+							// anyway. Same treatment an over-budget system marker gets.
+							const { cache_control: _dropped, ...rest } = part;
+							return rest;
 						} else if (
 							shouldApplyCacheControl &&
 							part.text.length >= minCacheableChars &&

--- a/packages/actions/src/transform-anthropic-messages.ts
+++ b/packages/actions/src/transform-anthropic-messages.ts
@@ -2,8 +2,10 @@ import { logger } from "@llmgateway/logger";
 import {
 	type AnthropicMessage,
 	type BaseMessage,
+	type CacheControl,
 	isImageUrlContent,
 	isTextContent,
+	isToolResultContent,
 	type MessageContent,
 	type TextContent,
 	type ToolResultContent,
@@ -12,6 +14,26 @@ import {
 
 import { parseToolCallArguments } from "./parse-tool-call-arguments.js";
 import { ImageSizeLimitError, processImageUrl } from "./process-image-url.js";
+
+/**
+ * Last caller-supplied cache breakpoint in an OpenAI-format content array. On a
+ * tool message the array is lowered to a single tool_result block, so the last
+ * marker is the one that ends the prefix.
+ */
+function findCacheControl(
+	content: BaseMessage["content"],
+): CacheControl | undefined {
+	if (!Array.isArray(content)) {
+		return undefined;
+	}
+	let marker: CacheControl | undefined;
+	for (const part of content) {
+		if (isTextContent(part) && part.cache_control) {
+			marker = part.cache_control;
+		}
+	}
+	return marker;
+}
 
 /**
  * Transforms Anthropic messages
@@ -95,17 +117,28 @@ export async function transformAnthropicMessages(
 		let content: MessageContent[] = [];
 
 		// A tool-result message has its content rebuilt into a tool_result block
-		// below, discarding whatever we assemble here. Skip cache_control
-		// accounting for it — otherwise auto-injecting (or counting a
-		// caller-supplied marker on) a text block that gets thrown away still
-		// consumes one of Anthropic's 4 cache_control slots, starving the real
-		// cacheable blocks (and the turn boundary) of markers.
+		// below, discarding whatever we would assemble here — so skip the whole
+		// first pass for it. Assembling it would fetch (and size-check) images
+		// that never reach the provider, and its cache_control accounting would
+		// spend one of Anthropic's 4 slots on a block that is thrown away,
+		// starving the real cacheable blocks (and the turn boundary) of markers.
 		const originalRole = m.role === "user" && m.tool_call_id ? "tool" : m.role;
 		const isDiscardedToolResult =
 			originalRole === "tool" && !!m.tool_call_id && m.content !== undefined;
 
+		// The caller's own breakpoint does survive: Anthropic accepts
+		// cache_control on a tool_result block, and in an agentic loop that is
+		// exactly where the stable prefix ends. It arrives either on the dedicated
+		// message field (Anthropic Messages API callers, whose tool_result content
+		// is lowered to a string) or on a text part (OpenAI-format callers).
+		const toolResultCacheControl = isDiscardedToolResult
+			? (m.tool_result_cache_control ?? findCacheControl(m.content))
+			: undefined;
+
 		// Handle existing content
-		if (Array.isArray(m.content)) {
+		if (isDiscardedToolResult) {
+			content = [];
+		} else if (Array.isArray(m.content)) {
 			// Process all images in parallel for better performance
 			content = await Promise.all(
 				m.content.map(async (part: MessageContent) => {
@@ -142,7 +175,7 @@ export async function transformAnthropicMessages(
 							} as TextContent;
 						}
 					}
-					if (!isDiscardedToolResult && isTextContent(part) && part.text) {
+					if (isTextContent(part) && part.text) {
 						if (part.cache_control) {
 							// Count caller-supplied markers toward Anthropic's 4-block
 							// cap so subsequent auto-injection and the turn-boundary
@@ -170,7 +203,6 @@ export async function transformAnthropicMessages(
 		} else if (m.content && typeof m.content === "string") {
 			// Handle string content - automatically add cache_control for long prompts
 			const shouldCache =
-				!isDiscardedToolResult &&
 				shouldApplyCacheControl &&
 				m.content.length >= minCacheableChars &&
 				cacheControlCount < maxCacheControlBlocks;
@@ -294,6 +326,14 @@ export async function transformAnthropicMessages(
 					} as ToolResultContent,
 				];
 			}
+
+			// Re-attach the caller's breakpoint to the last block, which is where the
+			// prefix ends, without exceeding Anthropic's four-breakpoint limit.
+			if (toolResultCacheControl && cacheControlCount < maxCacheControlBlocks) {
+				const last = content[content.length - 1] as ToolResultContent;
+				last.cache_control = toolResultCacheControl;
+				cacheControlCount++;
+			}
 		}
 
 		// Filter out empty text content blocks as Anthropic requires non-empty text
@@ -368,21 +408,21 @@ export async function transformAnthropicMessages(
 				Array.isArray(boundaryMsg.content) &&
 				boundaryMsg.content.length > 0
 			) {
-				// Find the last text content block in the boundary message.
-				let lastTextIdx = -1;
+				// Find the last block that can carry a breakpoint. Text is the common
+				// case, but agent loops may put a tool_result at the boundary.
+				let lastCacheableIdx = -1;
 				for (let i = boundaryMsg.content.length - 1; i >= 0; i--) {
-					const part = boundaryMsg.content[i];
-					if (part && isTextContent(part as MessageContent)) {
-						lastTextIdx = i;
+					const part = boundaryMsg.content[i] as MessageContent | undefined;
+					if (part && (isTextContent(part) || isToolResultContent(part))) {
+						lastCacheableIdx = i;
 						break;
 					}
 				}
-				if (lastTextIdx >= 0) {
-					const target = boundaryMsg.content[lastTextIdx] as TextContent;
+				if (lastCacheableIdx >= 0) {
+					const target = boundaryMsg.content[lastCacheableIdx] as
+						TextContent | ToolResultContent;
 					if (!target.cache_control) {
-						(boundaryMsg.content[lastTextIdx] as TextContent).cache_control = {
-							type: "ephemeral",
-						};
+						target.cache_control = { type: "ephemeral" };
 						cacheControlCount++;
 					}
 				}

--- a/packages/models/src/types.ts
+++ b/packages/models/src/types.ts
@@ -236,6 +236,13 @@ export interface OpenAIFunctionToolInput {
 	 * tool search tool discovers it. Stripped for every other upstream.
 	 */
 	defer_loading?: boolean;
+	/**
+	 * Anthropic-only: cache breakpoint ending the tool-definitions prefix, which
+	 * Anthropic renders before system and messages. Placed on the last tool it
+	 * caches every tool up to and including that one. Stripped for every other
+	 * upstream, which would reject the unknown property.
+	 */
+	cache_control?: CacheControl;
 }
 
 // Web search tool input type
@@ -274,6 +281,7 @@ export interface AnthropicTool {
 	name: string;
 	description?: string;
 	input_schema: FunctionParameter;
+	cache_control?: CacheControl;
 }
 
 export interface GoogleTool {

--- a/packages/models/src/types.ts
+++ b/packages/models/src/types.ts
@@ -13,14 +13,20 @@ export interface PromptCacheBreakpoint {
 	mode?: "explicit";
 }
 
+/**
+ * Anthropic prompt-cache breakpoint. Ends a cacheable prefix; Anthropic allows
+ * at most 4 of them per request across tools, system and messages.
+ */
+export interface CacheControl {
+	type: "ephemeral";
+	ttl?: "5m" | "1h";
+}
+
 // Base content types
 export interface TextContent {
 	type: "text";
 	text: string;
-	cache_control?: {
-		type: "ephemeral";
-		ttl?: "5m" | "1h";
-	};
+	cache_control?: CacheControl;
 	prompt_cache_breakpoint?: PromptCacheBreakpoint;
 }
 
@@ -86,6 +92,12 @@ export interface ToolResultContent {
 	// Anthropic accepts a block array here as well as a plain string; the array
 	// form is what carries `tool_reference` blocks for a client-side tool search.
 	content: string | AnthropicNativeBlock[];
+	// Anthropic accepts a cache breakpoint on a tool_result block ("Tool use and
+	// tool results: content blocks in the messages.content array, in both user
+	// and assistant turns" —
+	// platform.claude.com/docs/en/build-with-claude/prompt-caching), which is
+	// where the stable prefix of an agentic loop usually ends.
+	cache_control?: CacheControl;
 }
 
 /**
@@ -160,6 +172,12 @@ export interface BaseMessage {
 	// is how a client-side tool search returns `tool_reference` blocks. Replayed
 	// on the Anthropic Messages API only and stripped for every other upstream.
 	anthropic_native_blocks?: AnthropicNativeBlock[];
+	// Caller-supplied cache breakpoint on the `tool_result` block this tool
+	// message came from. The OpenAI-format tool message lowers that block to a
+	// plain string and has nowhere to put the marker, so it rides here and is
+	// re-attached to the tool_result block on the Anthropic Messages API path.
+	// Stripped for every other upstream, which would reject the unknown field.
+	tool_result_cache_control?: CacheControl;
 }
 
 // Provider-specific message formats


### PR DESCRIPTION
Anthropic allows at most 4 prompt-cache breakpoints per request, rendered in the order `tools` → `system` → `messages`. The gateway was mishandling them in four separate places, each of which silently degrades caching in exactly the long agentic conversations the turn-boundary heuristic exists to optimise. Nothing errored — the requests just stopped caching.

This includes #3114 (rebased onto current main, original commits and authorship preserved) plus the follow-ups that came out of reviewing it, so it supersedes that PR.

## What was broken

**Budget spent on discarded content.** A tool-result message has the content we assemble in the first pass thrown away and rebuilt into a `tool_result` block, but the cache_control accounting still ran on that soon-discarded text. A handful of long tool outputs exhausted all 4 slots, and the genuinely cacheable turns after them got nothing. (#3114)

**Caller breakpoints on `tool_result` dropped entirely.** Anthropic accepts a breakpoint on a `tool_result` block, and in an agentic loop that is where the stable prefix ends. The request schema stripped the field before the conversion ever saw it.

**Turn boundary skipped bare tool results.** The boundary marker only considered text blocks, so it did nothing whenever that message was a `tool_result` — which is what a native turn mixing a tool result with new text lowers to.

**Caller breakpoints on tool definitions dropped.** Parsed by the request schema, then discarded by the tool conversion. Tools sit at the base of the cache hierarchy, so this is the largest cacheable prefix a caller has, and the one an agentic client sets on a tool catalogue that never changes between turns.

Also fixed on the way: the first pass was fetching (and size-checking) images inside tool-result content that is discarded moments later, which since the `ImageSizeLimitError` rethrow can fail a request over bytes that never reach the provider.

## Constraints worth knowing when reviewing

- **Ordering drives the budget.** Tool markers render first, so they seed the count the system and message passes work against. Counting them afterwards would let those passes spend slots the tools already took, and Anthropic rejects the fifth breakpoint outright.
- **Every marker is now trimmed against the same budget.** System markers already were; tool, `tool_result` and caller message markers now are too. Caller message markers in particular were counted but never capped, which was survivable while the budget started at zero and is not once the tools seed it. Trimming happens from the end, since the earlier markers cover the longer prefixes. A caller that over-marks loses the extras rather than having the whole request rejected.
- **Longer TTLs must precede shorter ones.** Forwarding tool markers made one invalid ordering reachable that dropping them had masked: a 5m tool marker sits ahead of any 1h marker the caller set later. A 5m tool marker is now dropped when a 1h marker follows it — in a later tool, in the system prompt, or in the messages — keeping the 1h breakpoint the caller paid the 2x write premium for. A 1h tool marker is always safe, since everything the gateway injects is ttl-less/5m and lands after it.
- Every new field is stripped for non-Anthropic upstreams, which reject unknown properties, and never emitted for projects that opted out of provider cache writes.

## Deliberately not included

- `cache_control` on Anthropic's **server** tools is still dropped (`web_search` at the conversion, `tool_search` at schema parsing). The tool-search tool is forced to position 0, so a breakpoint there caches almost nothing; the web-search tool is synthesised from internal config that has no field for it. Neither can cause an error — they only forgo a cache write.
- The web-search tool is appended after the function tools, so a caller-marked last custom tool covers a prefix short by that one small definition. The order is deterministic, so the prefix stays stable across turns.

## Verification

Unit tests were added for each fix and every one was confirmed to fail with its fix reverted. Beyond the suite, the three message-level fixes were checked end to end by pointing a gateway at a recording upstream and diffing the wire payload before and after: previously the caller's marker and the turn boundary both produced zero `cache_control` and the image URL was fetched; afterwards both markers arrive and the fetch is gone.

`pnpm build`, `pnpm lint` and `pnpm test:unit` all pass (two failures on the suite are pre-existing on a clean tree — a timezone-dependent assertion and a log-count assertion).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Anthropic prompt-caching support for tool results and function tools.
  * Supports ephemeral cache breakpoints with 5-minute or 1-hour expiration options.
  * Preserves compatible cache markers when requests are transformed.

* **Bug Fixes**
  * Prevents Anthropic-only cache settings from being sent to other providers.
  * Enforces Anthropic’s four-marker limit and compatible TTL ordering.
  * Prevents discarded tool-message images from triggering unnecessary image fetching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->