### PR TITLE
fix(shared): block IPv6 transition ranges

### DIFF
--- a/packages/shared/src/url-safety.spec.ts
+++ b/packages/shared/src/url-safety.spec.ts
@@ -36,6 +36,35 @@ describe("isPrivateOrReservedIp", () => {
 		expect(isPrivateOrReservedIp("::ffff:0808:0808")).toBe(false); // 8.8.8.8
 	});
 
+	it("flags IPv6 transition addresses embedding internal IPv4 targets", () => {
+		expect(isPrivateOrReservedIp("64:ff9b::a9fe:a9fe")).toBe(true); // NAT64 → 169.254.169.254
+		expect(isPrivateOrReservedIp("64:ff9b::169.254.169.254")).toBe(true); // NAT64 dotted form
+		expect(isPrivateOrReservedIp("64:ff9b::7f00:1")).toBe(true); // NAT64 → 127.0.0.1
+		expect(isPrivateOrReservedIp("64:ff9b::808:808")).toBe(false); // NAT64 → 8.8.8.8 (public)
+		expect(isPrivateOrReservedIp("64:ff9b:1::1")).toBe(true); // NAT64 local-use /48
+		expect(isPrivateOrReservedIp("2002:a9fe:a9fe::1")).toBe(true); // 6to4 → 169.254.169.254
+		expect(isPrivateOrReservedIp("2002:7f00:1::1")).toBe(true); // 6to4 → 127.0.0.1
+		expect(isPrivateOrReservedIp("2001::1")).toBe(true); // Teredo 2001::/32
+		expect(isPrivateOrReservedIp("2001:0:5ef5:79fb::1")).toBe(true); // Teredo
+	});
+
+	it("flags multicast, discard, documentation and non-canonical IPv6 forms", () => {
+		expect(isPrivateOrReservedIp("ff02::1")).toBe(true); // multicast
+		expect(isPrivateOrReservedIp("100::1")).toBe(true); // discard-only 100::/64
+		expect(isPrivateOrReservedIp("2001:db8::1")).toBe(true); // documentation
+		expect(isPrivateOrReservedIp("3fff::1")).toBe(true); // documentation 3fff::/20
+		expect(isPrivateOrReservedIp("0:0:0:0:0:0:0:1")).toBe(true); // uncompressed ::1
+		expect(isPrivateOrReservedIp("::7f00:1")).toBe(true); // IPv4-compatible → 127.0.0.1
+		expect(isPrivateOrReservedIp("fe80::1%eth0")).toBe(true); // zone index
+		expect(isPrivateOrReservedIp("beef::cafe::1")).toBe(true); // malformed → fail closed
+	});
+
+	it("allows public IPv6", () => {
+		expect(isPrivateOrReservedIp("2606:4700::6810:84e5")).toBe(false);
+		expect(isPrivateOrReservedIp("2a00:1450:4001:829::200e")).toBe(false);
+		expect(isPrivateOrReservedIp("2600:1f18:222:e900::1")).toBe(false);
+	});
+
 	it("flags IANA special-use IPv4 ranges", () => {
 		for (const ip of [
 			"192.0.0.1", // 192.0.0.0/24

--- a/packages/shared/src/url-safety.ts
+++ b/packages/shared/src/url-safety.ts
@@ -6,6 +6,54 @@
 
 const IPV4_RE = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
 
+/**
+ * Parse an IPv6 literal into its 8 hextets. Returns null on anything malformed
+ * so callers can fail closed. Handles `::` compression, an embedded dotted-quad
+ * tail (`::ffff:127.0.0.1`), and strips a zone index (`fe80::1%eth0`).
+ */
+function parseIpv6(host: string): number[] | null {
+	let s = host.split("%")[0];
+
+	const v4Tail = s.match(/^(.*:)(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+	if (v4Tail) {
+		const m = v4Tail[2].match(IPV4_RE);
+		if (!m) {
+			return null;
+		}
+		const o = m.slice(1, 5).map((x) => Number(x));
+		if (o.some((x) => x > 255)) {
+			return null;
+		}
+		s = `${v4Tail[1]}${((o[0] << 8) | o[1]).toString(16)}:${((o[2] << 8) | o[3]).toString(16)}`;
+	}
+
+	const halves = s.split("::");
+	if (halves.length > 2) {
+		return null;
+	}
+	const head = halves[0] ? halves[0].split(":") : [];
+	const tail = halves.length === 2 && halves[1] ? halves[1].split(":") : [];
+	if (halves.length === 1 && head.length !== 8) {
+		return null;
+	}
+	if (halves.length === 2 && head.length + tail.length > 7) {
+		return null;
+	}
+	const groups = [
+		...head,
+		...(Array(8 - head.length - tail.length).fill("0") as string[]),
+		...tail,
+	];
+	const hextets: number[] = [];
+	for (const g of groups) {
+		if (!/^[0-9a-f]{1,4}$/.test(g)) {
+			return null;
+		}
+		hextets.push(parseInt(g, 16));
+	}
+	return hextets;
+}
+
 /** True for an IPv4/IPv6 literal that must never be a webhook destination. */
 export function isPrivateOrReservedIp(ip: string): boolean {
 	const host = ip
@@ -66,32 +114,69 @@ export function isPrivateOrReservedIp(ip: string): boolean {
 		return false;
 	}
 
-	// IPv6 (or IPv4-mapped IPv6).
+	// IPv6. Parse to hextets so non-canonical spellings (0:0:0:0:0:0:0:1) and
+	// IPv4-embedding transition addresses (NAT64/6to4/Teredo) can't slip past
+	// string matching; malformed literals fail closed.
 	if (host.includes(":")) {
-		if (host === "::1" || host === "::") {
-			return true; // loopback / unspecified
+		const h = parseIpv6(host);
+		if (!h) {
+			return true;
 		}
-		if (/^fe[89ab]/.test(host)) {
+		// Last 32 bits as dotted quad, for prefixes that embed an IPv4 target.
+		const embeddedV4 = () =>
+			isPrivateOrReservedIp(
+				`${h[6] >> 8}.${h[6] & 0xff}.${h[7] >> 8}.${h[7] & 0xff}`,
+			);
+		if (h.every((x) => x === 0)) {
+			return true; // :: unspecified
+		}
+		if (h.slice(0, 7).every((x) => x === 0) && h[7] === 1) {
+			return true; // ::1 loopback
+		}
+		// IPv4-mapped ::ffff:0:0/96 (dotted or hex form) and the deprecated
+		// IPv4-compatible ::/96 — both route to the embedded IPv4.
+		if (
+			h.slice(0, 5).every((x) => x === 0) &&
+			(h[5] === 0xffff || h[5] === 0)
+		) {
+			return embeddedV4();
+		}
+		if (
+			h[0] === 0x64 &&
+			h[1] === 0xff9b &&
+			h[2] === 0 &&
+			h[3] === 0 &&
+			h[4] === 0 &&
+			h[5] === 0
+		) {
+			return embeddedV4(); // NAT64 well-known prefix 64:ff9b::/96
+		}
+		if (h[0] === 0x64 && h[1] === 0xff9b && h[2] === 1) {
+			return true; // NAT64 local-use 64:ff9b:1::/48
+		}
+		if (h[0] === 0x2002) {
+			return true; // 6to4 2002::/16 (embeds IPv4 relay target)
+		}
+		if (h[0] === 0x2001 && h[1] <= 0x01ff) {
+			return true; // 2001::/23 IETF special-purpose (Teredo, benchmarking, ORCHID)
+		}
+		if (h[0] === 0x2001 && h[1] === 0xdb8) {
+			return true; // documentation 2001:db8::/32
+		}
+		if (h[0] === 0x3fff && (h[1] & 0xf000) === 0) {
+			return true; // documentation 3fff::/20
+		}
+		if (h[0] === 0x100 && h[1] === 0 && h[2] === 0 && h[3] === 0) {
+			return true; // discard-only 100::/64
+		}
+		if ((h[0] & 0xffc0) === 0xfe80) {
 			return true; // link-local fe80::/10
 		}
-		if (host.startsWith("fc") || host.startsWith("fd")) {
+		if ((h[0] & 0xfe00) === 0xfc00) {
 			return true; // ULA fc00::/7
 		}
-		// IPv4-mapped IPv6 in dotted form, e.g. ::ffff:127.0.0.1
-		const mapped = host.match(
-			/(?:::ffff:)(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/,
-		);
-		if (mapped) {
-			return isPrivateOrReservedIp(mapped[1]);
-		}
-		// IPv4-mapped IPv6 in hex form, e.g. ::ffff:7f00:1 (127.0.0.1) or
-		// ::ffff:a9fe:a9fe (169.254.169.254) — dns.lookup can surface this shape.
-		const mappedHex = host.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
-		if (mappedHex) {
-			const high = parseInt(mappedHex[1], 16);
-			const low = parseInt(mappedHex[2], 16);
-			const ipv4 = `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
-			return isPrivateOrReservedIp(ipv4);
+		if ((h[0] & 0xff00) === 0xff00) {
+			return true; // multicast ff00::/8
 		}
 		return false;
 	}


### PR DESCRIPTION
## Problem

`isPrivateOrReservedIp` (`packages/shared/src/url-safety.ts`) — the shared SSRF guard behind webhook URLs, provider base URLs, and user-supplied content URLs — matched IPv6 addresses with string patterns and only caught `::1`/`::`, link-local, ULA, and IPv4-mapped forms. IPv6 transition addresses that embed an IPv4 destination fell through to "allowed" (GHSA-4qfg-95m9-g438):

- NAT64 well-known prefix `64:ff9b::/96` (e.g. `64:ff9b::a9fe:a9fe` → 169.254.169.254)
- 6to4 `2002::/16` (e.g. `2002:7f00:1::` → 127.0.0.1)
- Teredo `2001::/32`, multicast `ff00::/8`

String matching also missed non-canonical spellings of already-blocked addresses, e.g. `0:0:0:0:0:0:0:1` (loopback uncompressed).

Practical impact was limited because all three surfaces already enforce https + `redirect: "error"` (TLS cert validation blocks reading responses from hosts that can't present a valid cert for the requested name, and IMDS is http-only), but the resolved-IP layer exists to stop blind SSRF and internal services with valid certs — so it must not be bypassable by respelling an address.

## Approach

Replace the pattern checks with a small pure IPv6 parser (`::` compression, embedded dotted-quad tail, zone-index strip) and numeric range checks on the hextets. Malformed literals now fail closed. Blocked on top of the existing ranges:

- NAT64 `64:ff9b::/96` (checks the embedded IPv4, like IPv4-mapped) and local-use `64:ff9b:1::/48`
- 6to4 `2002::/16`, `2001::/23` IETF special-purpose (Teredo, benchmarking, ORCHID)
- documentation `2001:db8::/32` and `3fff::/20`, discard-only `100::/64`, multicast `ff00::/8`
- deprecated IPv4-compatible `::/96` (embedded IPv4 check)
- any non-canonical spelling of the above, since matching is now numeric

Stays free of `node:net` so the module remains browser-safe; the DNS-resolution layer in `url-safety-node.ts` and the worker webhook delivery path pick up the fix automatically since they re-check resolved addresses through the same function.

## Verification

- New unit tests cover every reported vector, the non-canonical/malformed forms, and public-IPv6 negatives (`pnpm vitest run packages/shared/src/url-safety*.spec.ts` — 25 passing)
- `pnpm format` and full `pnpm build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Improvements**
  - Improved validation of IPv6 addresses, including compressed formats, embedded IPv4 addresses, and zone indexes.
  - Blocks additional reserved, private, multicast, documentation, and transition-network IPv6 ranges.
  - Rejects malformed or non-canonical IPv6 inputs more reliably.

- **Tests**
  - Added coverage for IPv6 transition mechanisms, special-purpose ranges, malformed addresses, and publicly routable IPv6 addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->