### PR TITLE
fix(ui): show discounts in model OG cards

### DIFF
--- a/apps/ui/src/app/models/[name]/[provider]/opengraph-image.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/opengraph-image.tsx
@@ -1,5 +1,7 @@
 import { ImageResponse } from "next/og";
 
+import { discountFraction, getEffectiveProviderDiscount } from "@/lib/discount";
+import { fetchModelDiscounts } from "@/lib/fetch-models";
 import Logo from "@/lib/icons/Logo";
 import { formatContextSize } from "@/lib/utils";
 
@@ -23,13 +25,7 @@ export const size = {
 	height: 630,
 };
 export const contentType = "image/png";
-// Baked at build time rather than revalidated every 60s: rendering these cards
-// on demand runs satori inside the request, which the production pods do not
-// have the headroom for and which took the whole route down with a 503. The
-// canonical /models/[name] pages point their og:image here too, so this route
-// backs every model card on the site. Discount badges therefore refresh per
-// deploy instead of per minute — social scrapers cache these for days anyway.
-export const dynamic = "force-static";
+export const revalidate = 60;
 export const dynamicParams = false;
 
 export function generateStaticParams() {
@@ -138,14 +134,15 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 								? FireworksIconStatic
 								: getProviderIcon(selectedMapping.providerId)
 			: null;
-		// Cards show list prices, not discounted ones. Discounts live in the
-		// database behind the API, and API_URL is a runtime env var that is not
-		// set during the image build, so a lookup here can only ever fail and
-		// fall back to "no discount" — at the cost of one dead request per
-		// generated card. The price rendering below still handles a discount, so
-		// restoring the badge is a matter of feeding it one from a build-time
-		// source.
-		const discountNum = 0;
+		const discounts = await fetchModelDiscounts(decodedName);
+		const effectiveDiscount = selectedMapping
+			? getEffectiveProviderDiscount(
+					discounts,
+					selectedMapping.providerId,
+					decodedName,
+				)
+			: undefined;
+		const discountNum = discountFraction(effectiveDiscount);
 
 		const hasPricingTiers = (selectedMapping?.pricingTiers?.length ?? 0) > 1;
 		const pricing = getEffectivePricePerMillion(selectedMapping, discountNum);


### PR DESCRIPTION
## Problem

Model detail OpenGraph cards always rendered list prices because the route hard-coded the effective discount to zero.

## Fix

- load active admin-configured discounts through the existing public model discount endpoint
- apply the existing provider/model precedence rules
- refresh cached OG cards every 60 seconds

## Verification

- `pnpm format`
- `pnpm build`

No screenshots requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model preview images now display provider-specific discounted pricing.
  * Pricing information refreshes automatically every 60 seconds to reflect current discounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->