### PR TITLE
fix(api): re-verify email on change, gate admin

### DIFF
--- a/apps/api/src/middleware/admin.ts
+++ b/apps/api/src/middleware/admin.ts
@@ -29,7 +29,7 @@ export const adminAuthMiddleware = createMiddleware<ServerTypes>(
 			});
 		}
 
-		if (!isAdminEmail(authUser.email)) {
+		if (!isAdminEmail(authUser.email) || !authUser.emailVerified) {
 			throw new HTTPException(403, {
 				message: "Admin access required",
 			});
@@ -47,7 +47,7 @@ export const adminMiddleware = createMiddleware<ServerTypes>(
 			throw new HTTPException(401, { message: "Unauthorized" });
 		}
 
-		if (!isAdminEmail(authUser.email)) {
+		if (!isAdminEmail(authUser.email) || !authUser.emailVerified) {
 			throw new HTTPException(403, { message: "Admin access required" });
 		}
 

--- a/apps/api/src/routes/user.spec.ts
+++ b/apps/api/src/routes/user.spec.ts
@@ -402,6 +402,49 @@ describe("user accounts and email editability", () => {
 		expect(json.user.emailVerified).toBe(true);
 	});
 
+	it("PATCH /user/me should store a changed email lowercased", async () => {
+		const res = await app.request("/user/me", {
+			method: "PATCH",
+			headers: {
+				Cookie: token,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ email: "Mixed.Case@Example.COM" }),
+		});
+
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		expect(json.user.email).toBe("mixed.case@example.com");
+		expect(json.user.emailVerified).toBe(false);
+	});
+
+	it("PATCH /user/me should reject a case variant of another account's email", async () => {
+		await db.insert(tables.user).values({
+			id: "taken-user-id",
+			name: "Taken",
+			email: "taken@example.com",
+			emailVerified: true,
+		});
+
+		const res = await app.request("/user/me", {
+			method: "PATCH",
+			headers: {
+				Cookie: token,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ email: "TAKEN@example.com" }),
+		});
+
+		expect(res.status).toBe(400);
+
+		const stored = await db.query.user.findFirst({
+			where: { id: { eq: "test-user-id" } },
+		});
+		expect(stored!.email).toBe("admin@example.com");
+
+		await db.delete(tables.user).where(eq(tables.user.id, "taken-user-id"));
+	});
+
 	it("PATCH /user/me should reject an email already used by another account", async () => {
 		await db.insert(tables.user).values({
 			id: "taken-user-id",

--- a/apps/api/src/routes/user.spec.ts
+++ b/apps/api/src/routes/user.spec.ts
@@ -364,4 +364,68 @@ describe("user accounts and email editability", () => {
 		const json = await res.json();
 		expect(json.user.accounts).toHaveLength(2);
 	});
+
+	it("PATCH /user/me should reset emailVerified when the email changes", async () => {
+		const res = await app.request("/user/me", {
+			method: "PATCH",
+			headers: {
+				Cookie: token,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ email: "changed@example.com" }),
+		});
+
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		expect(json.user.email).toBe("changed@example.com");
+		expect(json.user.emailVerified).toBe(false);
+		expect(json.user.isAdmin).toBe(false);
+
+		const stored = await db.query.user.findFirst({
+			where: { id: { eq: "test-user-id" } },
+		});
+		expect(stored!.emailVerified).toBe(false);
+	});
+
+	it("PATCH /user/me should keep emailVerified when the email is unchanged", async () => {
+		const res = await app.request("/user/me", {
+			method: "PATCH",
+			headers: {
+				Cookie: token,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ email: "admin@example.com", name: "Same Email" }),
+		});
+
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		expect(json.user.emailVerified).toBe(true);
+	});
+
+	it("PATCH /user/me should reject an email already used by another account", async () => {
+		await db.insert(tables.user).values({
+			id: "taken-user-id",
+			name: "Taken",
+			email: "taken@example.com",
+			emailVerified: true,
+		});
+
+		const res = await app.request("/user/me", {
+			method: "PATCH",
+			headers: {
+				Cookie: token,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ email: "taken@example.com" }),
+		});
+
+		expect(res.status).toBe(400);
+
+		const stored = await db.query.user.findFirst({
+			where: { id: { eq: "test-user-id" } },
+		});
+		expect(stored!.email).toBe("admin@example.com");
+
+		await db.delete(tables.user).where(eq(tables.user.id, "taken-user-id"));
+	});
 });

