### PR TITLE
fix(gateway): validate provider image URLs

### DIFF
--- a/apps/gateway/src/chat/tools/convert-images-to-base64.spec.ts
+++ b/apps/gateway/src/chat/tools/convert-images-to-base64.spec.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { convertImagesToBase64 } from "./convert-images-to-base64.js";
+
+function image(url: string) {
+	return { type: "image_url" as const, image_url: { url } };
+}
+
+describe("convertImagesToBase64 URL safety", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllEnvs();
+	});
+
+	it.each([
+		"http://cdn.example.com/image.png",
+		"https://127.0.0.1/image.png",
+		"https://169.254.169.254/latest/meta-data",
+		"https://10.0.0.1/image.png",
+		"https://metadata.google.internal/image.png",
+	])("does not fetch an unsafe provider image URL: %s", async (url) => {
+		vi.stubEnv("ALLOW_INSECURE_PROVIDER_URLS", "false");
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+		const input = image(url);
+
+		await expect(convertImagesToBase64([input])).resolves.toEqual([input]);
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("refuses redirects when fetching a provider image", async () => {
+		vi.stubEnv("ALLOW_INSECURE_PROVIDER_URLS", "true");
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(new Uint8Array([1, 2, 3]), {
+				headers: { "content-type": "image/png" },
+			}),
+		);
+
+		const result = await convertImagesToBase64([
+			image("https://cdn.example.com/image.png"),
+		]);
+
+		expect(fetchSpy).toHaveBeenCalledWith("https://cdn.example.com/image.png", {
+			redirect: "error",
+		});
+		expect(result[0]?.image_url.url).toBe("data:image/png;base64,AQID");
+	});
+});

--- a/apps/gateway/src/chat/tools/convert-images-to-base64.ts
+++ b/apps/gateway/src/chat/tools/convert-images-to-base64.ts
@@ -1,4 +1,5 @@
 import { logger } from "@llmgateway/logger";
+import { assertSafeUserContentUrl } from "@llmgateway/shared/url-safety-node";
 
 import type { ImageObject } from "./types.js";
 
