### PR TITLE
fix(admin): validate limit/offset params to prevent DoS via oversized limits

### DIFF
--- a/apps/api/src/routes/admin-limit-validation.spec.ts
+++ b/apps/api/src/routes/admin-limit-validation.spec.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+const originalAdminEmails = process.env.ADMIN_EMAILS;
+
+describe("admin limit/offset validation", () => {
+	let cookie: string;
+
+	beforeEach(async () => {
+		process.env.ADMIN_EMAILS = "admin@example.com";
+		cookie = await createTestUser();
+	});
+
+	afterEach(async () => {
+		if (originalAdminEmails === undefined) {
+			delete process.env.ADMIN_EMAILS;
+		} else {
+			process.env.ADMIN_EMAILS = originalAdminEmails;
+		}
+		await deleteAll();
+	});
+
+	describe("GET /admin/model-provider-mappings", () => {
+		const path = "/admin/model-provider-mappings";
+
+		it("rejects limit above max (100)", async () => {
+			const res = await app.request(`${path}?limit=99999999`, {
+				headers: { Cookie: cookie },
+			});
+			expect(res.status).toBe(400);
+		});
+
+		it("rejects negative limit", async () => {
+			const res = await app.request(`${path}?limit=-1`, {
+				headers: { Cookie: cookie },
+			});
+			expect(res.status).toBe(400);
+		});
+
+		it("rejects negative offset", async () => {
+			const res = await app.request(`${path}?offset=-1`, {
+				headers: { Cookie: cookie },
+			});
+			expect(res.status).toBe(400);
+		});
+	});
+
+	describe("GET /admin/organizations/:orgId/projects/:projectId/model-provider-stats", () => {
+		const path =
+			"/admin/organizations/org-test/projects/proj-test/model-provider-stats";
+
+		it("rejects limit above max (100)", async () => {
+			const res = await app.request(`${path}?limit=99999999`, {
+				headers: { Cookie: cookie },
+			});
+			expect(res.status).toBe(400);
+		});
+
+		it("rejects negative limit", async () => {
+			const res = await app.request(`${path}?limit=-1`, {
+				headers: { Cookie: cookie },
+			});
+			expect(res.status).toBe(400);
+		});
+
+		it("rejects negative offset", async () => {
+			const res = await app.request(`${path}?offset=-1`, {
+				headers: { Cookie: cookie },
+			});
+			expect(res.status).toBe(400);
+		});
+	});
+});

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -10398,8 +10398,8 @@ const getProjectModelProviderStats = createRoute({
 				.enum(["logsCount", "errorsCount", "cost", "modelId", "providerId"])
 				.optional(),
 			sortOrder: z.enum(["asc", "desc"]).optional(),
-			limit: z.coerce.number().optional(),
-			offset: z.coerce.number().optional(),
+			limit: z.coerce.number().min(1).max(100).optional(),
+			offset: z.coerce.number().min(0).optional(),
 			from: z.string().optional(),
 			to: z.string().optional(),
 		}),
@@ -10645,8 +10645,8 @@ const getModelProviderMappings = createRoute({
 				])
 				.optional(),
 			sortOrder: z.enum(["asc", "desc"]).optional(),
-			limit: z.coerce.number().optional(),
-			offset: z.coerce.number().optional(),
+			limit: z.coerce.number().min(1).max(100).optional(),
+			offset: z.coerce.number().min(0).optional(),
 			from: z.string().optional(),
 			to: z.string().optional(),
 		}),


### PR DESCRIPTION
Bug: Admin endpoints getProjectModelProviderStats and getModelProviderMappings accepted unvalidated limit and offset query params, allowing DoS via extreme limits (e.g. limit=99999999, offset=-1). Fix: Added Zod validation with .min(1).max(100) on limit and .min(0) on offset for both endpoints. Verification: 6 test cases in admin-limit-validation.spec.ts, red-to-green (stash fix -> tests fail, unstash -> 6/6 pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination validation for admin model-provider endpoints.
  * Requests with negative offsets, invalid limits, or limits above 100 are now rejected with an HTTP 400 response.

* **Tests**
  * Added coverage to verify pagination boundaries and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->