### PR TITLE
feat(admin): show token split in stats table

### DIFF
--- a/ee/admin/src/app/global-stats/client.tsx
+++ b/ee/admin/src/app/global-stats/client.tsx
@@ -974,6 +974,11 @@ export function GlobalStatsClient() {
 												</td>
 												<td className="px-3 py-2 text-right tabular-nums">
 													{metricFormatter(chartMetric)(b[chartMetric])}
+													{chartMetric === "totalTokens" ? (
+														<span className="block whitespace-nowrap text-xs font-normal text-muted-foreground">
+															{`(in ${compactNumberFormatter.format(b.inputTokens)} · cached ${compactNumberFormatter.format(b.cachedTokens)} · out ${compactNumberFormatter.format(b.outputTokens)})`}
+														</span>
+													) : null}
 												</td>
 											</tr>
 										))

--- a/ee/admin/src/app/global-stats/client.tsx
+++ b/ee/admin/src/app/global-stats/client.tsx
@@ -972,8 +972,17 @@ export function GlobalStatsClient() {
 												<td className="px-3 py-2 font-mono text-xs">
 													{b.label}
 												</td>
-												<td className="px-3 py-2 text-right tabular-nums">
-													{metricFormatter(chartMetric)(b[chartMetric])}
+												<td
+													className="px-3 py-2 text-right tabular-nums"
+													title={
+														chartMetric === "totalTokens"
+															? numberFormatter.format(b.totalTokens)
+															: undefined
+													}
+												>
+													{chartMetric === "totalTokens"
+														? compactNumberFormatter.format(b.totalTokens)
+														: metricFormatter(chartMetric)(b[chartMetric])}
 													{chartMetric === "totalTokens" ? (
 														<span className="block whitespace-nowrap text-xs font-normal text-muted-foreground">
 															{`(in ${compactNumberFormatter.format(b.inputTokens)} · cached ${compactNumberFormatter.format(b.cachedTokens)} · out ${compactNumberFormatter.format(b.outputTokens)})`}


### PR DESCRIPTION
## Problem

On the admin **Global Stats** page, the breakdown table next to the share pie only prints a single, fully spelled-out number per row when the *Total tokens* metric is selected — `760,750,613`. It is hard to scan, and the composition behind it (input / cached / output) is invisible even though the endpoint already returns all three fields per row.

## Change

For the *Total tokens* metric:

- Format the row total compactly (`760.8M`, `4.7B`), matching the y-axis and the stat cards. The exact grouped number is kept as the cell's `title`, so it is one hover away.
- Add the input / cached / output split in parentheses beneath it, in muted small text.

The Requests and Cost views are untouched — Cost in particular reads worse compacted (`$5.9K` vs `$5,907.00`).

No API change: `globalStatsBreakdownItemSchema` already carries `inputTokens`, `cachedTokens` and `outputTokens` for every row, in all three model views (Mappings / Canonical / Providers) and every grouping.

## Screenshots

Captured against a locally seeded stack with synthetic `global_model_stats` rows.

**Light**

| Before | After |
| --- | --- |
| <img width="400" alt="breakdown table before, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/1a3c5cdbb896f36616aab18fd7a610e9ba91b32e/before-light.png" /> | <img width="400" alt="breakdown table after, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/1a3c5cdbb896f36616aab18fd7a610e9ba91b32e/after-light.png" /> |

**Dark**

| Before | After |
| --- | --- |
| <img width="400" alt="breakdown table before, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/1a3c5cdbb896f36616aab18fd7a610e9ba91b32e/before-dark.png" /> | <img width="400" alt="breakdown table after, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/1a3c5cdbb896f36616aab18fd7a610e9ba91b32e/after-dark.png" /> |

## Verification

`pnpm format` and a full `pnpm build` pass; the screenshots are from the real pre- and post-change admin builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)