### PR TITLE
perf(worker): settle billing into balances faster

### DIFF
--- a/apps/gateway/src/lib/cached-queries.ts
+++ b/apps/gateway/src/lib/cached-queries.ts
@@ -32,6 +32,7 @@ import {
 	getEffectiveDiscount,
 	getEffectiveRateLimit,
 	addApiKeyPeriodDuration,
+	organizationCacheTag,
 	providerKeyAllowsModel,
 	organization as organizationTable,
 	project as projectTable,
@@ -333,11 +334,16 @@ export async function findOrganizationCachedById(
 	id: string,
 ): Promise<Organization | undefined> {
 	return await swrWrap(`org:${id}`, [organizationTableName], async () => {
+		// Tagged per org so the worker can evict exactly this entry right after
+		// debiting credits (it writes via the uncached client, so table-level
+		// auto-invalidation never fires for those debits). This is what keeps
+		// the credit gates near-fresh without shortening the cache TTL.
 		const results = await db
 			.select()
 			.from(organizationTable)
 			.where(eq(organizationTable.id, id))
-			.limit(1);
+			.limit(1)
+			.$withCache({ tag: organizationCacheTag(id), autoInvalidate: true });
 		return results[0];
 	});
 }

--- a/apps/worker/src/log-processing.spec.ts
+++ b/apps/worker/src/log-processing.spec.ts
@@ -3,9 +3,11 @@ import { randomUUID } from "node:crypto";
 import { afterAll, beforeEach, describe, expect, test } from "vitest";
 
 import {
+	cdb,
 	eq,
 	isNull,
 	db,
+	organizationCacheTag,
 	tables,
 	log,
 	organization,
@@ -187,6 +189,51 @@ describe("Log Processing", () => {
 			});
 
 			expect(Number(updatedOrg!.credits)).toBe(initialCredits - 0.01);
+		});
+
+		test("evicts the debited org's tagged cache entry after settling", async () => {
+			// Same tagged read the gateway's findOrganizationCachedById uses.
+			const readCached = async () =>
+				(
+					await cdb
+						.select()
+						.from(organization)
+						.where(eq(organization.id, testOrg.id))
+						.limit(1)
+						.$withCache({
+							tag: organizationCacheTag(testOrg.id),
+							autoInvalidate: true,
+						})
+				)[0];
+
+			// Prime the cache entry with the pre-debit balance.
+			const before = await readCached();
+			expect(Number(before.credits)).toBe(100);
+
+			await db.insert(log).values({
+				requestId: "test-request-cache-evict",
+				organizationId: testOrg.id,
+				projectId: testProject.id,
+				apiKeyId: testApiKey.id,
+				cost: 0.01,
+				cached: false,
+				usedMode: "credits",
+				duration: 2000,
+				requestedModel: "openai/gpt-4o-mini",
+				requestedProvider: "openai",
+				usedModel: "gpt-4o-mini",
+				usedProvider: "openai",
+				responseSize: 150,
+				mode: "credits",
+			});
+
+			await batchProcessLogs();
+
+			// The debit goes through the uncached client, so without the
+			// worker's eviction this read would serve the stale 100.00 for the
+			// full cache TTL.
+			const after = await readCached();
+			expect(Number(after.credits)).toBe(99.99);
 		});
 
 		test("should accrue premium weekly usage for provider-prefixed premium models on dev plans", async () => {

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -27,6 +27,7 @@ import {
 	enqueueWebhookDeliveries,
 	eq,
 	inArray,
+	invalidateOrganizationsCache,
 	isNotNull,
 	isApiKeyPeriodLimitConfigured,
 	log,
@@ -136,8 +137,11 @@ const LOG_QUEUE_CONCURRENCY = Math.max(
 	Number(process.env.LOG_QUEUE_CONCURRENCY) || 4,
 );
 const CREDIT_BATCH_SIZE = Number(process.env.CREDIT_BATCH_SIZE) || 100;
+// 1s: this interval is the floor of the spend-to-balance settlement gap the
+// credit gates operate on, so it directly bounds how far a burst can
+// overshoot a balance. Idle cost is one lock round-trip per tick.
 const BATCH_PROCESSING_INTERVAL_SECONDS =
-	Number(process.env.CREDIT_BATCH_INTERVAL) || 5;
+	Number(process.env.CREDIT_BATCH_INTERVAL) || 1;
 const VIDEO_JOB_POLL_INTERVAL_SECONDS =
 	Number(process.env.VIDEO_JOB_POLL_INTERVAL_SECONDS) || 5;
 const VIDEO_WEBHOOK_POLL_INTERVAL_SECONDS =
@@ -1029,6 +1033,10 @@ export async function batchProcessLogs(): Promise<number> {
 
 	let processedCount = 0;
 	const deductedOrgIds: string[] = [];
+	// Every org whose row was debited this batch (plan pools or regular
+	// credits). Their tagged cache entries are evicted after commit so the
+	// gateway's credit gates see the new balance immediately.
+	const settledOrgIds: string[] = [];
 	// Provider keys (BYOK or managed) whose accumulated usage crossed their
 	// spend limit this batch — deactivated after the transaction commits.
 	let overLimitProviderKeyIds: string[] = [];
@@ -1377,6 +1385,8 @@ export async function batchProcessLogs(): Promise<number> {
 				if (totalCost.lessThanOrEqualTo(0)) {
 					continue;
 				}
+
+				settledOrgIds.push(orgId);
 
 				const org = await tx.query.organization.findFirst({
 					where: { id: { eq: orgId } },
@@ -1773,6 +1783,12 @@ export async function batchProcessLogs(): Promise<number> {
 			return unprocessedLogs.rows.length;
 		});
 
+		// Evict the debited orgs' tagged cache entries so the gateway's next
+		// org read (and thus its credit gate) sees the new balance now rather
+		// than after the cache TTL — the debits above went through the plain
+		// client, which never fires cache invalidation. Best-effort.
+		await invalidateOrganizationsCache(settledOrgIds);
+
 		// Auto-deactivate provider keys that hit their spend limit. Goes through
 		// cdb so the gateway's provider_key read cache and SWR mirrors are
 		// invalidated and the key drops out of rotation promptly — and only runs
@@ -2113,8 +2129,10 @@ async function runLogQueueLoop(loopIndex = 0) {
 				// straight into the next batch instead of sleeping. Tying this to
 				// LOG_QUEUE_BATCH_SIZE was wrong: when the batch size is raised
 				// above the steady-state queue depth the sleep fired every cycle.
+				// 250ms keeps queue latency out of the billing settlement gap at
+				// the cost of four cheap LPOPs per idle second.
 				if (drained === 0) {
-					await interruptibleSleep(1000);
+					await interruptibleSleep(250);
 				}
 			} catch (error) {
 				logger.error(

--- a/packages/db/src/cache-helpers.ts
+++ b/packages/db/src/cache-helpers.ts
@@ -3,7 +3,7 @@ import { and, eq, getTableName } from "drizzle-orm";
 import { swrWrap } from "@llmgateway/cache";
 import { logger } from "@llmgateway/logger";
 
-import { cdb } from "./cdb.js";
+import { cdb, drizzleCache } from "./cdb.js";
 import {
 	project as projectTable,
 	providerKey as providerKeyTable,
@@ -14,6 +14,40 @@ import type { InferSelectModel } from "drizzle-orm";
 
 const projectTableName = getTableName(projectTable);
 const providerKeyTableName = getTableName(providerKeyTable);
+
+/**
+ * Cache tag under which the gateway caches an organization's row (see
+ * `findOrganizationCachedById`). Shared with the worker, which evicts these
+ * tags right after debiting credits so the gateway's credit gates see the new
+ * balance immediately instead of after the cache TTL.
+ */
+export function organizationCacheTag(organizationId: string): string {
+	return `org:${organizationId}`;
+}
+
+/**
+ * Evict the tagged org-row cache entries for the given organizations.
+ * Best-effort: a failure only delays freshness until the TTL, so it must
+ * never break the caller (the worker's billing loop).
+ */
+export async function invalidateOrganizationsCache(
+	organizationIds: string[],
+): Promise<void> {
+	if (organizationIds.length === 0) {
+		return;
+	}
+	try {
+		await drizzleCache.onMutate({
+			tags: organizationIds.map(organizationCacheTag),
+		});
+	} catch (error) {
+		logger.error(
+			"Error invalidating organization cache tags",
+			error instanceof Error ? error : new Error(String(error)),
+			{ organizationIds },
+		);
+	}
+}
 
 /**
  * Look up project caching settings.

--- a/packages/db/src/cdb.ts
+++ b/packages/db/src/cdb.ts
@@ -6,13 +6,17 @@ import { pool } from "./db.js";
 import { RedisCache } from "./redis-cache.js";
 import { relations } from "./relations.js";
 
+// Exported so writers that bypass this client (the worker debits credits via
+// the plain `db` client inside a transaction) can still evict tagged entries.
+export const drizzleCache = new RedisCache(redisClient);
+
 // Use the shared pool from db.ts instead of creating a separate pool
 // This prevents connection exhaustion from having multiple pools
 const _cdb = drizzle({
 	client: pool,
 	casing: "snake_case",
 	relations,
-	cache: new RedisCache(redisClient),
+	cache: drizzleCache,
 });
 
 /**


### PR DESCRIPTION
## Problem

A burst of expensive requests can spend far past an organization's balance because the credit gates only see the stored balance, and settlement lags behind spending. The gap had three parts after a request completes: the log queue idle poll (~1s), the credit batch loop (5s interval), and — the dominant term — the gateway's cached org row, which stayed stale for its full TTL after every debit because the worker debits through the uncached client and no invalidation ever fired.

## Approach

Make billing settle into the balance faster instead of adding logic at the gates. Nothing is added to the gateway hot path — it keeps its single cached org read.

- **Targeted cache eviction on debit**: the gateway's org-row cache entry is now tagged per org (`organizationCacheTag`), and `batchProcessLogs` evicts exactly the debited orgs' entries after the transaction commits (`invalidateOrganizationsCache`, best-effort). The next request after a debit reads the fresh balance instead of a stale one for up to the TTL. Non-debited orgs' cache hit rates are untouched.
- **Batch debit loop**: default interval 5s → 1s (still env-overridable via `CREDIT_BATCH_INTERVAL`; idle cost is one lock round-trip per tick, and the loop already drains continuously under backlog).
- **Log queue**: idle poll 1s → 250ms (four cheap LPOPs per idle second).

Settlement now reaches the credit gates ~1–2s after a request completes, down from up to ~65s. The remaining exposure is cost of requests still mid-stream, which is inherent to post-paid billing.

## Verification

- New test in `log-processing.spec.ts`: primes the tagged cache entry, runs `batchProcessLogs`, and asserts the debited balance is visible immediately (it would serve the stale value without the eviction). Full file 28/28.
- `api.spec.ts` (181 tests) and `worker.spec.ts` pass; `pnpm build` and `pnpm format` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Credit processing now runs more frequently, helping balances update sooner.
  - Reduced background polling delays improve responsiveness during credit settlement.

- **Bug Fixes**
  - Organization balances now refresh promptly after credits are processed, preventing stale balance information from being displayed.
  - Improved cache updates ensure subsequent balance checks reflect the latest debits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->