### PR TITLE
feat(models): restore RanoAI DeepSeek

### DIFF
--- a/packages/actions/src/get-provider-headers.spec.ts
+++ b/packages/actions/src/get-provider-headers.spec.ts
@@ -13,6 +13,16 @@ afterEach(() => {
 });
 
 describe("getProviderHeaders", () => {
+	it("disables response compression for RanoAI", () => {
+		expect(
+			getProviderHeaders("ranoai", "token", { requestId: "request-id" }),
+		).toEqual({
+			"x-request-id": "request-id",
+			Authorization: "Bearer token",
+			"Accept-Encoding": "identity",
+		});
+	});
+
 	describe("google-vertex", () => {
 		it("returns no auth header by default (api-key mode)", () => {
 			expect(

--- a/packages/actions/src/get-provider-headers.ts
+++ b/packages/actions/src/get-provider-headers.ts
@@ -132,6 +132,14 @@ export function getProviderHeaders(
 				...requestIdHeader,
 				"xi-api-key": token,
 			};
+		case "ranoai":
+			return {
+				...requestIdHeader,
+				Authorization: `Bearer ${token}`,
+				// RanoAI serves Brotli responses that Node leaves compressed when the
+				// gateway's production upstream dispatcher is installed.
+				"Accept-Encoding": "identity",
+			};
 		case "openai":
 		case "inference.net":
 		case "xai":

--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -835,8 +835,8 @@ export const deepseekModels = [
 			},
 			{
 				// RanoAI serves DeepSeek V4 Flash on Furiosa RNGD NPUs. The NPU
-				// deployment enforces a 128000-token window shared between the prompt
-				// and max_tokens, so a request 400s once the two together exceed it.
+				// deployment exposes a 1M-token context and accepts up to 393216 output
+				// tokens, rejecting 393217.
 				// Reasoning arrives as `reasoning_content` (streamed as deltas) only
 				// when `reasoning_effort` is passed explicitly — a request without it
 				// returns no reasoning at all, and "none" suppresses it.
@@ -849,13 +849,12 @@ export const deepseekModels = [
 				// `input_cache_read` rate /v1/models advertises.
 				providerId: "ranoai",
 				externalId: "deepseek-v4-flash",
-				deactivatedAt: new Date("2026-08-09"),
-				inputPrice: "0.15e-6",
-				outputPrice: "0.35e-6",
-				cachedInputPrice: "0.05e-6",
+				inputPrice: "0.14e-6",
+				outputPrice: "0.28e-6",
+				cachedInputPrice: "0.028e-6",
 				requestPrice: "0",
-				contextSize: 128000,
-				maxOutput: 128000,
+				contextSize: 1000000,
+				maxOutput: 393216,
 				// RanoAI serves NVFP4 weights; the catalogue's quantization union only
 				// carries the generic 4-bit float value.
 				quantization: "fp4",
@@ -872,7 +871,9 @@ export const deepseekModels = [
 				],
 				vision: false,
 				tools: true,
-				jsonOutput: true,
+				// json_object returns valid JSON but often ignores requested fields and
+				// emits an empty object; schema-constrained output is reliable.
+				jsonOutput: false,
 				jsonOutputSchema: true,
 				supportsN: true,
 			},


### PR DESCRIPTION
## Problem

RanoAI resumed service with only DeepSeek V4 Flash and updated pricing and context metadata. Its restarted API also serves Brotli responses that the production gateway dispatcher does not decode.

## Changes

- reactivate `ranoai/deepseek-v4-flash`
- update per-million-token prices to 0.14 input, 0.028 cached input, and 0.28 output
- set the context window to 1,000,000 tokens and the verified output cap to 393,216
- retain schema-constrained JSON and disable unreliable plain JSON-object mode
- request identity encoding from RanoAI so production responses remain parseable

## Verification

- authenticated `/v1/models`: only `deepseek-v4-flash`, ready, with matching prices and context
- output boundary: 393,216 accepted; 393,217 rejected
- reasoning efforts: none, minimal, low, medium, high, xhigh, and max accepted
- JSON schema passed in streaming and non-streaming requests; plain JSON object ignored requested fields in 3/5 focused probes
- small billing probe: 16 input and 11 output tokens reconciled exactly to 0.00000532 USD
- cached billing probe: 210 uncached input, 23,808 cached input, and 2 output tokens reconciled exactly to 0.000696584 USD
- `pnpm format`
- `pnpm build`
- focused catalogue/header tests: 159 passed
- `TEST_MODELS=ranoai/deepseek-v4-flash FULL_MODE=true pnpm test:e2e`: 108 passed, 95 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for RanoAI requests with reliable authentication and request tracking.
  * Disabled response compression for RanoAI to improve compatibility.
* **Model Updates**
  * Updated DeepSeek V4 Flash on RanoAI with a 1-million-token context window.
  * Increased maximum output to 393,216 tokens and revised pricing.
  * Schema-constrained output remains available; unrestricted JSON object output is no longer supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->