### PR TITLE
feat(worker): credit processing health heartbeat

### DIFF
--- a/apps/worker/src/log-processing.spec.ts
+++ b/apps/worker/src/log-processing.spec.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 
 import {
 	eq,
@@ -13,8 +13,9 @@ import {
 	apiKey,
 	user,
 } from "@llmgateway/db";
+import { logger } from "@llmgateway/logger";
 
-import { batchProcessLogs } from "./worker.js";
+import { batchProcessLogs, reportCreditProcessingHealth } from "./worker.js";
 
 describe("Log Processing", () => {
 	interface TestIds {
@@ -1126,6 +1127,94 @@ describe("Log Processing", () => {
 			});
 			expect(Number(updated!.usage)).toBeCloseTo(0.06, 8);
 			expect(updated!.status).toBe("inactive");
+		});
+	});
+
+	describe("reportCreditProcessingHealth", () => {
+		const tenMinutesMs = 10 * 60 * 1000;
+
+		interface HeartbeatFields {
+			kind: string;
+			backlog: number;
+			backlogCapped: boolean;
+			lagSeconds: number;
+			consecutiveFailures: number;
+			batchSize: number;
+		}
+
+		const findHeartbeat = (calls: unknown[][]) =>
+			calls.find((args) => args[0] === "credit processing heartbeat")?.[1] as
+				HeartbeatFields | undefined;
+
+		const insertUnprocessedLog = async (createdAt: Date) =>
+			await db.insert(log).values({
+				requestId: `heartbeat-${randomUUID()}`,
+				createdAt,
+				organizationId: testOrg.id,
+				projectId: testProject.id,
+				apiKeyId: testApiKey.id,
+				cost: 0.001,
+				cached: false,
+				usedMode: "credits",
+				duration: 1000,
+				requestedModel: "openai/gpt-4o-mini",
+				requestedProvider: "openai",
+				usedModel: "gpt-4o-mini",
+				usedProvider: "openai",
+				responseSize: 100,
+				mode: "credits",
+			});
+
+		test("reports the backlog size and the age of the oldest unprocessed log", async () => {
+			const oldest = new Date(Date.now() - tenMinutesMs);
+			await insertUnprocessedLog(oldest);
+			await insertUnprocessedLog(new Date());
+
+			const info = vi.spyOn(logger, "info").mockImplementation(() => {});
+			try {
+				await reportCreditProcessingHealth(true);
+
+				const heartbeat = findHeartbeat(info.mock.calls);
+				expect(heartbeat).toBeTruthy();
+				expect(heartbeat!.kind).toBe("credit-batch");
+				expect(heartbeat!.backlog).toBe(2);
+				expect(heartbeat!.backlogCapped).toBe(false);
+				expect(heartbeat!.lagSeconds).toBeGreaterThanOrEqual(9 * 60);
+				expect(heartbeat!.consecutiveFailures).toBe(0);
+			} finally {
+				info.mockRestore();
+			}
+		});
+
+		test("reports an empty backlog with no lag once the batch has drained", async () => {
+			await insertUnprocessedLog(new Date(Date.now() - tenMinutesMs));
+			await batchProcessLogs();
+
+			const info = vi.spyOn(logger, "info").mockImplementation(() => {});
+			try {
+				await reportCreditProcessingHealth(true);
+
+				const heartbeat = findHeartbeat(info.mock.calls);
+				expect(heartbeat).toBeTruthy();
+				expect(heartbeat!.backlog).toBe(0);
+				expect(heartbeat!.lagSeconds).toBe(0);
+			} finally {
+				info.mockRestore();
+			}
+		});
+
+		test("throttles unforced heartbeats so a draining loop cannot spam the query", async () => {
+			await insertUnprocessedLog(new Date());
+			await reportCreditProcessingHealth(true);
+
+			const info = vi.spyOn(logger, "info").mockImplementation(() => {});
+			try {
+				await reportCreditProcessingHealth();
+
+				expect(findHeartbeat(info.mock.calls)).toBeUndefined();
+			} finally {
+				info.mockRestore();
+			}
 		});
 	});
 });

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -138,6 +138,16 @@ const LOG_QUEUE_CONCURRENCY = Math.max(
 const CREDIT_BATCH_SIZE = Number(process.env.CREDIT_BATCH_SIZE) || 100;
 const BATCH_PROCESSING_INTERVAL_SECONDS =
 	Number(process.env.CREDIT_BATCH_INTERVAL) || 5;
+// How often the credit-processing heartbeat below is emitted. Independent of
+// the batch interval because the loop skips its sleep while draining a backlog,
+// which is exactly when the heartbeat's own query must not run every cycle.
+const CREDIT_HEARTBEAT_INTERVAL_SECONDS =
+	Number(process.env.CREDIT_HEARTBEAT_INTERVAL_SECONDS) || 30;
+// Upper bound on the backlog count so a large stall cannot turn the heartbeat
+// into a scan of the entire `log_processed_at_null_idx` partial index. Above
+// this the reported count saturates and `backlogCapped` is set.
+const CREDIT_BACKLOG_COUNT_CAP =
+	Number(process.env.CREDIT_BACKLOG_COUNT_CAP) || 100000;
 const VIDEO_JOB_POLL_INTERVAL_SECONDS =
 	Number(process.env.VIDEO_JOB_POLL_INTERVAL_SECONDS) || 5;
 const VIDEO_WEBHOOK_POLL_INTERVAL_SECONDS =
@@ -1021,6 +1031,12 @@ export async function cleanupExpiredModelHistory(): Promise<void> {
 	}
 }
 
