### PR TITLE
feat(ui): show API key limit status + filters

### DIFF
--- a/apps/ui/src/components/api-keys/api-key-limit-fields.tsx
+++ b/apps/ui/src/components/api-keys/api-key-limit-fields.tsx
@@ -176,7 +176,7 @@ export function validateApiKeyLimitPayloadWithinMemberBudget(
 	);
 }
 
-export function formatCurrencyAmount(value: string): string {
+export function formatCurrencyAmount(value: string | number): string {
 	return `$${Number(value).toFixed(2)}`;
 }
 
@@ -202,6 +202,26 @@ export function formatPeriodLimitSummary(
 	}
 
 	return `${formatCurrencyAmount(apiKey.periodUsageLimit)} / ${formatPeriodWindowLabel(apiKey.periodUsageDurationValue, apiKey.periodUsageDurationUnit)}`;
+}
+
+export function formatApiKeyPeriodResetLabel(
+	resetAt: string | Date | null | undefined,
+): string | null {
+	if (resetAt === null || resetAt === undefined) {
+		return null;
+	}
+
+	const date = resetAt instanceof Date ? resetAt : new Date(resetAt);
+	if (Number.isNaN(date.getTime())) {
+		return null;
+	}
+
+	return Intl.DateTimeFormat(undefined, {
+		month: "short",
+		day: "numeric",
+		hour: "2-digit",
+		minute: "2-digit",
+	}).format(date);
 }
 
 export function formatCurrentPeriodUsageSummary(
@@ -230,20 +250,7 @@ export function formatCurrentPeriodUsageSummary(
 		};
 	}
 
