### PR TITLE
fix(models): together DeepSeek V4 returns reasoning

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -383,7 +383,6 @@ export const deepseekModels = [
 				// reasoning_effort.
 				reasoningEfforts: ["none", "high", "max"],
 				requiresDisableThinkingParam: true,
-				reasoningOutput: "omit",
 				vision: false,
 				tools: true,
 				jsonOutput: true,
@@ -827,7 +826,6 @@ export const deepseekModels = [
 				// through the `thinking` switch, not through reasoning_effort.
 				reasoningEfforts: ["none", "xhigh", "max"],
 				requiresDisableThinkingParam: true,
-				reasoningOutput: "omit",
 				vision: false,
 				tools: true,
 				jsonOutput: true,


### PR DESCRIPTION
## Problem

Both Together AI DeepSeek V4 mappings (`together-ai/deepseek-v4-pro`, `together-ai/deepseek-v4-flash`) carried `reasoningOutput: "omit"`, claiming the deployments never return reasoning content. They do.

Probed live against `api.together.xyz`, buffered and streaming:

| mapping | upstream field | reasoning returned |
| --- | --- | --- |
| `deepseek-ai/DeepSeek-V4-Pro-0813` | `reasoning_content` | yes, buffered + streamed deltas |
| `deepseek-ai/DeepSeek-V4-Flash-0731` | `reasoning` | yes, buffered + streamed deltas |

Note the two deployments use *different* field names for the same thing. The gateway's response parser already reads `reasoning ?? reasoning_content`, so both were being surfaced correctly all along — only the catalogue metadata was wrong.

## Impact

`reasoningOutput` is metadata-only (no gateway request/response behaviour keys off it), so the fallout was:

- the models page reported these mappings as returning no reasoning output
- `chat-reasoning`, `chat-rs` and `chat-full` e2e all gate their reasoning assertions on `reasoningOutput !== "omit"`, so the reasoning coverage for these two mappings was silently skipped

## Change

Drop `reasoningOutput: "omit"` from both mappings. Nothing else changes — `reasoningEfforts` and `requiresDisableThinkingParam` were verified separately and are correct.

## Verification

`TEST_MODELS="together-ai/deepseek-v4-pro,together-ai/deepseek-v4-flash" FULL_MODE=true pnpm test:e2e` against an isolated worktree stack: **28 files passed, 113 tests passed, 0 failed**. The previously-skipped reasoning assertions now run and pass:

```
✓ basic reasoning 'together-ai/deepseek-v4-pro'
✓ basic reasoning 'together-ai/deepseek-v4-flash'
✓ reasoning + streaming 'together-ai/deepseek-v4-pro'
✓ reasoning + streaming 'together-ai/deepseek-v4-flash'
✓ reasoning + tool calls 'together-ai/deepseek-v4-pro'
✓ reasoning + tool calls 'together-ai/deepseek-v4-flash'
✓ reasoning effort 'none' / 'high' / 'max'   (pro)
✓ reasoning effort 'none' / 'xhigh' / 'max'  (flash)
```

`pnpm format` and `pnpm build` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)