### PR TITLE
fix(playground): harden MCP server URLs

### DIFF
--- a/apps/playground/src/app/api/chat/route.ts
+++ b/apps/playground/src/app/api/chat/route.ts
@@ -29,6 +29,10 @@ import { fetchServerData } from "@/lib/server-api";
 
 import { createLLMGateway } from "@llmgateway/ai-sdk-provider";
 import { LOUNGE_SOURCE } from "@llmgateway/shared/lounge-source";
+import {
+	assertSafeResolvedUserUrl,
+	fetchSafeUserUrl,
+} from "@llmgateway/shared/url-safety-node";
 
 export const maxDuration = 300; // 5 minutes
 
@@ -348,156 +352,6 @@ function isMcpImageContent(value: unknown): value is McpImageContent {
 interface McpToolDefinition {
 	description?: string;
 	execute: (...args: unknown[]) => Promise<unknown> | unknown;
-}
-
-/**
- * SSRF Protection: Validate MCP server URLs to prevent Server-Side Request Forgery
- * Blocks private/local addresses and validates against allowlist if configured
- */
-function validateMcpServerUrl(urlString: string): {
-	valid: boolean;
-	error?: string;
-	url?: URL;
-} {
-	let url: URL;
-	try {
-		url = new URL(urlString);
-	} catch {
-		return { valid: false, error: "Invalid URL format" };
-	}
-
-	// Only allow HTTP(S) protocols
-	if (!["http:", "https:"].includes(url.protocol)) {
-		return {
-			valid: false,
-			error: `Invalid protocol: ${url.protocol}. Only HTTP(S) allowed.`,
-		};
-	}
-
-	const hostname = url.hostname.toLowerCase();
-
-	// Allow localhost in development mode
-	const isDevelopment = process.env.NODE_ENV === "development";
-
-	// Block localhost and common local hostnames (except in development)
-	const blockedHostnames = [
-		"localhost",
-		"127.0.0.1",
-		"0.0.0.0",
-		"[::1]",
-		"::1",
-		"local",
-		"internal",
-		"intranet",
-		"corp",
-		"private",
-	];
-
-	if (!isDevelopment) {
-		if (
-			blockedHostnames.includes(hostname) ||
-			hostname.endsWith(".local") ||
-			hostname.endsWith(".localhost") ||
-			hostname.endsWith(".internal")
-		) {
-			return {
-				valid: false,
-				error: `Blocked hostname: ${hostname}. Local/internal addresses not allowed.`,
-			};
-		}
-	}
-
-	// Check if hostname is an IP address and validate against private ranges (except in development)
-	if (!isDevelopment) {
-		const ipValidation = validateIpAddress(hostname);
-		if (ipValidation.isIp && !ipValidation.isPublic) {
-			return {
-				valid: false,
-				error: `Blocked IP address: ${hostname}. Private/reserved IP ranges not allowed.`,
-			};
-		}
-	}
-
-	// Optional: Check against allowlist if configured
-	const allowedHosts = process.env.MCP_ALLOWED_HOSTS?.split(",").map((h) =>
-		h.trim().toLowerCase(),
-	);
-	if (allowedHosts && allowedHosts.length > 0) {
-		const isAllowed = allowedHosts.some(
-			(allowed) => hostname === allowed || hostname.endsWith(`.${allowed}`),
-		);
-		if (!isAllowed) {
-			return {
-				valid: false,
-				error: `Hostname ${hostname} not in allowlist`,
-			};
-		}
-	}
-
-	return { valid: true, url };
-}
-
-/**
- * Validate if a string is an IP address and check if it's in private/reserved ranges
- */
-function validateIpAddress(hostname: string): {
-	isIp: boolean;
-	isPublic: boolean;
-} {
-	// IPv4 pattern
-	const ipv4Pattern = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
-	const ipv4Match = hostname.match(ipv4Pattern);
-
-	if (ipv4Match) {
-		const octets = ipv4Match.slice(1, 5).map(Number);
-
-		// Validate octet ranges
-		if (octets.some((o) => o > 255)) {
-			return { isIp: true, isPublic: false };
-		}
-
-		const [a, b, c] = octets;
-
-		// Check private/reserved IPv4 ranges
-		const isPrivate =
-			a === 0 || // 0.0.0.0/8 - Current network
-			a === 10 || // 10.0.0.0/8 - Private
-			(a === 100 && b >= 64 && b <= 127) || // 100.64.0.0/10 - Carrier-grade NAT
-			a === 127 || // 127.0.0.0/8 - Loopback
-			(a === 169 && b === 254) || // 169.254.0.0/16 - Link-local
-			(a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12 - Private
-			(a === 192 && b === 0 && c === 0) || // 192.0.0.0/24 - IETF Protocol
-			(a === 192 && b === 0 && c === 2) || // 192.0.2.0/24 - TEST-NET-1
-			(a === 192 && b === 88 && c === 99) || // 192.88.99.0/24 - 6to4 relay
-			(a === 192 && b === 168) || // 192.168.0.0/16 - Private
-			(a === 198 && b >= 18 && b <= 19) || // 198.18.0.0/15 - Benchmark
-			(a === 198 && b === 51 && c === 100) || // 198.51.100.0/24 - TEST-NET-2
-			(a === 203 && b === 0 && c === 113) || // 203.0.113.0/24 - TEST-NET-3
-			a >= 224; // 224.0.0.0+ - Multicast and reserved
-
-		return { isIp: true, isPublic: !isPrivate };
-	}
-
-	// IPv6 pattern (simplified - handles bracketed and non-bracketed)
-	const ipv6Hostname = hostname.replace(/^\[|\]$/g, "");
-	if (ipv6Hostname.includes(":")) {
-		// Check common private/reserved IPv6 patterns
-		const lowerIpv6 = ipv6Hostname.toLowerCase();
-		const isPrivate =
-			lowerIpv6 === "::1" || // Loopback
-			lowerIpv6 === "::" || // Unspecified
-			lowerIpv6.startsWith("fc") || // fc00::/7 - Unique local
-			lowerIpv6.startsWith("fd") || // fc00::/7 - Unique local
-			lowerIpv6.startsWith("fe80") || // fe80::/10 - Link-local
-			lowerIpv6.startsWith("::ffff:127.") || // IPv4-mapped loopback
-			lowerIpv6.startsWith("::ffff:10.") || // IPv4-mapped private
-			lowerIpv6.startsWith("::ffff:192.168.") || // IPv4-mapped private
-			lowerIpv6.startsWith("::ffff:172."); // IPv4-mapped private (partial check)
-
-		return { isIp: true, isPublic: !isPrivate };
-	}
-
-	return { isIp: false, isPublic: true };
 }
 
 interface McpServerConfig {
@@ -1008,22 +862,30 @@ export async function POST(req: Request) {
 		for (const server of enabledMcpServers) {
 			try {
 				// SSRF Protection: Validate URL before creating transport
-				const urlValidation = validateMcpServerUrl(server.url);
-				if (!urlValidation.valid) {
-					continue; // Skip this server
+				const serverUrl = await assertSafeResolvedUserUrl(server.url);
+				const allowedHosts = process.env.MCP_ALLOWED_HOSTS?.split(",").map(
+					(host) => host.trim().toLowerCase(),
+				);
+				if (
+					allowedHosts?.length &&
+					!allowedHosts.some(
+						(host) =>
+							serverUrl.hostname === host ||
+							serverUrl.hostname.endsWith(`.${host}`),
+					)
+				) {
+					continue;
 				}
 
 				// Use the official MCP SDK transport for better compatibility
-				const transport = new StreamableHTTPClientTransport(
-					urlValidation.url!,
-					{
-						requestInit: {
-							headers: server.apiKey
-								? { Authorization: `Bearer ${server.apiKey}` }
-								: undefined,
-						},
+				const transport = new StreamableHTTPClientTransport(serverUrl, {
+					fetch: fetchSafeUserUrl,
+					requestInit: {
+						headers: server.apiKey
+							? { Authorization: `Bearer ${server.apiKey}` }
+							: undefined,
 					},
-				);
+				});
 
 				const clientPromise = createMCPClient({ transport });
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -122,6 +122,7 @@
 		"resend": "6.8.0",
 		"sonner": "^2.0.7",
 		"tailwind-merge": "3.4.0",
+		"undici": "8.9.0",
 		"zod": "3.25.75"
 	},
 	"devDependencies": {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -281,6 +281,7 @@ export {
 export {
 	assertSafeContentUrl,
 	assertSafeProviderBaseUrl,
+	assertSafeUserUrl,
 	assertSafeWebhookUrl,
 	isPrivateOrReservedIp,
 	isProviderUrlGuardEnabled,

--- a/packages/shared/src/url-safety-fetch.spec.ts
+++ b/packages/shared/src/url-safety-fetch.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { fetchSafeUserUrl } from "./url-safety-node.js";
+
+import type { LookupFunction } from "node:net";
+
+const mocks = vi.hoisted(() => ({
+	agentOptions: [] as unknown[],
+	dnsLookup: vi.fn(),
+	fetch: vi.fn(),
+}));
+
+vi.mock("node:dns", () => ({
+	lookup: mocks.dnsLookup,
+}));
+
+vi.mock("undici", () => ({
+	Agent: class {
+		public constructor(options: unknown) {
+			mocks.agentOptions.push(options);
+		}
+	},
+	fetch: mocks.fetch,
+}));
+
+describe("fetchSafeUserUrl", () => {
+	it("forces redirect errors on every fetch", async () => {
+		mocks.fetch.mockResolvedValue(new Response(null, { status: 204 }));
+
+		await fetchSafeUserUrl("https://mcp.example.com/rpc", {
+			method: "POST",
+			redirect: "follow",
+		});
+
+		expect(mocks.fetch).toHaveBeenCalledWith(
+			new URL("https://mcp.example.com/rpc"),
+			expect.objectContaining({
+				method: "POST",
+				redirect: "error",
+				dispatcher: expect.anything(),
+			}),
+		);
+	});
+
+	it("rejects http before starting a fetch", async () => {
+		mocks.fetch.mockClear();
+
+		await expect(
+			fetchSafeUserUrl("http://mcp.example.com/rpc"),
+		).rejects.toThrow("must use https");
+		expect(mocks.fetch).not.toHaveBeenCalled();
+	});
+
+	it("rejects unsafe addresses during socket DNS lookup", async () => {
+		mocks.fetch.mockResolvedValue(new Response(null, { status: 204 }));
+		await fetchSafeUserUrl("https://mcp.example.com/rpc");
+
+		const options = mocks.agentOptions[0] as {
+			connect?: { lookup?: LookupFunction };
+		};
+		const safeLookup = options.connect?.lookup;
+		expect(safeLookup).toBeDefined();
+
+		mocks.dnsLookup.mockImplementationOnce(
+			(
+				_hostname: string,
+				_options: unknown,
+				callback: (
+					error: NodeJS.ErrnoException | null,
+					addresses: { address: string; family: number }[],
+				) => void,
+			) => {
+				callback(null, [{ address: "127.0.0.1", family: 4 }]);
+			},
+		);
+
+		const lookupError = await new Promise<NodeJS.ErrnoException | null>(
+			(resolve) => {
+				safeLookup?.("mcp.example.com", { all: true }, (error) => {
+					resolve(error);
+				});
+			},
+		);
+		expect(lookupError?.code).toBe("EACCES");
+	});
+});

--- a/packages/shared/src/url-safety-node.spec.ts
+++ b/packages/shared/src/url-safety-node.spec.ts
@@ -1,6 +1,15 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { assertSafeUserContentUrl } from "./url-safety-node.js";
+import {
+	assertSafeResolvedUserUrl,
+	assertSafeUserContentUrl,
+} from "./url-safety-node.js";
+
+const lookupMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:dns/promises", () => ({
+	lookup: lookupMock,
+}));
 
 describe("assertSafeUserContentUrl", () => {
 	const originalFlag = process.env.ALLOW_INSECURE_PROVIDER_URLS;
@@ -16,6 +25,8 @@ describe("assertSafeUserContentUrl", () => {
 	describe("with the guard enabled", () => {
 		beforeEach(() => {
 			delete process.env.ALLOW_INSECURE_PROVIDER_URLS;
+			lookupMock.mockReset();
+			lookupMock.mockResolvedValue([{ address: "8.8.8.8", family: 4 }]);
 		});
 
 		it("rejects http URLs before any DNS lookup", async () => {
@@ -46,11 +57,31 @@ describe("assertSafeUserContentUrl", () => {
 				assertSafeUserContentUrl("data:image/png;base64,iVBORw0KGgo="),
 			).resolves.toBeUndefined();
 		});
+
+		it("rejects hostnames resolving to unsafe addresses", async () => {
+			lookupMock.mockResolvedValue([{ address: "169.254.169.254", family: 4 }]);
+
+			await expect(
+				assertSafeResolvedUserUrl("https://mcp.example.com/rpc"),
+			).rejects.toThrow("resolves to a disallowed address");
+		});
+
+		it("accepts hostnames only when every resolved address is public", async () => {
+			lookupMock.mockResolvedValue([
+				{ address: "8.8.8.8", family: 4 },
+				{ address: "2606:4700:4700::1111", family: 6 },
+			]);
+
+			await expect(
+				assertSafeResolvedUserUrl("https://mcp.example.com/rpc"),
+			).resolves.toEqual(new URL("https://mcp.example.com/rpc"));
+		});
 	});
 
 	describe("with the guard disabled", () => {
 		beforeEach(() => {
 			process.env.ALLOW_INSECURE_PROVIDER_URLS = "true";
+			lookupMock.mockReset();
 		});
 
 		it("is a no-op even for http and internal targets", async () => {

--- a/packages/shared/src/url-safety-node.ts
+++ b/packages/shared/src/url-safety-node.ts
@@ -5,14 +5,73 @@
  * address is also rejected. Kept in a separate entrypoint because it imports
  * `node:dns` and must not leak into the browser barrel.
  */
+import { lookup as lookupCallback } from "node:dns";
 import { lookup } from "node:dns/promises";
+
+import { Agent, fetch as undiciFetch } from "undici";
 
 import {
 	assertSafeContentUrl,
 	assertSafeProviderBaseUrl,
+	assertSafeUserUrl,
 	isPrivateOrReservedIp,
 	isProviderUrlGuardEnabled,
 } from "./url-safety.js";
+
+import type { LookupAllOptions } from "node:dns";
+import type { LookupFunction } from "node:net";
+
+const safeUserUrlLookup: LookupFunction = (hostname, options, callback) => {
+	const lookupOptions: LookupAllOptions = {
+		...options,
+		all: true,
+	};
+
+	lookupCallback(hostname, lookupOptions, (error, addresses) => {
+		if (error) {
+			callback(error, []);
+			return;
+		}
+
+		const blockedAddress = addresses.find(({ address }) =>
+			isPrivateOrReservedIp(address),
+		);
+		if (blockedAddress) {
+			const lookupError = new Error(
+				`User-provided URL host ${hostname} resolves to a disallowed address (${blockedAddress.address})`,
+			) as NodeJS.ErrnoException;
+			lookupError.code = "EACCES";
+			callback(lookupError, []);
+			return;
+		}
+
+		if (options.all) {
+			callback(null, addresses);
+			return;
+		}
+
+		const [address] = addresses;
+		if (!address) {
+			const lookupError = new Error(
+				`User-provided URL host ${hostname} did not resolve`,
+			) as NodeJS.ErrnoException;
+			lookupError.code = "ENOTFOUND";
+			callback(lookupError, []);
+			return;
+		}
+
+		callback(null, address.address, address.family);
+	});
+};
+
+let safeUserUrlAgent: Agent | undefined;
+
+function getSafeUserUrlAgent(): Agent {
+	safeUserUrlAgent ??= new Agent({
+		connect: { lookup: safeUserUrlLookup },
+	});
+	return safeUserUrlAgent;
+}
 
 /**
  * Resolve a hostname and throw if any returned address is private/reserved
@@ -51,6 +110,31 @@ export async function assertSafeProviderUrl(rawUrl: string): Promise<void> {
 	const url = assertSafeProviderBaseUrl(rawUrl);
 
 	await assertResolvedHostSafe(url.hostname, "Provider base URL");
+}
+
+/** Validate a user-controlled outbound URL, including all current DNS results. */
+export async function assertSafeResolvedUserUrl(rawUrl: string): Promise<URL> {
+	const url = assertSafeUserUrl(rawUrl);
+	await assertResolvedHostSafe(url.hostname, "User-provided URL");
+	return url;
+}
+
+/**
+ * Fetch a user-controlled URL without redirects. The custom DNS lookup rejects
+ * unsafe addresses as part of socket creation, avoiding a validation/fetch DNS
+ * race while preserving the original hostname for TLS verification.
+ */
+export async function fetchSafeUserUrl(
+	input: string | URL,
+	init?: RequestInit,
+): Promise<Response> {
+	const url = assertSafeUserUrl(input.toString());
+	const requestInit = { ...init, redirect: "error" as const };
+
+	return (await undiciFetch(url, {
+		...requestInit,
+		dispatcher: getSafeUserUrlAgent(),
+	} as Parameters<typeof undiciFetch>[1])) as unknown as Response;
 }
 
 /**

--- a/packages/shared/src/url-safety.spec.ts
+++ b/packages/shared/src/url-safety.spec.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
 	assertSafeContentUrl,
 	assertSafeProviderBaseUrl,
+	assertSafeUserUrl,
 	isPrivateOrReservedIp,
 	isProviderUrlGuardEnabled,
 } from "./url-safety.js";
@@ -178,6 +179,23 @@ describe("assertSafeContentUrl", () => {
 		expect(() => assertSafeContentUrl("gopher://127.0.0.1")).toThrow();
 		expect(() => assertSafeContentUrl("not a url")).toThrow(
 			"Invalid content URL",
+		);
+	});
+});
+
+describe("assertSafeUserUrl", () => {
+	it("accepts only public https targets", () => {
+		expect(() =>
+			assertSafeUserUrl("https://mcp.example.com/rpc"),
+		).not.toThrow();
+		expect(() => assertSafeUserUrl("http://mcp.example.com/rpc")).toThrow(
+			"must use https",
+		);
+		expect(() => assertSafeUserUrl("https://127.0.0.1/rpc")).toThrow(
+			"private or reserved",
+		);
+		expect(() => assertSafeUserUrl("https://service.internal/rpc")).toThrow(
+			"disallowed internal host",
 		);
 	});
 });

--- a/packages/shared/src/url-safety.ts
+++ b/packages/shared/src/url-safety.ts
@@ -281,6 +281,41 @@ export function assertSafeProviderBaseUrl(rawUrl: string): URL {
 	return url;
 }
 
+function assertSafeHttpsUrl(rawUrl: string, label: string): URL {
+	let url: URL;
+	try {
+		url = new URL(rawUrl);
+	} catch {
+		throw new Error(`Invalid ${label[0].toLowerCase()}${label.slice(1)}`);
+	}
+
+	if (url.protocol !== "https:") {
+		throw new Error(`${label} must use https`);
+	}
+
+	const host = url.hostname.toLowerCase();
+
+	if (
+		BLOCKED_HOSTS.has(host) ||
+		BLOCKED_HOST_SUFFIXES.some((suffix) => host.endsWith(suffix))
+	) {
+		throw new Error(`${label} points at a disallowed internal host`);
+	}
+
+	const isIpLiteral =
+		IPV4_RE.test(host) || host.includes(":") || rawUrl.includes("[");
+	if (isIpLiteral && isPrivateOrReservedIp(host)) {
+		throw new Error(`${label} points at a private or reserved address`);
+	}
+
+	return url;
+}
+
+/** Validate any user-controlled server-side fetch target before DNS lookup. */
+export function assertSafeUserUrl(rawUrl: string): URL {
+	return assertSafeHttpsUrl(rawUrl, "User-provided URL");
+}
+
 /**
  * Validate a user-supplied content URL (an image/video/document URL embedded in
  * a chat-completion, image, or video request) that the gateway will fetch
@@ -292,31 +327,5 @@ export function assertSafeProviderBaseUrl(rawUrl: string): URL {
  * internal address is also rejected.
  */
 export function assertSafeContentUrl(rawUrl: string): URL {
-	let url: URL;
-	try {
-		url = new URL(rawUrl);
-	} catch {
-		throw new Error("Invalid content URL");
-	}
-
-	if (url.protocol !== "https:") {
-		throw new Error("Content URL must use https");
-	}
-
-	const host = url.hostname.toLowerCase();
-
-	if (
-		BLOCKED_HOSTS.has(host) ||
-		BLOCKED_HOST_SUFFIXES.some((s) => host.endsWith(s))
-	) {
-		throw new Error("Content URL points at a disallowed internal host");
-	}
-
-	const isIpLiteral =
-		IPV4_RE.test(host) || host.includes(":") || rawUrl.includes("[");
-	if (isIpLiteral && isPrivateOrReservedIp(host)) {
-		throw new Error("Content URL points at a private or reserved address");
-	}
-
-	return url;
+	return assertSafeHttpsUrl(rawUrl, "Content URL");
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1748,6 +1748,9 @@ importers:
       tailwind-merge:
         specifier: 3.4.0
         version: 3.4.0
+      undici:
+        specifier: 8.9.0
+        version: 8.9.0
       zod:
         specifier: 3.25.75
         version: 3.25.75


### PR DESCRIPTION
## Problem

Playground MCP server URLs were protected only by literal hostname and IP checks. A public hostname resolving to a private, loopback, or link-local address could therefore reach internal services, and the transport could follow redirects.

## Approach

- reuse the shared HTTPS, internal-host, reserved-IP, and DNS checks
- validate every resolved address before creating the MCP transport
- route every MCP request through a guarded fetch that refuses redirects
- pin socket connections to addresses approved by the connection-time DNS lookup, closing the DNS validation/fetch race
- keep the existing optional `MCP_ALLOWED_HOSTS` restriction

## Verification

- `pnpm format`
- `pnpm build`
- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run --no-file-parallelism packages/shared/src/url-safety.spec.ts packages/shared/src/url-safety-node.spec.ts packages/shared/src/url-safety-fetch.spec.ts` (31 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Improved protection for server-side requests to user-provided URLs.
  * Blocked unsafe protocols, private or reserved network addresses, and unsafe DNS resolutions.
  * Prevented redirects to potentially unsafe destinations.
  * Applied stronger validation to MCP server connections and transport requests.

* **Bug Fixes**
  * Improved handling of unsafe addresses discovered during DNS lookup.
  * Added broader validation coverage for public, private, and internal URL targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->