### PR TITLE
fix(api): scope IAM rule mutations to the API key

### DIFF
--- a/apps/api/src/routes/keys-api.spec.ts
+++ b/apps/api/src/routes/keys-api.spec.ts
@@ -475,6 +475,159 @@ describe("keys route", () => {
 		expect(await readActiveIamRules()).toHaveLength(1);
 	});
 
+	// Regression tests for GHSA-pjj8-5gpw-f42r: the rule mutation endpoints
+	// authorized only the {id} API key while resolving the rule by {ruleId}
+	// alone, letting any authenticated user tamper with other organizations'
+	// IAM rules.
+	describe("IAM rule tenant isolation", () => {
+		beforeEach(async () => {
+			// A victim organization the test user is NOT a member of, with its own
+			// project, API key, and IAM rule.
+			await db.insert(tables.organization).values({
+				id: "victim-org-id",
+				name: "Victim Organization",
+				billingEmail: "victim@example.com",
+			});
+			await db.insert(tables.project).values({
+				id: "victim-project-id",
+				name: "Victim Project",
+				organizationId: "victim-org-id",
+			});
+			await db.insert(tables.user).values({
+				id: "victim-user-id",
+				name: "Victim User",
+				email: "victim-user@example.com",
+				emailVerified: true,
+			});
+			await db.insert(tables.apiKey).values({
+				id: "victim-api-key-id",
+				token: "victim-api-key-token",
+				projectId: "victim-project-id",
+				description: "Victim Key",
+				createdBy: "victim-user-id",
+			});
+			await db.insert(tables.apiKeyIamRule).values({
+				id: "victim-rule-id",
+				apiKeyId: "victim-api-key-id",
+				ruleType: "allow_models",
+				ruleValue: { models: ["openai/gpt-4o-mini"] },
+				status: "active",
+			});
+		});
+
+		test("PATCH cannot update another organization's IAM rule", async () => {
+			const res = await app.request(
+				"/keys/api/test-api-key-id/iam/victim-rule-id",
+				{
+					method: "PATCH",
+					headers: {
+						"Content-Type": "application/json",
+						Cookie: token,
+					},
+					body: JSON.stringify({ status: "inactive" }),
+				},
+			);
+			expect(res.status).toBe(404);
+
+			const rule = await db.query.apiKeyIamRule.findFirst({
+				where: { id: { eq: "victim-rule-id" } },
+			});
+			expect(rule?.status).toBe("active");
+		});
+
+		test("DELETE cannot delete another organization's IAM rule", async () => {
+			const res = await app.request(
+				"/keys/api/test-api-key-id/iam/victim-rule-id",
+				{
+					method: "DELETE",
+					headers: {
+						Cookie: token,
+					},
+				},
+			);
+			expect(res.status).toBe(404);
+
+			const rule = await db.query.apiKeyIamRule.findFirst({
+				where: { id: { eq: "victim-rule-id" } },
+			});
+			expect(rule).toBeDefined();
+		});
+
+		test("PATCH and DELETE still work for a rule on the caller's own key", async () => {
+			await db.insert(tables.apiKeyIamRule).values({
+				id: "own-rule-id",
+				apiKeyId: "test-api-key-id",
+				ruleType: "allow_models",
+				ruleValue: { models: ["openai/gpt-4o-mini"] },
+				status: "active",
+			});
+
+			const patch = await app.request(
+				"/keys/api/test-api-key-id/iam/own-rule-id",
+				{
+					method: "PATCH",
+					headers: {
+						"Content-Type": "application/json",
+						Cookie: token,
+					},
+					body: JSON.stringify({ status: "inactive" }),
+				},
+			);
+			expect(patch.status).toBe(200);
+			const patched = await patch.json();
+			expect(patched.rule.status).toBe("inactive");
+
+			const del = await app.request(
+				"/keys/api/test-api-key-id/iam/own-rule-id",
+				{
+					method: "DELETE",
+					headers: {
+						Cookie: token,
+					},
+				},
+			);
+			expect(del.status).toBe(200);
+
+			const rule = await db.query.apiKeyIamRule.findFirst({
+				where: { id: { eq: "own-rule-id" } },
+			});
+			expect(rule).toBeUndefined();
+		});
+	});
+
+	test("GET /keys/api without projectId hides other members' keys from developers", async () => {
+		await seedOtherMemberKey({});
+		// Give the developer a credential account (same password as the admin
+		// fixture) and sign in as them.
+		await db.insert(tables.account).values({
+			id: "other-account-id",
+			providerId: "credential",
+			accountId: "other-account-id",
+			userId: "other-user-id",
+			password:
+				"c11ef27a7f9264be08db228ebb650888:a4d985a9c6bd98608237fd507534424950aa7fc255930d972242b81cbe78594f8568feb0d067e95ddf7be242ad3e9d013f695f4414fce68bfff091079f1dc460",
+		});
+		const auth = await app.request("/auth/sign-in/email", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				email: "other-developer@example.com",
+				password: "admin@example.com1A",
+			}),
+		});
+		expect(auth.status).toBe(200);
+		const devToken = auth.headers.get("set-cookie")!;
+
+		const res = await app.request("/keys/api", {
+			headers: { Cookie: devToken },
+		});
+		expect(res.status).toBe(200);
+		const json = await res.json();
+		const ids = json.apiKeys.map((key: { id: string }) => key.id);
+		expect(ids).toContain("other-api-key-id");
+		expect(ids).not.toContain("test-api-key-id");
+	});
+
 	test("POST /keys/api creates a period usage limit", async () => {
 		const res = await app.request("/keys/api", {
 			method: "POST",

--- a/apps/api/src/routes/keys-api.ts
+++ b/apps/api/src/routes/keys-api.ts
@@ -15,6 +15,7 @@ import { getUserProjectIds } from "@/utils/authorization.js";
 
 import { logAuditEvent } from "@llmgateway/audit";
 import {
+	and,
 	apiKeyPeriodDurationMaxValues,
 	apiKeyPeriodDurationUnits,
 	cdb,
@@ -1252,10 +1253,22 @@ keysApi.openapi(list, async (c) => {
 		});
 	}
 
+	// Projects where the user is a "developer" member: developers may only ever
+	// see their OWN keys, regardless of whether the listing is project-scoped.
+	const developerProjectIds = new Set(
+		userOrgs
+			.filter((org) => org.role === "developer")
+			.flatMap((org) =>
+				org
+					.organization!.projects.filter(
+						(project) => project.status !== "deleted",
+					)
+					.map((project) => project.id),
+			),
+	);
+
 	// Determine user's role for the relevant organization
 	let userRole: "owner" | "admin" | "developer" = "developer";
-	// Project-scoped "developer" members may only ever see their OWN keys.
-	let developerScoped = false;
 	if (projectId) {
 		const project = await db.query.project.findFirst({
 			where: {
@@ -1271,17 +1284,14 @@ keysApi.openapi(list, async (c) => {
 			);
 			if (userOrg) {
 				userRole = userOrg.role as "owner" | "admin" | "developer";
-				developerScoped = userRole === "developer";
 			}
 		}
 	}
 
-	// Owners/admins see all keys (with an optional "mine" filter); developers are
-	// always restricted to the keys they created.
-	const shouldFilterByCreator = filter === "mine" || developerScoped;
+	const shouldFilterByCreator = filter === "mine";
 
 	// Get API keys for the specified project or all accessible projects
-	const apiKeys = await db.query.apiKey.findMany({
+	const fetchedApiKeys = await db.query.apiKey.findMany({
 		where: {
 			projectId: {
 				in: projectId ? [projectId] : projectIds,
@@ -1306,6 +1316,11 @@ keysApi.openapi(list, async (c) => {
 			},
 		},
 	});
+
+	const apiKeys = fetchedApiKeys.filter(
+		(key) =>
+			key.createdBy === user.id || !developerProjectIds.has(key.projectId),
+	);
 
 	// Get organization plan info if projectId is specified. The cap is org-wide,
 	// so currentCount counts active developer keys across ALL of the org's
@@ -2503,25 +2518,36 @@ keysApi.openapi(updateIamRule, async (c) => {
 		});
 	}
 
-	// Get the existing rule to track changes
+	// Get the existing rule to track changes; the apiKeyId predicate is the
+	// tenant boundary — without it any authenticated user could target another
+	// organization's rule via {ruleId} (GHSA-pjj8-5gpw-f42r).
 	const existingRule = await db.query.apiKeyIamRule.findFirst({
 		where: {
 			id: {
 				eq: ruleId,
 			},
+			apiKeyId: {
+				eq: id,
+			},
 		},
 	});
 
+	if (!existingRule) {
+		throw new HTTPException(404, {
+			message: "IAM rule not found",
+		});
+	}
+
 	// Re-validate using the effective ruleType + ruleValue after merging
 	// with the existing rule, so partial updates can't bypass CIDR checks.
-	if (existingRule && (updateData.ruleType || updateData.ruleValue)) {
+	if (updateData.ruleType || updateData.ruleValue) {
 		validateIamRuleInput({
 			ruleType: updateData.ruleType ?? existingRule.ruleType,
 			ruleValue: updateData.ruleValue ?? existingRule.ruleValue,
 		});
 	}
 
-	const effectiveRuleType = updateData.ruleType ?? existingRule?.ruleType;
+	const effectiveRuleType = updateData.ruleType ?? existingRule.ruleType;
 	assertEnterpriseForIpCidrRule(
 		effectiveRuleType,
 		apiKey.project.organization?.id,
@@ -2535,7 +2561,12 @@ keysApi.openapi(updateIamRule, async (c) => {
 		[updatedRule] = await cdb
 			.update(tables.apiKeyIamRule)
 			.set(updateData)
-			.where(eq(tables.apiKeyIamRule.id, ruleId))
+			.where(
+				and(
+					eq(tables.apiKeyIamRule.id, ruleId),
+					eq(tables.apiKeyIamRule.apiKeyId, id),
+				),
+			)
 			.returning();
 	}
 
@@ -2555,17 +2586,17 @@ keysApi.openapi(updateIamRule, async (c) => {
 			apiKeyId: id,
 			changes: {
 				...(updateData.ruleType !== undefined &&
-				existingRule?.ruleType !== updateData.ruleType
+				existingRule.ruleType !== updateData.ruleType
 					? {
 							ruleType: {
-								old: existingRule?.ruleType,
+								old: existingRule.ruleType,
 								new: updateData.ruleType,
 							},
 						}
 					: {}),
 				...(updateData.status !== undefined &&
-				existingRule?.status !== updateData.status
-					? { status: { old: existingRule?.status, new: updateData.status } }
+				existingRule.status !== updateData.status
+					? { status: { old: existingRule.status, new: updateData.status } }
 					: {}),
 			},
 		},
@@ -2672,10 +2703,17 @@ keysApi.openapi(deleteIamRule, async (c) => {
 		});
 	}
 
-	// Delete the IAM rule
+	// Delete the IAM rule; the apiKeyId predicate is the tenant boundary —
+	// without it any authenticated user could delete another organization's
+	// rule via {ruleId} (GHSA-pjj8-5gpw-f42r).
 	const result = await cdb
 		.delete(tables.apiKeyIamRule)
-		.where(eq(tables.apiKeyIamRule.id, ruleId))
+		.where(
+			and(
+				eq(tables.apiKeyIamRule.id, ruleId),
+				eq(tables.apiKeyIamRule.apiKeyId, id),
+			),
+		)
 		.returning();
 
 	if (!result.length) {


### PR DESCRIPTION
## Problem

GHSA-pjj8-5gpw-f42r: `PATCH` and `DELETE /keys/api/{id}/iam/{ruleId}` authorized the caller against the `{id}` API key, but then resolved and mutated the IAM rule by `{ruleId}` alone — no `apiKeyId` constraint on the read or the write. Any authenticated user could pass their own key as `{id}` and a foreign rule id as `{ruleId}` to rewrite or delete another organization's IAM rules (IP allowlists, model/provider allowlists), taking effect on live gateway traffic immediately via the `cdb` cache invalidation.

Additionally, `GET /keys/api` only applied the developer-role "own keys only" restriction inside the `if (projectId)` branch, so a developer omitting `projectId` could enumerate every key (and IAM rule id) across their organizations.

## Fix

- `PATCH /keys/api/{id}/iam/{ruleId}`: the rule lookup now requires `apiKeyId = {id}` and returns 404 when the rule doesn't belong to the authorized key; the `UPDATE` carries the same predicate as a second layer.
- `DELETE /keys/api/{id}/iam/{ruleId}`: the `DELETE` now requires `apiKeyId = {id}`, returning 404 on a cross-key rule id.
- `GET /keys/api`: developer-role members are now restricted to keys they created in every org where they hold the developer role, regardless of whether `projectId` is passed. The dashboard always passes `projectId`, so UI behavior is unchanged.

This matches the already-correct master-key implementations in `v1-master.ts`, which scope the rule lookup by `apiKeyId` and 404 before mutating.

## Verification

- New regression tests: cross-tenant PATCH and DELETE now 404 and leave the victim rule untouched; same-key PATCH/DELETE still work; developer listing without `projectId` no longer returns other members' keys.
- `apps/api/src/routes/keys-api.spec.ts` passes (37 tests) against an isolated stack; `pnpm format` and `pnpm build` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)