### PR TITLE
fix(gateway): scope response cache keys by project

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -6310,6 +6310,104 @@ describe("api", () => {
 		expect(afterBypass.filter((log) => log.cached).length).toBe(1);
 	});
 
+	// GHSA-h9ww-f95j-h54c: cache keys are project-scoped, so a byte-identical
+	// request from another organization must never replay a victim's cached
+	// response.
+	test("/v1/chat/completions cache is not shared across tenants", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id-cache-victim",
+			token: "real-token-cache-victim",
+			projectId: "project-id",
+			description: "Victim API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-cache-victim",
+			token: "sk-test-key",
+			provider: "openai",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		await db
+			.update(tables.project)
+			.set({ cachingEnabled: true })
+			.where(eq(tables.project.id, "project-id"));
+
+		// Second, unrelated organization with caching enabled as well.
+		await db.insert(tables.organization).values({
+			id: "org-id-attacker",
+			name: "Attacker Organization",
+			billingEmail: "attacker",
+			plan: "pro",
+			retentionLevel: "retain",
+			credits: "100.00",
+		});
+
+		await db.insert(tables.project).values({
+			id: "project-id-attacker",
+			name: "Attacker Project",
+			organizationId: "org-id-attacker",
+			mode: "api-keys",
+			cachingEnabled: true,
+		});
+
+		await db.insert(tables.apiKey).values({
+			id: "token-id-cache-attacker",
+			token: "real-token-cache-attacker",
+			projectId: "project-id-attacker",
+			description: "Attacker API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-cache-attacker",
+			token: "sk-test-key",
+			provider: "openai",
+			organizationId: "org-id-attacker",
+			baseUrl: mockServerUrl,
+		});
+
+		const body = JSON.stringify({
+			model: "openai/gpt-4o-mini",
+			messages: [{ role: "user", content: `Cross tenant? ${randomUUID()}` }],
+		});
+
+		const makeRequest = (token: string) =>
+			app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${token}`,
+				},
+				body,
+			});
+
+		// Victim primes the cache (setCache is a no-op under NODE_ENV=test).
+		const originalNodeEnv = process.env.NODE_ENV;
+		try {
+			process.env.NODE_ENV = "development";
+			const primeRes = await makeRequest("real-token-cache-victim");
+			expect(primeRes.status).toBe(200);
+			expect(primeRes.headers.get("x-llmgateway-cache")).toBeNull();
+		} finally {
+			process.env.NODE_ENV = originalNodeEnv;
+		}
+
+		// The victim's own replay hits, proving the entry exists...
+		const victimReplay = await makeRequest("real-token-cache-victim");
+		expect(victimReplay.status).toBe(200);
+		expect(victimReplay.headers.get("x-llmgateway-cache")).toBe("HIT");
+
+		// ...but the byte-identical request from another tenant must miss.
+		const attackerRes = await makeRequest("real-token-cache-attacker");
+		expect(attackerRes.status).toBe(200);
+		expect(attackerRes.headers.get("x-llmgateway-cache")).toBeNull();
+		const attackerJson = await attackerRes.json();
+		expect(attackerJson.metadata.cached).toBeUndefined();
+	});
+
 	test("/v1/chat/completions streaming cache hits are marked and free", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id-cache-stream",

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -6342,7 +6342,7 @@ chat.openapi(completions, async (c) => {
 		};
 
 		if (stream) {
-			streamingCacheKey = generateStreamingCacheKey(cachePayload);
+			streamingCacheKey = generateStreamingCacheKey(project.id, cachePayload);
 			const cachedStreamingResponse =
 				await getStreamingCache(streamingCacheKey);
 			if (cachedStreamingResponse?.metadata.completed) {
@@ -6698,7 +6698,7 @@ chat.openapi(completions, async (c) => {
 				);
 			}
 		} else {
-			cacheKey = generateCacheKey(cachePayload);
+			cacheKey = generateCacheKey(project.id, cachePayload);
 			const cachedResponse = cacheKey ? await getCache(cacheKey) : null;
 			if (cachedResponse) {
 				// Log the cached request

--- a/packages/cache/src/cache.spec.ts
+++ b/packages/cache/src/cache.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { generateCacheKey, generateStreamingCacheKey } from "./cache.js";
+
+// Regression tests for GHSA-h9ww-f95j-h54c: the response-cache key must be
+// tenant-scoped so byte-identical request bodies from different projects can
+// never collide on the same Redis key. setCache is a no-op under
+// NODE_ENV=test, so isolation is asserted on key construction directly.
+describe("generateCacheKey", () => {
+	const payload = {
+		provider: "openai",
+		model: "gpt-4o",
+		messages: [{ role: "user", content: "hello" }],
+	};
+
+	it("prefixes the key with the tenant scope", () => {
+		expect(generateCacheKey("project-a", payload)).toMatch(
+			/^project-a:[0-9a-f]{64}$/,
+		);
+	});
+
+	it("produces different keys for different scopes with identical payloads", () => {
+		expect(generateCacheKey("project-a", payload)).not.toBe(
+			generateCacheKey("project-b", payload),
+		);
+	});
+
+	it("payload fields cannot forge another tenant's scope", () => {
+		expect(
+			generateCacheKey("project-a", { ...payload, scope: "project-b" }),
+		).toMatch(/^project-a:/);
+	});
+});
+
+describe("generateStreamingCacheKey", () => {
+	it("scopes the streaming key identically", () => {
+		const payload = { model: "gpt-4o" };
+		expect(generateStreamingCacheKey("project-a", payload)).toBe(
+			`stream:${generateCacheKey("project-a", payload)}`,
+		);
+		expect(generateStreamingCacheKey("project-a", payload)).not.toBe(
+			generateStreamingCacheKey("project-b", payload),
+		);
+	});
+});

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -4,11 +4,23 @@ import { logger } from "@llmgateway/logger";
 
 import { storageRedisClient } from "./storage-redis.js";
 
-export function generateCacheKey(payload: Record<string, any>): string {
-	return crypto
+/**
+ * Generate a response-cache key scoped to a tenant.
+ *
+ * The scope (e.g. the project id) is a mandatory, server-derived key prefix:
+ * the payload is built from the request body, so hashing it alone would let
+ * any tenant replay another tenant's request bytes and collide on the same
+ * Redis key, reading their cached LLM response (GHSA-h9ww-f95j-h54c).
+ */
+export function generateCacheKey(
+	scope: string,
+	payload: Record<string, any>,
+): string {
+	const hash = crypto
 		.createHash("sha256")
 		.update(JSON.stringify(payload))
 		.digest("hex");
+	return `${scope}:${hash}`;
 }
 
 export async function setCache(
@@ -67,9 +79,10 @@ interface StreamingCacheData {
 }
 
 export function generateStreamingCacheKey(
+	scope: string,
 	payload: Record<string, any>,
 ): string {
-	return `stream:${generateCacheKey(payload)}`;
+	return `stream:${generateCacheKey(scope, payload)}`;
 }
 
 export async function setStreamingCache(


### PR DESCRIPTION
## Problem

The gateway response-cache key was a bare SHA-256 of request-derived fields only (provider, model, messages, sampling/reasoning params). No tenant identifier participated in the key, and all tenants share one storage Redis, so two organizations sending byte-identical request bodies collided on the same Redis key. Any tenant with caching enabled could replay another tenant's request body and receive that tenant's cached model output verbatim (content, reasoning, tool calls) — for free, with no upstream call and no trace on the victim's side. Both the non-streaming and streaming (`stream:`-prefixed) paths were affected.

Reported in GHSA-h9ww-f95j-h54c.

## Fix

`generateCacheKey` and `generateStreamingCacheKey` now require an explicit server-derived scope as a separate parameter, prefixed onto the key (`<scope>:<sha256>` / `stream:<scope>:<sha256>`). The gateway passes `project.id` at both call sites; the write paths reuse the same generated keys, so read and write are both scoped. Making the scope a required parameter means a tenant-less key is no longer constructible, and because it is a key prefix rather than a payload field, request-body content cannot forge another tenant's scope.

Existing tenant-less cache entries are unreachable under the new key format and simply expire with their TTL — no flush needed.

## Verification

- New unit tests on key construction (`packages/cache/src/cache.spec.ts`) — scope prefixes the key, identical payloads under different scopes never collide, payload fields cannot forge a scope. Asserted on key generation directly since `setCache` is a no-op under `NODE_ENV=test`.
- New integration regression test (`api.spec.ts`): a victim project primes the cache and replays with a HIT, then a second organization sends the byte-identical body and must miss. Confirmed the test fails against the previous tenant-less key derivation.
- Full affected spec files pass (195 tests) on an isolated stack; `pnpm format` and full `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)