-	const resetAt =
-		apiKey.currentPeriodResetAt !== null &&
-		apiKey.currentPeriodResetAt !== undefined
-			? new Date(apiKey.currentPeriodResetAt)
-			: null;
-	const resetLabel =
-		resetAt && !Number.isNaN(resetAt.getTime())
-			? Intl.DateTimeFormat(undefined, {
-					month: "short",
-					day: "numeric",
-					hour: "2-digit",
-					minute: "2-digit",
-				}).format(resetAt)
-			: null;
+	const resetLabel = formatApiKeyPeriodResetLabel(apiKey.currentPeriodResetAt);
 
 	return {
 		summary: `${formatCurrencyAmount(apiKey.currentPeriodUsage)} / ${formatCurrencyAmount(apiKey.periodUsageLimit)}`,

--- a/apps/ui/src/components/api-keys/api-key-limit-indicators.tsx
+++ b/apps/ui/src/components/api-keys/api-key-limit-indicators.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { AlertTriangleIcon, OctagonAlertIcon } from "lucide-react";
+
+import { Badge } from "@/lib/components/badge";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/lib/components/tooltip";
+import { cn } from "@/lib/utils";
+
+import {
+	formatApiKeyPeriodResetLabel,
+	formatCurrencyAmount,
+	formatPeriodWindowLabel,
+} from "./api-key-limit-fields";
+
+import type {
+	ApiKeyLimitGauge,
+	ApiKeyLimitState,
+	ApiKeyLimitStatus,
+} from "./api-key-limit-status";
+import type { ApiKey } from "@/lib/types";
+
+export const apiKeyLimitTextTone: Record<ApiKeyLimitState, string> = {
+	ok: "",
+	approaching: "text-amber-600 dark:text-amber-500",
+	reached: "text-destructive",
+};
+
+const barTone: Record<ApiKeyLimitState, string> = {
+	ok: "bg-primary/50",
+	approaching: "bg-amber-500",
+	reached: "bg-destructive",
+};
+
+export function ApiKeyLimitMeter({
+	className,
+	gauge,
+}: {
+	className?: string;
+	gauge: ApiKeyLimitGauge;
+}) {
+	const percent = Math.min(100, Math.max(0, gauge.ratio * 100));
+
+	return (
+		<div
+			className={cn(
+				"bg-muted h-1 w-20 overflow-hidden rounded-full",
+				className,
+			)}
+		>
+			<div
+				className={cn("h-full rounded-full", barTone[gauge.state])}
+				style={{ width: `${percent}%` }}
+			/>
+		</div>
+	);
+}
+
+function formatRatio(gauge: ApiKeyLimitGauge): string {
+	return `${formatCurrencyAmount(gauge.usage)} of ${formatCurrencyAmount(gauge.limit)} used (${Math.min(999, Math.round(gauge.ratio * 100))}%)`;
+}
+
+export function describeApiKeyLimitStatus(
+	apiKey: ApiKey,
+	status: ApiKeyLimitStatus,
+): string[] {
+	const lines: string[] = [];
+
+	if (status.total && status.total.state !== "ok") {
+		lines.push(
+			status.total.state === "reached"
+				? `All-time limit reached — ${formatRatio(status.total)}. This key stays blocked until you raise or remove the limit.`
+				: `All-time limit — ${formatRatio(status.total)}.`,
+		);
+	}
+
+	if (status.period && status.period.state !== "ok") {
+		const windowLabel =
+			apiKey.periodUsageDurationValue !== null &&
+			apiKey.periodUsageDurationUnit !== null
+				? formatPeriodWindowLabel(
+						apiKey.periodUsageDurationValue,
+						apiKey.periodUsageDurationUnit,
+					)
+				: null;
+		const resetLabel = formatApiKeyPeriodResetLabel(
+			apiKey.currentPeriodResetAt,
+		);
+		const period = windowLabel
+			? `the current ${windowLabel} period`
+			: "the current period";
+
+		lines.push(
+			status.period.state === "reached"
+				? `Recurring limit reached — ${formatRatio(status.period)} in ${period}. Requests resume automatically ${resetLabel ? `on ${resetLabel}` : "when the next period starts"}.`
+				: `Recurring limit — ${formatRatio(status.period)} in ${period}${resetLabel ? `, resets ${resetLabel}` : ""}.`,
+		);
+	}
+
+	return lines;
+}
+
+function limitBadgeLabel(status: ApiKeyLimitStatus): string | null {
+	const totalReached = status.total?.state === "reached";
+	const periodReached = status.period?.state === "reached";
+
+	if (totalReached && periodReached) {
+		return "Limits reached";
+	}
+	if (totalReached) {
+		return "Total limit reached";
+	}
+	if (periodReached) {
+		return "Period limit reached";
+	}
+
+	const totalNear = status.total?.state === "approaching";
+	const periodNear = status.period?.state === "approaching";
+
+	if (totalNear && periodNear) {
+		return "Near limits";
+	}
+	if (totalNear) {
+		return "Near total limit";
+	}
+	if (periodNear) {
+		return "Near period limit";
+	}
+
+	return null;
+}
+
+export function ApiKeyLimitBadge({
+	apiKey,
+	status,
+}: {
+	apiKey: ApiKey;
+	status: ApiKeyLimitStatus;
+}) {
+	const label = limitBadgeLabel(status);
+	if (!label) {
+		return null;
+	}
+
+	const reached = status.state === "reached";
+	const Icon = reached ? OctagonAlertIcon : AlertTriangleIcon;
+
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<Badge
+					variant="secondary"
+					className={cn(
+						"flex cursor-help items-center gap-1 px-1 py-[2px] text-xs font-medium",
+						reached
+							? "bg-destructive/10 text-destructive border-destructive/50"
+							: "bg-amber-500/10 text-amber-600 border-amber-600/50 dark:text-amber-500 dark:border-amber-500/50",
+					)}
+				>
+					<Icon className="h-3.5 w-3.5" />
+					{label}
+				</Badge>
+			</TooltipTrigger>
+			<TooltipContent>
+				<div className="max-w-xs space-y-1 text-xs">
+					{describeApiKeyLimitStatus(apiKey, status).map((line) => (
+						<p key={line}>{line}</p>
+					))}
+				</div>
+			</TooltipContent>
+		</Tooltip>
+	);
+}