@@ -8,9 +9,19 @@ const RETRY_DELAY_MS = 1000;
 async function fetchImageWithRetry(
 	url: string,
 ): Promise<{ contentType: string; base64: string } | null> {
+	try {
+		await assertSafeUserContentUrl(url);
+	} catch (error) {
+		logger.warn("Refusing unsafe image URL from provider response", {
+			url,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return null;
+	}
+
 	for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
 		try {
-			const response = await fetch(url);
+			const response = await fetch(url, { redirect: "error" });
 			if (response.ok) {
 				const contentType = response.headers.get("content-type") ?? "image/png";
 				const arrayBuffer = await response.arrayBuffer();

--- a/apps/gateway/src/images/images.ts
+++ b/apps/gateway/src/images/images.ts
@@ -250,11 +250,7 @@ async function extractImagesFromChatResponse(
 				) {
 					// Handle URL-based images (e.g. Z.AI, Alibaba, ByteDance)
 					try {
-						// Trusted upstream provider response, not request input: skip the
-						// user-content SSRF guard (CDNs may redirect to signed URLs).
-						const result = await processImageUrl(imageUrl, false, 20, null, {
-							validateSsrf: false,
-						});
+						const result = await processImageUrl(imageUrl);
 						imageObjects.push({
 							b64_json: result.data,
 							revised_prompt: prompt,

--- a/packages/actions/src/process-image-url.spec.ts
+++ b/packages/actions/src/process-image-url.spec.ts
@@ -5,7 +5,6 @@ import { RequestError } from "./request-error.js";
 
 const MAX_SIZE_MB = 1;
 const REMOTE_URL = "https://example.com/huge.png";
-const NO_SSRF = { validateSsrf: false } as const;
 
 function imageResponseWithContentLength(bytes: number): Response {
 	return new Response(new Uint8Array(0), {
@@ -51,7 +50,6 @@ describe("processImageUrl size limits", () => {
 			false,
 			MAX_SIZE_MB,
 			"free",
-			NO_SSRF,
 		).catch((err: unknown) => err);
 
 		expect(error).toBeInstanceOf(ImageSizeLimitError);
@@ -70,7 +68,6 @@ describe("processImageUrl size limits", () => {
 			false,
 			MAX_SIZE_MB,
 			"free",
-			NO_SSRF,
 		).catch((err: unknown) => err);
 
 		expect(error).toBeInstanceOf(ImageSizeLimitError);
@@ -89,7 +86,6 @@ describe("processImageUrl size limits", () => {
 			false,
 			MAX_SIZE_MB,
 			"free",
-			NO_SSRF,
 		).catch((err: unknown) => err);
 
 		expect(error).toBeInstanceOf(RequestError);
@@ -114,7 +110,6 @@ describe("processImageUrl size limits", () => {
 			false,
 			MAX_SIZE_MB,
 			"free",
-			NO_SSRF,
 		).catch((err: unknown) => err);
 
 		expect(error).toBeInstanceOf(ImageSizeLimitError);
@@ -134,7 +129,6 @@ describe("processImageUrl size limits", () => {
 			false,
 			MAX_SIZE_MB,
 			"free",
-			NO_SSRF,
 		).catch((err: unknown) => err);
 		const dataUrl = await processImageUrl(
 			`data:image/png;base64,${"A".repeat(2 * 1024 * 1024)}`,
@@ -162,7 +156,6 @@ describe("processImageUrl size limits", () => {
 			false,
 			MAX_SIZE_MB,
 			"free",
-			NO_SSRF,
 		).catch((err: unknown) => err);
 
 		expect((error as Error).message).not.toContain("(1.0MB)");
@@ -180,7 +173,6 @@ describe("processImageUrl size limits", () => {
 			false,
 			MAX_SIZE_MB,
 			null,
-			NO_SSRF,
 		).catch((err: unknown) => err);
 
 		expect((error as Error).message).toBe(
@@ -199,7 +191,7 @@ describe("processImageUrl size limits", () => {
 		);
 
 		await expect(
-			processImageUrl(REMOTE_URL, false, MAX_SIZE_MB, "free", NO_SSRF),
+			processImageUrl(REMOTE_URL, false, MAX_SIZE_MB, "free"),
 		).rejects.toThrow("URL does not point to a valid image");
 	});
 
@@ -209,8 +201,21 @@ describe("processImageUrl size limits", () => {
 		);
 
 		await expect(
-			processImageUrl(REMOTE_URL, false, MAX_SIZE_MB, "free", NO_SSRF),
+			processImageUrl(REMOTE_URL, false, MAX_SIZE_MB, "free"),
 		).rejects.toThrow("Failed to process image from URL");
+	});
+
+	it("refuses redirects even when the URL guard is disabled", async () => {
+		vi.stubEnv("ALLOW_INSECURE_PROVIDER_URLS", "true");
+		const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(new Uint8Array(0), {
+				headers: { "content-type": "image/png" },
+			}),
+		);
+
+		await processImageUrl(REMOTE_URL);
+
+		expect(fetchSpy).toHaveBeenCalledWith(REMOTE_URL, { redirect: "error" });
 	});
 });
 
@@ -247,7 +252,6 @@ describe("processImageUrl data URLs", () => {
 			false,
 			MAX_SIZE_MB,
 			"free",
-			NO_SSRF,
 		);
 
 		expect(Buffer.from(data, "base64").byteLength).toBe(

--- a/packages/actions/src/process-image-url.ts
+++ b/packages/actions/src/process-image-url.ts
@@ -107,19 +107,13 @@ async function readBodyWithLimit(
 /**
  * Processes an image URL or data URL and converts it to base64.
  *
- * `validateSsrf` (default true) applies the user-content SSRF guard to remote
- * URLs before fetching and refuses redirects, so a tenant-supplied image URL in
- * a chat/image/video request cannot make the gateway fetch an internal host.
- * Pass `validateSsrf: false` only for URLs that originate from a trusted upstream
- * provider response (which may legitimately redirect to a signed CDN URL), not
- * from the request body.
+ * Remote URLs are SSRF-validated before fetching and redirects are refused.
  */
 export async function processImageUrl(
 	url: string,
 	isProd = false,
 	maxSizeMB = 20,
 	userPlan: "free" | "pro" | "enterprise" | null = null,
-	{ validateSsrf = true }: { validateSsrf?: boolean } = {},
 ): Promise<{ data: string; mimeType: string }> {
 	// Handle data URLs directly without network fetch
 	if (url.startsWith("data:")) {
@@ -191,19 +185,12 @@ export async function processImageUrl(
 		throw new RequestError("Image URLs must use HTTPS protocol in production");
 	}
 
-	// SSRF: a tenant-supplied content URL must not resolve to an internal host.
-	// No-op when the guard is disabled (self-hosted / local test).
-	if (validateSsrf) {
-		await assertSafeUserContentUrl(url);
-	}
+	// SSRF: remote content must not resolve to an internal host. This also
+	// enforces HTTPS unless explicitly disabled for a self-hosted deployment.
+	await assertSafeUserContentUrl(url);
 
 	try {
-		const response = await fetch(url, {
-			// SSRF: refuse redirects so a validated public host cannot 3xx the
-			// gateway onward to an internal one. Trusted provider-response URLs opt
-			// out (validateSsrf: false) since CDNs legitimately redirect.
-			redirect: validateSsrf ? "error" : "follow",
-		});
+		const response = await fetch(url, { redirect: "error" });
 
 		if (!response.ok) {
 			logger.warn(`Failed to fetch image from URL (${response.status})`, {


### PR DESCRIPTION
## Problem

Provider-returned image URLs are fetched server-side and converted to base64. Custom providers make those response URLs tenant-controlled, but the chat converter skipped the shared URL-safety guard and followed redirects. The Images API also had an explicit validation bypass for provider responses.

## Approach

- validate provider image URLs before each conversion fetch
- require HTTPS and reject private, reserved, and internal destinations through the shared guard
- refuse redirects for all remote image downloads, including when insecure provider URLs are enabled for self-hosting
- remove the trusted-provider-response bypass from the Images API
- cover HTTP, loopback, private, metadata, internal-host, and redirect cases

Provider CDNs must now return the final HTTPS media URL rather than redirecting to it.

## Verification

- `pnpm format`
- `pnpm build`
- `pnpm exec vitest run apps/gateway/src/chat/tools/convert-images-to-base64.spec.ts packages/actions/src/process-image-url.spec.ts packages/shared/src/url-safety-node.spec.ts --no-file-parallelism` (24 tests)