### PR TITLE
fix(ui): render AWS Mantle OG logo

### DIFF
--- a/apps/ui/src/app/models/[name]/[provider]/opengraph-image.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/opengraph-image.tsx
@@ -28,6 +28,25 @@ export const contentType = "image/png";
 export const revalidate = 60;
 export const dynamicParams = false;
 
+const getOgProviderIcon = (providerId: string) => {
+	if (providerId === "aws-bedrock" || providerId === "aws-mantle") {
+		return AWSBedrockIconStatic;
+	}
+	if (providerId === "minimax") {
+		return MinimaxIconStatic;
+	}
+	if (providerId === "google-ai-studio") {
+		return GoogleStudioAIIconStatic;
+	}
+	if (providerId === "xai") {
+		return XAIIconStatic;
+	}
+	if (providerId === "fireworks") {
+		return FireworksIconStatic;
+	}
+	return getProviderIcon(providerId);
+};
+
 export function generateStaticParams() {
 	const params: { name: string; provider: string }[] = [];
 
@@ -122,17 +141,7 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 			(p) => p.id === selectedMapping?.providerId,
 		);
 		const ProviderIcon = selectedMapping
-			? selectedMapping.providerId === "minimax"
-				? MinimaxIconStatic
-				: selectedMapping.providerId === "aws-bedrock"
-					? AWSBedrockIconStatic
-					: selectedMapping.providerId === "google-ai-studio"
-						? GoogleStudioAIIconStatic
-						: selectedMapping.providerId === "xai"
-							? XAIIconStatic
-							: selectedMapping.providerId === "fireworks"
-								? FireworksIconStatic
-								: getProviderIcon(selectedMapping.providerId)
+			? getOgProviderIcon(selectedMapping.providerId)
 			: null;
 		const discounts = await fetchModelDiscounts(decodedName);
 		const effectiveDiscount = selectedMapping
@@ -216,18 +225,7 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 		);
 		const supportingProviders = uniqueProviderIds
 			.map((providerId) => {
-				const icon =
-					providerId === "aws-bedrock"
-						? AWSBedrockIconStatic
-						: providerId === "minimax"
-							? MinimaxIconStatic
-							: providerId === "google-ai-studio"
-								? GoogleStudioAIIconStatic
-								: providerId === "xai"
-									? XAIIconStatic
-									: providerId === "fireworks"
-										? FireworksIconStatic
-										: getProviderIcon(providerId);
+				const icon = getOgProviderIcon(providerId);
 				const info = providerDefinitions.find((p) => p.id === providerId);
 				return {
 					id: providerId,


### PR DESCRIPTION
## Problem

GPT-5.6 OpenGraph cards rendered AWS Mantle SVG stylesheet text instead of a clean provider logo.

## Approach

- Route both AWS provider IDs through the Satori-safe static AWS icon.
- Share the OG provider icon selector between the primary and supporting logos.

## Verification

- `pnpm format`
- `pnpm build`
- Used an isolated local stack to set a 20% AWS Mantle and GPT-5.6 Sol discount in the admin UI.
- Confirmed the model page and OG image render green 20% labels, discounted prices, and a clean AWS logo.

## Screenshots

### Reported AWS badge

![AWS badge rendering stylesheet text](https://raw.githubusercontent.com/theopenco/llmgateway/b104daddb92b88f4409bfb45202ca62b78fc6a7d/before.png)

### Admin discount

![20% model discount configured in the admin UI](https://raw.githubusercontent.com/theopenco/llmgateway/b104daddb92b88f4409bfb45202ca62b78fc6a7d/admin-discount.png)

### Model page

![Green 20% discount and discounted model prices](https://raw.githubusercontent.com/theopenco/llmgateway/b104daddb92b88f4409bfb45202ca62b78fc6a7d/model-page.png)

### Fixed OG image

![OG image with green 20% discount and clean AWS logo](https://raw.githubusercontent.com/theopenco/llmgateway/b104daddb92b88f4409bfb45202ca62b78fc6a7d/og-image.png)