### PR TITLE
feat(models): add DeepSeek time-based pricing

### DIFF
--- a/apps/api/src/routes/internal-models.ts
+++ b/apps/api/src/routes/internal-models.ts
@@ -56,6 +56,25 @@ const pricingTierSchema = z.object({
 	cacheWriteInputPrice1h: z.string().nullable(),
 });
 
+const timeBasedTokenPricesSchema = z.object({
+	inputPrice: z.string(),
+	outputPrice: z.string(),
+	cachedInputPrice: z.string().nullable(),
+});
+
+const peakPricingSchema = z.object({
+	peak: timeBasedTokenPricesSchema,
+	offPeak: timeBasedTokenPricesSchema,
+	hoursUtc: z.array(z.tuple([z.number(), z.number()])),
+	offPeakDays: z
+		.object({
+			daysOfWeek: z.array(z.number()),
+			utcOffsetMinutes: z.number(),
+			timeZoneLabel: z.string(),
+		})
+		.nullable(),
+});
+
 // Model provider mapping schema
 const modelProviderMappingSchema = z.object({
 	id: z.string(),
@@ -111,6 +130,7 @@ const modelProviderMappingSchema = z.object({
 	perSecondPrice: z.record(z.string()).nullable(),
 	perImagePrice: z.record(z.string()).nullable(),
 	pricingTiers: z.array(pricingTierSchema).nullable(),
+	peakPricing: peakPricingSchema.nullable(),
 	serviceTiers: z.array(z.string()).nullable(),
 	deprecatedAt: z.coerce.date().nullable(),
 	deactivatedAt: z.coerce.date().nullable(),
@@ -342,6 +362,45 @@ internalModels.openapi(getModelsRoute, async (c) => {
 								: null,
 					}));
 				})(),
+				peakPricing: sharedMapping?.peakPricing
+					? {
+							peak: {
+								inputPrice: String(sharedMapping.peakPricing.peak.inputPrice),
+								outputPrice: String(sharedMapping.peakPricing.peak.outputPrice),
+								cachedInputPrice:
+									sharedMapping.peakPricing.peak.cachedInputPrice !== undefined
+										? String(sharedMapping.peakPricing.peak.cachedInputPrice)
+										: null,
+							},
+							offPeak: {
+								inputPrice: String(
+									sharedMapping.peakPricing.offPeak.inputPrice,
+								),
+								outputPrice: String(
+									sharedMapping.peakPricing.offPeak.outputPrice,
+								),
+								cachedInputPrice:
+									sharedMapping.peakPricing.offPeak.cachedInputPrice !==
+									undefined
+										? String(sharedMapping.peakPricing.offPeak.cachedInputPrice)
+										: null,
+							},
+							hoursUtc: sharedMapping.peakPricing.hoursUtc.map(
+								([start, end]) => [start, end] as [number, number],
+							),
+							offPeakDays: sharedMapping.peakPricing.offPeakDays
+								? {
+										daysOfWeek: [
+											...sharedMapping.peakPricing.offPeakDays.daysOfWeek,
+										],
+										utcOffsetMinutes:
+											sharedMapping.peakPricing.offPeakDays.utcOffsetMinutes,
+										timeZoneLabel:
+											sharedMapping.peakPricing.offPeakDays.timeZoneLabel,
+									}
+								: null,
+						}
+					: null,
 				serviceTiers: (() => {
 					const tiers = sharedMapping?.serviceTiers ?? null;
 					if (!tiers || tiers.length === 0) {

--- a/apps/gateway/src/lib/costs.spec.ts
+++ b/apps/gateway/src/lib/costs.spec.ts
@@ -2406,6 +2406,34 @@ describe("peak / off-peak time-of-day pricing (DeepSeek)", () => {
 		expect(pro.cachedInputCost).toBeCloseTo(0.044);
 	});
 
+	it("bills off-peak rates during Beijing weekends", async () => {
+		setTime("2026-08-29T02:00:00Z"); // Saturday 10:00 Beijing — normally peak
+
+		const flash = await calculateCosts(
+			"deepseek-v4-flash",
+			"deepseek",
+			null,
+			2_000_000,
+			1_000_000,
+			1_000_000,
+		);
+		expect(flash.inputCost).toBeCloseTo(0.22);
+		expect(flash.outputCost).toBeCloseTo(0.66);
+		expect(flash.cachedInputCost).toBeCloseTo(0.007);
+
+		const pro = await calculateCosts(
+			"deepseek-v4-pro",
+			"deepseek",
+			null,
+			2_000_000,
+			1_000_000,
+			1_000_000,
+		);
+		expect(pro.inputCost).toBeCloseTo(0.66);
+		expect(pro.outputCost).toBeCloseTo(1.98);
+		expect(pro.cachedInputCost).toBeCloseTo(0.022);
+	});
+
 	it("bills off-peak rates at the first window boundary (04:00 UTC)", async () => {
 		setTime("2026-08-17T04:00:00Z");
 

--- a/apps/gateway/src/lib/costs.spec.ts
+++ b/apps/gateway/src/lib/costs.spec.ts
@@ -2461,22 +2461,4 @@ describe("peak / off-peak time-of-day pricing (DeepSeek)", () => {
 		);
 		expect(flash.inputCost).toBeCloseTo(0.44);
 	});
-
-	it("bills base (regular flat) rates before effectiveAt", async () => {
-		vi.useFakeTimers({ shouldAdvanceTime: true });
-		vi.setSystemTime(new Date("2026-08-13T08:00:00Z")); // before effectiveAt
-
-		const flash = await calculateCosts(
-			"deepseek-v4-flash",
-			"deepseek",
-			null,
-			2_000_000,
-			1_000_000,
-			1_000_000,
-		);
-		// The base (regular) flat prices apply before effectiveAt
-		expect(flash.inputCost).toBeCloseTo(0.14); // base: 0.14e-6 * 1M (prompt - cached = 1M)
-		expect(flash.outputCost).toBeCloseTo(0.28); // base: 0.28e-6 * 1M
-		expect(flash.cachedInputCost).toBeCloseTo(0.0028); // base: 0.0028e-6 * 1M
-	});
 });

--- a/apps/ui/src/components/models/adapt-model.ts
+++ b/apps/ui/src/components/models/adapt-model.ts
@@ -110,6 +110,37 @@ export function adaptProviderMapping(
 								: null,
 					}))
 				: null,
+			peakPricing: p.peakPricing
+				? {
+						peak: {
+							inputPrice: String(p.peakPricing.peak.inputPrice),
+							outputPrice: String(p.peakPricing.peak.outputPrice),
+							cachedInputPrice:
+								p.peakPricing.peak.cachedInputPrice !== undefined
+									? String(p.peakPricing.peak.cachedInputPrice)
+									: null,
+						},
+						offPeak: {
+							inputPrice: String(p.peakPricing.offPeak.inputPrice),
+							outputPrice: String(p.peakPricing.offPeak.outputPrice),
+							cachedInputPrice:
+								p.peakPricing.offPeak.cachedInputPrice !== undefined
+									? String(p.peakPricing.offPeak.cachedInputPrice)
+									: null,
+						},
+						hoursUtc: p.peakPricing.hoursUtc.map(([start, end]) => [
+							start,
+							end,
+						]),
+						offPeakDays: p.peakPricing.offPeakDays
+							? {
+									daysOfWeek: [...p.peakPricing.offPeakDays.daysOfWeek],
+									utcOffsetMinutes: p.peakPricing.offPeakDays.utcOffsetMinutes,
+									timeZoneLabel: p.peakPricing.offPeakDays.timeZoneLabel,
+								}
+							: null,
+					}
+				: null,
 			serviceTiers: p.serviceTiers ?? null,
 			discount: p.discount ?? null,
 			stability: p.stability ?? null,

--- a/packages/actions/src/models.spec.ts
+++ b/packages/actions/src/models.spec.ts
@@ -1397,6 +1397,11 @@ describe("getCheapestFromAvailableProviders", () => {
 					[1, 4],
 					[6, 10],
 				] as [number, number][],
+				offPeakDays: {
+					effectiveAt: "2026-08-22T16:00:00Z",
+					daysOfWeek: [0, 6] as const,
+					utcOffsetMinutes: 480,
+				},
 			},
 		};
 