--- a/apps/ui/src/components/api-keys/api-key-limit-status.spec.ts
+++ b/apps/ui/src/components/api-keys/api-key-limit-status.spec.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import { getApiKeyLimitStatus } from "./api-key-limit-status";
+
+import type { ApiKey } from "@/lib/types";
+
+const now = new Date("2026-08-22T12:00:00.000Z");
+
+function key(overrides: Partial<ApiKey> = {}): ApiKey {
+	return {
+		currentPeriodResetAt: null,
+		currentPeriodUsage: "0",
+		periodUsageDurationUnit: null,
+		periodUsageDurationValue: null,
+		periodUsageLimit: null,
+		usage: "0",
+		usageLimit: null,
+		...overrides,
+	} as ApiKey;
+}
+
+describe("getApiKeyLimitStatus", () => {
+	it("reports no state when no limit is configured", () => {
+		const status = getApiKeyLimitStatus(key({ usage: "42" }), now);
+
+		expect(status).toEqual({ period: null, state: null, total: null });
+	});
+
+	it("flags an all-time limit that has been reached", () => {
+		const status = getApiKeyLimitStatus(
+			key({ usage: "10", usageLimit: "10" }),
+			now,
+		);
+
+		expect(status.state).toBe("reached");
+		expect(status.total).toEqual({
+			limit: 10,
+			ratio: 1,
+			state: "reached",
+			usage: 10,
+		});
+	});
+
+	it("flags an all-time limit that is close to being reached", () => {
+		const status = getApiKeyLimitStatus(
+			key({ usage: "8", usageLimit: "10" }),
+			now,
+		);
+
+		expect(status.state).toBe("approaching");
+	});
+
+	it("stays ok below the warning ratio", () => {
+		const status = getApiKeyLimitStatus(
+			key({ usage: "7.99", usageLimit: "10" }),
+			now,
+		);
+
+		expect(status.state).toBe("ok");
+	});
+
+	it("treats a zero limit as reached", () => {
+		const status = getApiKeyLimitStatus(
+			key({ usage: "0", usageLimit: "0" }),
+			now,
+		);
+
+		expect(status.total).toMatchObject({ ratio: 1, state: "reached" });
+	});
+
+	it("flags a recurring limit that has been reached", () => {
+		const status = getApiKeyLimitStatus(
+			key({
+				currentPeriodResetAt: "2026-08-27T12:00:00.000Z",
+				currentPeriodUsage: "5.38",
+				periodUsageDurationUnit: "week",
+				periodUsageDurationValue: 1,
+				periodUsageLimit: "5",
+			}),
+			now,
+		);
+
+		expect(status.state).toBe("reached");
+		expect(status.period).toMatchObject({ limit: 5, state: "reached" });
+		expect(status.total).toBeNull();
+	});
+
+	it("clears a recurring limit once its reset date has passed", () => {
+		const status = getApiKeyLimitStatus(
+			key({
+				currentPeriodResetAt: "2026-08-20T12:00:00.000Z",
+				currentPeriodUsage: "5.38",
+				periodUsageDurationUnit: "week",
+				periodUsageDurationValue: 1,
+				periodUsageLimit: "5",
+			}),
+			now,
+		);
+
+		expect(status.state).toBe("ok");
+		expect(status.period).toMatchObject({ state: "ok", usage: 0 });
+	});
+
+	it("ignores a recurring limit with an incomplete window", () => {
+		const status = getApiKeyLimitStatus(
+			key({ currentPeriodUsage: "9", periodUsageLimit: "5" }),
+			now,
+		);
+
+		expect(status).toEqual({ period: null, state: null, total: null });
+	});
+
+	it("reports the worst state across both limits", () => {
+		const status = getApiKeyLimitStatus(
+			key({
+				currentPeriodResetAt: "2026-08-27T12:00:00.000Z",
+				currentPeriodUsage: "1",
+				periodUsageDurationUnit: "week",
+				periodUsageDurationValue: 1,
+				periodUsageLimit: "5",
+				usage: "20",
+				usageLimit: "20",
+			}),
+			now,
+		);
+
+		expect(status.period?.state).toBe("ok");
+		expect(status.total?.state).toBe("reached");
+		expect(status.state).toBe("reached");
+	});
+});

