### PR TITLE
fix(security): prevent polynomial ReDoS

### DIFF
--- a/packages/actions/src/get-provider-endpoint.spec.ts
+++ b/packages/actions/src/get-provider-endpoint.spec.ts
@@ -935,6 +935,28 @@ describe("getProviderEndpoint", () => {
 				"https://bedrock-proxy.internal/openai/v1/chat/completions",
 			);
 		});
+
+		it("normalizes a long run of trailing base URL slashes", () => {
+			const endpoint = getProviderEndpoint(
+				"aws-bedrock",
+				`https://bedrock-proxy.internal/openai/v1${"/".repeat(100_000)}`,
+				"grok-4-3",
+				undefined,
+				false,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				"us-west-2",
+				true,
+				"grok-4-3",
+			);
+
+			expect(endpoint).toBe(
+				"https://bedrock-proxy.internal/openai/v1/chat/completions",
+			);
+		});
 	});
 
 	describe("alibaba regions", () => {

--- a/packages/actions/src/get-provider-endpoint.ts
+++ b/packages/actions/src/get-provider-endpoint.ts
@@ -19,7 +19,17 @@ import {
 import type { ProviderKeyOptions } from "@llmgateway/db";
 
 function appendPath(url: string, path: string): string {
-	return `${url.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+	let urlEnd = url.length;
+	while (urlEnd > 0 && url[urlEnd - 1] === "/") {
+		urlEnd--;
+	}
+
+	let pathStart = 0;
+	while (pathStart < path.length && path[pathStart] === "/") {
+		pathStart++;
+	}
+
+	return `${url.slice(0, urlEnd)}/${path.slice(pathStart)}`;
 }
 
 function getBedrockMantleBaseUrl(url: string, region?: string): string {

--- a/packages/actions/src/transform-google-messages.spec.ts
+++ b/packages/actions/src/transform-google-messages.spec.ts
@@ -446,6 +446,25 @@ describe("parseGoogleUpstreamDocumentError", () => {
 		expect(result?.mimeType).toBe("application/zip");
 	});
 
+	it("handles long whitespace around the MIME type", () => {
+		const body = JSON.stringify({
+			error: {
+				message: `Unsupported MIME type:${" ".repeat(100_000)}application/zip${" ".repeat(100_000)}.`,
+			},
+		});
+		const result = parseGoogleUpstreamDocumentError(body, "google-ai-studio");
+		expect(result?.mimeType).toBe("application/zip");
+	});
+
+	it("returns null when the MIME type is empty", () => {
+		const body = JSON.stringify({
+			error: { message: `Unsupported MIME type:${" ".repeat(100_000)}` },
+		});
+		expect(
+			parseGoogleUpstreamDocumentError(body, "google-ai-studio"),
+		).toBeNull();
+	});
+
 	it("returns null for unrelated Google errors", () => {
 		const body = JSON.stringify({
 			error: {

--- a/packages/actions/src/transform-google-messages.ts
+++ b/packages/actions/src/transform-google-messages.ts
@@ -160,12 +160,19 @@ export function parseGoogleUpstreamDocumentError(
 	if (typeof message !== "string") {
 		return null;
 	}
-	const match = message.match(/^Unsupported MIME type:\s*(.+?)\.?\s*$/i);
-	if (!match) {
+	const prefix = "unsupported mime type:";
+	if (message.slice(0, prefix.length).toLowerCase() !== prefix) {
+		return null;
+	}
+	let mimeType = message.slice(prefix.length).trim();
+	if (mimeType.endsWith(".")) {
+		mimeType = mimeType.slice(0, -1).trimEnd();
+	}
+	if (!mimeType || mimeType.includes("\n") || mimeType.includes("\r")) {
 		return null;
 	}
 	return new UnsupportedDocumentFormatError(
-		match[1].trim(),
+		mimeType,
 		resolveGoogleProviderTarget(providerId),
 	);
 }

--- a/packages/shared/src/video-access.spec.ts
+++ b/packages/shared/src/video-access.spec.ts
@@ -50,6 +50,16 @@ describe("video access tokens", () => {
 		expect(verifyVideoContentAccessToken(token, "log-1")).toBe(true);
 	});
 
+	test("creates URL-safe unpadded tokens", () => {
+		process.env.NODE_ENV = "test";
+		process.env[VIDEO_CONTENT_TOKEN_SECRET_ENV] = "configured-secret";
+
+		const token = createVideoContentAccessToken("log-/+=");
+
+		expect(token).not.toMatch(/[+/=]/);
+		expect(verifyVideoContentAccessToken(token, "log-/+=")).toBe(true);
+	});
+
 	test("allows the development fallback in development", () => {
 		process.env.NODE_ENV = "development";
 		setOptionalEnv(VIDEO_CONTENT_TOKEN_SECRET_ENV, undefined);

--- a/packages/shared/src/video-access.ts
+++ b/packages/shared/src/video-access.ts
@@ -32,19 +32,11 @@ function getVideoContentTokenSecret(): string {
 }
 
 function base64urlEncode(input: string): string {
-	return Buffer.from(input)
-		.toString("base64")
-		.replace(/\+/g, "-")
-		.replace(/\//g, "_")
-		.replace(/=+$/g, "");
+	return Buffer.from(input).toString("base64url");
 }
 
 function base64urlDecode(input: string): string {
-	const padded = input.replace(/-/g, "+").replace(/_/g, "/");
-	const remainder = padded.length % 4;
-	const normalized =
-		remainder === 0 ? padded : `${padded}${"=".repeat(4 - remainder)}`;
-	return Buffer.from(normalized, "base64").toString("utf8");
+	return Buffer.from(input, "base64url").toString("utf8");
 }
 
 function signJwtSegment(
@@ -54,10 +46,7 @@ function signJwtSegment(
 ): string {
 	return createHmac("sha256", secret)
 		.update(`${header}.${payload}`)
-		.digest("base64")
-		.replace(/\+/g, "-")
-		.replace(/\//g, "_")
-		.replace(/=+$/g, "");
+		.digest("base64url");
 }
 
 function getDefaultVideoContentExpiryDate(): Date {


### PR DESCRIPTION
## Problem

CodeQL found three polynomial regular expressions operating on uncontrolled input in endpoint normalization, Google upstream error parsing, and video access token encoding.

## Changes

- replace slash-trimming regexes with bounded string scans
- parse unsupported MIME errors with deterministic string operations
- use Node's native base64url encoding and decoding
- add regression coverage with adversarial long inputs and URL-safe tokens

## Verification

- `pnpm format`
- `pnpm test:unit packages/actions/src/get-provider-endpoint.spec.ts packages/actions/src/transform-google-messages.spec.ts packages/shared/src/video-access.spec.ts` (104 tests)
- `pnpm build`