@@ -1416,6 +1421,16 @@ describe("getCheapestFromAvailableProviders", () => {
 					deepseekLikeMapping,
 					undefined,
 					new Date("2026-08-17T12:00:00Z"),
+				).toNumber(),
+			).toBe((0.66e-6 + 1.98e-6) / 2);
+		});
+
+		it("returns the off-peak average during Beijing weekends", () => {
+			expect(
+				getProviderSelectionPrice(
+					deepseekLikeMapping,
+					undefined,
+					new Date("2026-08-29T02:00:00Z"),
 				).toNumber(),
 			).toBe((0.66e-6 + 1.98e-6) / 2);
 		});

--- a/packages/actions/src/models.spec.ts
+++ b/packages/actions/src/models.spec.ts
@@ -1398,6 +1398,7 @@ describe("getCheapestFromAvailableProviders", () => {
 				offPeakDays: {
 					daysOfWeek: [0, 6] as const,
 					utcOffsetMinutes: 480,
+					timeZoneLabel: "Beijing time",
 				},
 			},
 		};

--- a/packages/actions/src/models.spec.ts
+++ b/packages/actions/src/models.spec.ts
@@ -1375,14 +1375,12 @@ describe("getCheapestFromAvailableProviders", () => {
 
 	describe("time-of-day pricing in provider selection", () => {
 		// Mirrors the DeepSeek V4 Pro first-party mapping: peak 01:00-04:00 and
-		// 06:00-10:00 UTC at double the off-peak rates, base (regular) flat
-		// rates before effectiveAt.
+		// 06:00-10:00 UTC at double the off-peak rates.
 		const deepseekLikeMapping = {
 			inputPrice: "0.435e-6",
 			outputPrice: "0.87e-6",
 			cachedInputPrice: "0.003625e-6",
 			peakPricing: {
-				effectiveAt: "2026-08-16T16:00:00Z",
 				peak: {
 					inputPrice: "1.32e-6",
 					outputPrice: "3.96e-6",
@@ -1398,7 +1396,6 @@ describe("getCheapestFromAvailableProviders", () => {
 					[6, 10],
 				] as [number, number][],
 				offPeakDays: {
-					effectiveAt: "2026-08-22T16:00:00Z",
 					daysOfWeek: [0, 6] as const,
 					utcOffsetMinutes: 480,
 				},
@@ -1435,16 +1432,6 @@ describe("getCheapestFromAvailableProviders", () => {
 			).toBe((0.66e-6 + 1.98e-6) / 2);
 		});
 
-		it("returns the base average before effectiveAt", () => {
-			expect(
-				getProviderSelectionPrice(
-					deepseekLikeMapping,
-					undefined,
-					new Date("2026-08-15T12:00:00Z"),
-				).toNumber(),
-			).toBe((0.435e-6 + 0.87e-6) / 2);
-		});
-
 		it("returns the plain average for a mapping without peakPricing", () => {
 			expect(
 				getProviderSelectionPrice({
@@ -1455,9 +1442,9 @@ describe("getCheapestFromAvailableProviders", () => {
 		});
 
 		it("ranks with peak rates through full provider selection", async () => {
-			// The deepseek mapping's peak window covers every hour and
-			// effectiveAt is in the past, so the selection price is the peak
-			// rate regardless of wall clock. At the raw base rates deepseek's
+			// The deepseek mapping's peak window covers every hour, so the
+			// selection price is the peak rate regardless of wall clock. At the
+			// raw base rates, DeepSeek's
 			// average (0.375e-6) beats openai's (0.75e-6); with peak rates
 			// applied deepseek's average rises to 1.125e-6 and openai wins —
 			// so selecting openai proves time-of-day pricing was applied.
@@ -1479,7 +1466,6 @@ describe("getCheapestFromAvailableProviders", () => {
 						inputPrice: "0.25e-6",
 						outputPrice: "0.5e-6",
 						peakPricing: {
-							effectiveAt: "2020-01-01T00:00:00Z",
 							peak: {
 								inputPrice: "0.75e-6",
 								outputPrice: "1.5e-6",

--- a/packages/models/src/helpers.spec.ts
+++ b/packages/models/src/helpers.spec.ts
@@ -26,6 +26,7 @@ const peakPricedMapping = {
 		offPeakDays: {
 			daysOfWeek: [0, 6],
 			utcOffsetMinutes: 480,
+			timeZoneLabel: "Beijing time",
 		},
 	},
 } satisfies Pick<

--- a/packages/models/src/helpers.spec.ts
+++ b/packages/models/src/helpers.spec.ts
@@ -24,6 +24,11 @@ const peakPricedMapping = {
 			[1, 4],
 			[6, 10],
 		],
+		offPeakDays: {
+			effectiveAt: "2026-08-22T16:00:00Z",
+			daysOfWeek: [0, 6],
+			utcOffsetMinutes: 480,
+		},
 	},
 } satisfies Pick<
 	ProviderModelMapping,
@@ -76,6 +81,37 @@ describe("resolveTimeBasedPricing", () => {
 			inputPrice: "0.22e-6",
 			outputPrice: "0.66e-6",
 			cachedInputPrice: "0.007e-6",
+		});
+	});
+
+	it.each([
+		["Sunday", "2026-08-23T02:00:00Z"],
+		["Saturday", "2026-08-29T02:00:00Z"],
+	])("applies off-peak rates all day on Beijing %s", (_label, iso) => {
+		expect(resolveTimeBasedPricing(peakPricedMapping, at(iso))).toEqual({
+			inputPrice: "0.22e-6",
+			outputPrice: "0.66e-6",
+			cachedInputPrice: "0.007e-6",
+		});
+	});
+
+	it("keeps peak rates on weekdays after the weekend rule takes effect", () => {
+		expect(
+			resolveTimeBasedPricing(peakPricedMapping, at("2026-08-24T02:00:00Z")),
+		).toEqual({
+			inputPrice: "0.44e-6",
+			outputPrice: "1.32e-6",
+			cachedInputPrice: "0.014e-6",
+		});
+	});
+
+	it("keeps peak rates before the weekend rule takes effect", () => {
+		expect(
+			resolveTimeBasedPricing(peakPricedMapping, at("2026-08-22T02:00:00Z")),
+		).toEqual({
+			inputPrice: "0.44e-6",
+			outputPrice: "1.32e-6",
+			cachedInputPrice: "0.014e-6",
 		});
 	});
 

--- a/packages/models/src/helpers.spec.ts
+++ b/packages/models/src/helpers.spec.ts
@@ -9,7 +9,6 @@ const peakPricedMapping = {
 	outputPrice: "0.28e-6",
 	cachedInputPrice: "0.0028e-6",
 	peakPricing: {
-		effectiveAt: "2026-08-16T16:00:00Z",
 		peak: {
 			inputPrice: "0.44e-6",
 			outputPrice: "1.32e-6",
@@ -25,7 +24,6 @@ const peakPricedMapping = {
 			[6, 10],
 		],
 		offPeakDays: {
-			effectiveAt: "2026-08-22T16:00:00Z",
 			daysOfWeek: [0, 6],
 			utcOffsetMinutes: 480,
 		},
@@ -95,7 +93,7 @@ describe("resolveTimeBasedPricing", () => {
 		});
 	});
 
-	it("keeps peak rates on weekdays after the weekend rule takes effect", () => {
+	it("keeps peak rates on weekdays", () => {
 		expect(
 			resolveTimeBasedPricing(peakPricedMapping, at("2026-08-24T02:00:00Z")),
 		).toEqual({
@@ -105,79 +103,11 @@ describe("resolveTimeBasedPricing", () => {
 		});
 	});
 
-	it("keeps peak rates before the weekend rule takes effect", () => {
-		expect(
-			resolveTimeBasedPricing(peakPricedMapping, at("2026-08-22T02:00:00Z")),
-		).toEqual({
-			inputPrice: "0.44e-6",
-			outputPrice: "1.32e-6",
-			cachedInputPrice: "0.014e-6",
-		});
-	});
-
-	const effectiveAtMapping = {
-		inputPrice: "0.14e-6",
-		outputPrice: "0.28e-6",
-		cachedInputPrice: "0.0028e-6",
-		peakPricing: {
-			effectiveAt: "2026-08-16T16:00:00Z",
-			peak: {
-				inputPrice: "0.44e-6",
-				outputPrice: "1.32e-6",
-				cachedInputPrice: "0.014e-6",
-			},
-			offPeak: {
-				inputPrice: "0.22e-6",
-				outputPrice: "0.66e-6",
-				cachedInputPrice: "0.007e-6",
-			},
-			hoursUtc: [
-				[1, 4],
-				[6, 10],
-			],
-		},
-	} satisfies Pick<
-		ProviderModelMapping,
-		"inputPrice" | "outputPrice" | "cachedInputPrice" | "peakPricing"
-	>;
-
-	it("returns the base (regular) prices before effectiveAt", () => {
-		expect(
-			resolveTimeBasedPricing(effectiveAtMapping, at("2026-08-16T15:59:00Z")),
-		).toEqual({
-			inputPrice: "0.14e-6",
-			outputPrice: "0.28e-6",
-			cachedInputPrice: "0.0028e-6",
-		});
-		expect(
-			resolveTimeBasedPricing(effectiveAtMapping, at("2026-08-16T16:00:00Z")),
-		).toEqual({
-			inputPrice: "0.22e-6",
-			outputPrice: "0.66e-6",
-			cachedInputPrice: "0.007e-6",
-		}); // at effectiveAt — off-peak rates apply
-		expect(
-			resolveTimeBasedPricing(effectiveAtMapping, at("2026-08-16T17:00:00Z")),
-		).toEqual({
-			inputPrice: "0.22e-6",
-			outputPrice: "0.66e-6",
-			cachedInputPrice: "0.007e-6",
-		}); // off-peak hour on effective date — off-peak rates
-		expect(
-			resolveTimeBasedPricing(effectiveAtMapping, at("2026-08-17T02:00:00Z")),
-		).toEqual({
-			inputPrice: "0.44e-6",
-			outputPrice: "1.32e-6",
-			cachedInputPrice: "0.014e-6",
-		}); // peak hour after effectiveAt — peak rates
-	});
-
 	it("returns undefined peak cached rate when peakPricing omits it", () => {
 		const mapping = {
 			inputPrice: "0.14e-6",
 			outputPrice: "0.28e-6",
 			peakPricing: {
-				effectiveAt: "2026-08-16T16:00:00Z",
 				peak: {
 					inputPrice: "0.44e-6",
 					outputPrice: "1.32e-6",

--- a/packages/models/src/helpers.ts
+++ b/packages/models/src/helpers.ts
@@ -201,7 +201,8 @@ export function supportsOpenAIExplicitPromptCache(modelName: string): boolean {
  * cachedInputPrice are always returned. With `peakPricing`, the base fields
  * (the regular flat rates) apply before `effectiveAt`; on/after it, the
  * `peak` rates apply while `now` (UTC) falls inside a peak window and the
- * `offPeak` rates otherwise.
+ * `offPeak` rates otherwise. A matching `offPeakDays` calendar day overrides
+ * the hourly windows once that rule is effective.
  */
 export function resolveTimeBasedPricing(
 	mapping: Pick<
@@ -230,10 +231,18 @@ export function resolveTimeBasedPricing(
 			cachedInputPrice: mapping.cachedInputPrice,
 		};
 	}
+	const offPeakDays = peakPricing.offPeakDays;
+	const utcOffsetMilliseconds = (offPeakDays?.utcOffsetMinutes ?? 0) * 60_000;
+	const isOffPeakDay =
+		offPeakDays !== undefined &&
+		now.getTime() >= Date.parse(offPeakDays.effectiveAt) &&
+		offPeakDays.daysOfWeek.includes(
+			new Date(now.getTime() + utcOffsetMilliseconds).getUTCDay(),
+		);
 	const hour = now.getUTCHours();
-	const isPeak = peakPricing.hoursUtc.some(
-		([start, end]) => hour >= start && hour < end,
-	);
+	const isPeak =
+		!isOffPeakDay &&
+		peakPricing.hoursUtc.some(([start, end]) => hour >= start && hour < end);
 	const tier = isPeak ? peakPricing.peak : peakPricing.offPeak;
 	return {
 		inputPrice: tier.inputPrice,

--- a/packages/models/src/helpers.ts
+++ b/packages/models/src/helpers.ts
@@ -198,11 +198,10 @@ export function supportsOpenAIExplicitPromptCache(modelName: string): boolean {
 /**
  * Resolve the per-token rates that apply to a mapping at a given instant.
  * Without `peakPricing`, the mapping's base inputPrice/outputPrice/
- * cachedInputPrice are always returned. With `peakPricing`, the base fields
- * (the regular flat rates) apply before `effectiveAt`; on/after it, the
- * `peak` rates apply while `now` (UTC) falls inside a peak window and the
- * `offPeak` rates otherwise. A matching `offPeakDays` calendar day overrides
- * the hourly windows once that rule is effective.
+ * cachedInputPrice are always returned. With `peakPricing`, the `peak` rates
+ * apply while `now` (UTC) falls inside a peak window and the `offPeak` rates
+ * otherwise. A matching `offPeakDays` calendar day overrides the hourly
+ * windows.
  */
 export function resolveTimeBasedPricing(
 	mapping: Pick<
@@ -223,19 +222,10 @@ export function resolveTimeBasedPricing(
 			cachedInputPrice: mapping.cachedInputPrice,
 		};
 	}
-	// Before effectiveAt, charge the base (regular flat) prices.
-	if (now.getTime() < Date.parse(peakPricing.effectiveAt)) {
-		return {
-			inputPrice: mapping.inputPrice ?? "0",
-			outputPrice: mapping.outputPrice ?? "0",
-			cachedInputPrice: mapping.cachedInputPrice,
-		};
-	}
 	const offPeakDays = peakPricing.offPeakDays;
 	const utcOffsetMilliseconds = (offPeakDays?.utcOffsetMinutes ?? 0) * 60_000;
 	const isOffPeakDay =
 		offPeakDays !== undefined &&
-		now.getTime() >= Date.parse(offPeakDays.effectiveAt) &&
 		offPeakDays.daysOfWeek.includes(
 			new Date(now.getTime() + utcOffsetMilliseconds).getUTCDay(),
 		);

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -318,23 +318,14 @@ export interface ProviderModelMapping {
 	 */
 	pricingTiers?: PricingTier[];
 	/**
-	 * Peak/off-peak time-of-day pricing. The mapping's base
-	 * inputPrice/outputPrice/cachedInputPrice are the regular flat prices,
-	 * billed before `effectiveAt` (and always when `peakPricing` is absent).
-	 * On/after `effectiveAt`, `peak` applies while the current UTC hour falls
-	 * inside `hoursUtc` and `offPeak` applies otherwise. `offPeakDays` can
-	 * override those windows for provider-defined local calendar days. Only
-	 * DeepSeek's first-party API uses this today.
+	 * Peak/off-peak time-of-day pricing. When present, `peak` applies while the
+	 * current UTC hour falls inside `hoursUtc` and `offPeak` applies otherwise.
+	 * `offPeakDays` can override those windows for provider-defined local
+	 * calendar days. Only DeepSeek's first-party API uses this today.
 	 */
 	peakPricing?: {
 		/**
-		 * ISO-8601 instant when peak/off-peak pricing takes effect. Before
-		 * this date the mapping's base inputPrice/outputPrice/cachedInputPrice
-		 * (the regular flat rates) apply.
-		 */
-		effectiveAt: string;
-		/**
-		 * Prices charged during peak hours (on/after effectiveAt).
+		 * Prices charged during peak hours.
 		 */
 		peak: {
 			/**
@@ -353,7 +344,7 @@ export interface ProviderModelMapping {
 			cachedInputPrice?: Price;
 		};
 		/**
-		 * Prices charged during off-peak hours (on/after effectiveAt).
+		 * Prices charged during off-peak hours.
 		 */
 		offPeak: {
 			/**
@@ -379,10 +370,9 @@ export interface ProviderModelMapping {
 		/**
 		 * Local calendar days that are always billed off-peak. Days use
 		 * JavaScript's numbering (Sunday = 0, Saturday = 6), shifted from UTC by
-		 * `utcOffsetMinutes`. The override applies on/after its own effectiveAt.
+		 * `utcOffsetMinutes`.
 		 */
 		offPeakDays?: {
-			effectiveAt: string;
 			daysOfWeek: readonly number[];
 			utcOffsetMinutes: number;
 		};

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -322,9 +322,9 @@ export interface ProviderModelMapping {
 	 * inputPrice/outputPrice/cachedInputPrice are the regular flat prices,
 	 * billed before `effectiveAt` (and always when `peakPricing` is absent).
 	 * On/after `effectiveAt`, `peak` applies while the current UTC hour falls
-	 * inside `hoursUtc` and `offPeak` applies otherwise. Only DeepSeek's
-	 * first-party API uses this today — peak 01:00-04:00 and 06:00-10:00 UTC
-	 * at double the off-peak rates, effective 2026-08-16.
+	 * inside `hoursUtc` and `offPeak` applies otherwise. `offPeakDays` can
+	 * override those windows for provider-defined local calendar days. Only
+	 * DeepSeek's first-party API uses this today.
 	 */
 	peakPricing?: {
 		/**
@@ -376,6 +376,16 @@ export interface ProviderModelMapping {
 		 * hours outside these ranges are off-peak.
 		 */
 		hoursUtc: readonly [start: number, end: number][];
+		/**
+		 * Local calendar days that are always billed off-peak. Days use
+		 * JavaScript's numbering (Sunday = 0, Saturday = 6), shifted from UTC by
+		 * `utcOffsetMinutes`. The override applies on/after its own effectiveAt.
+		 */
+		offPeakDays?: {
+			effectiveAt: string;
+			daysOfWeek: readonly number[];
+			utcOffsetMinutes: number;
+		};
 	};
 	/**
 	 * Maximum context window size in tokens

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -375,6 +375,8 @@ export interface ProviderModelMapping {
 		offPeakDays?: {
 			daysOfWeek: readonly number[];
 			utcOffsetMinutes: number;
+			/** Human-readable time zone used in pricing disclosures. */
+			timeZoneLabel: string;
 		};
 	};
 	/**

--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -307,6 +307,7 @@ export const deepseekModels = [
 					offPeakDays: {
 						daysOfWeek: [0, 6],
 						utcOffsetMinutes: 480,
+						timeZoneLabel: "Beijing time",
 					},
 				},
 				requestPrice: "0",
@@ -627,6 +628,7 @@ export const deepseekModels = [
 					offPeakDays: {
 						daysOfWeek: [0, 6],
 						utcOffsetMinutes: 480,
+						timeZoneLabel: "Beijing time",
 					},
 				},
 				requestPrice: "0",

--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -283,16 +283,13 @@ export const deepseekModels = [
 			{
 				providerId: "deepseek",
 				externalId: "deepseek-v4-pro",
-				// Base fields are the regular flat rates, billed before
-				// effectiveAt (2026-08-16 16:00 UTC). On/after, peak hours
-				// (01:00-04:00 and 06:00-10:00 UTC) bill at the peak rates
-				// below, all other hours at the offPeak rates. From 2026-08-23
-				// Beijing time, weekends are off-peak all day.
+				// Peak hours (01:00-04:00 and 06:00-10:00 UTC) bill at the peak
+				// rates below. All other hours and Beijing-time weekends bill at
+				// the off-peak rates.
 				inputPrice: "0.435e-6",
 				outputPrice: "0.87e-6",
 				cachedInputPrice: "0.003625e-6",
 				peakPricing: {
-					effectiveAt: "2026-08-16T16:00:00Z",
 					peak: {
 						inputPrice: "1.32e-6",
 						outputPrice: "3.96e-6",
@@ -308,7 +305,6 @@ export const deepseekModels = [
 						[6, 10],
 					],
 					offPeakDays: {
-						effectiveAt: "2026-08-22T16:00:00Z",
 						daysOfWeek: [0, 6],
 						utcOffsetMinutes: 480,
 					},
@@ -607,16 +603,13 @@ export const deepseekModels = [
 			{
 				providerId: "deepseek",
 				externalId: "deepseek-v4-flash",
-				// Base fields are the regular flat rates, billed before
-				// effectiveAt (2026-08-16 16:00 UTC). On/after, peak hours
-				// (01:00-04:00 and 06:00-10:00 UTC) bill at the peak rates
-				// below, all other hours at the offPeak rates. From 2026-08-23
-				// Beijing time, weekends are off-peak all day.
+				// Peak hours (01:00-04:00 and 06:00-10:00 UTC) bill at the peak
+				// rates below. All other hours and Beijing-time weekends bill at
+				// the off-peak rates.
 				inputPrice: "0.14e-6",
 				outputPrice: "0.28e-6",
 				cachedInputPrice: "0.0028e-6",
 				peakPricing: {
-					effectiveAt: "2026-08-16T16:00:00Z",
 					peak: {
 						inputPrice: "0.44e-6",
 						outputPrice: "1.32e-6",
@@ -632,7 +625,6 @@ export const deepseekModels = [
 						[6, 10],
 					],
 					offPeakDays: {
-						effectiveAt: "2026-08-22T16:00:00Z",
 						daysOfWeek: [0, 6],
 						utcOffsetMinutes: 480,
 					},

--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -286,7 +286,8 @@ export const deepseekModels = [
 				// Base fields are the regular flat rates, billed before
 				// effectiveAt (2026-08-16 16:00 UTC). On/after, peak hours
 				// (01:00-04:00 and 06:00-10:00 UTC) bill at the peak rates
-				// below, all other hours at the offPeak rates.
+				// below, all other hours at the offPeak rates. From 2026-08-23
+				// Beijing time, weekends are off-peak all day.
 				inputPrice: "0.435e-6",
 				outputPrice: "0.87e-6",
 				cachedInputPrice: "0.003625e-6",
@@ -306,6 +307,11 @@ export const deepseekModels = [
 						[1, 4],
 						[6, 10],
 					],
+					offPeakDays: {
+						effectiveAt: "2026-08-22T16:00:00Z",
+						daysOfWeek: [0, 6],
+						utcOffsetMinutes: 480,
+					},
 				},
 				requestPrice: "0",
 				contextSize: 1050000,
@@ -604,7 +610,8 @@ export const deepseekModels = [
 				// Base fields are the regular flat rates, billed before
 				// effectiveAt (2026-08-16 16:00 UTC). On/after, peak hours
 				// (01:00-04:00 and 06:00-10:00 UTC) bill at the peak rates
-				// below, all other hours at the offPeak rates.
+				// below, all other hours at the offPeak rates. From 2026-08-23
+				// Beijing time, weekends are off-peak all day.
 				inputPrice: "0.14e-6",
 				outputPrice: "0.28e-6",
 				cachedInputPrice: "0.0028e-6",
@@ -624,6 +631,11 @@ export const deepseekModels = [
 						[1, 4],
 						[6, 10],
 					],
+					offPeakDays: {
+						effectiveAt: "2026-08-22T16:00:00Z",
+						daysOfWeek: [0, 6],
+						utcOffsetMinutes: 480,
+					},
 				},
 				requestPrice: "0",
 				contextSize: 1050000,

--- a/packages/shared/src/components/models-directory/api-types.ts
+++ b/packages/shared/src/components/models-directory/api-types.ts
@@ -72,6 +72,24 @@ export interface ApiModelProviderMapping {
 		cacheWriteInputPrice: string | null;
 		cacheWriteInputPrice1h: string | null;
 	}> | null;
+	peakPricing?: {
+		peak: {
+			inputPrice: string;
+			outputPrice: string;
+			cachedInputPrice: string | null;
+		};
+		offPeak: {
+			inputPrice: string;
+			outputPrice: string;
+			cachedInputPrice: string | null;
+		};
+		hoursUtc: Array<[number, number]>;
+		offPeakDays: {
+			daysOfWeek: number[];
+			utcOffsetMinutes: number;
+			timeZoneLabel: string;
+		} | null;
+	} | null;
 	serviceTiers?: string[] | null;
 	discount: string | null;
 	stability: "stable" | "beta" | "unstable" | "experimental" | null;

--- a/packages/shared/src/components/models-directory/model-card.tsx
+++ b/packages/shared/src/components/models-directory/model-card.tsx
@@ -4,6 +4,7 @@ import {
 	AlertTriangle,
 	AlertCircle,
 	Ban,
+	CalendarClock,
 	Copy,
 	Check,
 	ChevronDown,
@@ -38,6 +39,7 @@ import { cn } from "@/lib/utils";
 import { formatContextSize, formatDeprecationDate } from "./format";
 import { ModelCodeExampleDialog } from "./model-code-example-dialog";
 import { ModelStatusBadge } from "./model-status-badge";
+import { formatPeakPricingSchedule } from "./pricing-schedule";
 import { XIcon } from "./x-icon";
 
 import type {
@@ -612,6 +614,9 @@ export function ProviderSection({
 	const [activeRegionIdx, setActiveRegionIdx] = useState(0);
 	const [showTokenPricing, setShowTokenPricing] = useState(false);
 	const [showMappingDetails, setShowMappingDetails] = useState(false);
+	const [timeBasedPricingMode, setTimeBasedPricingMode] = useState<
+		"peak" | "offPeak"
+	>("peak");
 	const [selectedServiceTierId, setSelectedServiceTierId] =
 		useState("standard");
 	const activeMapping = mappings[activeRegionIdx] ?? mappings[0];
@@ -637,6 +642,16 @@ export function ProviderSection({
 	const hasImageCostEstimate = hasEstimatedImageCost(activeMapping);
 	const shouldShowTokenPricing =
 		!isImageGen || showTokenPricing || !hasImageCostEstimate;
+	const timeBasedPrices = activeMapping.peakPricing?.[timeBasedPricingMode];
+	const displayedInputPrice =
+		timeBasedPrices?.inputPrice ?? activeMapping.inputPrice;
+	const displayedCachedInputPrice =
+		timeBasedPrices?.cachedInputPrice ?? activeMapping.cachedInputPrice;
+	const displayedOutputPrice =
+		timeBasedPrices?.outputPrice ?? activeMapping.outputPrice;
+	const pricingSchedule = activeMapping.peakPricing
+		? formatPeakPricingSchedule(activeMapping.peakPricing)
+		: null;
 
 	return (
 		<div className="flex flex-1 flex-col rounded-lg border border-border/50 bg-muted/20 overflow-hidden">
@@ -1068,11 +1083,48 @@ export function ProviderSection({
 					})()
 				) : (
 					<div className="space-y-2">
+						{activeMapping.peakPricing && (
+							<div className="flex items-center justify-between gap-3">
+								<span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+									Time-based pricing
+								</span>
+								<div
+									className="flex h-7 items-center rounded-md border border-border/50 bg-background p-0.5"
+									role="group"
+									aria-label="Pricing rate"
+								>
+									{(
+										[
+											["peak", "Peak"],
+											["offPeak", "Off-peak"],
+										] as const
+									).map(([mode, label]) => {
+										const isSelected = timeBasedPricingMode === mode;
+										return (
+											<button
+												key={mode}
+												type="button"
+												onClick={() => setTimeBasedPricingMode(mode)}
+												className={cn(
+													"h-6 rounded px-2 text-[10px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+													isSelected
+														? "bg-muted text-foreground shadow-sm"
+														: "text-muted-foreground hover:text-foreground",
+												)}
+												aria-pressed={isSelected}
+											>
+												{label}
+											</button>
+										);
+									})}
+								</div>
+							</div>
+						)}
 						<div className="grid grid-cols-3 gap-px rounded-md bg-border/30 border border-border/30 overflow-hidden">
 							<div className="bg-background p-2">
 								<PriceCell
 									label="Input"
-									price={activeMapping.inputPrice}
+									price={displayedInputPrice}
 									discount={activeMapping.discount}
 									unit="/M tokens"
 									formatPrice={formatPrice}
@@ -1082,7 +1134,7 @@ export function ProviderSection({
 							<div className="bg-background p-2">
 								<PriceCell
 									label={detailed ? "Cache Read" : "Cached"}
-									price={activeMapping.cachedInputPrice}
+									price={displayedCachedInputPrice}
 									discount={activeMapping.discount}
 									unit="/M tokens"
 									formatPrice={formatPrice}
@@ -1092,7 +1144,7 @@ export function ProviderSection({
 							<div className="bg-background p-2">
 								<PriceCell
 									label="Output"
-									price={activeMapping.outputPrice}
+									price={displayedOutputPrice}
 									discount={activeMapping.discount}
 									unit="/M tokens"
 									formatPrice={formatPrice}
@@ -1100,6 +1152,28 @@ export function ProviderSection({
 								/>
 							</div>
 						</div>
+						{pricingSchedule && (
+							<div className="flex items-start gap-2 px-0.5 pt-0.5 text-[11px] leading-relaxed text-muted-foreground">
+								<CalendarClock className="mt-0.5 h-3.5 w-3.5 shrink-0 text-foreground/65" />
+								<div>
+									<p>
+										<span className="font-medium text-foreground">Peak:</span>{" "}
+										{pricingSchedule.peakDays}, {pricingSchedule.peakHours}{" "}
+										{pricingSchedule.timeZoneLabel}.
+									</p>
+									<p>
+										<span className="font-medium text-foreground">
+											Off-peak:
+										</span>{" "}
+										{pricingSchedule.peakDays} outside those hours
+										{pricingSchedule.offPeakDays
+											? `, plus all day ${pricingSchedule.offPeakDays}`
+											: ""}
+										.
+									</p>
+								</div>
+							</div>
+						)}
 						{activeMapping.ocrPagePrice !== null &&
 							activeMapping.ocrPagePrice !== undefined &&
 							Number(activeMapping.ocrPagePrice) > 0 && (

--- a/packages/shared/src/components/models-directory/pricing-schedule.spec.ts
+++ b/packages/shared/src/components/models-directory/pricing-schedule.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { formatPeakPricingSchedule } from "./pricing-schedule";
+
+describe("formatPeakPricingSchedule", () => {
+	it("formats DeepSeek weekday windows in Beijing time", () => {
+		expect(
+			formatPeakPricingSchedule({
+				peak: {
+					inputPrice: "0.44e-6",
+					outputPrice: "1.32e-6",
+					cachedInputPrice: "0.014e-6",
+				},
+				offPeak: {
+					inputPrice: "0.22e-6",
+					outputPrice: "0.66e-6",
+					cachedInputPrice: "0.007e-6",
+				},
+				hoursUtc: [
+					[1, 4],
+					[6, 10],
+				],
+				offPeakDays: {
+					daysOfWeek: [0, 6],
+					utcOffsetMinutes: 480,
+					timeZoneLabel: "Beijing time",
+				},
+			}),
+		).toEqual({
+			peakDays: "Monday–Friday",
+			offPeakDays: "Saturday and Sunday",
+			peakHours: "09:00–12:00 and 14:00–18:00",
+			timeZoneLabel: "Beijing time",
+		});
+	});
+});

--- a/packages/shared/src/components/models-directory/pricing-schedule.ts
+++ b/packages/shared/src/components/models-directory/pricing-schedule.ts
@@ -1,0 +1,75 @@
+import type { ApiModelProviderMapping } from "./api-types";
+
+type PeakPricing = NonNullable<ApiModelProviderMapping["peakPricing"]>;
+
+const orderedDays = [1, 2, 3, 4, 5, 6, 0] as const;
+const dayNames = [
+	"Sunday",
+	"Monday",
+	"Tuesday",
+	"Wednesday",
+	"Thursday",
+	"Friday",
+	"Saturday",
+] as const;
+
+function formatDays(days: number[]): string {
+	const uniqueDays = orderedDays.filter((day) => days.includes(day));
+	if (uniqueDays.length === 7) {
+		return "Every day";
+	}
+	if (
+		uniqueDays.length === 5 &&
+		uniqueDays.every((day, index) => day === orderedDays[index])
+	) {
+		return "Monday–Friday";
+	}
+
+	const names = uniqueDays.map((day) => dayNames[day]);
+	if (names.length <= 1) {
+		return names[0] ?? "";
+	}
+	if (names.length === 2) {
+		return `${names[0]} and ${names[1]}`;
+	}
+	return `${names.slice(0, -1).join(", ")}, and ${names.at(-1)}`;
+}
+
+function formatTime(hourUtc: number, utcOffsetMinutes: number): string {
+	const minutesPerDay = 24 * 60;
+	const utcMinutes = hourUtc * 60;
+	const localMinutes =
+		(((utcMinutes + utcOffsetMinutes) % minutesPerDay) + minutesPerDay) %
+		minutesPerDay;
+	const hours = Math.floor(localMinutes / 60);
+	const minutes = localMinutes % 60;
+	return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
+}
+
+export function formatPeakPricingSchedule(peakPricing: PeakPricing): {
+	peakDays: string;
+	offPeakDays: string | null;
+	peakHours: string;
+	timeZoneLabel: string;
+} {
+	const offPeakDays = peakPricing.offPeakDays;
+	const utcOffsetMinutes = offPeakDays?.utcOffsetMinutes ?? 0;
+	const allDayOffPeakDays = offPeakDays?.daysOfWeek ?? [];
+	const peakDays = orderedDays.filter(
+		(day) => !allDayOffPeakDays.includes(day),
+	);
+	const peakHours = peakPricing.hoursUtc
+		.map(
+			([start, end]) =>
+				`${formatTime(start, utcOffsetMinutes)}–${formatTime(end, utcOffsetMinutes)}`,
+		)
+		.join(" and ");
+
+	return {
+		peakDays: formatDays(peakDays),
+		offPeakDays:
+			allDayOffPeakDays.length > 0 ? formatDays(allDayOffPeakDays) : null,
+		peakHours,
+		timeZoneLabel: offPeakDays?.timeZoneLabel ?? "UTC",
+	};
+}


### PR DESCRIPTION
## Summary

- Bill DeepSeek V4 Pro and Flash at off-peak rates all day Saturday and Sunday in Beijing time.
- Keep weekday peak pricing from 09:00–12:00 and 14:00–18:00 Beijing time, with off-peak pricing outside those windows.
- Apply the configured pricing immediately without activation-date gates; activation is controlled by merging this PR at the provider cutover.
- Show a Peak/Off-peak pricing toggle and the full schedule on model cards.
- Cover pricing resolution, provider selection, gateway cost calculation, and schedule formatting.

## Scope

This changes only the first-party DeepSeek mappings for DeepSeek V4 Pro and DeepSeek V4 Flash. Model capabilities and routing are unchanged.

## Screenshots

### Light

<img width="405" alt="DeepSeek model card with peak pricing selected in light mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/a3361c82b7f1e2119ca03b528f1bb45485eec834/deepseek-pricing-light-peak.png" />
<img width="405" alt="DeepSeek model card with off-peak pricing selected in light mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/a3361c82b7f1e2119ca03b528f1bb45485eec834/deepseek-pricing-light-off-peak.png" />

### Dark

<img width="405" alt="DeepSeek model card with peak pricing selected in dark mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/a3361c82b7f1e2119ca03b528f1bb45485eec834/deepseek-pricing-dark-peak.png" />
<img width="405" alt="DeepSeek model card with off-peak pricing selected in dark mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/a3361c82b7f1e2119ca03b528f1bb45485eec834/deepseek-pricing-dark-off-peak.png" />

## Verification

- `pnpm format`
- `pnpm exec vitest run --no-file-parallelism --reporter=dot packages/shared/src/components/models-directory/pricing-schedule.spec.ts packages/models/src/helpers.spec.ts packages/actions/src/models.spec.ts apps/gateway/src/lib/costs.spec.ts` (167 tests)
- `pnpm exec turbo run build --cache=local:rw` (17/17 tasks)
- Desktop light/dark and mobile visual verification; both pricing states update correctly and the mobile card has no horizontal overflow.
