### PR TITLE
feat(models): add Qwen3 0.6B embedder

### DIFF
--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -3550,6 +3550,29 @@ export const alibabaModels = [
 		],
 	},
 	{
+		id: "qwen3-embedding-0.6b",
+		name: "Qwen3 Embedding 0.6B",
+		description:
+			"Compact Qwen3 embedding model with 32K context and configurable output dimensions (32–1024) via Matryoshka representation learning, supporting 100+ languages.",
+		family: "alibaba",
+		output: ["embedding"],
+		releasedAt: new Date("2025-06-05"),
+		providers: [
+			{
+				providerId: "deepinfra",
+				externalId: "Qwen/Qwen3-Embedding-0.6B",
+				inputPrice: "0.01e-6",
+				outputPrice: "0",
+				requestPrice: "0",
+				contextSize: 32768,
+				streaming: false,
+				tools: false,
+				jsonOutput: false,
+				embeddings: true,
+			},
+		],
+	},
+	{
 		id: "qwen3-embedding-8b",
 		name: "Qwen3 Embedding 8B",
 		description:


### PR DESCRIPTION
Closes #3720.

## Summary

- add `qwen3-embedding-0.6b` to the Alibaba model family
- map it to DeepInfra as `Qwen/Qwen3-Embedding-0.6B`
- declare embedding-only routing, 32,768-token context, and $0.01/M input pricing

## Provider evidence

DeepInfra's live models API reports the deployment as an embedding model with a 32,768-token context and `0.000001` cents per input token ($0.01/M). The [Qwen model card](https://huggingface.co/Qwen/Qwen3-Embedding-0.6B) reports a 1,024-dimensional default with Matryoshka output dimensions from 32 to 1,024 and support for 100+ languages.

Live DeepInfra probes confirmed:

- default and `dimensions: 1024` return 1,024 values
- `dimensions: 32` returns 32 values
- a 32,769-token input is rejected against the 32,768-token context limit
- an 18-token gateway request records $0.00000018 input/total cost
- an 8,508-token gateway request records $0.00008508 input/total cost

Both gateway costs exactly match `tokens × 0.01e-6`; output and request costs remain zero.

## Verification

- `pnpm exec vitest run --no-file-parallelism packages/models/src/model-metadata.spec.ts packages/models/src/providers.spec.ts packages/models/src/realtime-models.spec.ts apps/gateway/src/lib/costs.spec.ts` — 144 passed
- `TEST_MODELS='deepinfra/qwen3-embedding-0.6b' FULL_MODE=true pnpm test:e2e` — mapping passed; 28 files passed
- `pnpm format`
- `pnpm build` — 17 tasks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Alibaba’s Qwen3 Embedding 0.6B model through DeepInfra.
  * Enabled embedding generation with a 32K context window and updated pricing details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->