+// Number of consecutive `batchProcessLogs` transactions that rolled back. Reset
+// on every batch that commits, so a sustained value means the same batch keeps
+// failing rather than an occasional transient error.
+let creditBatchConsecutiveFailures = 0;
+let lastCreditHeartbeatAt = 0;
+
 export async function batchProcessLogs(): Promise<number> {
 	const lockAcquired = await acquireLock(CREDIT_PROCESSING_LOCK_KEY);
 	if (!lockAcquired) {
@@ -1773,6 +1789,8 @@ export async function batchProcessLogs(): Promise<number> {
 			return unprocessedLogs.rows.length;
 		});
 
+		creditBatchConsecutiveFailures = 0;
+
 		// Auto-deactivate provider keys that hit their spend limit. Goes through
 		// cdb so the gateway's provider_key read cache and SWR mirrors are
 		// invalidated and the key drops out of rotation promptly — and only runs
@@ -1838,15 +1856,83 @@ export async function batchProcessLogs(): Promise<number> {
 			}
 		}
 	} catch (error) {
+		creditBatchConsecutiveFailures++;
 		logger.error(
 			"Error processing batch credit deductions",
 			error instanceof Error ? error : new Error(String(error)),
+			{
+				kind: "credit-batch-error",
+				consecutiveFailures: creditBatchConsecutiveFailures,
+			},
 		);
 	} finally {
 		await releaseLock(CREDIT_PROCESSING_LOCK_KEY);
 	}
 
 	return processedCount;
