### PR TITLE
fix(gateway): route matching custom models

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -42,7 +42,6 @@ import {
 } from "@/lib/coding-models.js";
 import {
 	complianceBlockMessage,
-	filterCompliantProviders,
 	getActiveCompliancePolicy,
 	isModelIdCompliant,
 	isProviderIdCompliant,
@@ -439,6 +438,37 @@ function isCustomAutoRoutingMapping(
 		"customProviderKeyId" in mapping &&
 		"customProviderName" in mapping
 	);
+}
+
+async function keepCheapestCustomRoutingMapping(
+	providers: ProviderModelMapping[],
+	modelId: string,
+	organizationId: string,
+	providerDiscountResolver: ReturnType<typeof createProviderDiscountResolver>,
+): Promise<ProviderModelMapping[]> {
+	let cheapestCustomProvider: ProviderModelMapping | undefined;
+	let cheapestCustomPrice = Number.MAX_VALUE;
+	for (const provider of providers) {
+		if (!isCustomAutoRoutingMapping(provider)) {
+			continue;
+		}
+		const { price } = await getDiscountedProviderSelectionPrice(
+			provider,
+			modelId,
+			{
+				organizationId,
+				providerDiscountResolver,
+			},
+		);
+		if (price.toNumber() < cheapestCustomPrice) {
+			cheapestCustomPrice = price.toNumber();
+			cheapestCustomProvider = provider;
+		}
+	}
+	return [
+		...providers.filter((provider) => !isCustomAutoRoutingMapping(provider)),
+		...(cheapestCustomProvider ? [cheapestCustomProvider] : []),
+	];
 }
 
 function filterRegionsByAvailableKeys(
@@ -3116,24 +3146,102 @@ chat.openapi(completions, async (c) => {
 		activeModelInfo: modelInfo,
 		clientIp,
 	});
-	if (!iamValidation.allowed) {
+	const routingCustomProviderKeysById = new Map<
+		string,
+		InferSelectModel<typeof tables.providerKey>
+	>();
+	const routingCustomModelsByName = new Map<string, CustomModel[]>();
+	if (
+		requestedProvider === undefined &&
+		organization.plan === "enterprise" &&
+		project.mode !== "credits" &&
+		!isDevPlan
+	) {
+		const [providerKeys, customModels] = await Promise.all([
+			findActiveProviderKeys(project.organizationId),
+			findActiveCustomModels(project.organizationId),
+		]);
+		for (const key of providerKeys) {
+			if (key.provider === "custom" && key.name !== null) {
+				routingCustomProviderKeysById.set(key.id, key);
+			}
+		}
+		for (const customModel of customModels) {
+			const matchingModels =
+				routingCustomModelsByName.get(customModel.modelName) ?? [];
+			matchingModels.push(customModel);
+			routingCustomModelsByName.set(customModel.modelName, matchingModels);
+		}
+	}
+	const customRoutingMappings = (
+		await Promise.all(
+			(routingCustomModelsByName.get(modelInfo.id) ?? [])
+				.filter(customModelHasRoutingPrice)
+				.map(async (customModel) => {
+					const providerKey = routingCustomProviderKeysById.get(
+						customModel.providerKeyId,
+					);
+					if (!providerKey?.name) {
+						return undefined;
+					}
+					const mapping: CustomAutoRoutingMapping = {
+						...customModelToProviderMapping(customModel),
+						customProviderKeyId: providerKey.id,
+						customProviderName: providerKey.name,
+					};
+					const customIam = await validateRequestModelAccess({
+						apiKey,
+						organizationId: project.organizationId,
+						requestedModel: modelInfo.id,
+						requestedProvider: "custom",
+						customProviderName: providerKey.name,
+						activeModelInfo: { ...modelInfo, providers: [mapping] },
+						clientIp,
+						autoRouting: true,
+					});
+					return customIam.allowed ? mapping : undefined;
+				}),
+		)
+	).filter(
+		(mapping): mapping is CustomAutoRoutingMapping => mapping !== undefined,
+	);
+	if (!iamValidation.allowed && customRoutingMappings.length === 0) {
 		throwIamException(iamValidation.reason ?? "Model access denied");
+	}
+	if (customRoutingMappings.length > 0) {
+		modelInfo = {
+			...modelInfo,
+			providers: [...modelInfo.providers, ...customRoutingMappings],
+		};
+		routingExpandedModelProviders = [
+			...routingExpandedModelProviders,
+			...customRoutingMappings,
+		];
+		allModelProviders = [...allModelProviders, ...customRoutingMappings];
 	}
 	// IAM allowed providers - used to filter available providers during routing
 	const iamAllowedProviders = iamValidation.allowedProviders;
 
 	// IAM-filtered model providers for routing and retry fallback paths.
 	// Recomputed after auto-routing because that block replaces modelInfo.
-	let iamFilteredModelProviders = iamAllowedProviders
-		? modelInfo.providers.filter((p) =>
-				iamAllowedProviders.includes(p.providerId),
-			)
-		: modelInfo.providers;
-	let expandedIamFilteredModelProviders = iamAllowedProviders
-		? routingExpandedModelProviders.filter((p) =>
-				iamAllowedProviders.includes(p.providerId),
-			)
-		: routingExpandedModelProviders;
+	let iamFilteredModelProviders = iamValidation.allowed
+		? iamAllowedProviders
+			? modelInfo.providers.filter(
+					(p) =>
+						isCustomAutoRoutingMapping(p) ||
+						iamAllowedProviders.includes(p.providerId),
+				)
+			: modelInfo.providers
+		: customRoutingMappings;
+	let expandedIamFilteredModelProviders = iamValidation.allowed
+		? iamAllowedProviders
+			? routingExpandedModelProviders.filter(
+					(p) =>
+						isCustomAutoRoutingMapping(p) ||
+						iamAllowedProviders.includes(p.providerId),
+				)
+			: routingExpandedModelProviders
+		: customRoutingMappings;
 
 	// Resolved before the compliance gate: a custom provider key's self-attested
 	// posture is what the policy is evaluated against, and the auto-routing
@@ -3164,11 +3272,28 @@ chat.openapi(completions, async (c) => {
 	// none remain. Applied after every (re)computation of the IAM-filtered arrays.
 	const compliancePolicy = getActiveCompliancePolicy(organization);
 
-	const applyCompliancePolicy = <T extends { providerId: string }>(
+	const applyCompliancePolicy = <T extends ProviderModelMapping>(
 		list: T[],
 	): T[] =>
 		compliancePolicy
-			? filterCompliantProviders(list, compliancePolicy, complianceContext)
+			? list.filter((provider) => {
+					const context = isCustomAutoRoutingMapping(provider)
+						? {
+								customAttestation:
+									routingCustomProviderKeysById.get(
+										provider.customProviderKeyId,
+									)?.complianceAttestation ?? null,
+								customProviderName: provider.customProviderName,
+							}
+						: complianceContext;
+					return (
+						isProviderIdCompliant(
+							provider.providerId,
+							compliancePolicy,
+							context,
+						) && isModelIdCompliant(modelInfo.id, compliancePolicy, context)
+					);
+				})
 			: list;
 
 	const enforceCompliancePolicy = async () => {
@@ -3194,19 +3319,7 @@ chat.openapi(completions, async (c) => {
 			usedProvider !== "llmgateway" &&
 			usedProvider !== "custom" &&
 			!isProviderIdCompliant(usedProvider, compliancePolicy, complianceContext);
-		// The policy's model lists block the model outright, regardless of which
-		// provider would serve it (custom-provider requests also answer to their
-		// `<customProvider>/<model>` ref).
-		const modelBlocked = !isModelIdCompliant(
-			modelInfo.id,
-			compliancePolicy,
-			complianceContext,
-		);
-		if (
-			iamFilteredModelProviders.length === 0 ||
-			pinnedBlocked ||
-			modelBlocked
-		) {
+		if (iamFilteredModelProviders.length === 0 || pinnedBlocked) {
 			await logComplianceBlock(project.organizationId, {
 				apiKeyId: apiKey.id,
 				model: requestedModel,
@@ -3310,6 +3423,21 @@ chat.openapi(completions, async (c) => {
 	// so the request is billed at the catalog rates; undefined otherwise (those
 	// requests stay unbilled, as before).
 	let customPricingMapping: ProviderModelMapping | undefined;
+	const applySelectedCustomProvider = (provider: ProviderModelMapping) => {
+		if (!isCustomAutoRoutingMapping(provider)) {
+			return;
+		}
+		const providerKey = routingCustomProviderKeysById.get(
+			provider.customProviderKeyId,
+		);
+		customProviderName = provider.customProviderName;
+		customProviderKey = providerKey;
+		customPricingMapping = provider;
+		complianceContext = {
+			customAttestation: providerKey?.complianceAttestation ?? null,
+			customProviderName: provider.customProviderName,
+		};
+	};
 
 	// Validate the custom provider against the database if one was requested
 	if (customProviderKey) {
@@ -3781,31 +3909,13 @@ chat.openapi(completions, async (c) => {
 					return true;
 				},
 			);
-			let cheapestCustomProvider: ProviderModelMapping | undefined;
-			let cheapestCustomPrice = Number.MAX_VALUE;
-			for (const provider of suitableProviders) {
-				if (!isCustomAutoRoutingMapping(provider)) {
-					continue;
-				}
-				const { price } = await getDiscountedProviderSelectionPrice(
-					provider,
+			const deduplicatedSuitableProviders =
+				await keepCheapestCustomRoutingMapping(
+					suitableProviders,
 					modelDef.id,
-					{
-						organizationId: project.organizationId,
-						providerDiscountResolver,
-					},
+					project.organizationId,
+					providerDiscountResolver,
 				);
-				if (price.toNumber() < cheapestCustomPrice) {
-					cheapestCustomPrice = price.toNumber();
-					cheapestCustomProvider = provider;
-				}
-			}
-			const deduplicatedSuitableProviders = [
-				...suitableProviders.filter(
-					(provider) => !isCustomAutoRoutingMapping(provider),
-				),
-				...(cheapestCustomProvider ? [cheapestCustomProvider] : []),
-			];
 			const preferredSuitableProviders = preferProvidersWithKeys(
 				project.mode,
 				deduplicatedSuitableProviders,
@@ -4744,6 +4854,7 @@ chat.openapi(completions, async (c) => {
 			usedInternalModel = modelInfo.id;
 			usedExternalId = iamFilteredModelProviders[0].externalId;
 			usedRegion = iamFilteredModelProviders[0].region;
+			applySelectedCustomProvider(iamFilteredModelProviders[0]);
 			// This shortcut bypasses provider selection (and with it the sticky
 			// pinning inside getCheapestFromAvailableProviders), but the session is
 			// now genuinely served by this provider — e.g. a service_tier request
@@ -4799,10 +4910,16 @@ chat.openapi(completions, async (c) => {
 				reasoningEffort: reasoning_effort,
 			};
 			const filteredOutProvidersDirect: FilteredProvider[] = [];
-			const availableModelProviders = filterEligibleModelProviders(
+			const eligibleModelProviders = filterEligibleModelProviders(
 				preparedModelProviders,
 				{ ...eligibilityOptions, n, stream },
 				filteredOutProvidersDirect,
+			);
+			const availableModelProviders = await keepCheapestCustomRoutingMapping(
+				eligibleModelProviders,
+				modelInfo.id,
+				project.organizationId,
+				providerDiscountResolver,
 			);
 
 			if (availableModelProviders.length === 0) {
@@ -4903,9 +5020,12 @@ chat.openapi(completions, async (c) => {
 			const modelWithPricing = rawModelWithPricing
 				? {
 						...rawModelWithPricing,
-						providers: expandAllProviderRegions(
-							rawModelWithPricing.providers as ProviderModelMapping[],
-						),
+						providers: [
+							...expandAllProviderRegions(
+								rawModelWithPricing.providers as ProviderModelMapping[],
+							),
+							...availableModelProviders.filter(isCustomAutoRoutingMapping),
+						],
 					}
 				: undefined;
 
@@ -5004,6 +5124,25 @@ chat.openapi(completions, async (c) => {
 					usedInternalModel = modelWithPricing.id;
 					usedExternalId = selectedProvider.externalId;
 					usedRegion = selectedProvider.region;
+					applySelectedCustomProvider(selectedProvider);
+					if (usedProvider === "custom") {
+						modelInfo = {
+							...modelInfo,
+							providers: modelInfo.providers.filter(
+								(provider) =>
+									provider.providerId !== "custom" ||
+									(isCustomAutoRoutingMapping(provider) &&
+										provider.customProviderName === customProviderName),
+							),
+						};
+					} else {
+						modelInfo = {
+							...modelInfo,
+							providers: modelInfo.providers.filter(
+								(provider) => provider.providerId !== "custom",
+							),
+						};
+					}
 					routingMetadata = await addContentFilterRoutingMetadata(
 						{
 							...cheapestResult.metadata,
@@ -5069,12 +5208,14 @@ chat.openapi(completions, async (c) => {
 					usedInternalModel = modelInfo.id;
 					usedExternalId = routingCandidates[0].externalId;
 					usedRegion = routingCandidates[0].region;
+					applySelectedCustomProvider(routingCandidates[0]);
 				}
 			} else {
 				usedProvider = contentFilterPreferredProviders[0].providerId;
 				usedInternalModel = modelInfo.id;
 				usedExternalId = contentFilterPreferredProviders[0].externalId;
 				usedRegion = contentFilterPreferredProviders[0].region;
+				applySelectedCustomProvider(contentFilterPreferredProviders[0]);
 			}
 		}
 	}

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -434,6 +434,31 @@ describe("fallback and error status code handling", () => {
 	}
 
 	describe("custom provider auto routing", () => {
+		test("routes a canonical model id to a cheaper matching custom model", async () => {
+			await setupCustomAutoRouting();
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer auto-custom-token",
+				},
+				body: JSON.stringify({
+					model: "claude-haiku-4-5",
+					routing: "price",
+					messages: [{ role: "user", content: "Hello custom route!" }],
+				}),
+			});
+
+			expect(res.status).toBe(200);
+			const logs = await waitForLogs(1);
+			expect(logs).toHaveLength(1);
+			expect(logs[0].requestedModel).toBe("claude-haiku-4-5");
+			expect(logs[0].usedProvider).toBe("custom");
+			expect(logs[0].usedModel).toBe("my-custom/claude-haiku-4-5");
+			expect(Number(logs[0].cost)).toBeGreaterThan(0);
+		});
+
 		test("routes to a priced custom model with a matching catalog id", async () => {
 			await setupCustomAutoRouting();
 

--- a/apps/gateway/src/lib/cached-queries-swr.spec.ts
+++ b/apps/gateway/src/lib/cached-queries-swr.spec.ts
@@ -11,6 +11,7 @@ import {
 	eq,
 	apiKey,
 	apiKeyIamRule,
+	customModel,
 	discount,
 	organization,
 	project,
@@ -24,6 +25,7 @@ import {
 import { getApiKeyFingerprint } from "./api-key-fingerprint.js";
 import {
 	findActiveIamRules,
+	findActiveCustomModels,
 	findActiveProviderKeys,
 	findApiKeyByToken,
 	findEffectiveDiscount,
@@ -44,6 +46,8 @@ const testApiKeyId = "test-api-key-swr";
 const testApiKeyToken = "sk-test-swr-token";
 const testProviderKeyOpenAi = "test-provider-key-swr-openai";
 const testProviderKeyAnthropic = "test-provider-key-swr-anthropic";
+const testCustomProviderKey = "test-provider-key-swr-custom";
+const testCustomModelId = "test-custom-model-swr";
 const testIamRuleId = "test-iam-rule-swr";
 const testDiscountId = "test-discount-swr";
 const testRoutingScoreMultiplierId = "test-routing-score-multiplier-swr";
@@ -148,6 +152,25 @@ describe("cached-queries SWR integration", () => {
 			provider: "anthropic",
 			organizationId: testOrgId,
 			status: "active",
+		});
+
+		await db.insert(providerKey).values({
+			id: testCustomProviderKey,
+			token: "swr-test-custom-token",
+			provider: "custom",
+			name: "swr-custom-provider",
+			baseUrl: "https://custom.example.com",
+			organizationId: testOrgId,
+			status: "active",
+		});
+
+		await db.insert(customModel).values({
+			id: testCustomModelId,
+			providerKeyId: testCustomProviderKey,
+			organizationId: testOrgId,
+			modelName: "swr-custom-model",
+			inputPrice: "1e-6",
+			outputPrice: "2e-6",
 		});
 
 		await db.insert(apiKeyIamRule).values({
@@ -262,6 +285,21 @@ describe("cached-queries SWR integration", () => {
 
 			const mirror = await redisClient.get(
 				`${SWR_PREFIX}providerKey:active:${testOrgId}`,
+			);
+			expect(mirror).not.toBeNull();
+		});
+
+		it("findActiveCustomModels primes mirror at customModel:active:{org}", async () => {
+			const result = await findActiveCustomModels(testOrgId);
+			expect(result).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ id: testCustomModelId }),
+				]),
+			);
+			await waitForSwrMirrorWrites();
+
+			const mirror = await redisClient.get(
+				`${SWR_PREFIX}customModel:active:${testOrgId}`,
 			);
 			expect(mirror).not.toBeNull();
 		});
@@ -509,6 +547,25 @@ describe("cached-queries SWR integration", () => {
 			const result = await findEffectiveDiscount(testOrgId, "openai", "gpt-4");
 			expect(result.discount).toBe("0.25");
 			expect(result.source).toBe("org_provider_model");
+
+			selectSpy.mockRestore();
+		});
+
+		it("returns active custom models from SWR when DB errors", async () => {
+			await findActiveCustomModels(testOrgId);
+			await waitForSwrMirrorWrites();
+			await flushDrizzleCache();
+
+			const selectSpy = vi.spyOn(cdb, "select").mockImplementation(() => {
+				throw new Error("postgres unavailable");
+			});
+
+			const result = await findActiveCustomModels(testOrgId);
+			expect(result).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ id: testCustomModelId }),
+				]),
+			);
 
 			selectSpy.mockRestore();
 		});


### PR DESCRIPTION
## Problem

Canonical model requests only considered official provider mappings. A priced custom model with the same canonical model name could participate in cross-model `auto` routing, but not in provider selection for a request using that model name directly.

## Approach

- Include active, fully priced custom mappings in unpinned canonical model routing.
- Apply IAM, compliance, capability, project-mode, and routing filters to custom candidates.
- Preserve the selected custom key and catalog pricing for execution, billing, metadata, and fallback.
- Deduplicate custom candidates to the cheapest mapping because they share the synthetic `custom` provider ID.
- Add a regression test for a bare canonical model selecting its cheaper matching custom mapping.
- Verify the custom-model catalogue lookup uses the existing CDB cache and SWR outage fallback.

The dynamic-route model dropdown remains a separate follow-up; this PR changes gateway routing only.

## Verification

- `pnpm format`
- `pnpm build` — 17 build tasks successful
- `pnpm exec vitest run apps/gateway/src/lib/cached-queries-swr.spec.ts --no-file-parallelism` — 21 tests passed
- `pnpm exec vitest run --no-file-parallelism apps/gateway/src/fallback.spec.ts` — 62 tests passed
- Local isolated-stack E2E: configured an OpenAI-compatible custom provider and matching priced model through the seeded dashboard, confirmed Automatic routing, then sent a bare canonical model request to the local gateway and received a 200 response with `used_provider: custom`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic routing for eligible enterprise custom providers based on model availability, compliance, and pricing.
  * Custom-provider routing now selects the lowest-cost eligible provider and preserves provider and model details across routing scenarios.

* **Bug Fixes**
  * Improved compliance evaluation for requests involving multiple custom providers.
  * Ensured routed requests and usage logs accurately record the selected provider, underlying model, requested model, and cost.

* **Tests**
  * Added coverage for price-based custom-provider routing, logging, and cached custom-model retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
