### PR TITLE
feat(admin): manage payment methods

### DIFF
--- a/apps/api/src/routes/admin-org-details.ts
+++ b/apps/api/src/routes/admin-org-details.ts
@@ -365,6 +365,7 @@ const adminPaymentMethodSchema = z.object({
 	id: z.string(),
 	type: z.string(),
 	createdAt: z.string(),
+	isDefault: z.boolean(),
 	card: z
 		.object({
 			brand: z.string(),
@@ -374,6 +375,89 @@ const adminPaymentMethodSchema = z.object({
 		})
 		.nullable(),
 });
+
+type PaymentMethodOrganization = Pick<
+	typeof tables.organization.$inferSelect,
+	| "id"
+	| "stripeCustomerId"
+	| "stripeSubscriptionId"
+	| "devPlanStripeSubscriptionId"
+	| "chatPlanStripeSubscriptionId"
+>;
+
+function getStripeId(
+	value: string | { id: string } | null | undefined,
+): string | null {
+	return typeof value === "string" ? value : (value?.id ?? null);
+}
+
+async function getOrganizationPaymentMethodState(
+	org: PaymentMethodOrganization,
+) {
+	if (!org.stripeCustomerId) {
+		return null;
+	}
+
+	const stripe = getStripe();
+	const subscriptionIds = [
+		org.stripeSubscriptionId,
+		org.devPlanStripeSubscriptionId,
+		org.chatPlanStripeSubscriptionId,
+	].filter((id): id is string => Boolean(id));
+
+	const [paymentMethods, customer, localPaymentMethods, subscriptions] =
+		await Promise.all([
+			stripe.paymentMethods.list({
+				customer: org.stripeCustomerId,
+				type: "card",
+				limit: 100,
+			}),
+			stripe.customers.retrieve(org.stripeCustomerId),
+			db.query.paymentMethod.findMany({
+				where: { organizationId: org.id },
+			}),
+			Promise.all(
+				subscriptionIds.map(async (id) => ({
+					id,
+					subscription: await stripe.subscriptions.retrieve(id),
+				})),
+			),
+		]);
+
+	if (customer.deleted) {
+		throw new HTTPException(404, { message: "Stripe customer not found" });
+	}
+
+	const defaultPaymentMethodIds = new Set<string>();
+	const customerDefaultId = getStripeId(
+		customer.invoice_settings?.default_payment_method,
+	);
+	if (customerDefaultId) {
+		defaultPaymentMethodIds.add(customerDefaultId);
+	}
+	for (const { subscription } of subscriptions) {
+		const subscriptionDefaultId = getStripeId(
+			subscription.default_payment_method,
+		);
+		if (subscriptionDefaultId) {
+			defaultPaymentMethodIds.add(subscriptionDefaultId);
+		}
+	}
+	for (const paymentMethod of localPaymentMethods) {
+		if (paymentMethod.isDefault) {
+			defaultPaymentMethodIds.add(paymentMethod.stripePaymentMethodId);
+		}
+	}
+
+	return {
+		paymentMethods: paymentMethods.data,
+		customer,
+		customerDefaultId,
+		localPaymentMethods,
+		subscriptions,
+		defaultPaymentMethodIds,
+	};
+}
 
 const getOrganizationPaymentMethods = createRoute({
 	method: "get",
@@ -408,17 +492,17 @@ adminOrgDetails.openapi(getOrganizationPaymentMethods, async (c) => {
 		return c.json({ paymentMethods: [] });
 	}
 
-	const paymentMethods = await getStripe().paymentMethods.list({
-		customer: org.stripeCustomerId,
-		type: "card",
-		limit: 100,
-	});
+	const state = await getOrganizationPaymentMethodState(org);
+	if (!state) {
+		return c.json({ paymentMethods: [] });
+	}
 
 	return c.json({
-		paymentMethods: paymentMethods.data.map((paymentMethod) => ({
+		paymentMethods: state.paymentMethods.map((paymentMethod) => ({
 			id: paymentMethod.id,
 			type: paymentMethod.type,
 			createdAt: new Date(paymentMethod.created * 1000).toISOString(),
+			isDefault: state.defaultPaymentMethodIds.has(paymentMethod.id),
 			card: paymentMethod.card
 				? {
 						brand: paymentMethod.card.brand,
@@ -439,6 +523,15 @@ const deleteOrganizationPaymentMethod = createRoute({
 			orgId: z.string(),
 			paymentMethodId: z.string(),
 		}),
+		body: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						replacementPaymentMethodId: z.string().optional(),
+					}),
+				},
+			},
+		},
 	},
 	responses: {
 		200: {
@@ -452,11 +545,15 @@ const deleteOrganizationPaymentMethod = createRoute({
 		404: {
 			description: "Organization or payment method not found.",
 		},
+		400: {
+			description: "A valid replacement is required for a default method.",
+		},
 	},
 });
 
 adminOrgDetails.openapi(deleteOrganizationPaymentMethod, async (c) => {
 	const { orgId, paymentMethodId } = c.req.valid("param");
+	const { replacementPaymentMethodId } = c.req.valid("json");
 	const org = await requireOrganization(orgId);
 	const user = c.get("user");
 
@@ -475,15 +572,108 @@ adminOrgDetails.openapi(deleteOrganizationPaymentMethod, async (c) => {
 		throw new HTTPException(404, { message: "Payment method not found" });
 	}
 
-	await getStripe().paymentMethods.detach(paymentMethodId);
-	await db
-		.delete(tables.paymentMethod)
-		.where(
-			and(
-				eq(tables.paymentMethod.organizationId, orgId),
-				eq(tables.paymentMethod.stripePaymentMethodId, paymentMethodId),
-			),
-		);
+	const state = await getOrganizationPaymentMethodState(org);
+	if (!state) {
+		throw new HTTPException(404, { message: "Payment method not found" });
+	}
+
+	const remainingPaymentMethods = state.paymentMethods.filter(
+		(candidate) => candidate.id !== paymentMethodId,
+	);
+	const isDefault = state.defaultPaymentMethodIds.has(paymentMethodId);
+	const replacementPaymentMethod = replacementPaymentMethodId
+		? remainingPaymentMethods.find(
+				(candidate) => candidate.id === replacementPaymentMethodId,
+			)
+		: undefined;
+
+	if (isDefault && remainingPaymentMethods.length > 0) {
+		if (!replacementPaymentMethod) {
+			throw new HTTPException(400, {
+				message:
+					"Select another attached payment method before deleting the default method.",
+			});
+		}
+	} else if (replacementPaymentMethodId && !replacementPaymentMethod) {
+		throw new HTTPException(400, {
+			message: "Replacement payment method is not attached to this customer.",
+		});
+	}
+
+	const replacementId = replacementPaymentMethod?.id ?? null;
+	const clearAllDefaults = remainingPaymentMethods.length === 0;
+	const stripe = getStripe();
+	const shouldUpdateCustomerDefault =
+		clearAllDefaults || state.customerDefaultId === paymentMethodId;
+	const subscriptionsToUpdate = state.subscriptions.filter(
+		({ subscription }) =>
+			clearAllDefaults ||
+			getStripeId(subscription.default_payment_method) === paymentMethodId,
+	);
+
+	if (shouldUpdateCustomerDefault) {
+		await stripe.customers.update(org.stripeCustomerId, {
+			invoice_settings: {
+				default_payment_method: replacementId ?? "",
+			},
+		});
+	}
+	for (const { id } of subscriptionsToUpdate) {
+		await stripe.subscriptions.update(id, {
+			default_payment_method: replacementId ?? "",
+		});
+	}
+
+	await stripe.paymentMethods.detach(paymentMethodId);
+
+	const localPaymentMethod = state.localPaymentMethods.find(
+		(candidate) => candidate.stripePaymentMethodId === paymentMethodId,
+	);
+	const localReplacement = replacementId
+		? state.localPaymentMethods.find(
+				(candidate) => candidate.stripePaymentMethodId === replacementId,
+			)
+		: undefined;
+	const disableAutoTopUp = clearAllDefaults;
+
+	await db.transaction(async (tx) => {
+		if (localPaymentMethod?.isDefault) {
+			await tx
+				.update(tables.paymentMethod)
+				.set({ isDefault: false })
+				.where(eq(tables.paymentMethod.organizationId, orgId));
+
+			if (localReplacement) {
+				await tx
+					.update(tables.paymentMethod)
+					.set({ isDefault: true })
+					.where(eq(tables.paymentMethod.id, localReplacement.id));
+			} else if (replacementPaymentMethod) {
+				await tx.insert(tables.paymentMethod).values({
+					organizationId: orgId,
+					stripePaymentMethodId: replacementPaymentMethod.id,
+					type: replacementPaymentMethod.type,
+					isDefault: true,
+				});
+			}
+		}
+
+		if (disableAutoTopUp) {
+			await tx
+				.update(tables.organization)
+				.set({ autoTopUpEnabled: false })
+				.where(eq(tables.organization.id, orgId));
+		}
+
+		await tx
+			.delete(tables.paymentMethod)
+			.where(
+				and(
+					eq(tables.paymentMethod.organizationId, orgId),
+					eq(tables.paymentMethod.stripePaymentMethodId, paymentMethodId),
+				),
+			);
+	});
 
 	await logAuditEvent({
 		organizationId: orgId,
@@ -493,6 +683,8 @@ adminOrgDetails.openapi(deleteOrganizationPaymentMethod, async (c) => {
 		resourceId: paymentMethodId,
 		metadata: {
 			cardLast4: paymentMethod.card?.last4,
+			replacementPaymentMethodId: replacementId,
+			autoTopUpDisabled: disableAutoTopUp && org.autoTopUpEnabled,
 		},
 	});
 

--- a/apps/api/src/routes/admin-org-details.ts
+++ b/apps/api/src/routes/admin-org-details.ts
@@ -3,7 +3,9 @@ import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
 import { adminMiddleware } from "@/middleware/admin.js";
+import { getStripe } from "@/routes/payments.js";
 
+import { logAuditEvent } from "@llmgateway/audit";
 import {
 	and,
 	auditLogActions,
@@ -355,6 +357,146 @@ adminOrgDetails.openapi(getOrganizationSettings, async (c) => {
 			createdAt: key.createdAt.toISOString(),
 		})),
 	});
+});
+
+// ==================== Payment Methods ====================
+
+const adminPaymentMethodSchema = z.object({
+	id: z.string(),
+	type: z.string(),
+	createdAt: z.string(),
+	card: z
+		.object({
+			brand: z.string(),
+			last4: z.string(),
+			expiryMonth: z.number(),
+			expiryYear: z.number(),
+		})
+		.nullable(),
+});
+
+const getOrganizationPaymentMethods = createRoute({
+	method: "get",
+	path: "/organizations/{orgId}/payment-methods",
+	request: {
+		params: z.object({
+			orgId: z.string(),
+		}),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						paymentMethods: z.array(adminPaymentMethodSchema),
+					}),
+				},
+			},
+			description: "Payment methods attached to the Stripe customer.",
+		},
+		404: {
+			description: "Organization not found.",
+		},
+	},
+});
+
+adminOrgDetails.openapi(getOrganizationPaymentMethods, async (c) => {
+	const { orgId } = c.req.valid("param");
+	const org = await requireOrganization(orgId);
+
+	if (!org.stripeCustomerId) {
+		return c.json({ paymentMethods: [] });
+	}
+
+	const paymentMethods = await getStripe().paymentMethods.list({
+		customer: org.stripeCustomerId,
+		type: "card",
+		limit: 100,
+	});
+
+	return c.json({
+		paymentMethods: paymentMethods.data.map((paymentMethod) => ({
+			id: paymentMethod.id,
+			type: paymentMethod.type,
+			createdAt: new Date(paymentMethod.created * 1000).toISOString(),
+			card: paymentMethod.card
+				? {
+						brand: paymentMethod.card.brand,
+						last4: paymentMethod.card.last4,
+						expiryMonth: paymentMethod.card.exp_month,
+						expiryYear: paymentMethod.card.exp_year,
+					}
+				: null,
+		})),
+	});
+});
+
+const deleteOrganizationPaymentMethod = createRoute({
+	method: "delete",
+	path: "/organizations/{orgId}/payment-methods/{paymentMethodId}",
+	request: {
+		params: z.object({
+			orgId: z.string(),
+			paymentMethodId: z.string(),
+		}),
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({ success: z.boolean() }),
+				},
+			},
+			description: "Payment method detached from Stripe and removed locally.",
+		},
+		404: {
+			description: "Organization or payment method not found.",
+		},
+	},
+});
+
+adminOrgDetails.openapi(deleteOrganizationPaymentMethod, async (c) => {
+	const { orgId, paymentMethodId } = c.req.valid("param");
+	const org = await requireOrganization(orgId);
+	const user = c.get("user");
+
+	if (!org.stripeCustomerId || !user) {
+		throw new HTTPException(404, { message: "Payment method not found" });
+	}
+
+	const paymentMethod =
+		await getStripe().paymentMethods.retrieve(paymentMethodId);
+	const stripeCustomerId =
+		typeof paymentMethod.customer === "string"
+			? paymentMethod.customer
+			: (paymentMethod.customer?.id ?? null);
+
+	if (stripeCustomerId !== org.stripeCustomerId) {
+		throw new HTTPException(404, { message: "Payment method not found" });
+	}
+
+	await getStripe().paymentMethods.detach(paymentMethodId);
+	await db
+		.delete(tables.paymentMethod)
+		.where(
+			and(
+				eq(tables.paymentMethod.organizationId, orgId),
+				eq(tables.paymentMethod.stripePaymentMethodId, paymentMethodId),
+			),
+		);
+
+	await logAuditEvent({
+		organizationId: orgId,
+		userId: user.id,
+		action: "payment.method.delete",
+		resourceType: "payment_method",
+		resourceId: paymentMethodId,
+		metadata: {
+			cardLast4: paymentMethod.card?.last4,
+		},
+	});
+
+	return c.json({ success: true });
 });
 
 // ==================== Guardrails ====================

--- a/apps/api/src/routes/admin-org-details.ts
+++ b/apps/api/src/routes/admin-org-details.ts
@@ -1,5 +1,6 @@
 import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
+import Stripe from "stripe";
 import { z } from "zod";
 
 import { adminMiddleware } from "@/middleware/admin.js";
@@ -385,10 +386,66 @@ type PaymentMethodOrganization = Pick<
 	| "chatPlanStripeSubscriptionId"
 >;
 
+interface OrganizationSubscription {
+	id: string;
+	kind: "default" | "devPlan" | "chatPlan";
+	subscription: Stripe.Subscription | null;
+}
+
 function getStripeId(
 	value: string | { id: string } | null | undefined,
 ): string | null {
 	return typeof value === "string" ? value : (value?.id ?? null);
+}
+
+function isStripeMissingResourceError(
+	error: unknown,
+): error is Stripe.errors.StripeInvalidRequestError {
+	return (
+		error instanceof Stripe.errors.StripeInvalidRequestError &&
+		(error.code === "resource_missing" || error.statusCode === 404)
+	);
+}
+
+async function listCustomerPaymentMethods(
+	stripe: Stripe,
+	stripeCustomerId: string,
+) {
+	const paymentMethods: Stripe.PaymentMethod[] = [];
+	let startingAfter: string | undefined;
+
+	while (true) {
+		const page = await stripe.paymentMethods.list({
+			customer: stripeCustomerId,
+			limit: 100,
+			...(startingAfter ? { starting_after: startingAfter } : {}),
+		});
+		paymentMethods.push(...page.data);
+
+		if (!page.has_more || page.data.length === 0) {
+			return paymentMethods;
+		}
+		startingAfter = page.data[page.data.length - 1]?.id;
+	}
+}
+
+async function retrieveOrganizationSubscription(
+	stripe: Stripe,
+	id: string,
+	kind: OrganizationSubscription["kind"],
+): Promise<OrganizationSubscription> {
+	try {
+		return {
+			id,
+			kind,
+			subscription: await stripe.subscriptions.retrieve(id),
+		};
+	} catch (error) {
+		if (isStripeMissingResourceError(error)) {
+			return { id, kind, subscription: null };
+		}
+		throw error;
+	}
 }
 
 async function getOrganizationPaymentMethodState(
@@ -399,29 +456,43 @@ async function getOrganizationPaymentMethodState(
 	}
 
 	const stripe = getStripe();
-	const subscriptionIds = [
-		org.stripeSubscriptionId,
-		org.devPlanStripeSubscriptionId,
-		org.chatPlanStripeSubscriptionId,
-	].filter((id): id is string => Boolean(id));
+	const subscriptionRequests: Promise<OrganizationSubscription>[] = [];
+	if (org.stripeSubscriptionId) {
+		subscriptionRequests.push(
+			retrieveOrganizationSubscription(
+				stripe,
+				org.stripeSubscriptionId,
+				"default",
+			),
+		);
+	}
+	if (org.devPlanStripeSubscriptionId) {
+		subscriptionRequests.push(
+			retrieveOrganizationSubscription(
+				stripe,
+				org.devPlanStripeSubscriptionId,
+				"devPlan",
+			),
+		);
+	}
+	if (org.chatPlanStripeSubscriptionId) {
+		subscriptionRequests.push(
+			retrieveOrganizationSubscription(
+				stripe,
+				org.chatPlanStripeSubscriptionId,
+				"chatPlan",
+			),
+		);
+	}
 
 	const [paymentMethods, customer, localPaymentMethods, subscriptions] =
 		await Promise.all([
-			stripe.paymentMethods.list({
-				customer: org.stripeCustomerId,
-				type: "card",
-				limit: 100,
-			}),
+			listCustomerPaymentMethods(stripe, org.stripeCustomerId),
 			stripe.customers.retrieve(org.stripeCustomerId),
 			db.query.paymentMethod.findMany({
 				where: { organizationId: org.id },
 			}),
-			Promise.all(
-				subscriptionIds.map(async (id) => ({
-					id,
-					subscription: await stripe.subscriptions.retrieve(id),
-				})),
-			),
+			Promise.all(subscriptionRequests),
 		]);
 
 	if (customer.deleted) {
@@ -436,6 +507,9 @@ async function getOrganizationPaymentMethodState(
 		defaultPaymentMethodIds.add(customerDefaultId);
 	}
 	for (const { subscription } of subscriptions) {
+		if (!subscription) {
+			continue;
+		}
 		const subscriptionDefaultId = getStripeId(
 			subscription.default_payment_method,
 		);
@@ -450,8 +524,7 @@ async function getOrganizationPaymentMethodState(
 	}
 
 	return {
-		paymentMethods: paymentMethods.data,
-		customer,
+		paymentMethods,
 		customerDefaultId,
 		localPaymentMethods,
 		subscriptions,
@@ -548,6 +621,9 @@ const deleteOrganizationPaymentMethod = createRoute({
 		400: {
 			description: "A valid replacement is required for a default method.",
 		},
+		409: {
+			description: "The replacement card is already used elsewhere.",
+		},
 	},
 });
 
@@ -561,14 +637,34 @@ adminOrgDetails.openapi(deleteOrganizationPaymentMethod, async (c) => {
 		throw new HTTPException(404, { message: "Payment method not found" });
 	}
 
-	const paymentMethod =
-		await getStripe().paymentMethods.retrieve(paymentMethodId);
-	const stripeCustomerId =
-		typeof paymentMethod.customer === "string"
-			? paymentMethod.customer
-			: (paymentMethod.customer?.id ?? null);
+	const stripe = getStripe();
+	const localPaymentMethod = await db.query.paymentMethod.findFirst({
+		where: {
+			organizationId: { eq: orgId },
+			stripePaymentMethodId: { eq: paymentMethodId },
+		},
+	});
+	let paymentMethod: Stripe.PaymentMethod | null = null;
+	try {
+		paymentMethod = await stripe.paymentMethods.retrieve(paymentMethodId);
+	} catch (error) {
+		if (!isStripeMissingResourceError(error)) {
+			throw error;
+		}
+		if (!localPaymentMethod) {
+			throw new HTTPException(404, {
+				message: "Payment method not found",
+			});
+		}
+	}
 
-	if (stripeCustomerId !== org.stripeCustomerId) {
+	const stripeCustomerId = paymentMethod
+		? getStripeId(paymentMethod.customer)
+		: null;
+	const attachedToOrganization = stripeCustomerId === org.stripeCustomerId;
+	const hasDetachedLocalMethod =
+		stripeCustomerId === null && Boolean(localPaymentMethod);
+	if (!attachedToOrganization && !hasDetachedLocalMethod) {
 		throw new HTTPException(404, { message: "Payment method not found" });
 	}
 
@@ -602,14 +698,82 @@ adminOrgDetails.openapi(deleteOrganizationPaymentMethod, async (c) => {
 
 	const replacementId = replacementPaymentMethod?.id ?? null;
 	const clearAllDefaults = remainingPaymentMethods.length === 0;
-	const stripe = getStripe();
 	const shouldUpdateCustomerDefault =
 		clearAllDefaults || state.customerDefaultId === paymentMethodId;
 	const subscriptionsToUpdate = state.subscriptions.filter(
-		({ subscription }) =>
-			clearAllDefaults ||
-			getStripeId(subscription.default_payment_method) === paymentMethodId,
+		(
+			entry,
+		): entry is OrganizationSubscription & {
+			subscription: Stripe.Subscription;
+		} => {
+			if (!entry.subscription) {
+				return false;
+			}
+			return (
+				clearAllDefaults ||
+				getStripeId(entry.subscription.default_payment_method) ===
+					paymentMethodId
+			);
+		},
 	);
+	const subscriptionUsesReplacement = (
+		kind: OrganizationSubscription["kind"],
+	) =>
+		Boolean(replacementId) &&
+		state.subscriptions.some(
+			(entry) =>
+				entry.kind === kind &&
+				entry.subscription &&
+				getStripeId(entry.subscription.default_payment_method) ===
+					replacementId,
+		);
+	const updateDevPlanFingerprint = clearAllDefaults
+		? Boolean(org.devPlanStripeSubscriptionId)
+		: subscriptionsToUpdate.some((entry) => entry.kind === "devPlan") ||
+			subscriptionUsesReplacement("devPlan");
+	const updateChatPlanFingerprint = clearAllDefaults
+		? Boolean(org.chatPlanStripeSubscriptionId)
+		: subscriptionsToUpdate.some((entry) => entry.kind === "chatPlan") ||
+			subscriptionUsesReplacement("chatPlan");
+	const replacementFingerprint =
+		replacementPaymentMethod?.card?.fingerprint ?? null;
+
+	if (
+		replacementId &&
+		(updateDevPlanFingerprint || updateChatPlanFingerprint) &&
+		!replacementFingerprint
+	) {
+		throw new HTTPException(400, {
+			message: "DevPass and Chat subscriptions require a replacement card.",
+		});
+	}
+
+	if (replacementFingerprint && updateDevPlanFingerprint) {
+		const conflictingOrganization = await db.query.organization.findFirst({
+			where: {
+				devPlanCardFingerprint: { eq: replacementFingerprint },
+				id: { ne: orgId },
+			},
+		});
+		if (conflictingOrganization) {
+			throw new HTTPException(409, {
+				message: "Replacement card is already used by another organization.",
+			});
+		}
+	}
+	if (replacementFingerprint && updateChatPlanFingerprint) {
+		const conflictingOrganization = await db.query.organization.findFirst({
+			where: {
+				chatPlanCardFingerprint: { eq: replacementFingerprint },
+				id: { ne: orgId },
+			},
+		});
+		if (conflictingOrganization) {
+			throw new HTTPException(409, {
+				message: "Replacement card is already used by another organization.",
+			});
+		}
+	}
 
 	if (shouldUpdateCustomerDefault) {
 		await stripe.customers.update(org.stripeCustomerId, {
@@ -624,20 +788,26 @@ adminOrgDetails.openapi(deleteOrganizationPaymentMethod, async (c) => {
 		});
 	}
 
-	await stripe.paymentMethods.detach(paymentMethodId);
+	if (attachedToOrganization) {
+		await stripe.paymentMethods.detach(paymentMethodId);
+	}
 
-	const localPaymentMethod = state.localPaymentMethods.find(
-		(candidate) => candidate.stripePaymentMethodId === paymentMethodId,
-	);
 	const localReplacement = replacementId
 		? state.localPaymentMethods.find(
 				(candidate) => candidate.stripePaymentMethodId === replacementId,
 			)
 		: undefined;
 	const disableAutoTopUp = clearAllDefaults;
+	const shouldReconcileLocalDefault =
+		clearAllDefaults ||
+		shouldUpdateCustomerDefault ||
+		Boolean(localPaymentMethod?.isDefault) ||
+		(hasDetachedLocalMethod &&
+			Boolean(replacementId) &&
+			state.customerDefaultId === replacementId);
 
 	await db.transaction(async (tx) => {
-		if (localPaymentMethod?.isDefault) {
+		if (shouldReconcileLocalDefault) {
 			await tx
 				.update(tables.paymentMethod)
 				.set({ isDefault: false })
@@ -658,10 +828,22 @@ adminOrgDetails.openapi(deleteOrganizationPaymentMethod, async (c) => {
 			}
 		}
 
-		if (disableAutoTopUp) {
+		if (
+			disableAutoTopUp ||
+			updateDevPlanFingerprint ||
+			updateChatPlanFingerprint
+		) {
 			await tx
 				.update(tables.organization)
-				.set({ autoTopUpEnabled: false })
+				.set({
+					...(disableAutoTopUp ? { autoTopUpEnabled: false } : {}),
+					...(updateDevPlanFingerprint
+						? { devPlanCardFingerprint: replacementFingerprint }
+						: {}),
+					...(updateChatPlanFingerprint
+						? { chatPlanCardFingerprint: replacementFingerprint }
+						: {}),
+				})
 				.where(eq(tables.organization.id, orgId));
 		}
 
@@ -682,7 +864,7 @@ adminOrgDetails.openapi(deleteOrganizationPaymentMethod, async (c) => {
 		resourceType: "payment_method",
 		resourceId: paymentMethodId,
 		metadata: {
-			cardLast4: paymentMethod.card?.last4,
+			cardLast4: paymentMethod?.card?.last4,
 			replacementPaymentMethodId: replacementId,
 			autoTopUpDisabled: disableAutoTopUp && org.autoTopUpEnabled,
 		},

--- a/apps/api/src/routes/admin-org-details.ts
+++ b/apps/api/src/routes/admin-org-details.ts
@@ -716,9 +716,20 @@ adminOrgDetails.openapi(deleteOrganizationPaymentMethod, async (c) => {
 			);
 		},
 	);
-	const subscriptionUsesReplacement = (
+	const subscriptionInheritsChangedCustomerDefault = (
 		kind: OrganizationSubscription["kind"],
 	) =>
+		shouldUpdateCustomerDefault &&
+		state.subscriptions.some(
+			(entry) =>
+				entry.kind === kind &&
+				entry.subscription &&
+				!getStripeId(entry.subscription.default_payment_method),
+		);
+	const subscriptionUsesRetryReplacement = (
+		kind: OrganizationSubscription["kind"],
+	) =>
+		hasDetachedLocalMethod &&
 		Boolean(replacementId) &&
 		state.subscriptions.some(
 			(entry) =>
@@ -730,11 +741,13 @@ adminOrgDetails.openapi(deleteOrganizationPaymentMethod, async (c) => {
 	const updateDevPlanFingerprint = clearAllDefaults
 		? Boolean(org.devPlanStripeSubscriptionId)
 		: subscriptionsToUpdate.some((entry) => entry.kind === "devPlan") ||
-			subscriptionUsesReplacement("devPlan");
+			subscriptionInheritsChangedCustomerDefault("devPlan") ||
+			subscriptionUsesRetryReplacement("devPlan");
 	const updateChatPlanFingerprint = clearAllDefaults
 		? Boolean(org.chatPlanStripeSubscriptionId)
 		: subscriptionsToUpdate.some((entry) => entry.kind === "chatPlan") ||
-			subscriptionUsesReplacement("chatPlan");
+			subscriptionInheritsChangedCustomerDefault("chatPlan") ||
+			subscriptionUsesRetryReplacement("chatPlan");
 	const replacementFingerprint =
 		replacementPaymentMethod?.card?.fingerprint ?? null;
 

--- a/apps/api/src/routes/admin-payment-methods.spec.ts
+++ b/apps/api/src/routes/admin-payment-methods.spec.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db, eq, tables } from "@llmgateway/db";
+
+import type * as PaymentsModule from "@/routes/payments.js";
+
+const stripeMock = vi.hoisted(() => ({
+	paymentMethods: {
+		list: vi.fn(),
+		retrieve: vi.fn(),
+		detach: vi.fn(),
+	},
+}));
+
+vi.mock("@/routes/payments.js", async (importOriginal) => {
+	const original = await importOriginal<typeof PaymentsModule>();
+	return {
+		...original,
+		getStripe: () => stripeMock,
+	};
+});
+
+const originalAdminEmails = process.env.ADMIN_EMAILS;
+const ORG_ID = "admin-payment-methods-org";
+const STRIPE_CUSTOMER_ID = "cus_admin_payment_methods";
+const STRIPE_PAYMENT_METHOD_ID = "pm_admin_payment_method";
+
+async function request(path = "", init?: RequestInit) {
+	return await app.request(
+		`/admin/organizations/${ORG_ID}/payment-methods${path}`,
+		init,
+	);
+}
+
+describe("admin organization payment methods", () => {
+	let cookie: string;
+
+	beforeEach(async () => {
+		process.env.ADMIN_EMAILS = "admin@example.com";
+		cookie = await createTestUser();
+		vi.clearAllMocks();
+
+		await db.insert(tables.organization).values({
+			id: ORG_ID,
+			name: "Admin Payment Methods Org",
+			billingEmail: "payments@test.example",
+			stripeCustomerId: STRIPE_CUSTOMER_ID,
+		});
+
+		stripeMock.paymentMethods.list.mockResolvedValue({ data: [] });
+		stripeMock.paymentMethods.retrieve.mockResolvedValue({
+			id: STRIPE_PAYMENT_METHOD_ID,
+			customer: STRIPE_CUSTOMER_ID,
+			type: "card",
+			card: {
+				brand: "visa",
+				last4: "4242",
+				exp_month: 12,
+				exp_year: 2030,
+			},
+		});
+		stripeMock.paymentMethods.detach.mockResolvedValue({
+			id: STRIPE_PAYMENT_METHOD_ID,
+		});
+	});
+
+	afterEach(async () => {
+		if (originalAdminEmails === undefined) {
+			delete process.env.ADMIN_EMAILS;
+		} else {
+			process.env.ADMIN_EMAILS = originalAdminEmails;
+		}
+		await deleteAll();
+	});
+
+	it("lists cards attached to the Stripe customer", async () => {
+		stripeMock.paymentMethods.list.mockResolvedValue({
+			data: [
+				{
+					id: STRIPE_PAYMENT_METHOD_ID,
+					type: "card",
+					created: 1_893_456_000,
+					card: {
+						brand: "visa",
+						last4: "4242",
+						exp_month: 12,
+						exp_year: 2030,
+					},
+				},
+			],
+		});
+
+		const response = await request("", { headers: { Cookie: cookie } });
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			paymentMethods: [
+				{
+					id: STRIPE_PAYMENT_METHOD_ID,
+					type: "card",
+					createdAt: "2030-01-01T00:00:00.000Z",
+					card: {
+						brand: "visa",
+						last4: "4242",
+						expiryMonth: 12,
+						expiryYear: 2030,
+					},
+				},
+			],
+		});
+		expect(stripeMock.paymentMethods.list).toHaveBeenCalledWith({
+			customer: STRIPE_CUSTOMER_ID,
+			type: "card",
+			limit: 100,
+		});
+	});
+
+	it("returns an empty list when the organization has no Stripe customer", async () => {
+		await db
+			.update(tables.organization)
+			.set({ stripeCustomerId: null })
+			.where(eq(tables.organization.id, ORG_ID));
+
+		const response = await request("", { headers: { Cookie: cookie } });
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({ paymentMethods: [] });
+		expect(stripeMock.paymentMethods.list).not.toHaveBeenCalled();
+	});
+
+	it("detaches the Stripe method and removes its local reference", async () => {
+		await db.insert(tables.paymentMethod).values({
+			id: "local-payment-method",
+			organizationId: ORG_ID,
+			stripePaymentMethodId: STRIPE_PAYMENT_METHOD_ID,
+			type: "card",
+			isDefault: true,
+		});
+
+		const response = await request(`/${STRIPE_PAYMENT_METHOD_ID}`, {
+			method: "DELETE",
+			headers: { Cookie: cookie },
+		});
+
+		expect(response.status).toBe(200);
+		expect(stripeMock.paymentMethods.detach).toHaveBeenCalledWith(
+			STRIPE_PAYMENT_METHOD_ID,
+		);
+		expect(
+			await db.query.paymentMethod.findFirst({
+				where: { id: { eq: "local-payment-method" } },
+			}),
+		).toBeUndefined();
+
+		const auditLog = await db.query.auditLog.findFirst({
+			where: {
+				organizationId: { eq: ORG_ID },
+				action: { eq: "payment.method.delete" },
+			},
+		});
+		expect(auditLog).toMatchObject({
+			resourceId: STRIPE_PAYMENT_METHOD_ID,
+			metadata: { cardLast4: "4242" },
+		});
+	});
+
+	it("refuses to detach a method belonging to another customer", async () => {
+		stripeMock.paymentMethods.retrieve.mockResolvedValue({
+			id: STRIPE_PAYMENT_METHOD_ID,
+			customer: "cus_someone_else",
+			type: "card",
+			card: { last4: "4242" },
+		});
+
+		const response = await request(`/${STRIPE_PAYMENT_METHOD_ID}`, {
+			method: "DELETE",
+			headers: { Cookie: cookie },
+		});
+
+		expect(response.status).toBe(404);
+		expect(stripeMock.paymentMethods.detach).not.toHaveBeenCalled();
+	});
+});

--- a/apps/api/src/routes/admin-payment-methods.spec.ts
+++ b/apps/api/src/routes/admin-payment-methods.spec.ts
@@ -8,10 +8,18 @@ import { db, eq, tables } from "@llmgateway/db";
 import type * as PaymentsModule from "@/routes/payments.js";
 
 const stripeMock = vi.hoisted(() => ({
+	customers: {
+		retrieve: vi.fn(),
+		update: vi.fn(),
+	},
 	paymentMethods: {
 		list: vi.fn(),
 		retrieve: vi.fn(),
 		detach: vi.fn(),
+	},
+	subscriptions: {
+		retrieve: vi.fn(),
+		update: vi.fn(),
 	},
 }));
 
@@ -27,12 +35,26 @@ const originalAdminEmails = process.env.ADMIN_EMAILS;
 const ORG_ID = "admin-payment-methods-org";
 const STRIPE_CUSTOMER_ID = "cus_admin_payment_methods";
 const STRIPE_PAYMENT_METHOD_ID = "pm_admin_payment_method";
+const REPLACEMENT_PAYMENT_METHOD_ID = "pm_admin_replacement";
+const SUBSCRIPTION_ID = "sub_admin_payment_methods";
 
 async function request(path = "", init?: RequestInit) {
 	return await app.request(
 		`/admin/organizations/${ORG_ID}/payment-methods${path}`,
 		init,
 	);
+}
+
+async function deletePaymentMethod(
+	cookie: string,
+	paymentMethodId = STRIPE_PAYMENT_METHOD_ID,
+	replacementPaymentMethodId?: string,
+) {
+	return await request(`/${paymentMethodId}`, {
+		method: "DELETE",
+		headers: { Cookie: cookie, "Content-Type": "application/json" },
+		body: JSON.stringify({ replacementPaymentMethodId }),
+	});
 }
 
 describe("admin organization payment methods", () => {
@@ -50,7 +72,29 @@ describe("admin organization payment methods", () => {
 			stripeCustomerId: STRIPE_CUSTOMER_ID,
 		});
 
-		stripeMock.paymentMethods.list.mockResolvedValue({ data: [] });
+		stripeMock.customers.retrieve.mockResolvedValue({
+			id: STRIPE_CUSTOMER_ID,
+			deleted: false,
+			invoice_settings: { default_payment_method: null },
+		});
+		stripeMock.customers.update.mockResolvedValue({
+			id: STRIPE_CUSTOMER_ID,
+		});
+		stripeMock.paymentMethods.list.mockResolvedValue({
+			data: [
+				{
+					id: STRIPE_PAYMENT_METHOD_ID,
+					type: "card",
+					created: 1_893_456_000,
+					card: {
+						brand: "visa",
+						last4: "4242",
+						exp_month: 12,
+						exp_year: 2030,
+					},
+				},
+			],
+		});
 		stripeMock.paymentMethods.retrieve.mockResolvedValue({
 			id: STRIPE_PAYMENT_METHOD_ID,
 			customer: STRIPE_CUSTOMER_ID,
@@ -65,6 +109,13 @@ describe("admin organization payment methods", () => {
 		stripeMock.paymentMethods.detach.mockResolvedValue({
 			id: STRIPE_PAYMENT_METHOD_ID,
 		});
+		stripeMock.subscriptions.retrieve.mockResolvedValue({
+			id: "sub_admin_payment_methods",
+			default_payment_method: null,
+		});
+		stripeMock.subscriptions.update.mockResolvedValue({
+			id: "sub_admin_payment_methods",
+		});
 	});
 
 	afterEach(async () => {
@@ -77,6 +128,13 @@ describe("admin organization payment methods", () => {
 	});
 
 	it("lists cards attached to the Stripe customer", async () => {
+		stripeMock.customers.retrieve.mockResolvedValue({
+			id: STRIPE_CUSTOMER_ID,
+			deleted: false,
+			invoice_settings: {
+				default_payment_method: STRIPE_PAYMENT_METHOD_ID,
+			},
+		});
 		stripeMock.paymentMethods.list.mockResolvedValue({
 			data: [
 				{
@@ -102,6 +160,7 @@ describe("admin organization payment methods", () => {
 					id: STRIPE_PAYMENT_METHOD_ID,
 					type: "card",
 					createdAt: "2030-01-01T00:00:00.000Z",
+					isDefault: true,
 					card: {
 						brand: "visa",
 						last4: "4242",
@@ -140,10 +199,7 @@ describe("admin organization payment methods", () => {
 			isDefault: true,
 		});
 
-		const response = await request(`/${STRIPE_PAYMENT_METHOD_ID}`, {
-			method: "DELETE",
-			headers: { Cookie: cookie },
-		});
+		const response = await deletePaymentMethod(cookie);
 
 		expect(response.status).toBe(200);
 		expect(stripeMock.paymentMethods.detach).toHaveBeenCalledWith(
@@ -167,6 +223,172 @@ describe("admin organization payment methods", () => {
 		});
 	});
 
+	it("requires an attached replacement before deleting a default method", async () => {
+		stripeMock.customers.retrieve.mockResolvedValue({
+			id: STRIPE_CUSTOMER_ID,
+			deleted: false,
+			invoice_settings: {
+				default_payment_method: STRIPE_PAYMENT_METHOD_ID,
+			},
+		});
+		stripeMock.paymentMethods.list.mockResolvedValue({
+			data: [
+				{ id: STRIPE_PAYMENT_METHOD_ID, type: "card" },
+				{ id: REPLACEMENT_PAYMENT_METHOD_ID, type: "card" },
+			],
+		});
+
+		const response = await deletePaymentMethod(cookie);
+
+		expect(response.status).toBe(400);
+		expect(stripeMock.customers.update).not.toHaveBeenCalled();
+		expect(stripeMock.paymentMethods.detach).not.toHaveBeenCalled();
+	});
+
+	it("moves Stripe and local defaults before detaching the default method", async () => {
+		await db
+			.update(tables.organization)
+			.set({
+				autoTopUpEnabled: true,
+				stripeSubscriptionId: SUBSCRIPTION_ID,
+			})
+			.where(eq(tables.organization.id, ORG_ID));
+		await db.insert(tables.paymentMethod).values([
+			{
+				id: "local-default-payment-method",
+				organizationId: ORG_ID,
+				stripePaymentMethodId: STRIPE_PAYMENT_METHOD_ID,
+				type: "card",
+				isDefault: true,
+			},
+			{
+				id: "local-replacement-payment-method",
+				organizationId: ORG_ID,
+				stripePaymentMethodId: REPLACEMENT_PAYMENT_METHOD_ID,
+				type: "card",
+				isDefault: false,
+			},
+		]);
+		stripeMock.customers.retrieve.mockResolvedValue({
+			id: STRIPE_CUSTOMER_ID,
+			deleted: false,
+			invoice_settings: {
+				default_payment_method: STRIPE_PAYMENT_METHOD_ID,
+			},
+		});
+		stripeMock.paymentMethods.list.mockResolvedValue({
+			data: [
+				{ id: STRIPE_PAYMENT_METHOD_ID, type: "card" },
+				{ id: REPLACEMENT_PAYMENT_METHOD_ID, type: "card" },
+			],
+		});
+		stripeMock.subscriptions.retrieve.mockResolvedValue({
+			id: SUBSCRIPTION_ID,
+			default_payment_method: STRIPE_PAYMENT_METHOD_ID,
+		});
+
+		const response = await deletePaymentMethod(
+			cookie,
+			STRIPE_PAYMENT_METHOD_ID,
+			REPLACEMENT_PAYMENT_METHOD_ID,
+		);
+
+		expect(response.status).toBe(200);
+		expect(stripeMock.customers.update).toHaveBeenCalledWith(
+			STRIPE_CUSTOMER_ID,
+			{
+				invoice_settings: {
+					default_payment_method: REPLACEMENT_PAYMENT_METHOD_ID,
+				},
+			},
+		);
+		expect(stripeMock.subscriptions.update).toHaveBeenCalledWith(
+			SUBSCRIPTION_ID,
+			{ default_payment_method: REPLACEMENT_PAYMENT_METHOD_ID },
+		);
+		expect(
+			stripeMock.customers.update.mock.invocationCallOrder[0],
+		).toBeLessThan(
+			stripeMock.paymentMethods.detach.mock.invocationCallOrder[0],
+		);
+		expect(
+			stripeMock.subscriptions.update.mock.invocationCallOrder[0],
+		).toBeLessThan(
+			stripeMock.paymentMethods.detach.mock.invocationCallOrder[0],
+		);
+
+		const replacement = await db.query.paymentMethod.findFirst({
+			where: { id: { eq: "local-replacement-payment-method" } },
+		});
+		expect(replacement?.isDefault).toBe(true);
+		expect(
+			await db.query.paymentMethod.findFirst({
+				where: { id: { eq: "local-default-payment-method" } },
+			}),
+		).toBeUndefined();
+		expect(
+			await db.query.organization.findFirst({
+				where: { id: { eq: ORG_ID } },
+			}),
+		).toMatchObject({ autoTopUpEnabled: true });
+	});
+
+	it("clears Stripe defaults and disables auto top-up for the last method", async () => {
+		const subscriptionIds = [
+			"sub_default_payment_methods",
+			"sub_devpass_payment_methods",
+			"sub_chat_payment_methods",
+		];
+		await db
+			.update(tables.organization)
+			.set({
+				autoTopUpEnabled: true,
+				stripeSubscriptionId: subscriptionIds[0],
+				devPlanStripeSubscriptionId: subscriptionIds[1],
+				chatPlanStripeSubscriptionId: subscriptionIds[2],
+			})
+			.where(eq(tables.organization.id, ORG_ID));
+		await db.insert(tables.paymentMethod).values({
+			id: "local-last-payment-method",
+			organizationId: ORG_ID,
+			stripePaymentMethodId: STRIPE_PAYMENT_METHOD_ID,
+			type: "card",
+			isDefault: true,
+		});
+		stripeMock.customers.retrieve.mockResolvedValue({
+			id: STRIPE_CUSTOMER_ID,
+			deleted: false,
+			invoice_settings: {
+				default_payment_method: STRIPE_PAYMENT_METHOD_ID,
+			},
+		});
+		stripeMock.subscriptions.retrieve.mockImplementation(
+			async (id: string) => ({
+				id,
+				default_payment_method: STRIPE_PAYMENT_METHOD_ID,
+			}),
+		);
+
+		const response = await deletePaymentMethod(cookie);
+
+		expect(response.status).toBe(200);
+		expect(stripeMock.customers.update).toHaveBeenCalledWith(
+			STRIPE_CUSTOMER_ID,
+			{ invoice_settings: { default_payment_method: "" } },
+		);
+		for (const subscriptionId of subscriptionIds) {
+			expect(stripeMock.subscriptions.update).toHaveBeenCalledWith(
+				subscriptionId,
+				{ default_payment_method: "" },
+			);
+		}
+		expect(
+			await db.query.organization.findFirst({
+				where: { id: { eq: ORG_ID } },
+			}),
+		).toMatchObject({ autoTopUpEnabled: false });
+	});
+
 	it("refuses to detach a method belonging to another customer", async () => {
 		stripeMock.paymentMethods.retrieve.mockResolvedValue({
 			id: STRIPE_PAYMENT_METHOD_ID,
@@ -177,7 +399,8 @@ describe("admin organization payment methods", () => {
 
 		const response = await request(`/${STRIPE_PAYMENT_METHOD_ID}`, {
 			method: "DELETE",
-			headers: { Cookie: cookie },
+			headers: { Cookie: cookie, "Content-Type": "application/json" },
+			body: JSON.stringify({}),
 		});
 
 		expect(response.status).toBe(404);

--- a/apps/api/src/routes/admin-payment-methods.spec.ts
+++ b/apps/api/src/routes/admin-payment-methods.spec.ts
@@ -1,3 +1,4 @@
+import Stripe from "stripe";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { app } from "@/index.js";
@@ -110,11 +111,11 @@ describe("admin organization payment methods", () => {
 			id: STRIPE_PAYMENT_METHOD_ID,
 		});
 		stripeMock.subscriptions.retrieve.mockResolvedValue({
-			id: "sub_admin_payment_methods",
+			id: SUBSCRIPTION_ID,
 			default_payment_method: null,
 		});
 		stripeMock.subscriptions.update.mockResolvedValue({
-			id: "sub_admin_payment_methods",
+			id: SUBSCRIPTION_ID,
 		});
 	});
 
@@ -172,7 +173,6 @@ describe("admin organization payment methods", () => {
 		});
 		expect(stripeMock.paymentMethods.list).toHaveBeenCalledWith({
 			customer: STRIPE_CUSTOMER_ID,
-			type: "card",
 			limit: 100,
 		});
 	});
@@ -188,6 +188,69 @@ describe("admin organization payment methods", () => {
 		expect(response.status).toBe(200);
 		expect(await response.json()).toEqual({ paymentMethods: [] });
 		expect(stripeMock.paymentMethods.list).not.toHaveBeenCalled();
+	});
+
+	it("lists every page of attached payment methods", async () => {
+		stripeMock.paymentMethods.list
+			.mockResolvedValueOnce({
+				data: [{ id: STRIPE_PAYMENT_METHOD_ID, type: "card", created: 1 }],
+				has_more: true,
+			})
+			.mockResolvedValueOnce({
+				data: [{ id: REPLACEMENT_PAYMENT_METHOD_ID, type: "card", created: 2 }],
+				has_more: false,
+			});
+
+		const response = await request("", { headers: { Cookie: cookie } });
+
+		expect(response.status).toBe(200);
+		expect((await response.json()).paymentMethods).toHaveLength(2);
+		expect(stripeMock.paymentMethods.list).toHaveBeenNthCalledWith(2, {
+			customer: STRIPE_CUSTOMER_ID,
+			limit: 100,
+			starting_after: STRIPE_PAYMENT_METHOD_ID,
+		});
+	});
+
+	it("does not use another organization's local default", async () => {
+		await db.insert(tables.organization).values({
+			id: "other-payment-method-org",
+			name: "Other Payment Method Org",
+			billingEmail: "other-payments@test.example",
+		});
+		await db.insert(tables.paymentMethod).values({
+			organizationId: "other-payment-method-org",
+			stripePaymentMethodId: STRIPE_PAYMENT_METHOD_ID,
+			type: "card",
+			isDefault: true,
+		});
+
+		const response = await request("", { headers: { Cookie: cookie } });
+
+		expect(response.status).toBe(200);
+		expect((await response.json()).paymentMethods[0]).toMatchObject({
+			id: STRIPE_PAYMENT_METHOD_ID,
+			isDefault: false,
+		});
+	});
+
+	it("ignores a missing stored Stripe subscription when listing methods", async () => {
+		await db
+			.update(tables.organization)
+			.set({ stripeSubscriptionId: SUBSCRIPTION_ID })
+			.where(eq(tables.organization.id, ORG_ID));
+		stripeMock.subscriptions.retrieve.mockRejectedValue(
+			new Stripe.errors.StripeInvalidRequestError({
+				type: "invalid_request_error",
+				code: "resource_missing",
+				message: `No such subscription: ${SUBSCRIPTION_ID}`,
+			}),
+		);
+
+		const response = await request("", { headers: { Cookie: cookie } });
+
+		expect(response.status).toBe(200);
+		expect((await response.json()).paymentMethods).toHaveLength(1);
 	});
 
 	it("detaches the Stripe method and removes its local reference", async () => {
@@ -245,6 +308,31 @@ describe("admin organization payment methods", () => {
 		expect(stripeMock.paymentMethods.detach).not.toHaveBeenCalled();
 	});
 
+	it("rejects a replacement that is not attached to the customer", async () => {
+		stripeMock.customers.retrieve.mockResolvedValue({
+			id: STRIPE_CUSTOMER_ID,
+			deleted: false,
+			invoice_settings: {
+				default_payment_method: STRIPE_PAYMENT_METHOD_ID,
+			},
+		});
+		stripeMock.paymentMethods.list.mockResolvedValue({
+			data: [
+				{ id: STRIPE_PAYMENT_METHOD_ID, type: "card" },
+				{ id: REPLACEMENT_PAYMENT_METHOD_ID, type: "card" },
+			],
+		});
+
+		const response = await deletePaymentMethod(
+			cookie,
+			STRIPE_PAYMENT_METHOD_ID,
+			"pm_not_attached",
+		);
+
+		expect(response.status).toBe(400);
+		expect(stripeMock.paymentMethods.detach).not.toHaveBeenCalled();
+	});
+
 	it("moves Stripe and local defaults before detaching the default method", async () => {
 		await db
 			.update(tables.organization)
@@ -255,11 +343,11 @@ describe("admin organization payment methods", () => {
 			.where(eq(tables.organization.id, ORG_ID));
 		await db.insert(tables.paymentMethod).values([
 			{
-				id: "local-default-payment-method",
+				id: "local-target-payment-method",
 				organizationId: ORG_ID,
 				stripePaymentMethodId: STRIPE_PAYMENT_METHOD_ID,
 				type: "card",
-				isDefault: true,
+				isDefault: false,
 			},
 			{
 				id: "local-replacement-payment-method",
@@ -267,6 +355,13 @@ describe("admin organization payment methods", () => {
 				stripePaymentMethodId: REPLACEMENT_PAYMENT_METHOD_ID,
 				type: "card",
 				isDefault: false,
+			},
+			{
+				id: "local-stale-default-payment-method",
+				organizationId: ORG_ID,
+				stripePaymentMethodId: "pm_local_stale_default",
+				type: "card",
+				isDefault: true,
 			},
 		]);
 		stripeMock.customers.retrieve.mockResolvedValue({
@@ -323,14 +418,134 @@ describe("admin organization payment methods", () => {
 		expect(replacement?.isDefault).toBe(true);
 		expect(
 			await db.query.paymentMethod.findFirst({
-				where: { id: { eq: "local-default-payment-method" } },
+				where: { id: { eq: "local-target-payment-method" } },
 			}),
 		).toBeUndefined();
+		expect(
+			await db.query.paymentMethod.findFirst({
+				where: { id: { eq: "local-stale-default-payment-method" } },
+			}),
+		).toMatchObject({ isDefault: false });
 		expect(
 			await db.query.organization.findFirst({
 				where: { id: { eq: ORG_ID } },
 			}),
 		).toMatchObject({ autoTopUpEnabled: true });
+	});
+
+	it("keeps non-card methods and auto top-up when replacing the last card", async () => {
+		await db
+			.update(tables.organization)
+			.set({ autoTopUpEnabled: true })
+			.where(eq(tables.organization.id, ORG_ID));
+		stripeMock.customers.retrieve.mockResolvedValue({
+			id: STRIPE_CUSTOMER_ID,
+			deleted: false,
+			invoice_settings: {
+				default_payment_method: STRIPE_PAYMENT_METHOD_ID,
+			},
+		});
+		stripeMock.paymentMethods.list.mockResolvedValue({
+			data: [
+				{ id: STRIPE_PAYMENT_METHOD_ID, type: "card" },
+				{ id: REPLACEMENT_PAYMENT_METHOD_ID, type: "us_bank_account" },
+			],
+		});
+
+		const response = await deletePaymentMethod(
+			cookie,
+			STRIPE_PAYMENT_METHOD_ID,
+			REPLACEMENT_PAYMENT_METHOD_ID,
+		);
+
+		expect(response.status).toBe(200);
+		expect(stripeMock.customers.update).toHaveBeenCalledWith(
+			STRIPE_CUSTOMER_ID,
+			{
+				invoice_settings: {
+					default_payment_method: REPLACEMENT_PAYMENT_METHOD_ID,
+				},
+			},
+		);
+		expect(
+			await db.query.organization.findFirst({
+				where: { id: { eq: ORG_ID } },
+			}),
+		).toMatchObject({ autoTopUpEnabled: true });
+	});
+
+	it("updates the DevPass fingerprint with its replacement card", async () => {
+		await db
+			.update(tables.organization)
+			.set({
+				devPlanStripeSubscriptionId: SUBSCRIPTION_ID,
+				devPlanCardFingerprint: "old_fingerprint",
+			})
+			.where(eq(tables.organization.id, ORG_ID));
+		stripeMock.paymentMethods.list.mockResolvedValue({
+			data: [
+				{ id: STRIPE_PAYMENT_METHOD_ID, type: "card" },
+				{
+					id: REPLACEMENT_PAYMENT_METHOD_ID,
+					type: "card",
+					card: { fingerprint: "replacement_fingerprint" },
+				},
+			],
+		});
+		stripeMock.subscriptions.retrieve.mockResolvedValue({
+			id: SUBSCRIPTION_ID,
+			default_payment_method: STRIPE_PAYMENT_METHOD_ID,
+		});
+
+		const response = await deletePaymentMethod(
+			cookie,
+			STRIPE_PAYMENT_METHOD_ID,
+			REPLACEMENT_PAYMENT_METHOD_ID,
+		);
+
+		expect(response.status).toBe(200);
+		expect(
+			await db.query.organization.findFirst({
+				where: { id: { eq: ORG_ID } },
+			}),
+		).toMatchObject({ devPlanCardFingerprint: "replacement_fingerprint" });
+	});
+
+	it("rejects a replacement fingerprint used by another DevPass org", async () => {
+		await db
+			.update(tables.organization)
+			.set({ devPlanStripeSubscriptionId: SUBSCRIPTION_ID })
+			.where(eq(tables.organization.id, ORG_ID));
+		await db.insert(tables.organization).values({
+			id: "other-devpass-fingerprint-org",
+			name: "Other DevPass Fingerprint Org",
+			billingEmail: "other-devpass@test.example",
+			devPlanCardFingerprint: "replacement_fingerprint",
+		});
+		stripeMock.paymentMethods.list.mockResolvedValue({
+			data: [
+				{ id: STRIPE_PAYMENT_METHOD_ID, type: "card" },
+				{
+					id: REPLACEMENT_PAYMENT_METHOD_ID,
+					type: "card",
+					card: { fingerprint: "replacement_fingerprint" },
+				},
+			],
+		});
+		stripeMock.subscriptions.retrieve.mockResolvedValue({
+			id: SUBSCRIPTION_ID,
+			default_payment_method: STRIPE_PAYMENT_METHOD_ID,
+		});
+
+		const response = await deletePaymentMethod(
+			cookie,
+			STRIPE_PAYMENT_METHOD_ID,
+			REPLACEMENT_PAYMENT_METHOD_ID,
+		);
+
+		expect(response.status).toBe(409);
+		expect(stripeMock.subscriptions.update).not.toHaveBeenCalled();
+		expect(stripeMock.paymentMethods.detach).not.toHaveBeenCalled();
 	});
 
 	it("clears Stripe defaults and disables auto top-up for the last method", async () => {
@@ -346,6 +561,8 @@ describe("admin organization payment methods", () => {
 				stripeSubscriptionId: subscriptionIds[0],
 				devPlanStripeSubscriptionId: subscriptionIds[1],
 				chatPlanStripeSubscriptionId: subscriptionIds[2],
+				devPlanCardFingerprint: "dev_fingerprint",
+				chatPlanCardFingerprint: "chat_fingerprint",
 			})
 			.where(eq(tables.organization.id, ORG_ID));
 		await db.insert(tables.paymentMethod).values({
@@ -386,7 +603,52 @@ describe("admin organization payment methods", () => {
 			await db.query.organization.findFirst({
 				where: { id: { eq: ORG_ID } },
 			}),
-		).toMatchObject({ autoTopUpEnabled: false });
+		).toMatchObject({
+			autoTopUpEnabled: false,
+			devPlanCardFingerprint: null,
+			chatPlanCardFingerprint: null,
+		});
+	});
+
+	it("cleans up a local row after Stripe already detached the method", async () => {
+		await db.insert(tables.paymentMethod).values({
+			id: "local-detached-payment-method",
+			organizationId: ORG_ID,
+			stripePaymentMethodId: STRIPE_PAYMENT_METHOD_ID,
+			type: "card",
+			isDefault: true,
+		});
+		stripeMock.paymentMethods.retrieve.mockResolvedValue({
+			id: STRIPE_PAYMENT_METHOD_ID,
+			customer: null,
+			type: "card",
+		});
+		stripeMock.paymentMethods.list.mockResolvedValue({ data: [] });
+
+		const response = await deletePaymentMethod(cookie);
+
+		expect(response.status).toBe(200);
+		expect(stripeMock.paymentMethods.detach).not.toHaveBeenCalled();
+		expect(
+			await db.query.paymentMethod.findFirst({
+				where: { id: { eq: "local-detached-payment-method" } },
+			}),
+		).toBeUndefined();
+	});
+
+	it("maps a missing Stripe payment method to not found", async () => {
+		stripeMock.paymentMethods.retrieve.mockRejectedValue(
+			new Stripe.errors.StripeInvalidRequestError({
+				type: "invalid_request_error",
+				code: "resource_missing",
+				message: `No such payment method: ${STRIPE_PAYMENT_METHOD_ID}`,
+			}),
+		);
+
+		const response = await deletePaymentMethod(cookie);
+
+		expect(response.status).toBe(404);
+		expect(stripeMock.paymentMethods.detach).not.toHaveBeenCalled();
 	});
 
 	it("refuses to detach a method belonging to another customer", async () => {

--- a/apps/api/src/routes/admin-payment-methods.spec.ts
+++ b/apps/api/src/routes/admin-payment-methods.spec.ts
@@ -511,6 +511,156 @@ describe("admin organization payment methods", () => {
 		).toMatchObject({ devPlanCardFingerprint: "replacement_fingerprint" });
 	});
 
+	it("updates plan fingerprints inherited from the customer default", async () => {
+		const chatSubscriptionId = "sub_chat_inherited_payment_method";
+		await db
+			.update(tables.organization)
+			.set({
+				devPlanStripeSubscriptionId: SUBSCRIPTION_ID,
+				chatPlanStripeSubscriptionId: chatSubscriptionId,
+				devPlanCardFingerprint: "old_dev_fingerprint",
+				chatPlanCardFingerprint: "old_chat_fingerprint",
+			})
+			.where(eq(tables.organization.id, ORG_ID));
+		stripeMock.customers.retrieve.mockResolvedValue({
+			id: STRIPE_CUSTOMER_ID,
+			deleted: false,
+			invoice_settings: {
+				default_payment_method: STRIPE_PAYMENT_METHOD_ID,
+			},
+		});
+		stripeMock.paymentMethods.list.mockResolvedValue({
+			data: [
+				{ id: STRIPE_PAYMENT_METHOD_ID, type: "card" },
+				{
+					id: REPLACEMENT_PAYMENT_METHOD_ID,
+					type: "card",
+					card: { fingerprint: "replacement_fingerprint" },
+				},
+			],
+		});
+		stripeMock.subscriptions.retrieve.mockImplementation(
+			async (id: string) => ({
+				id,
+				default_payment_method: null,
+			}),
+		);
+
+		const response = await deletePaymentMethod(
+			cookie,
+			STRIPE_PAYMENT_METHOD_ID,
+			REPLACEMENT_PAYMENT_METHOD_ID,
+		);
+
+		expect(response.status).toBe(200);
+		expect(stripeMock.subscriptions.update).not.toHaveBeenCalled();
+		expect(
+			await db.query.organization.findFirst({
+				where: { id: { eq: ORG_ID } },
+			}),
+		).toMatchObject({
+			devPlanCardFingerprint: "replacement_fingerprint",
+			chatPlanCardFingerprint: "replacement_fingerprint",
+		});
+	});
+
+	it("does not update an unaffected plan fingerprint", async () => {
+		await db
+			.update(tables.organization)
+			.set({
+				devPlanStripeSubscriptionId: SUBSCRIPTION_ID,
+				devPlanCardFingerprint: "existing_fingerprint",
+			})
+			.where(eq(tables.organization.id, ORG_ID));
+		stripeMock.customers.retrieve.mockResolvedValue({
+			id: STRIPE_CUSTOMER_ID,
+			deleted: false,
+			invoice_settings: {
+				default_payment_method: REPLACEMENT_PAYMENT_METHOD_ID,
+			},
+		});
+		stripeMock.paymentMethods.list.mockResolvedValue({
+			data: [
+				{ id: STRIPE_PAYMENT_METHOD_ID, type: "card" },
+				{ id: REPLACEMENT_PAYMENT_METHOD_ID, type: "us_bank_account" },
+			],
+		});
+		stripeMock.subscriptions.retrieve.mockResolvedValue({
+			id: SUBSCRIPTION_ID,
+			default_payment_method: REPLACEMENT_PAYMENT_METHOD_ID,
+		});
+
+		const response = await deletePaymentMethod(
+			cookie,
+			STRIPE_PAYMENT_METHOD_ID,
+			REPLACEMENT_PAYMENT_METHOD_ID,
+		);
+
+		expect(response.status).toBe(200);
+		expect(stripeMock.customers.update).not.toHaveBeenCalled();
+		expect(stripeMock.subscriptions.update).not.toHaveBeenCalled();
+		expect(
+			await db.query.organization.findFirst({
+				where: { id: { eq: ORG_ID } },
+			}),
+		).toMatchObject({ devPlanCardFingerprint: "existing_fingerprint" });
+	});
+
+	it("updates a plan fingerprint when retrying after detachment", async () => {
+		await db
+			.update(tables.organization)
+			.set({
+				devPlanStripeSubscriptionId: SUBSCRIPTION_ID,
+				devPlanCardFingerprint: "old_fingerprint",
+			})
+			.where(eq(tables.organization.id, ORG_ID));
+		await db.insert(tables.paymentMethod).values({
+			id: "local-detached-plan-payment-method",
+			organizationId: ORG_ID,
+			stripePaymentMethodId: STRIPE_PAYMENT_METHOD_ID,
+			type: "card",
+			isDefault: true,
+		});
+		stripeMock.paymentMethods.retrieve.mockResolvedValue({
+			id: STRIPE_PAYMENT_METHOD_ID,
+			customer: null,
+			type: "card",
+		});
+		stripeMock.customers.retrieve.mockResolvedValue({
+			id: STRIPE_CUSTOMER_ID,
+			deleted: false,
+			invoice_settings: {
+				default_payment_method: REPLACEMENT_PAYMENT_METHOD_ID,
+			},
+		});
+		stripeMock.paymentMethods.list.mockResolvedValue({
+			data: [
+				{
+					id: REPLACEMENT_PAYMENT_METHOD_ID,
+					type: "card",
+					card: { fingerprint: "replacement_fingerprint" },
+				},
+			],
+		});
+		stripeMock.subscriptions.retrieve.mockResolvedValue({
+			id: SUBSCRIPTION_ID,
+			default_payment_method: REPLACEMENT_PAYMENT_METHOD_ID,
+		});
+
+		const response = await deletePaymentMethod(
+			cookie,
+			STRIPE_PAYMENT_METHOD_ID,
+			REPLACEMENT_PAYMENT_METHOD_ID,
+		);
+
+		expect(response.status).toBe(200);
+		expect(
+			await db.query.organization.findFirst({
+				where: { id: { eq: ORG_ID } },
+			}),
+		).toMatchObject({ devPlanCardFingerprint: "replacement_fingerprint" });
+	});
+
 	it("rejects a replacement fingerprint used by another DevPass org", async () => {
 		await db
 			.update(tables.organization)

--- a/ee/admin/src/app/organizations/[orgId]/org-settings-tab.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/org-settings-tab.tsx
@@ -31,6 +31,11 @@ import {
 import { failureLabel } from "@llmgateway/shared";
 import { providerLogoUrls } from "@llmgateway/shared/components";
 
+import {
+	PaymentMethodsList,
+	type AdminPaymentMethod,
+} from "./payment-methods-list";
+
 import type { paths } from "@/lib/api/v1";
 import type { ReactElement, ReactNode } from "react";
 
@@ -256,7 +261,19 @@ function RefBadgeList({ refs }: { refs: string[] | undefined }) {
 	);
 }
 
-export function OrgSettingsTab({ settings }: { settings: SettingsResponse }) {
+export function OrgSettingsTab({
+	settings,
+	paymentMethods,
+	paymentMethodsLoadError,
+	onDeletePaymentMethod,
+}: {
+	settings: SettingsResponse;
+	paymentMethods: AdminPaymentMethod[] | null;
+	paymentMethodsLoadError: boolean;
+	onDeletePaymentMethod: (
+		paymentMethodId: string,
+	) => Promise<{ success: boolean; error?: string }>;
+}) {
 	const { organization: org, customProviders } = settings;
 	const policy =
 		org.providerCompliancePolicy as ProviderCompliancePolicy | null;
@@ -541,6 +558,12 @@ export function OrgSettingsTab({ settings }: { settings: SettingsResponse }) {
 							)}
 						</SettingRow>
 					</div>
+
+					<PaymentMethodsList
+						paymentMethods={paymentMethods}
+						loadError={paymentMethodsLoadError}
+						onDelete={onDeletePaymentMethod}
+					/>
 				</CardContent>
 			</Card>
 

--- a/ee/admin/src/app/organizations/[orgId]/org-settings-tab.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/org-settings-tab.tsx
@@ -272,6 +272,7 @@ export function OrgSettingsTab({
 	paymentMethodsLoadError: boolean;
 	onDeletePaymentMethod: (
 		paymentMethodId: string,
+		replacementPaymentMethodId?: string,
 	) => Promise<{ success: boolean; error?: string }>;
 }) {
 	const { organization: org, customProviders } = settings;
@@ -562,6 +563,7 @@ export function OrgSettingsTab({
 					<PaymentMethodsList
 						paymentMethods={paymentMethods}
 						loadError={paymentMethodsLoadError}
+						autoTopUpEnabled={org.autoTopUpEnabled}
 						onDelete={onDeletePaymentMethod}
 					/>
 				</CardContent>

--- a/ee/admin/src/app/organizations/[orgId]/organization-tab-url.spec.ts
+++ b/ee/admin/src/app/organizations/[orgId]/organization-tab-url.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { buildOrganizationTabUrl } from "./organization-tab-url";
+
+describe("buildOrganizationTabUrl", () => {
+	it("selects a tab while preserving other query parameters", () => {
+		expect(
+			buildOrganizationTabUrl(
+				"/organizations/org-id",
+				new URLSearchParams("txPage=2"),
+				"settings",
+			),
+		).toBe("/organizations/org-id?txPage=2&tab=settings");
+	});
+
+	it("replaces a selected tab", () => {
+		expect(
+			buildOrganizationTabUrl(
+				"/organizations/org-id",
+				new URLSearchParams("tab=settings&txPage=2"),
+				"guardrails",
+			),
+		).toBe("/organizations/org-id?tab=guardrails&txPage=2");
+	});
+
+	it("removes the default tab without leaving a trailing query", () => {
+		expect(
+			buildOrganizationTabUrl(
+				"/organizations/org-id",
+				new URLSearchParams("tab=settings"),
+				"transactions",
+			),
+		).toBe("/organizations/org-id");
+	});
+});

--- a/ee/admin/src/app/organizations/[orgId]/organization-tab-url.ts
+++ b/ee/admin/src/app/organizations/[orgId]/organization-tab-url.ts
@@ -1,0 +1,14 @@
+export function buildOrganizationTabUrl(
+	pathname: string,
+	searchParams: URLSearchParams,
+	tab: string,
+) {
+	const nextSearchParams = new URLSearchParams(searchParams);
+	if (tab === "transactions") {
+		nextSearchParams.delete("tab");
+	} else {
+		nextSearchParams.set("tab", tab);
+	}
+	const query = nextSearchParams.toString();
+	return query ? `${pathname}?${query}` : pathname;
+}

--- a/ee/admin/src/app/organizations/[orgId]/organization-tabs.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/organization-tabs.tsx
@@ -4,6 +4,8 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 import { Tabs } from "@/components/ui/tabs";
 
+import { buildOrganizationTabUrl } from "./organization-tab-url";
+
 import type { ComponentProps } from "react";
 
 export function OrganizationTabs({
@@ -17,14 +19,19 @@ export function OrganizationTabs({
 	return (
 		<Tabs
 			{...props}
-			defaultValue={defaultValue}
+			value={defaultValue}
 			onValueChange={(value) => {
-				if (value !== "settings" || searchParams.get("tab") === "settings") {
+				if ((searchParams.get("tab") ?? "transactions") === value) {
 					return;
 				}
-				const nextSearchParams = new URLSearchParams(searchParams);
-				nextSearchParams.set("tab", "settings");
-				router.push(`${pathname}?${nextSearchParams.toString()}`);
+				router.push(
+					buildOrganizationTabUrl(
+						pathname,
+						new URLSearchParams(searchParams),
+						value,
+					),
+					{ scroll: false },
+				);
 			}}
 		/>
 	);

--- a/ee/admin/src/app/organizations/[orgId]/organization-tabs.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/organization-tabs.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import { Tabs } from "@/components/ui/tabs";
+
+import type { ComponentProps } from "react";
+
+export function OrganizationTabs({
+	defaultValue,
+	...props
+}: ComponentProps<typeof Tabs>) {
+	const pathname = usePathname();
+	const router = useRouter();
+	const searchParams = useSearchParams();
+
+	return (
+		<Tabs
+			{...props}
+			defaultValue={defaultValue}
+			onValueChange={(value) => {
+				if (value !== "settings" || searchParams.get("tab") === "settings") {
+					return;
+				}
+				const nextSearchParams = new URLSearchParams(searchParams);
+				nextSearchParams.set("tab", "settings");
+				router.push(`${pathname}?${nextSearchParams.toString()}`);
+			}}
+		/>
+	);
+}

--- a/ee/admin/src/app/organizations/[orgId]/page.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/page.tsx
@@ -859,11 +859,15 @@ export default async function OrganizationPage({
 							settings={settingsData}
 							paymentMethods={paymentMethodsData?.paymentMethods ?? null}
 							paymentMethodsLoadError={!paymentMethodsData}
-							onDeletePaymentMethod={async (paymentMethodId) => {
+							onDeletePaymentMethod={async (
+								paymentMethodId,
+								replacementPaymentMethodId,
+							) => {
 								"use server";
 								return await deleteOrganizationPaymentMethod(
 									orgId,
 									paymentMethodId,
+									replacementPaymentMethodId,
 								);
 							}}
 						/>

--- a/ee/admin/src/app/organizations/[orgId]/page.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/page.tsx
@@ -35,6 +35,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
 	addManualCreditsToOrganization,
 	blockOrganization,
+	deleteOrganizationPaymentMethod,
 	giftCreditsToOrganization,
 	manageOrganization,
 	updateReferralBonus,
@@ -219,6 +220,7 @@ export default async function OrganizationPage({
 		auditLogsRes,
 		orgMetricsRes,
 		settingsRes,
+		paymentMethodsRes,
 		guardrailsRes,
 		ssoRes,
 	] = await Promise.all([
@@ -260,6 +262,9 @@ export default async function OrganizationPage({
 		$api.GET("/admin/organizations/{orgId}/settings", {
 			params: { path: { orgId } },
 		}),
+		$api.GET("/admin/organizations/{orgId}/payment-methods", {
+			params: { path: { orgId } },
+		}),
 		$api.GET("/admin/organizations/{orgId}/guardrails", {
 			params: { path: { orgId } },
 		}),
@@ -275,6 +280,7 @@ export default async function OrganizationPage({
 	const membersData = membersRes.data;
 	const auditLogsData = auditLogsRes.data;
 	const settingsData = settingsRes.data;
+	const paymentMethodsData = paymentMethodsRes.data;
 	const guardrailsData = guardrailsRes.data;
 	const ssoData = ssoRes.data;
 
@@ -849,7 +855,18 @@ export default async function OrganizationPage({
 
 				<TabsContent value="settings">
 					{settingsData ? (
-						<OrgSettingsTab settings={settingsData} />
+						<OrgSettingsTab
+							settings={settingsData}
+							paymentMethods={paymentMethodsData?.paymentMethods ?? null}
+							paymentMethodsLoadError={!paymentMethodsData}
+							onDeletePaymentMethod={async (paymentMethodId) => {
+								"use server";
+								return await deleteOrganizationPaymentMethod(
+									orgId,
+									paymentMethodId,
+								);
+							}}
+						/>
 					) : (
 						<p className="py-8 text-center text-sm text-muted-foreground">
 							Failed to load organization settings

--- a/ee/admin/src/app/organizations/[orgId]/page.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/page.tsx
@@ -31,7 +31,7 @@ import {
 	TableHeader,
 	TableRow,
 } from "@/components/ui/table";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
 	addManualCreditsToOrganization,
 	blockOrganization,
@@ -54,6 +54,7 @@ import { OrgCostByModel } from "./org-cost-by-model";
 import { OrgCostByModelTimeseries } from "./org-cost-by-model-timeseries";
 import { OrgMetricsSection } from "./org-metrics";
 import { OrgSettingsTab } from "./org-settings-tab";
+import { OrganizationTabs } from "./organization-tabs";
 import { ProviderKeysTable } from "./provider-keys-table";
 import { ReferralBonusDialog } from "./referral-bonus-dialog";
 import { SendEmailDialog } from "./send-email-dialog";
@@ -211,6 +212,12 @@ export default async function OrganizationPage({
 	const alOffset = (alPage - 1) * alLimit;
 
 	const $api = await createServerApiClient();
+	const paymentMethodsRequest =
+		activeTab === "settings"
+			? $api.GET("/admin/organizations/{orgId}/payment-methods", {
+					params: { path: { orgId } },
+				})
+			: Promise.resolve(null);
 	const [
 		transactionsRes,
 		projectsRes,
@@ -262,9 +269,7 @@ export default async function OrganizationPage({
 		$api.GET("/admin/organizations/{orgId}/settings", {
 			params: { path: { orgId } },
 		}),
-		$api.GET("/admin/organizations/{orgId}/payment-methods", {
-			params: { path: { orgId } },
-		}),
+		paymentMethodsRequest,
 		$api.GET("/admin/organizations/{orgId}/guardrails", {
 			params: { path: { orgId } },
 		}),
@@ -280,7 +285,7 @@ export default async function OrganizationPage({
 	const membersData = membersRes.data;
 	const auditLogsData = auditLogsRes.data;
 	const settingsData = settingsRes.data;
-	const paymentMethodsData = paymentMethodsRes.data;
+	const paymentMethodsData = paymentMethodsRes?.data;
 	const guardrailsData = guardrailsRes.data;
 	const ssoData = ssoRes.data;
 
@@ -534,7 +539,7 @@ export default async function OrganizationPage({
 				</section>
 			)}
 
-			<Tabs defaultValue={activeTab}>
+			<OrganizationTabs defaultValue={activeTab}>
 				<TabsList className="w-full justify-start overflow-x-auto sm:w-auto">
 					<TabsTrigger value="transactions">
 						<Receipt className="mr-1.5 h-4 w-4" />
@@ -897,7 +902,7 @@ export default async function OrganizationPage({
 						</p>
 					)}
 				</TabsContent>
-			</Tabs>
+			</OrganizationTabs>
 		</div>
 	);
 }

--- a/ee/admin/src/app/organizations/[orgId]/payment-methods-list.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/payment-methods-list.tsx
@@ -1,9 +1,16 @@
 "use client";
 
-import { CreditCard, Loader2, RefreshCw, Trash2 } from "lucide-react";
+import {
+	AlertTriangle,
+	CreditCard,
+	Loader2,
+	RefreshCw,
+	Trash2,
+} from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -14,11 +21,20 @@ import {
 	DialogTitle,
 	DialogTrigger,
 } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 
 export interface AdminPaymentMethod {
 	id: string;
 	type: string;
 	createdAt: string;
+	isDefault: boolean;
 	card: {
 		brand: string;
 		last4: string;
@@ -29,8 +45,11 @@ export interface AdminPaymentMethod {
 
 interface DeletePaymentMethodDialogProps {
 	paymentMethod: AdminPaymentMethod;
+	paymentMethods: AdminPaymentMethod[];
+	autoTopUpEnabled: boolean;
 	onDelete: (
 		paymentMethodId: string,
+		replacementPaymentMethodId?: string,
 	) => Promise<{ success: boolean; error?: string }>;
 }
 
@@ -50,20 +69,33 @@ function paymentMethodLabel(paymentMethod: AdminPaymentMethod) {
 
 function DeletePaymentMethodDialog({
 	paymentMethod,
+	paymentMethods,
+	autoTopUpEnabled,
 	onDelete,
 }: DeletePaymentMethodDialogProps) {
 	const router = useRouter();
+	const replacementOptions = paymentMethods.filter(
+		(candidate) => candidate.id !== paymentMethod.id,
+	);
 	const [open, setOpen] = useState(false);
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const [replacementPaymentMethodId, setReplacementPaymentMethodId] = useState(
+		replacementOptions[0]?.id ?? "",
+	);
 	const label = paymentMethodLabel(paymentMethod);
+	const requiresReplacement =
+		paymentMethod.isDefault && replacementOptions.length > 0;
 
 	const handleDelete = async () => {
 		setLoading(true);
 		setError(null);
 
 		try {
-			const result = await onDelete(paymentMethod.id);
+			const result = await onDelete(
+				paymentMethod.id,
+				requiresReplacement ? replacementPaymentMethodId : undefined,
+			);
 			if (!result.success) {
 				setError(result.error ?? "Failed to delete payment method");
 				return;
@@ -90,6 +122,9 @@ function DeletePaymentMethodDialog({
 					return;
 				}
 				setOpen(nextOpen);
+				if (nextOpen) {
+					setReplacementPaymentMethodId(replacementOptions[0]?.id ?? "");
+				}
 				if (!nextOpen) {
 					setError(null);
 				}
@@ -111,11 +146,62 @@ function DeletePaymentMethodDialog({
 					<DialogTitle>Delete {label}?</DialogTitle>
 					<DialogDescription>
 						This detaches the payment method from the Stripe customer and
-						removes its local saved-method reference. Charges, renewals, and
-						automatic top-ups using this method will fail until another method
-						is selected. This action cannot be undone.
+						removes its local saved-method reference. This action cannot be
+						undone.
 					</DialogDescription>
 				</DialogHeader>
+
+				{requiresReplacement ? (
+					<div className="space-y-2">
+						<Label htmlFor={`replacement-${paymentMethod.id}`}>
+							Replacement default
+						</Label>
+						<p className="text-sm text-muted-foreground">
+							This method is currently a default. Choose another attached card
+							for Stripe and future charges before deleting it.
+						</p>
+						<Select
+							value={replacementPaymentMethodId}
+							onValueChange={setReplacementPaymentMethodId}
+							disabled={loading}
+						>
+							<SelectTrigger
+								id={`replacement-${paymentMethod.id}`}
+								className="w-full"
+							>
+								<SelectValue placeholder="Select a replacement" />
+							</SelectTrigger>
+							<SelectContent>
+								{replacementOptions.map((replacement) => (
+									<SelectItem key={replacement.id} value={replacement.id}>
+										{paymentMethodLabel(replacement)}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+				) : paymentMethod.isDefault ? (
+					<p className="text-sm text-muted-foreground">
+						No replacement remains. Stripe customer and subscription defaults
+						will be cleared, so renewals may fail until another card is added.
+					</p>
+				) : null}
+
+				{autoTopUpEnabled ? (
+					<div
+						className="flex gap-2 rounded-md bg-amber-50 px-3 py-2.5 text-sm text-amber-950 dark:bg-amber-950/50 dark:text-amber-100"
+						role="note"
+					>
+						<AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+						<p>
+							{replacementOptions.length === 0
+								? "Auto top-up is enabled and will be disabled because no payment method remains."
+								: paymentMethod.isDefault
+									? "Auto top-up is enabled. Future automatic top-ups will use the selected replacement."
+									: "Auto top-up is enabled. This card is not currently a default, so automatic top-ups will keep using the existing default."}
+						</p>
+					</div>
+				) : null}
 
 				{error ? (
 					<p className="text-sm text-destructive" role="alert">
@@ -134,7 +220,9 @@ function DeletePaymentMethodDialog({
 					<Button
 						variant="destructive"
 						onClick={handleDelete}
-						disabled={loading}
+						disabled={
+							loading || (requiresReplacement && !replacementPaymentMethodId)
+						}
 					>
 						{loading ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
 						Delete payment method
@@ -148,12 +236,15 @@ function DeletePaymentMethodDialog({
 export function PaymentMethodsList({
 	paymentMethods,
 	loadError,
+	autoTopUpEnabled,
 	onDelete,
 }: {
 	paymentMethods: AdminPaymentMethod[] | null;
 	loadError: boolean;
+	autoTopUpEnabled: boolean;
 	onDelete: (
 		paymentMethodId: string,
+		replacementPaymentMethodId?: string,
 	) => Promise<{ success: boolean; error?: string }>;
 }) {
 	const router = useRouter();
@@ -189,7 +280,12 @@ export function PaymentMethodsList({
 							>
 								<CreditCard className="h-5 w-5 shrink-0 text-muted-foreground" />
 								<div className="min-w-0 flex-1">
-									<p className="text-sm font-medium">{label}</p>
+									<div className="flex flex-wrap items-center gap-2">
+										<p className="text-sm font-medium">{label}</p>
+										{paymentMethod.isDefault ? (
+											<Badge variant="secondary">Default</Badge>
+										) : null}
+									</div>
 									<p className="mt-1 break-all font-mono text-xs text-muted-foreground">
 										{paymentMethod.card
 											? `Expires ${String(paymentMethod.card.expiryMonth).padStart(2, "0")}/${String(paymentMethod.card.expiryYear).slice(-2)} · `
@@ -199,6 +295,8 @@ export function PaymentMethodsList({
 								</div>
 								<DeletePaymentMethodDialog
 									paymentMethod={paymentMethod}
+									paymentMethods={paymentMethods}
+									autoTopUpEnabled={autoTopUpEnabled}
 									onDelete={onDelete}
 								/>
 							</div>

--- a/ee/admin/src/app/organizations/[orgId]/payment-methods-list.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/payment-methods-list.tsx
@@ -123,6 +123,7 @@ function DeletePaymentMethodDialog({
 				}
 				setOpen(nextOpen);
 				if (nextOpen) {
+					setError(null);
 					setReplacementPaymentMethodId(replacementOptions[0]?.id ?? "");
 				}
 				if (!nextOpen) {
@@ -157,8 +158,8 @@ function DeletePaymentMethodDialog({
 							Replacement default
 						</Label>
 						<p className="text-sm text-muted-foreground">
-							This method is currently a default. Choose another attached card
-							for Stripe and future charges before deleting it.
+							This method is currently a default. Choose another attached
+							payment method for Stripe and future charges before deleting it.
 						</p>
 						<Select
 							value={replacementPaymentMethodId}
@@ -183,7 +184,8 @@ function DeletePaymentMethodDialog({
 				) : paymentMethod.isDefault ? (
 					<p className="text-sm text-muted-foreground">
 						No replacement remains. Stripe customer and subscription defaults
-						will be cleared, so renewals may fail until another card is added.
+						will be cleared, so renewals may fail until another payment method
+						is added.
 					</p>
 				) : null}
 
@@ -198,7 +200,7 @@ function DeletePaymentMethodDialog({
 								? "Auto top-up is enabled and will be disabled because no payment method remains."
 								: paymentMethod.isDefault
 									? "Auto top-up is enabled. Future automatic top-ups will use the selected replacement."
-									: "Auto top-up is enabled. This card is not currently a default, so automatic top-ups will keep using the existing default."}
+									: "Auto top-up is enabled. This payment method is not currently a default, so automatic top-ups will keep using the existing default."}
 						</p>
 					</div>
 				) : null}
@@ -254,7 +256,7 @@ export function PaymentMethodsList({
 			<div>
 				<h3 className="text-sm font-medium">Payment methods</h3>
 				<p className="mt-1 text-sm text-muted-foreground">
-					Cards attached to the Stripe customer. Card details live in Stripe;
+					Methods attached to the Stripe customer. Their details live in Stripe;
 					standard top-up links are also tracked locally.
 				</p>
 			</div>

--- a/ee/admin/src/app/organizations/[orgId]/payment-methods-list.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/payment-methods-list.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { CreditCard, Loader2, RefreshCw, Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+
+export interface AdminPaymentMethod {
+	id: string;
+	type: string;
+	createdAt: string;
+	card: {
+		brand: string;
+		last4: string;
+		expiryMonth: number;
+		expiryYear: number;
+	} | null;
+}
+
+interface DeletePaymentMethodDialogProps {
+	paymentMethod: AdminPaymentMethod;
+	onDelete: (
+		paymentMethodId: string,
+	) => Promise<{ success: boolean; error?: string }>;
+}
+
+function formatBrand(brand: string) {
+	return brand
+		.split("_")
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(" ");
+}
+
+function paymentMethodLabel(paymentMethod: AdminPaymentMethod) {
+	if (!paymentMethod.card) {
+		return paymentMethod.type.replaceAll("_", " ");
+	}
+	return `${formatBrand(paymentMethod.card.brand)} ending in ${paymentMethod.card.last4}`;
+}
+
+function DeletePaymentMethodDialog({
+	paymentMethod,
+	onDelete,
+}: DeletePaymentMethodDialogProps) {
+	const router = useRouter();
+	const [open, setOpen] = useState(false);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const label = paymentMethodLabel(paymentMethod);
+
+	const handleDelete = async () => {
+		setLoading(true);
+		setError(null);
+
+		try {
+			const result = await onDelete(paymentMethod.id);
+			if (!result.success) {
+				setError(result.error ?? "Failed to delete payment method");
+				return;
+			}
+
+			setOpen(false);
+			router.refresh();
+		} catch (deleteError) {
+			setError(
+				deleteError instanceof Error
+					? deleteError.message
+					: "Failed to delete payment method",
+			);
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	return (
+		<Dialog
+			open={open}
+			onOpenChange={(nextOpen) => {
+				if (loading) {
+					return;
+				}
+				setOpen(nextOpen);
+				if (!nextOpen) {
+					setError(null);
+				}
+			}}
+		>
+			<DialogTrigger asChild>
+				<Button
+					variant="ghost"
+					size="sm"
+					className="text-destructive hover:text-destructive"
+					aria-label={`Delete ${label}`}
+				>
+					<Trash2 className="h-4 w-4" />
+					Delete
+				</Button>
+			</DialogTrigger>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Delete {label}?</DialogTitle>
+					<DialogDescription>
+						This detaches the payment method from the Stripe customer and
+						removes its local saved-method reference. Charges, renewals, and
+						automatic top-ups using this method will fail until another method
+						is selected. This action cannot be undone.
+					</DialogDescription>
+				</DialogHeader>
+
+				{error ? (
+					<p className="text-sm text-destructive" role="alert">
+						{error}
+					</p>
+				) : null}
+
+				<DialogFooter>
+					<Button
+						variant="outline"
+						onClick={() => setOpen(false)}
+						disabled={loading}
+					>
+						Cancel
+					</Button>
+					<Button
+						variant="destructive"
+						onClick={handleDelete}
+						disabled={loading}
+					>
+						{loading ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+						Delete payment method
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+export function PaymentMethodsList({
+	paymentMethods,
+	loadError,
+	onDelete,
+}: {
+	paymentMethods: AdminPaymentMethod[] | null;
+	loadError: boolean;
+	onDelete: (
+		paymentMethodId: string,
+	) => Promise<{ success: boolean; error?: string }>;
+}) {
+	const router = useRouter();
+
+	return (
+		<section className="space-y-3 border-t pt-6 md:col-span-2">
+			<div>
+				<h3 className="text-sm font-medium">Payment methods</h3>
+				<p className="mt-1 text-sm text-muted-foreground">
+					Cards attached to the Stripe customer. Card details live in Stripe;
+					standard top-up links are also tracked locally.
+				</p>
+			</div>
+
+			{loadError ? (
+				<div className="flex flex-col items-start gap-3 py-3 sm:flex-row sm:items-center sm:justify-between">
+					<p className="text-sm text-destructive" role="alert">
+						Payment methods could not be loaded from Stripe.
+					</p>
+					<Button variant="outline" size="sm" onClick={() => router.refresh()}>
+						<RefreshCw className="h-4 w-4" />
+						Try again
+					</Button>
+				</div>
+			) : paymentMethods?.length ? (
+				<div className="divide-y border-y">
+					{paymentMethods.map((paymentMethod) => {
+						const label = paymentMethodLabel(paymentMethod);
+						return (
+							<div
+								key={paymentMethod.id}
+								className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center"
+							>
+								<CreditCard className="h-5 w-5 shrink-0 text-muted-foreground" />
+								<div className="min-w-0 flex-1">
+									<p className="text-sm font-medium">{label}</p>
+									<p className="mt-1 break-all font-mono text-xs text-muted-foreground">
+										{paymentMethod.card
+											? `Expires ${String(paymentMethod.card.expiryMonth).padStart(2, "0")}/${String(paymentMethod.card.expiryYear).slice(-2)} · `
+											: ""}
+										{paymentMethod.id}
+									</p>
+								</div>
+								<DeletePaymentMethodDialog
+									paymentMethod={paymentMethod}
+									onDelete={onDelete}
+								/>
+							</div>
+						);
+					})}
+				</div>
+			) : (
+				<p className="py-3 text-sm text-muted-foreground">
+					No payment methods are attached to this Stripe customer.
+				</p>
+			)}
+		</section>
+	);
+}

--- a/ee/admin/src/lib/admin-organizations.ts
+++ b/ee/admin/src/lib/admin-organizations.ts
@@ -178,6 +178,28 @@ export async function setOrganizationStatus(
 	return { success: true };
 }
 
+export async function deleteOrganizationPaymentMethod(
+	orgId: string,
+	paymentMethodId: string,
+): Promise<{ success: boolean; error?: string }> {
+	const $api = await createServerApiClient();
+	const { data, error } = await $api.DELETE(
+		"/admin/organizations/{orgId}/payment-methods/{paymentMethodId}",
+		{
+			params: { path: { orgId, paymentMethodId } },
+		},
+	);
+
+	if (error || !data) {
+		const message =
+			(error as { message?: string } | undefined)?.message ??
+			"Failed to delete payment method";
+		return { success: false, error: message };
+	}
+
+	return { success: true };
+}
+
 export async function blockOrganization(orgId: string): Promise<{
 	success: boolean;
 	error?: string;

--- a/ee/admin/src/lib/admin-organizations.ts
+++ b/ee/admin/src/lib/admin-organizations.ts
@@ -181,12 +181,14 @@ export async function setOrganizationStatus(
 export async function deleteOrganizationPaymentMethod(
 	orgId: string,
 	paymentMethodId: string,
+	replacementPaymentMethodId?: string,
 ): Promise<{ success: boolean; error?: string }> {
 	const $api = await createServerApiClient();
 	const { data, error } = await $api.DELETE(
 		"/admin/organizations/{orgId}/payment-methods/{paymentMethodId}",
 		{
 			params: { path: { orgId, paymentMethodId } },
+			body: { replacementPaymentMethodId },
 		},
 	);
 


### PR DESCRIPTION
## Summary

- show every payment method attached to an organization's Stripe customer, including card brand, last four digits, expiry, and default status
- load payment methods only when an admin opens the Settings tab and paginate through the complete Stripe collection
- require an attached replacement before deleting a current default; otherwise clear customer and subscription defaults when the final method is removed
- keep Stripe defaults, local saved-method references, and DevPass/Chat card fingerprints synchronized when subscriptions inherit customer defaults, including retry-safe cleanup after partial failures
- disable automatic top-ups when no payment method remains and explain the exact automatic-top-up effect in the confirmation dialog
- tolerate only genuine missing Stripe resources while preserving authentication and availability errors
- audit deletions and reject methods or replacements that do not belong to the organization
- synchronize the selected organization tab with the URL across navigation, reload, and browser history

## Storage finding

Stripe is the source of truth for payment-method details. The database stores references for standard top-up payment methods and subscription card fingerprints, while some methods can exist only in Stripe. The admin view therefore lists Stripe directly and deletion synchronizes Stripe state with the related database records.

## Screenshots

| Before | After |
| --- | --- |
| ![Billing settings before payment methods](https://raw.githubusercontent.com/theopenco/llmgateway/04761745676b35294858a330db52de7a7314d879/admin-payment-methods-before-light.png) | ![Payment methods in light mode](https://raw.githubusercontent.com/theopenco/llmgateway/04761745676b35294858a330db52de7a7314d879/admin-payment-methods-after-light.png) |

| Light confirmation | Dark confirmation |
| --- | --- |
| ![Default-method deletion in light mode](https://raw.githubusercontent.com/theopenco/llmgateway/6b4bb862334e69449d2a8f2a41798cf0a6106f18/admin-payment-methods-dialog-feedback-light.png) | ![Default-method deletion in dark mode](https://raw.githubusercontent.com/theopenco/llmgateway/6b4bb862334e69449d2a8f2a41798cf0a6106f18/admin-payment-methods-dialog-feedback-dark.png) |

![Payment methods in dark mode](https://raw.githubusercontent.com/theopenco/llmgateway/04761745676b35294858a330db52de7a7314d879/admin-payment-methods-after-dark.png)

## Verification

- `pnpm format`
- `pnpm exec vitest run apps/api/src/routes/admin-payment-methods.spec.ts 'ee/admin/src/app/organizations/[orgId]/organization-tab-url.spec.ts' --no-file-parallelism` (22 tests)
- `pnpm build`
- verified Stripe replacement, final-method cleanup, and retry flows in test mode
- verified Settings-tab lazy loading and the confirmation dialog in light and dark themes
- verified tab navigation, reload, default-tab URLs, and browser history against the local admin dashboard


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added payment-method management to organization billing settings.
  * Displayed default methods, loading states, errors, and empty states.
  * Added retry handling and safe deletion with optional replacement methods.
  * Added warnings when deleting methods may affect auto top-up.
  * Updated organization settings navigation to preserve the selected tab.

* **Bug Fixes**
  * Improved synchronization of payment-method defaults after deletion.
  * Prevented invalid, unauthorized, or incomplete payment-method removals.
  * Disabled auto top-up when removing the final payment method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->