### PR TITLE
fix(routing): separate filtered candidates

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -6704,7 +6704,7 @@ describe("api", () => {
 			process.env.LLM_GOOGLE_CLOUD_PROJECT = "vertex-project";
 			process.env.LLM_GOOGLE_VERTEX_BASE_URL = mockServerUrl;
 
-			const makeRequest = (content: string) =>
+			const makeRequest = (content: string, model = "gemini-2.5-flash-lite") =>
 				app.request("/v1/chat/completions", {
 					method: "POST",
 					headers: {
@@ -6712,7 +6712,7 @@ describe("api", () => {
 						Authorization: "Bearer real-token",
 					},
 					body: JSON.stringify({
-						model: "gemini-2.5-flash-lite",
+						model,
 						messages: [{ role: "user", content }],
 					}),
 				});
@@ -6727,14 +6727,40 @@ describe("api", () => {
 			const secondJson = await secondRes.json();
 			expect(secondJson.metadata.used_provider).toBe("google-vertex");
 
-			const logs = await waitForLogs(2);
+			const directRes = await makeRequest(
+				"Direct provider rate limit request",
+				"google-ai-studio/gemini-2.5-flash-lite",
+			);
+			expect(directRes.status).toBe(200);
+			const directJson = await directRes.json();
+			expect(directJson.metadata.used_provider).toBe("google-vertex");
+
+			const logs = await waitForLogs(3);
 			const overflowLog = logs.find(
-				(log) => log.usedProvider === "google-vertex",
+				(log) =>
+					log.usedProvider === "google-vertex" &&
+					log.routingMetadata?.selectionReason !== "rate-limit-fallback",
 			);
 			expect(overflowLog?.routingMetadata?.providerScores).not.toContainEqual(
 				expect.objectContaining({ providerId: "google-ai-studio" }),
 			);
 			expect(overflowLog?.routingMetadata?.filteredProviders).toContainEqual({
+				providerId: "google-ai-studio",
+				reasons: ["provider is rate limited"],
+				codes: ["rate_limited"],
+			});
+
+			const directFallbackLog = logs.find(
+				(log) => log.routingMetadata?.selectionReason === "rate-limit-fallback",
+			);
+			expect(
+				directFallbackLog?.routingMetadata?.providerScores,
+			).not.toContainEqual(
+				expect.objectContaining({ providerId: "google-ai-studio" }),
+			);
+			expect(
+				directFallbackLog?.routingMetadata?.filteredProviders,
+			).toContainEqual({
 				providerId: "google-ai-studio",
 				reasons: ["provider is rate limited"],
 				codes: ["rate_limited"],

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -6726,6 +6726,19 @@ describe("api", () => {
 			expect(secondRes.status).toBe(200);
 			const secondJson = await secondRes.json();
 			expect(secondJson.metadata.used_provider).toBe("google-vertex");
+
+			const logs = await waitForLogs(2);
+			const overflowLog = logs.find(
+				(log) => log.usedProvider === "google-vertex",
+			);
+			expect(overflowLog?.routingMetadata?.providerScores).not.toContainEqual(
+				expect.objectContaining({ providerId: "google-ai-studio" }),
+			);
+			expect(overflowLog?.routingMetadata?.filteredProviders).toContainEqual({
+				providerId: "google-ai-studio",
+				reasons: ["provider is rate limited"],
+				codes: ["rate_limited"],
+			});
 		} finally {
 			if (previousVertexKey === undefined) {
 				delete process.env.LLM_GOOGLE_VERTEX_API_KEY;

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -804,15 +804,11 @@ function getContentFilterRoutingDecision(
 	};
 }
 
-async function addContentFilterRoutingMetadata(
+function addContentFilterRoutingMetadata(
 	routingMetadata: RoutingMetadata,
 	contentFilterMatched: boolean,
 	excludedProviders: ProviderModelMapping[],
-	modelId: string | undefined,
-	metricsMap: Map<string, ProviderMetrics>,
-	organizationId: string,
-	providerDiscountResolver: ReturnType<typeof createProviderDiscountResolver>,
-): Promise<RoutingMetadata> {
+): RoutingMetadata {
 	if (!contentFilterMatched) {
 		return routingMetadata;
 	}
@@ -820,39 +816,15 @@ async function addContentFilterRoutingMetadata(
 	const contentFilterExcludedProviders = [
 		...new Set(excludedProviders.map((provider) => provider.providerId)),
 	];
-
-	const providerScores =
-		excludedProviders.length === 0 || !modelId
-			? routingMetadata.providerScores
-			: [
-					...(await Promise.all(
-						excludedProviders.map(async (provider) => {
-							const metrics = metricsMap.get(
-								metricsKey(modelId, provider.providerId, provider.region),
-							);
-							const { price, discount } =
-								await getDiscountedProviderSelectionPrice(provider, modelId, {
-									organizationId,
-									providerDiscountResolver,
-								});
-
-							return {
-								providerId: provider.providerId,
-								region: provider.region,
-								score: -1,
-								uptime: metrics?.uptime ?? 0,
-								latency: metrics?.averageLatency ?? 0,
-								throughput: metrics?.throughput ?? 0,
-								price: price.toNumber(),
-								discount: discount.toNumber(),
-								cacheSupported: providerSupportsCaching(provider),
-								contentFilterProvider: true,
-								excludedByContentFilter: true,
-							};
-						}),
-					)),
-					...routingMetadata.providerScores,
-				];
+	const filteredProviders: FilteredProvider[] = [];
+	for (const filtered of routingMetadata.filteredProviders ?? []) {
+		mergeFilteredProvider(filteredProviders, filtered);
+	}
+	for (const providerId of contentFilterExcludedProviders) {
+		recordFilteredProvider(filteredProviders, providerId, [
+			exclusionReason("content_filter"),
+		]);
+	}
 
 	return {
 		...routingMetadata,
@@ -862,7 +834,8 @@ async function addContentFilterRoutingMetadata(
 			contentFilterExcludedProviders.length > 0
 				? contentFilterExcludedProviders
 				: undefined,
-		providerScores,
+		filteredProviders:
+			filteredProviders.length > 0 ? filteredProviders : undefined,
 	};
 }
 
@@ -4517,31 +4490,12 @@ chat.openapi(completions, async (c) => {
 							},
 						);
 
-						const originalProviderInfo = modelInfo.providers.find(
-							(p) => p.providerId === requestedProvider,
-						);
-						const {
-							price: originalProviderPrice,
-							discount: originalProviderDiscount,
-						} = await getDiscountedProviderSelectionPrice(
-							originalProviderInfo,
-							modelWithPricing.id,
-							{
-								organizationId: project.organizationId,
-								providerDiscountResolver,
-							},
-						);
-
-						const originalProviderScore = {
-							providerId: requestedProvider,
-							score: -1,
-							price: originalProviderPrice.toNumber(),
-							discount: originalProviderDiscount.toNumber(),
-							cacheSupported: providerSupportsCaching(originalProviderInfo),
-							rate_limited: true as const,
-						};
-
 						if (cheapestResult) {
+							recordFilteredProvider(
+								preRoutingFilteredProviders,
+								requestedProvider,
+								[exclusionReason("rate_limited")],
+							);
 							usedProvider = cheapestResult.provider.providerId;
 							usedInternalModel = modelInfo.id;
 							usedExternalId = cheapestResult.provider.externalId;
@@ -4551,10 +4505,6 @@ chat.openapi(completions, async (c) => {
 								selectionReason: "rate-limit-fallback",
 								originalProvider: requestedProvider,
 								originalProviderRateLimited: true,
-								providerScores: [
-									originalProviderScore,
-									...cheapestResult.metadata.providerScores,
-								],
 								...getNoFallbackRoutingMetadata(
 									noFallback,
 									xNoFallbackHeaderSet,
@@ -5041,10 +4991,7 @@ chat.openapi(completions, async (c) => {
 
 			if (modelWithPricing) {
 				// Fetch uptime/latency metrics from last 5 minutes for provider selection
-				const metricsCombinations = [
-					...routingCandidates,
-					...contentFilterRoutingExcludedProviders,
-				].map((provider) => ({
+				const metricsCombinations = routingCandidates.map((provider) => ({
 					modelId: modelWithPricing.id,
 					providerId: provider.providerId,
 					region: provider.region,
@@ -5153,7 +5100,7 @@ chat.openapi(completions, async (c) => {
 							),
 						};
 					}
-					routingMetadata = await addContentFilterRoutingMetadata(
+					routingMetadata = addContentFilterRoutingMetadata(
 						{
 							...cheapestResult.metadata,
 							selectedProvider: usedProvider,
@@ -5163,10 +5110,6 @@ chat.openapi(completions, async (c) => {
 						},
 						contentFilterMatched,
 						contentFilterRoutingExcludedProviders,
-						modelWithPricing.id,
-						metricsMap,
-						project.organizationId,
-						providerDiscountResolver,
 					);
 					// When every candidate is capped, routing fails open. Those providers
 					// were scored and remain candidates, so annotate their existing entries.
@@ -5308,10 +5251,7 @@ chat.openapi(completions, async (c) => {
 		let metricsMap: Map<string, ProviderMetrics> = new Map();
 
 		if (baseModelId && usedProvider !== "custom") {
-			const metricsCombinations = [
-				...routingMetadataProviders,
-				...contentFilterRoutingExcludedProviders,
-			].map((provider) => ({
+			const metricsCombinations = routingMetadataProviders.map((provider) => ({
 				modelId: baseModelId,
 				providerId: provider.providerId,
 				region: provider.region,
@@ -5378,7 +5318,7 @@ chat.openapi(completions, async (c) => {
 				}),
 			));
 
-		routingMetadata = await addContentFilterRoutingMetadata(
+		routingMetadata = addContentFilterRoutingMetadata(
 			{
 				availableProviders: routingMetadataProviders.map((p) => p.providerId),
 				selectedProvider: usedProvider,
@@ -5389,10 +5329,6 @@ chat.openapi(completions, async (c) => {
 			},
 			contentFilterMatched,
 			contentFilterRoutingExcludedProviders,
-			baseModelId,
-			metricsMap,
-			project.organizationId,
-			providerDiscountResolver,
 		);
 	}
 

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -5013,6 +5013,16 @@ chat.openapi(completions, async (c) => {
 				rateLimitedProviderIds,
 				providersWithKeys,
 			);
+			const routingCandidateProviderIds = new Set(
+				routingCandidates.map((candidate) => candidate.providerId),
+			);
+			for (const providerId of rateLimitedProviderIds) {
+				if (!routingCandidateProviderIds.has(providerId)) {
+					recordFilteredProvider(filteredOutProvidersDirect, providerId, [
+						exclusionReason("rate_limited"),
+					]);
+				}
+			}
 
 			const rawModelWithPricing = models.find(
 				(m) => m.id === usedInternalModel,
@@ -5158,46 +5168,19 @@ chat.openapi(completions, async (c) => {
 						project.organizationId,
 						providerDiscountResolver,
 					);
-					// Annotate rate-limited providers in routing metadata
-					if (rateLimitedProviderIds.size > 0) {
-						// Add filtered-out rate-limited providers as score entries
-						for (const rlProviderId of rateLimitedProviderIds) {
-							const existing = routingMetadata.providerScores.find(
-								(s) => s.providerId === rlProviderId,
-							);
-							if (existing) {
-								existing.rate_limited = true;
-							} else {
-								const providerInfo = modelInfo.providers.find(
-									(p) => p.providerId === rlProviderId,
-								);
-								const { price, discount } =
-									await getDiscountedProviderSelectionPrice(
-										providerInfo,
-										modelWithPricing.id,
-										{
-											organizationId: project.organizationId,
-											providerDiscountResolver,
-										},
-									);
-								routingMetadata.providerScores.push({
-									providerId: rlProviderId,
-									score: -1,
-									price: price.toNumber(),
-									discount: discount.toNumber(),
-									cacheSupported: providerSupportsCaching(providerInfo),
-									rate_limited: true,
-								});
-							}
+					// When every candidate is capped, routing fails open. Those providers
+					// were scored and remain candidates, so annotate their existing entries.
+					for (const score of routingMetadata.providerScores) {
+						if (rateLimitedProviderIds.has(score.providerId)) {
+							score.rate_limited = true;
 						}
 					}
 					{
-						const routingCandidateSet = new Set(routingCandidates);
 						await appendHybridDemotedProviderScores(
 							routingMetadata,
 							contentFilterPreferredProviders.filter(
 								(candidate) =>
-									!routingCandidateSet.has(candidate) &&
+									!routingCandidateProviderIds.has(candidate.providerId) &&
 									!rateLimitedProviderIds.has(candidate.providerId),
 							),
 							modelWithPricing.id,

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -2007,13 +2007,14 @@ describe("fallback and error status code handling", () => {
 					contentFilterRerouted: true,
 					contentFilterExcludedProviders: ["together-ai"],
 				});
-				expect(log.routingMetadata?.providerScores).toContainEqual(
-					expect.objectContaining({
-						providerId: "together-ai",
-						contentFilterProvider: true,
-						excludedByContentFilter: true,
-					}),
+				expect(log.routingMetadata?.providerScores).not.toContainEqual(
+					expect.objectContaining({ providerId: "together-ai" }),
 				);
+				expect(log.routingMetadata?.filteredProviders).toContainEqual({
+					providerId: "together-ai",
+					reasons: ["excluded by content-filter routing"],
+					codes: ["content_filter"],
+				});
 			} finally {
 				if (originalContentFilterFlag === undefined) {
 					delete togetherProvider.contentFilter;

--- a/apps/worker/src/services/routing-telemetry-aggregator.spec.ts
+++ b/apps/worker/src/services/routing-telemetry-aggregator.spec.ts
@@ -364,6 +364,13 @@ describe("routing telemetry aggregator", () => {
 			withMetadata({
 				selectionReason: "weighted-score",
 				availableProviders: ["openai"],
+				filteredProviders: [
+					{
+						providerId: "azure",
+						reasons: ["excluded by content-filter routing"],
+						codes: ["content_filter"],
+					},
+				],
 				contentFilterExcludedProviders: ["azure"],
 				providerScores: [
 					{ providerId: "aws-mantle", score: 0, price: 1, rate_limited: true },

--- a/apps/worker/src/services/routing-telemetry-aggregator.ts
+++ b/apps/worker/src/services/routing-telemetry-aggregator.ts
@@ -146,13 +146,12 @@ async function aggregateElections(tx: Tx, targetHour: Date) {
  * Per (model, provider, reason) exclusion counts for one hour, unioned from the
  * three places routing records an exclusion:
  *
- * - `filteredProviders[].codes` — capability, credential and service-tier drops
- * - `contentFilterExcludedProviders[]` — content-filter rerouting
- * - `providerScores[].rate_limited` — RPM-capped mappings
+ * - `filteredProviders[].codes` — pre-election drops
+ * - `contentFilterExcludedProviders[]` — content-filter compatibility summary
+ * - `providerScores[].rate_limited` — fail-open or retry-time RPM caps
  *
- * The last two already existed in routing metadata, so they are mapped onto
- * exclusion codes here rather than duplicated into filteredProviders by the
- * gateway.
+ * The last two preserve historical and runtime metadata forms. The distinct
+ * counts below prevent duplicated content-filter records from inflating totals.
  *
  * Two counts come out of this, and they answer different questions.
  * `excludedCount` is per reason — "how often did this constraint fire" — and
@@ -215,7 +214,7 @@ async function aggregateExclusions(tx: Tx, targetHour: Date) {
 					coalesce(hour_logs.metadata -> 'contentFilterExcludedProviders', '[]'::jsonb)
 				) as provider_id
 				union all
-				-- rate-limited mappings, annotated on the score entries
+				-- fail-open or retry-time rate limits, annotated on score entries
 				select
 					hour_logs.log_id,
 					hour_logs.model_id,

--- a/packages/shared/src/routing-telemetry.ts
+++ b/packages/shared/src/routing-telemetry.ts
@@ -46,9 +46,9 @@ export const ROUTING_EXCLUSION_REASON_MESSAGES = {
 	locked_region: "provider key is locked to a different region",
 	// Catalogue state.
 	deprecated: "mapping is deprecated",
-	// Runtime state. Pre-election rate limits use filteredProviders; fail-open and
-	// retry-time rate limits may still annotate providerScores. Content filters use
-	// contentFilterExcludedProviders. The hourly rollup reads all three forms.
+	// Runtime state. Pre-election exclusions use filteredProviders; fail-open and
+	// retry-time rate limits may still annotate providerScores. Content filters also
+	// retain their summary field for compatibility. The hourly rollup reads all forms.
 	rate_limited: "provider is rate limited",
 	content_filter: "excluded by content-filter routing",
 	compliance: "excluded by the organization's compliance policy",

--- a/packages/shared/src/routing-telemetry.ts
+++ b/packages/shared/src/routing-telemetry.ts
@@ -46,11 +46,9 @@ export const ROUTING_EXCLUSION_REASON_MESSAGES = {
 	locked_region: "provider key is locked to a different region",
 	// Catalogue state.
 	deprecated: "mapping is deprecated",
-	// Runtime state. `rate_limited` and `content_filter` are not emitted by
-	// recordFilteredProvider — routing already records them in their own metadata
-	// fields (providerScores[].rate_limited and contentFilterExcludedProviders),
-	// and the hourly rollup maps those onto these codes so every exclusion shows
-	// up in one place.
+	// Runtime state. Pre-election rate limits use filteredProviders; fail-open and
+	// retry-time rate limits may still annotate providerScores. Content filters use
+	// contentFilterExcludedProviders. The hourly rollup reads all three forms.
 	rate_limited: "provider is rate limited",
 	content_filter: "excluded by content-filter routing",
 	compliance: "excluded by the organization's compliance policy",


### PR DESCRIPTION
## Problem

Providers removed before an election were represented as synthetic `score: -1` entries. This made configured rate-limit and content-filter exclusions appear in the score list even though their scores never participated in provider selection.

## Approach

- record capped auto-routing candidates in `filteredProviders` with `rate_limited`
- do the same when a capped explicitly requested provider falls back to another provider
- record content-filter-rerouted providers in `filteredProviders` with `content_filter`
- omit excluded providers from score, price, and metrics calculations
- retain score annotations for all-capped fail-open and retry-time caps because those candidates did participate in the election
- retain low-uptime and hybrid-demoted scores because they remain intentional fallback targets
- preserve compatibility summary fields and deduplicate telemetry rollups

## Verification

- `pnpm format`
- `pnpm build`
- targeted gateway tests for generic caps, pinned-provider caps, and content-filter routing
- targeted worker test for exclusion telemetry deduplication