### PR TITLE
fix(api): expose key creator and project

### DIFF
--- a/apps/api/src/routes/v1-master.spec.ts
+++ b/apps/api/src/routes/v1-master.spec.ts
@@ -112,6 +112,43 @@ describe("v1/master cache invalidation", () => {
 		};
 	}
 
+	test("GET /keys maps each creator to their email", async () => {
+		await db.insert(tables.user).values({
+			id: "member-user-id",
+			name: "Member User",
+			email: "member@example.com",
+			emailVerified: true,
+		});
+		await db.insert(tables.apiKey).values({
+			id: "member-api-key-id",
+			token: "member-api-key-token",
+			projectId: "test-project-id",
+			description: "Member API Key",
+			createdBy: "member-user-id",
+		});
+
+		const listRes = await app.request("/v1/master/keys", {
+			headers: authHeaders(),
+		});
+		expect(listRes.status).toBe(200);
+		const list = await listRes.json();
+		expect(
+			list.apiKeys.find(
+				(apiKey: { id: string }) => apiKey.id === "member-api-key-id",
+			),
+		).toMatchObject({
+			createdBy: "member-user-id",
+			createdByEmail: "member@example.com",
+		});
+
+		const detailRes = await app.request("/v1/master/keys/member-api-key-id", {
+			headers: authHeaders(),
+		});
+		expect(detailRes.status).toBe(200);
+		const detail = await detailRes.json();
+		expect(detail.apiKey.createdByEmail).toBe("member@example.com");
+	});
+
 	test("PATCH /keys/{id} invalidates the gateway api_key cache", async () => {
 		// A per-run-unique key keeps the SWR key from colliding with entries left
 		// in Redis by earlier runs, which outlive deleteAll (it does not flush

--- a/apps/api/src/routes/v1-master.spec.ts
+++ b/apps/api/src/routes/v1-master.spec.ts
@@ -137,6 +137,7 @@ describe("v1/master cache invalidation", () => {
 				(apiKey: { id: string }) => apiKey.id === "member-api-key-id",
 			),
 		).toMatchObject({
+			projectName: "Test Project",
 			createdBy: "member-user-id",
 			createdByEmail: "member@example.com",
 		});
@@ -146,6 +147,7 @@ describe("v1/master cache invalidation", () => {
 		});
 		expect(detailRes.status).toBe(200);
 		const detail = await detailRes.json();
+		expect(detail.apiKey.projectName).toBe("Test Project");
 		expect(detail.apiKey.createdByEmail).toBe("member@example.com");
 	});
 