--- a/apps/api/src/routes/user.ts
+++ b/apps/api/src/routes/user.ts
@@ -121,18 +121,28 @@ function toPublicUser(
 	};
 }
 
-function isAdminEmail(email: string | null | undefined): boolean {
+// Admin authority is keyed on the email address, so an unverified one must
+// never count — otherwise changing your email to an unregistered ADMIN_EMAILS
+// address would grant admin. Mirrors adminAuthMiddleware.
+function isAdminUser(userRecord: {
+	email: string | null | undefined;
+	emailVerified: boolean;
+}): boolean {
+	if (!userRecord.emailVerified) {
+		return false;
+	}
+
 	const adminEmailsEnv = process.env.ADMIN_EMAILS ?? "";
 	const adminEmails = adminEmailsEnv
 		.split(",")
 		.map((value) => value.trim().toLowerCase())
 		.filter(Boolean);
 
-	if (!email || adminEmails.length === 0) {
+	if (!userRecord.email || adminEmails.length === 0) {
 		return false;
 	}
 
-	return adminEmails.includes(email.toLowerCase());
+	return adminEmails.includes(userRecord.email.toLowerCase());
 }
 
 const get = createRoute({
@@ -175,7 +185,7 @@ user.openapi(get, async (c) => {
 	}
 
 	const authInfo = await getUserAuthInfo(authUser.id);
-	const isAdmin = isAdminEmail(user.email);
+	const isAdmin = isAdminUser(user);
 	const license = getEnterpriseLicenseStatus();
 
 	return c.json({
@@ -355,6 +365,29 @@ user.openapi(updateUser, async (c) => {
 		});
 	}
 
+	const emailChanged =
+		updateData.email !== undefined &&
+		updateData.email.toLowerCase() !== userRecord.email.toLowerCase();
+
+	// A new address is unproven until the owner clicks the verification link, so
+	// reject it if another account already holds it (clean 400 instead of a DB
+	// constraint 500) and drop `emailVerified` below. Skipping this let an
+	// attacker point their account at an invited/admin address and inherit its
+	// authority, since invite auto-accept and admin checks key on email.
+	if (emailChanged) {
+		const existing = await db.query.user.findFirst({
+			where: {
+				email: updateData.email!,
+				id: { ne: authUser.id },
+			},
+		});
+		if (existing) {
+			throw new HTTPException(400, {
+				message: "That email address is already in use",
+			});
+		}
+	}
+
 	// Resolve the final state. `username` is only present in updateData when the
 	// client explicitly sends it (including null to clear it); otherwise the
 	// existing value is kept.
@@ -390,6 +423,10 @@ user.openapi(updateUser, async (c) => {
 		.update(tables.user)
 		.set({
 			...updateData,
+			// A changed address must be re-proven before it grants any authority.
+			// On self-hosted deployments the next sign-in re-verifies it (see
+			// auth/config.ts); on hosted the verification banner prompts the user.
+			...(emailChanged ? { emailVerified: false } : {}),
 		})
 		.where(eq(tables.user.id, authUser.id))
 		.returning();
@@ -399,7 +436,7 @@ user.openapi(updateUser, async (c) => {
 		await updateResendContact(updatedUser.email, { name: updateData.name });
 	}
 
-	const isAdmin = isAdminEmail(updatedUser.email);
+	const isAdmin = isAdminUser(updatedUser);
 
 	return c.json({
 		user: toPublicUser(updatedUser, authInfo, isAdmin),
@@ -757,7 +794,7 @@ user.openapi(completeOnboarding, async (c) => {
 		});
 	}
 
-	const isAdmin = isAdminEmail(updatedUser.email);
+	const isAdmin = isAdminUser(updatedUser);
 
 	return c.json({
 		user: toPublicUser(updatedUser, authInfo, isAdmin),

--- a/apps/api/src/routes/user.ts
+++ b/apps/api/src/routes/user.ts
@@ -15,7 +15,7 @@ import {
 import { notifyUserAccountDeleted } from "@/utils/discord.js";
 import { computeProfileData, profileSchema } from "@/utils/profile.js";
 
-import { and, db, eq, tables } from "@llmgateway/db";
+import { and, db, eq, ne, sql, tables } from "@llmgateway/db";
 import { getEnterpriseLicenseStatus } from "@llmgateway/shared/enterprise-license";
 
 import type { ServerTypes } from "@/vars.js";
@@ -203,7 +203,13 @@ user.openapi(get, async (c) => {
 
 const updateUserSchema = z.object({
 	name: z.string().optional(),
-	email: z.string().email("Invalid email address").optional(),
+	// Lowercased to match better-auth, which stores emails lowercase and looks
+	// them up lowercased on sign-in — a mixed-case stored email is unloginable.
+	email: z
+		.string()
+		.transform((v) => v.trim().toLowerCase())
+		.pipe(z.string().email("Invalid email address"))
+		.optional(),
 	username: z
 		.string()
 		.transform((v) => v.trim().toLowerCase())
@@ -367,20 +373,26 @@ user.openapi(updateUser, async (c) => {
 
 	const emailChanged =
 		updateData.email !== undefined &&
-		updateData.email.toLowerCase() !== userRecord.email.toLowerCase();
+		updateData.email !== userRecord.email.toLowerCase();
 
 	// A new address is unproven until the owner clicks the verification link, so
 	// reject it if another account already holds it (clean 400 instead of a DB
 	// constraint 500) and drop `emailVerified` below. Skipping this let an
 	// attacker point their account at an invited/admin address and inherit its
 	// authority, since invite auto-accept and admin checks key on email.
+	// Compared via lower() to also catch legacy mixed-case rows the DB's
+	// case-sensitive unique constraint would treat as distinct.
 	if (emailChanged) {
-		const existing = await db.query.user.findFirst({
-			where: {
-				email: updateData.email!,
-				id: { ne: authUser.id },
-			},
-		});
+		const [existing] = await db
+			.select({ id: tables.user.id })
+			.from(tables.user)
+			.where(
+				and(
+					sql`lower(${tables.user.email}) = ${updateData.email}`,
+					ne(tables.user.id, authUser.id),
+				),
+			)
+			.limit(1);
 		if (existing) {
 			throw new HTTPException(400, {
 				message: "That email address is already in use",


### PR DESCRIPTION
## Summary

Fixes the unverified email-change / invite-hijack chain reported in **GHSA-m2xm-956r-59cq**. `PATCH /user/me` let any password user change their email to an unregistered address while leaving `emailVerified` stale, and admin access keyed on `ADMIN_EMAILS` never checked verification. Because authorization is keyed on the email address (pending-invite auto-accept, `ADMIN_EMAILS` admin checks), an attacker could point their account at an invited or admin address and inherit its authority.

This is a real issue on **hosted** deployments too, not just self-hosted: a user who verified `attacker@evil.com` (so `emailVerified: true`) could PATCH their email to an invited victim's address, and the stale `emailVerified` made the sign-in hook auto-accept the pending org invite (`auth/config.ts` gates on `emailVerified`, not only `!isHosted`).

## Changes

- **`PATCH /user/me`**: when the email actually changes, reset `emailVerified` to `false`, and reject the change with a clean 400 if another account already holds that address. Self-hosted deployments re-verify on next sign-in as before; hosted users get the existing verification banner.
- **Admin gating**: `adminAuthMiddleware` / `adminMiddleware` now require `emailVerified` in addition to `isAdminEmail`, and the `isAdmin` response flag (`isAdminUser`) mirrors this — so squatting an unregistered `ADMIN_EMAILS` address (now unverified after the change) no longer grants admin.
- Regression tests for email-change verification reset, unchanged-email preservation, and duplicate-address rejection.

## Testing

- `apps/api/src/routes/user.spec.ts` + `apps/api/src/middleware/admin.spec.ts` — 28 passed
- `pnpm format`, `turbo run build --filter=api` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Admin access now requires a verified email address.
* **Bug Fixes**
  * Changing an account email resets its verification status.
  * Keeping the same email preserves verification.
  * Duplicate email updates are rejected without altering the existing account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->