+}
+
+/**
+ * Emits the credit-processing health heartbeat that alerting is built on.
+ *
+ * The per-row "log-process" line is written *inside* the batch transaction, so
+ * a batch that keeps rolling back re-logs the same rows every cycle and any
+ * throughput metric derived from it looks perfectly healthy while nothing is
+ * committed. This heartbeat reports only committed state — how far behind the
+ * oldest unprocessed log is, how big the backlog is, and how many batches in a
+ * row have failed — so a stall is visible as a stall.
+ *
+ * Reads `log` directly on purpose: the aggregation tables cannot answer "what
+ * has not been settled yet". Cost is bounded by CREDIT_BACKLOG_COUNT_CAP and
+ * the `log_processed_at_null_idx` partial index.
+ */
+export async function reportCreditProcessingHealth(
+	force = false,
+): Promise<void> {
+	const now = Date.now();
+	if (
+		!force &&
+		now - lastCreditHeartbeatAt < CREDIT_HEARTBEAT_INTERVAL_SECONDS * 1000
+	) {
+		return;
+	}
+	lastCreditHeartbeatAt = now;
+
+	// Diagnostics must never take the drain loop down with them.
+	try {
+		const result = await db.execute<{
+			backlog: number;
+			lag_seconds: number | null;
+		}>(sql`
+			SELECT
+				count(*)::int AS backlog,
+				COALESCE(EXTRACT(EPOCH FROM (now() - min(created_at))), 0)::float8 AS lag_seconds
+			FROM (
+				SELECT created_at
+				FROM ${log}
+				WHERE processed_at IS NULL
+				ORDER BY created_at ASC
+				LIMIT ${CREDIT_BACKLOG_COUNT_CAP}
+			) AS unprocessed
+		`);
+
+		const row = result.rows[0];
+		const backlog = Number(row?.backlog ?? 0);
+		const lagSeconds = Math.max(0, Number(row?.lag_seconds ?? 0));
+
+		logger.info("credit processing heartbeat", {
+			kind: "credit-batch",
+			backlog,
+			backlogCapped: backlog >= CREDIT_BACKLOG_COUNT_CAP,
+			lagSeconds,
+			consecutiveFailures: creditBatchConsecutiveFailures,
+			batchSize: CREDIT_BATCH_SIZE,
+		});
+	} catch (error) {
+		logger.warn("Failed to report credit processing health", {
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
 }
 
 async function checkLowBalanceAlerts(orgIds: string[]): Promise<void> {
@@ -2168,6 +2254,8 @@ async function runBatchProcessLoop() {
 		while (!isStopRequested()) {
 			try {
 				const processed = await batchProcessLogs();
+
+				await reportCreditProcessingHealth();
 
 				// A full batch means more unprocessed logs remain, so loop straight
 				// into the next batch instead of sleeping. Without this the loop is


### PR DESCRIPTION
## Why

The worker's `batchProcessLogs` loop is what actually charges organizations: it takes the oldest unprocessed `log` rows, deducts credits, and stamps `processed_at`. While it is stalled the gateway keeps serving requests, so every org spends against a frozen balance and the shortfall only lands whenever the backlog eventually drains.

Nothing today reports that. The per-row `log-process` line — the only credit-processing signal we export — is written **inside** the batch transaction, so a batch that keeps rolling back re-logs the same rows every cycle and any throughput metric derived from it reads perfectly healthy while nothing is committed. The only failure mode we can currently see is the loop stopping entirely.

## What

Emit a `credit-batch` heartbeat from the batch loop reporting committed state only:

| Field | Meaning |
| --- | --- |
| `lagSeconds` | age of the oldest log row still awaiting deduction |
| `backlog` | number of unsettled rows (saturates at `CREDIT_BACKLOG_COUNT_CAP`) |
| `backlogCapped` | whether `backlog` hit that cap |
| `consecutiveFailures` | batch transactions that rolled back in a row, reset on every commit |
| `batchSize` | the configured `CREDIT_BATCH_SIZE` |

The rollback path also gets `kind: "credit-batch-error"` so repeated failures are countable independently of the log text.

Cost is bounded: the heartbeat is throttled to one query per `CREDIT_HEARTBEAT_INTERVAL_SECONDS` (default 30s — deliberately independent of the batch interval, because the loop skips its sleep exactly when it is behind), the count saturates at 100k rows, and the query runs off the existing `log_processed_at_null_idx` partial index. It reads `log` directly because no aggregation table can answer "what has not been settled yet". A failing heartbeat warns and returns; it never takes the drain loop down with it.

Behaviour is otherwise unchanged — this is observability only. The underlying head-of-line blocking (one poison row halts credit deduction platform-wide) is deliberately **not** addressed here.

Alerting on these signals lands in `theopenco/llmgateway-infra#1570` — merge this first, since the "heartbeat missing" alert there fires on missing data.

## Verification

- `pnpm format`, `pnpm build` — clean
- 3 new specs in `apps/worker/src/log-processing.spec.ts` covering backlog + lag reporting, the drained state, and heartbeat throttling — all pass, as do the 27 existing specs in that file

Note: running the whole `apps/worker` suite locally produces 8 failures (`limit-hit-flush`, two `log-processing` provider-key tests, two `worker.spec` auto-top-up tests). The identical 8 fail on this branch with the changes stashed, so they are pre-existing cross-suite interference in this environment, not caused by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