--- a/apps/api/src/routes/v1-master.ts
+++ b/apps/api/src/routes/v1-master.ts
@@ -178,7 +178,7 @@ interface SerializableApiKey {
 	currentPeriodUsage: string;
 	currentPeriodStartedAt: Date | null;
 	creator?: { email: string } | null;
-	project: { name: string };
+	project: { name: string } | null;
 }
 
 /**
@@ -187,6 +187,10 @@ interface SerializableApiKey {
  * the time the current period resets. Never leaks the plain token.
  */
 function serializeApiKeyForMaster(apiKey: SerializableApiKey) {
+	if (!apiKey.project) {
+		throw new HTTPException(500, { message: "API key project not found" });
+	}
+
 	const currentPeriod = getApiKeyCurrentPeriodState(apiKey);
 
 	return {

--- a/apps/api/src/routes/v1-master.ts
+++ b/apps/api/src/routes/v1-master.ts
@@ -178,6 +178,7 @@ interface SerializableApiKey {
 	currentPeriodUsage: string;
 	currentPeriodStartedAt: Date | null;
 	creator?: { email: string } | null;
+	project: { name: string };
 }
 
 /**
@@ -195,6 +196,7 @@ function serializeApiKeyForMaster(apiKey: SerializableApiKey) {
 		description: apiKey.description,
 		status: apiKey.status,
 		projectId: apiKey.projectId,
+		projectName: apiKey.project.name,
 		createdBy: apiKey.createdBy,
 		createdByEmail: apiKey.creator?.email ?? null,
 		maskedToken: maskToken(apiKey.token),
@@ -577,6 +579,7 @@ const apiKeyDetailSchema = z.object({
 	description: z.string(),
 	status: z.enum(["active", "inactive", "deleted"]).nullable(),
 	projectId: z.string(),
+	projectName: z.string(),
 	createdBy: z.string(),
 	createdByEmail: z.string().nullable(),
 	maskedToken: z.string(),
@@ -761,6 +764,7 @@ v1Master.openapi(updateApiKey, async (c) => {
 		apiKey: serializeApiKeyForMaster({
 			...updated,
 			creator: existing.creator,
+			project: existing.project,
 		}),
 	});
 });
@@ -825,7 +829,10 @@ v1Master.openapi(listApiKeys, async (c) => {
 			status: { ne: "deleted" },
 		},
 		orderBy: { createdAt: "desc" },
-		with: { creator: { columns: { email: true } } },
+		with: {
+			creator: { columns: { email: true } },
+			project: { columns: { name: true } },
+		},
 	});
 
 	return c.json({ apiKeys: apiKeys.map(serializeApiKeyForMaster) });

--- a/apps/api/src/routes/v1-master.ts
+++ b/apps/api/src/routes/v1-master.ts
@@ -139,7 +139,10 @@ v1Master.use("*", async (c, next) => {
 async function loadApiKeyForOrg(apiKeyId: string, organizationId: string) {
 	const apiKey = await db.query.apiKey.findFirst({
 		where: { id: { eq: apiKeyId } },
-		with: { project: true },
+		with: {
+			project: true,
+			creator: { columns: { email: true } },
+		},
 	});
 
 	if (
@@ -174,6 +177,7 @@ interface SerializableApiKey {
 	periodUsageDurationUnit: "hour" | "day" | "week" | "month" | null;
 	currentPeriodUsage: string;
 	currentPeriodStartedAt: Date | null;
+	creator?: { email: string } | null;
 }
 
 /**
@@ -192,6 +196,7 @@ function serializeApiKeyForMaster(apiKey: SerializableApiKey) {
 		status: apiKey.status,
 		projectId: apiKey.projectId,
 		createdBy: apiKey.createdBy,
+		createdByEmail: apiKey.creator?.email ?? null,
 		maskedToken: maskToken(apiKey.token),
 		usageLimit: apiKey.usageLimit,
 		usage: apiKey.usage,
@@ -573,6 +578,7 @@ const apiKeyDetailSchema = z.object({
 	status: z.enum(["active", "inactive", "deleted"]).nullable(),
 	projectId: z.string(),
 	createdBy: z.string(),
+	createdByEmail: z.string().nullable(),
 	maskedToken: z.string(),
 	usageLimit: z.string().nullable(),
 	// Total spend accrued against `usageLimit` over the key's lifetime.
@@ -751,7 +757,12 @@ v1Master.openapi(updateApiKey, async (c) => {
 		});
 	}
 
-	return c.json({ apiKey: serializeApiKeyForMaster(updated) });
+	return c.json({
+		apiKey: serializeApiKeyForMaster({
+			...updated,
+			creator: existing.creator,
+		}),
+	});
 });
 
 const listApiKeysQuery = z.object({
@@ -814,6 +825,7 @@ v1Master.openapi(listApiKeys, async (c) => {
 			status: { ne: "deleted" },
 		},
 		orderBy: { createdAt: "desc" },
+		with: { creator: { columns: { email: true } } },
 	});
 
 	return c.json({ apiKeys: apiKeys.map(serializeApiKeyForMaster) });

--- a/apps/docs/content/features/master-keys.mdx
+++ b/apps/docs/content/features/master-keys.mdx
@@ -156,7 +156,7 @@ Response (200):
 
 `GET /v1/master/keys`
 
-Returns the developer-created gateway API keys in the master key's organization, each with its configured limits, the usage consumed so far, and — when a windowed limit is set — the time the current period resets. Pass an optional `projectId` query parameter to scope the list to a single project.
+Returns the developer-created gateway API keys in the master key's organization, each with its creator, project, configured limits, the usage consumed so far, and — when a windowed limit is set — the time the current period resets. `projectName` provides the human-readable project name alongside `projectId`. `createdBy` contains the creator's internal user ID, while `createdByEmail` contains their email address (`null` when unavailable). Pass an optional `projectId` query parameter to scope the list to a single project.
 
 ```bash
 curl "https://internal.llmgateway.io/v1/master/keys?projectId=proj_..." \
@@ -173,7 +173,9 @@ Response (200):
 			"description": "Customer ACME — production key",
 			"status": "active",
 			"projectId": "proj_...",
+			"projectName": "Customer ACME",
 			"createdBy": "usr_...",
+			"createdByEmail": "member@example.com",
 			"maskedToken": "llmgtwy_...abcd",
 			"usageLimit": "100.00",
 			"usage": "42.13",
@@ -225,7 +227,9 @@ Response (200):
 		"description": "Customer ACME — production key",
 		"status": "active",
 		"projectId": "proj_...",
+		"projectName": "Customer ACME",
 		"createdBy": "usr_...",
+		"createdByEmail": "member@example.com",
 		"maskedToken": "llmgtwy_...abcd",
 		"usageLimit": "100.00",
 		"usage": "42.13",


### PR DESCRIPTION
## Summary

- expose `createdByEmail` alongside the creator ID in master API key responses
- expose `projectName` alongside the project ID
- guard against a missing project relation
- document both response fields

## Verification

- `pnpm format`
- `pnpm build`
- `pnpm exec vitest run apps/api/src/routes/v1-master.spec.ts --no-file-parallelism`