--- a/apps/ui/src/components/api-keys/api-key-limit-status.ts
+++ b/apps/ui/src/components/api-keys/api-key-limit-status.ts
@@ -1,0 +1,109 @@
+import type { ApiKey } from "@/lib/types";
+
+/** Share of a limit at which a key is flagged as approaching it. */
+export const API_KEY_LIMIT_WARNING_RATIO = 0.8;
+
+export type ApiKeyLimitState = "ok" | "approaching" | "reached";
+
+export interface ApiKeyLimitGauge {
+	limit: number;
+	ratio: number;
+	state: ApiKeyLimitState;
+	usage: number;
+}
+
+export interface ApiKeyLimitStatus {
+	/** Recurring limit for the current period; unblocks itself on the reset date. */
+	period: ApiKeyLimitGauge | null;
+	/** Worst state across the configured limits; null when none are configured. */
+	state: ApiKeyLimitState | null;
+	/** All-time limit; stays blocked until it is raised or removed. */
+	total: ApiKeyLimitGauge | null;
+}
+
+type ApiKeyLimitFields = Pick<
+	ApiKey,
+	| "currentPeriodResetAt"
+	| "currentPeriodUsage"
+	| "periodUsageDurationUnit"
+	| "periodUsageDurationValue"
+	| "periodUsageLimit"
+	| "usage"
+	| "usageLimit"
+>;
+
+function buildGauge(
+	usage: string | number,
+	limit: string | null,
+): ApiKeyLimitGauge | null {
+	if (limit === null) {
+		return null;
+	}
+
+	const limitValue = Number(limit);
+	const usageValue = Number(usage);
+	if (!Number.isFinite(limitValue) || !Number.isFinite(usageValue)) {
+		return null;
+	}
+
+	// The gateway rejects on `usage >= limit`, so a zero limit blocks everything.
+	const ratio = limitValue > 0 ? usageValue / limitValue : 1;
+
+	return {
+		limit: limitValue,
+		ratio,
+		state:
+			usageValue >= limitValue
+				? "reached"
+				: ratio >= API_KEY_LIMIT_WARNING_RATIO
+					? "approaching"
+					: "ok",
+		usage: usageValue,
+	};
+}
+
+export function getApiKeyLimitStatus(
+	apiKey: ApiKeyLimitFields,
+	now: Date = new Date(),
+): ApiKeyLimitStatus {
+	const total = buildGauge(apiKey.usage, apiKey.usageLimit ?? null);
+
+	const periodConfigured =
+		apiKey.periodUsageLimit !== null &&
+		apiKey.periodUsageDurationValue !== null &&
+		apiKey.periodUsageDurationUnit !== null;
+
+	// The serialized period usage is a snapshot taken when the list was fetched;
+	// once the reset date passes the window has rolled over and usage is back to 0.
+	const resetAt = apiKey.currentPeriodResetAt
+		? new Date(apiKey.currentPeriodResetAt)
+		: null;
+	const periodElapsed =
+		resetAt !== null &&
+		!Number.isNaN(resetAt.getTime()) &&
+		resetAt.getTime() <= now.getTime();
+
+	const period = periodConfigured
+		? buildGauge(
+				periodElapsed ? 0 : apiKey.currentPeriodUsage,
+				apiKey.periodUsageLimit,
+			)
+		: null;
+
+	const gauges = [total, period].filter(
+		(gauge): gauge is ApiKeyLimitGauge => gauge !== null,
+	);
+
+	return {
+		period,
+		state:
+			gauges.length === 0
+				? null
+				: gauges.some((gauge) => gauge.state === "reached")
+					? "reached"
+					: gauges.some((gauge) => gauge.state === "approaching")
+						? "approaching"
+						: "ok",
+		total,
+	};
+}

