### PR TITLE
fix(gateway): avoid reasoning storage cost

### DIFF
--- a/apps/gateway/src/lib/logs.spec.ts
+++ b/apps/gateway/src/lib/logs.spec.ts
@@ -375,7 +375,12 @@ describe("calculateDataStorageCost", () => {
 		// promptTokens is the canonical input count in gateway logs.
 		// cachedTokens is tracked separately for pricing and diagnostics, but should
 		// not increase storage accounting a second time.
-		const cost = calculateDataStorageCost(500000, 250000, 250000, 250000);
+		const cost = calculateDataStorageCost(500000, 250000, 500000, 0);
+		expect(cost).toBe("0.01"); // 1M tokens * $0.01 per 1M = $0.01
+	});
+
+	it("does not double-count reasoning tokens included in completion tokens", () => {
+		const cost = calculateDataStorageCost(500000, 0, 500000, 250000);
 		expect(cost).toBe("0.01"); // 1M tokens * $0.01 per 1M = $0.01
 	});
 

--- a/apps/gateway/src/lib/logs.ts
+++ b/apps/gateway/src/lib/logs.ts
@@ -265,9 +265,10 @@ function getErrorTypeFromUnifiedFinishReason(
 
 /**
  * Calculate data storage cost based on token usage
- * $0.01 per 1M tokens (total tokens = input + output + reasoning)
+ * $0.01 per 1M tokens (total tokens = input + output)
  * promptTokens is the canonical total input count and already includes cached
- * input tokens for providers that report them separately.
+ * input tokens for providers that report them separately. completionTokens is
+ * the canonical total output count and already includes reasoning tokens.
  * Returns "0" if retention level is "none" since no data is stored
  */
 export function calculateDataStorageCost(
@@ -284,9 +285,8 @@ export function calculateDataStorageCost(
 
 	const prompt = Number(promptTokens) || 0;
 	const completion = Number(completionTokens) || 0;
-	const reasoning = Number(reasoningTokens) || 0;
 
-	const totalTokens = prompt + completion + reasoning;
+	const totalTokens = prompt + completion;
 
 	// $0.01 per 1M tokens
 	const cost = (totalTokens / 1_000_000) * 0.01;


### PR DESCRIPTION
## Problem

Storage billing added reasoning tokens to completion tokens even though the canonical completion count already includes reasoning, charging those tokens twice.

## Changes

- calculate storage cost from canonical prompt and completion totals only
- keep cached and reasoning usage as diagnostic fields without adding either twice
- add regression coverage for reasoning-inclusive completion totals

## Verification

- `pnpm test:unit apps/gateway/src/lib/logs.spec.ts`
- `pnpm format`
- `pnpm build`