### PR TITLE
docs: apps/admin no longer exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ curl -X POST https://api.llmgateway.io/v1/chat/completions \
 - `apps/api`: Hono backend
 - `apps/gateway`: API gateway for routing LLM requests
 - `apps/docs`: Documentation site
-- `apps/admin`: Internal admin dashboard
 - `packages/db`: Drizzle ORM schema and migrations
 - `packages/models`: Model and provider definitions
 - `packages/shared`: Shared types and utilities


### PR DESCRIPTION
The project structure lists `apps/admin`, which was removed in `eb302289c` ("feat(gateway): improve retry routing and request logging", 2026-04-06). It no longer exists on `main`.

Removed rather than repointed, since nothing replaced it.

Worth mentioning separately, and deliberately not changed here: `apps/` currently holds `playground`, `ui` and `worker` as well, and none of the three appears in that list. I have left them out because I would be guessing at what to call them, and a wrong description is worse than an absent one. Happy to add them if you say what they are.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented folder structure by removing the internal admin dashboard entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->