--- a/apps/ui/src/components/api-keys/api-keys-list.tsx
+++ b/apps/ui/src/components/api-keys/api-keys-list.tsx
@@ -56,6 +56,7 @@ import {
 import { toast } from "@/lib/components/use-toast";
 import { useApi } from "@/lib/fetch-client";
 import { extractOrgAndProjectFromPath } from "@/lib/navigation-utils";
+import { cn } from "@/lib/utils";
 
 import {
 	formatCurrentPeriodUsageSummary,
@@ -63,6 +64,12 @@ import {
 	formatPeriodLimitSummary,
 	type ApiKeyLimitPayload,
 } from "./api-key-limit-fields";
+import {
+	ApiKeyLimitBadge,
+	ApiKeyLimitMeter,
+	apiKeyLimitTextTone,
+} from "./api-key-limit-indicators";
+import { getApiKeyLimitStatus } from "./api-key-limit-status";
 import { ApiKeyLimitsDialog } from "./api-key-limits-dialog";
 import { formatApiKeyExpiry } from "./api-key-ttl-fields";
 import { CreateApiKeyDialog } from "./create-api-key-dialog";
@@ -70,6 +77,7 @@ import { ReactivateApiKeyDialog } from "./reactivate-api-key-dialog";
 import { RenameApiKeyDialog } from "./rename-api-key-dialog";
 import { RollApiKeyDialog } from "./roll-api-key-dialog";
 
+import type { ApiKeyLimitStatus } from "./api-key-limit-status";
 import type { ApiKey, Project } from "@/lib/types";
 import type { Route } from "next";
 
@@ -80,6 +88,7 @@ interface ApiKeysListProps {
 
 type StatusFilter = "all" | "active" | "inactive";
 type CreatorFilter = "mine" | "all";
+type LimitFilter = "all" | "approaching" | "reached";
 
 const PLAYGROUND_KEY_DESCRIPTION = "Auto-generated playground key";
 
@@ -114,6 +123,7 @@ export function ApiKeysList({
 	);
 	const [statusFilter, setStatusFilter] = useState<StatusFilter>("active");
 	const [creatorFilter, setCreatorFilter] = useState<CreatorFilter>("all");
+	const [limitFilter, setLimitFilter] = useState<LimitFilter>("all");
 	const [reactivateKey, setReactivateKey] = useState<ApiKey | null>(null);
 	const [rollKey, setRollKey] = useState<ApiKey | null>(null);
 	const [renameKey, setRenameKey] = useState<ApiKey | null>(null);
@@ -182,7 +192,13 @@ export function ApiKeysList({
 	const inactiveKeys = allKeys.filter((key) => key.status === "inactive");
 	const planLimits = data?.planLimits;
 
-	const filteredKeys = (() => {
+	const limitStatuses = new Map<string, ApiKeyLimitStatus>(
+		allKeys.map((key) => [key.id, getApiKeyLimitStatus(key)]),
+	);
+	const limitStatusOf = (key: ApiKey): ApiKeyLimitStatus =>
+		limitStatuses.get(key.id) ?? { period: null, state: null, total: null };
+
+	const statusFilteredKeys = (() => {
 		switch (statusFilter) {
 			case "active":
 				return activeKeys;
@@ -194,9 +210,28 @@ export function ApiKeysList({
 		}
 	})();
 
+	const approachingKeys = statusFilteredKeys.filter(
+		(key) => limitStatusOf(key).state === "approaching",
+	);
+	const reachedKeys = statusFilteredKeys.filter(
+		(key) => limitStatusOf(key).state === "reached",
+	);
+
+	const filteredKeys = (() => {
+		switch (limitFilter) {
+			case "approaching":
+				return approachingKeys;
+			case "reached":
+				return reachedKeys;
+			case "all":
+			default:
+				return statusFilteredKeys;
+		}
+	})();
+
 	// Auto-switch to a tab with content if current tab becomes empty
 	useEffect(() => {
-		if (filteredKeys.length === 0 && allKeys.length > 0) {
+		if (statusFilteredKeys.length === 0 && allKeys.length > 0) {
 			if (statusFilter === "active" && inactiveKeys.length > 0) {
 				setStatusFilter("inactive");
 			} else if (statusFilter === "inactive" && activeKeys.length > 0) {
@@ -206,12 +241,21 @@ export function ApiKeysList({
 			}
 		}
 	}, [
-		filteredKeys.length,
+		statusFilteredKeys.length,
 		allKeys.length,
 		activeKeys.length,
 		inactiveKeys.length,
 		statusFilter,
 	]);
+
+	// Drop a usage filter once no key in the current status tab matches it.
+	useEffect(() => {
+		if (limitFilter === "approaching" && approachingKeys.length === 0) {
+			setLimitFilter("all");
+		} else if (limitFilter === "reached" && reachedKeys.length === 0) {
+			setLimitFilter("all");
+		}
+	}, [limitFilter, approachingKeys.length, reachedKeys.length]);
 
 	// Show message if no project is selected
 	if (!selectedProject) {
@@ -453,28 +497,58 @@ export function ApiKeysList({
 		}
 	};
 
-	const renderCurrentPeriodUsage = (key: ApiKey) => {
-		const summary = formatCurrentPeriodUsageSummary(key);
+	const renderUsage = (key: ApiKey) => {
+		const total = limitStatusOf(key).total;
 
 		return (
 			<div className="space-y-1">
 				<div
-					className={
+					className={cn(
+						"font-mono text-xs",
+						total && apiKeyLimitTextTone[total.state],
+					)}
+				>
+					{formatCurrencyAmount(key.usage)}
+					{total ? ` / ${formatCurrencyAmount(total.limit)}` : ""}
+				</div>
+				{total && <ApiKeyLimitMeter gauge={total} />}
+			</div>
+		);
+	};
+
+	const renderCurrentPeriodUsage = (key: ApiKey) => {
+		const summary = formatCurrentPeriodUsageSummary(key);
+		const period = limitStatusOf(key).period;
+		const reached = period?.state === "reached";
+
+		return (
+			<div className="space-y-1">
+				<div
+					className={cn(
 						summary.windowLabel
 							? "font-mono text-xs"
-							: "text-muted-foreground text-xs"
-					}
+							: "text-muted-foreground text-xs",
+						period && apiKeyLimitTextTone[period.state],
+					)}
 				>
 					{summary.summary}
 				</div>
+				{period && <ApiKeyLimitMeter gauge={period} />}
 				{summary.windowLabel && (
 					<div className="text-muted-foreground text-xs">
 						Every {summary.windowLabel}
 					</div>
 				)}
 				{summary.resetLabel && (
-					<div className="text-muted-foreground text-xs">
-						Resets {summary.resetLabel}
+					<div
+						className={cn(
+							"text-xs",
+							reached
+								? "text-destructive font-medium"
+								: "text-muted-foreground",
+						)}
+					>
+						{reached ? "Unblocks" : "Resets"} {summary.resetLabel}
 					</div>
 				)}
 			</div>
@@ -496,18 +570,34 @@ export function ApiKeysList({
 		);
 	};
 
-	const renderLimitSummary = (key: ApiKey) => (
-		<div className="text-left">
-			<div className="font-mono text-xs">
-				{key.usageLimit
-					? formatCurrencyAmount(key.usageLimit)
-					: "No all-time limit"}
+	const renderLimitSummary = (key: ApiKey) => {
+		const { period, total } = limitStatusOf(key);
+
+		return (
+			<div className="text-left">
+				<div
+					className={cn(
+						"font-mono text-xs",
+						total && apiKeyLimitTextTone[total.state],
+					)}
+				>
+					{key.usageLimit
+						? formatCurrencyAmount(key.usageLimit)
+						: "No all-time limit"}
+				</div>
+				<div
+					className={cn(
+						"text-xs",
+						period && period.state !== "ok"
+							? apiKeyLimitTextTone[period.state]
+							: "text-muted-foreground",
+					)}
+				>
+					{formatPeriodLimitSummary(key)}
+				</div>
 			</div>
-			<div className="text-muted-foreground text-xs">
-				{formatPeriodLimitSummary(key)}
-			</div>
-		</div>
-	);
+		);
+	};
 
 	if (allKeys.length === 0) {
 		return (
@@ -559,45 +649,87 @@ export function ApiKeysList({
 					</Tabs>
 				)}
 
-				{/* Status Filter Tabs */}
-				<Tabs
-					value={statusFilter}
-					onValueChange={(value) => setStatusFilter(value as StatusFilter)}
-				>
-					<TabsList className="flex space-x-2 w-full md:w-fit">
-						<TabsTrigger value="all">
-							All{" "}
-							<Badge
-								variant={statusFilter === "all" ? "default" : "outline"}
-								className="text-xs"
-							>
-								{allKeys.length}
-							</Badge>
-						</TabsTrigger>
-						{activeKeys.length > 0 && (
-							<TabsTrigger value="active">
-								Active{" "}
+				<div className="flex flex-col gap-4 md:flex-row md:items-center">
+					{/* Status Filter Tabs */}
+					<Tabs
+						value={statusFilter}
+						onValueChange={(value) => setStatusFilter(value as StatusFilter)}
+					>
+						<TabsList className="flex space-x-2 w-full md:w-fit">
+							<TabsTrigger value="all">
+								All{" "}
 								<Badge
-									variant={statusFilter === "active" ? "default" : "outline"}
+									variant={statusFilter === "all" ? "default" : "outline"}
 									className="text-xs"
 								>
-									{activeKeys.length}
+									{allKeys.length}
 								</Badge>
 							</TabsTrigger>
-						)}
-						{inactiveKeys.length > 0 && (
-							<TabsTrigger value="inactive">
-								Inactive{" "}
-								<Badge
-									variant={statusFilter === "inactive" ? "default" : "outline"}
-									className="text-xs"
-								>
-									{inactiveKeys.length}
-								</Badge>
-							</TabsTrigger>
-						)}
-					</TabsList>
-				</Tabs>
+							{activeKeys.length > 0 && (
+								<TabsTrigger value="active">
+									Active{" "}
+									<Badge
+										variant={statusFilter === "active" ? "default" : "outline"}
+										className="text-xs"
+									>
+										{activeKeys.length}
+									</Badge>
+								</TabsTrigger>
+							)}
+							{inactiveKeys.length > 0 && (
+								<TabsTrigger value="inactive">
+									Inactive{" "}
+									<Badge
+										variant={
+											statusFilter === "inactive" ? "default" : "outline"
+										}
+										className="text-xs"
+									>
+										{inactiveKeys.length}
+									</Badge>
+								</TabsTrigger>
+							)}
+						</TabsList>
+					</Tabs>
+
+					{/* Usage Limit Filter Tabs */}
+					{(approachingKeys.length > 0 || reachedKeys.length > 0) && (
+						<Tabs
+							value={limitFilter}
+							onValueChange={(value) => setLimitFilter(value as LimitFilter)}
+						>
+							<TabsList className="flex space-x-2 w-full md:w-fit">
+								<TabsTrigger value="all">Any usage</TabsTrigger>
+								{approachingKeys.length > 0 && (
+									<TabsTrigger value="approaching">
+										Near limit{" "}
+										<Badge
+											variant={
+												limitFilter === "approaching" ? "default" : "outline"
+											}
+											className="text-xs"
+										>
+											{approachingKeys.length}
+										</Badge>
+									</TabsTrigger>
+								)}
+								{reachedKeys.length > 0 && (
+									<TabsTrigger value="reached">
+										Limit reached{" "}
+										<Badge
+											variant={
+												limitFilter === "reached" ? "default" : "outline"
+											}
+											className="text-xs"
+										>
+											{reachedKeys.length}
+										</Badge>
+									</TabsTrigger>
+								)}
+							</TabsList>
+						</Tabs>
+					)}
+				</div>
 			</div>
 
 			{/* Plan Limits Display */}
@@ -617,6 +749,12 @@ export function ApiKeysList({
 							</div>
 						)}
 					</div>
+				</div>
+			)}
+
+			{filteredKeys.length === 0 && (
+				<div className="text-muted-foreground py-10 text-center text-sm">
+					No API keys match the selected filters.
 				</div>
 			)}
 
@@ -663,6 +801,10 @@ export function ApiKeysList({
 									<TableCell>
 										<div className="space-y-1">
 											<StatusBadge status={key.status} variant="detailed" />
+											<ApiKeyLimitBadge
+												apiKey={key}
+												status={limitStatusOf(key)}
+											/>
 											{renderExpiry(key)}
 										</div>
 									</TableCell>
@@ -704,7 +846,7 @@ export function ApiKeysList({
 											</TooltipContent>
 										</Tooltip>
 									</TableCell>
-									<TableCell>{formatCurrencyAmount(key.usage)}</TableCell>
+									<TableCell>{renderUsage(key)}</TableCell>
 									<TableCell>{renderCurrentPeriodUsage(key)}</TableCell>
 									<TableCell>
 										<ApiKeyLimitsDialog
@@ -870,6 +1012,10 @@ export function ApiKeysList({
 												: key.description}
 										</h3>
 										<StatusBadge status={key.status} />
+										<ApiKeyLimitBadge
+											apiKey={key}
+											status={limitStatusOf(key)}
+										/>
 									</div>
 									{renderExpiry(key)}
 									<div className="flex items-center gap-2 mt-1">
@@ -977,9 +1123,7 @@ export function ApiKeysList({
 									<div className="text-xs text-muted-foreground mb-1">
 										Usage
 									</div>
-									<div className="font-mono text-xs break-all">
-										{formatCurrencyAmount(key.usage)}
-									</div>
+									{renderUsage(key)}
 								</div>
 								<div className="py-1">
 									<div className="text-xs text-muted-foreground mb-1">


### PR DESCRIPTION
## Problem

The API keys table showed usage and limits as plain numbers, so nothing told you whether a key was actually blocked. Worse, the two limits behave very differently and looked identical: an **all-time** limit blocks the key until someone raises it, while a **recurring** limit unblocks itself on the reset date the table already displays.

## Changes

- **Limit badge in the Status column** — `Total limit reached`, `Period limit reached`, `Limits reached`, or the amber `Near …` variants at ≥80% of a limit. The tooltip spells out which limit, how much is used, and — for a recurring limit — that requests resume automatically on the reset date.
- **Usage meters** — the Usage cell now reads `$25.00 / $25.00` with a bar; the Current Period cell gets the same treatment, and its reset line switches from `Resets …` to `Unblocks …` once the period limit is hit. The Limits cell tints whichever limit is exhausted.
- **New usage filters** next to the status tabs: `Near limit` and `Limit reached`, counted within the current status tab.
- Thresholds mirror the gateway's own check (`usage >= limit`, so a zero limit counts as reached); a period whose reset date has passed is treated as rolled over rather than blocked, since the list data is cached for 5 minutes.

Pure dashboard change — no API or gateway changes; every field used was already returned by `GET /keys/api`.

## Screenshots

Local seeded data.

### Before / after — light

<img width="1440" alt="API keys page before, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/0cdc5961cebe1a18c61de0116af5637fccca52e7/before-light.png" />

<img width="1440" alt="API keys page after, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/0cdc5961cebe1a18c61de0116af5637fccca52e7/after-light.png" />

### Before / after — dark

<img width="1440" alt="API keys page before, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/0cdc5961cebe1a18c61de0116af5637fccca52e7/before-dark.png" />

<img width="1440" alt="API keys page after, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/0cdc5961cebe1a18c61de0116af5637fccca52e7/after-dark.png" />

### Limit reached filter

<img width="1440" alt="Keys filtered to those that reached a limit" src="https://raw.githubusercontent.com/theopenco/llmgateway/0cdc5961cebe1a18c61de0116af5637fccca52e7/filter-reached.png" />

### Badge tooltip

<img width="1440" alt="Tooltip explaining that the recurring limit unblocks on the reset date" src="https://raw.githubusercontent.com/theopenco/llmgateway/0cdc5961cebe1a18c61de0116af5637fccca52e7/tooltip.png" />

## Verification

- `pnpm build` (17/17 tasks)
- `npx vitest run apps/ui/src` — 13 files, 104 tests, including 9 new cases for the limit-status helper
- Drove the page in an isolated local stack with seeded keys in each state

🤖 Generated with [Claude Code](https://claude.com/claude-code)