### PR TITLE
feat(realtime): pin instructions at secret mint

### DIFF
--- a/apps/docs/content/features/realtime.mdx
+++ b/apps/docs/content/features/realtime.mdx
@@ -167,8 +167,49 @@ Client secret behavior:
 - **Transcription pinning**: optionally pin an input transcription model at
   mint time via `session.audio.input.transcription.model`. The session can
   then only enable that transcription model.
+- **Instruction pinning**: optionally pin the session prompt at mint time via
+  `session.instructions` — see below.
+- **Voice**: optionally set the session's default output voice at mint time
+  via `session.audio.output.voice`. Unlike instructions this is only a
+  default; the client may still change it.
 - All authentication, credit, model access, and compliance checks run at
   mint time and again at connection time.
+
+### Server-Authoritative Instructions
+
+By default the session prompt is set by whoever holds the socket, so a browser
+client has to send `session.instructions` itself. If your server owns the
+prompt, pin it at mint time instead:
+
+```json
+{
+	"session": {
+		"type": "realtime",
+		"model": "gpt-realtime",
+		"instructions": "You are a support agent for ACME."
+	}
+}
+```
+
+The gateway then applies the instructions itself when the session connects, so
+the prompt never has to travel through the browser. It is not echoed in the
+mint response, and it is stripped from the `session.created` and
+`session.updated` events the client receives.
+
+Once pinned, the instructions are locked for the session's lifetime, the same
+way `session.model` is. A client that tries to change them gets an
+`instructions_locked` error event and the change is not applied — this covers
+both `session.update` and per-response `response.create.instructions`.
+
+Instructions larger than 16,384 estimated tokens are rejected at mint time with
+a 400 `instructions_too_large`, so an oversized prompt fails server-to-server
+rather than mid-call.
+
+<Callout type="info">
+	On Gemini realtime models the same pin applies to `setup.systemInstruction`,
+	and a client-supplied `systemInstruction` is rejected with the same
+	`instructions_locked` code.
+</Callout>
 
 ## Input Audio Transcription
 

--- a/apps/gateway/src/realtime/client-secrets-route.spec.ts
+++ b/apps/gateway/src/realtime/client-secrets-route.spec.ts
@@ -14,6 +14,7 @@ vi.mock("@/lib/extract-api-token.js", () => ({
 vi.mock("./client-secrets.js", () => ({
 	clampClientSecretTtl: () => 60,
 	createClientSecret: mocks.createClientSecret,
+	MAX_CLIENT_SECRET_INSTRUCTIONS_TOKENS: 16_384,
 }));
 
 vi.mock("./preflight.js", () => ({
@@ -32,7 +33,10 @@ describe("realtime client secrets route", () => {
 		mocks.runRealtimePreflight.mockResolvedValue({
 			match: {
 				modelId: "gpt-realtime-2.1-mini",
-				mapping: { providerId: "openai" },
+				mapping: {
+					providerId: "openai",
+					supportedVoices: ["marin", "cedar"],
+				},
 			},
 			allowedTranscriptionModelIds: [],
 			project: { organizationId: "org_test" },
@@ -67,5 +71,83 @@ describe("realtime client secrets route", () => {
 		expect((await response.json()).session.model).toBe(
 			"openai/gpt-realtime-2.1-mini",
 		);
+	});
+
+	async function mint(session: Record<string, unknown>) {
+		return await realtimeClientSecretsRoute.request("/client_secrets", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				session: { type: "realtime", model: "gpt-realtime-mini", ...session },
+			}),
+		});
+	}
+
+	it("pins instructions and voice on the secret", async () => {
+		const response = await mint({
+			instructions: "You are a support agent.",
+			audio: { output: { voice: "marin" } },
+		});
+
+		expect(response.status).toBe(200);
+		expect(mocks.createClientSecret).toHaveBeenCalledWith(
+			expect.objectContaining({
+				instructions: "You are a support agent.",
+				voice: "marin",
+			}),
+		);
+	});
+
+	it("does not echo pinned instructions back to the caller", async () => {
+		const response = await mint({ instructions: "secret prompt" });
+
+		expect(JSON.stringify(await response.json())).not.toContain(
+			"secret prompt",
+		);
+	});
+
+	it("defaults instructions and voice to null when not pinned", async () => {
+		await mint({});
+
+		expect(mocks.createClientSecret).toHaveBeenCalledWith(
+			expect.objectContaining({ instructions: null, voice: null }),
+		);
+	});
+
+	// The mint estimates chars/4, so this many characters sits exactly on the
+	// 16,384-token limit.
+	const charsAtCeiling = 4 * 16_384;
+
+	it("rejects instructions over the token ceiling", async () => {
+		const response = await mint({
+			instructions: "x".repeat(charsAtCeiling + 8),
+		});
+
+		expect(response.status).toBe(400);
+		expect((await response.json()).error.code).toBe("instructions_too_large");
+		expect(mocks.createClientSecret).not.toHaveBeenCalled();
+	});
+
+	it("accepts instructions just under the token ceiling", async () => {
+		const response = await mint({ instructions: "x".repeat(charsAtCeiling) });
+
+		expect(response.status).toBe(200);
+	});
+
+	it("rejects a voice the model does not support", async () => {
+		const response = await mint({
+			audio: { output: { voice: "not-a-voice" } },
+		});
+
+		expect(response.status).toBe(400);
+		expect((await response.json()).error.code).toBe("voice_not_supported");
+		expect(mocks.createClientSecret).not.toHaveBeenCalled();
+	});
+
+	it("still rejects unknown session fields", async () => {
+		const response = await mint({ temperature: 0.5 });
+
+		expect(response.status).toBe(400);
+		expect((await response.json()).error.code).toBe("invalid_request");
 	});
 });

--- a/apps/gateway/src/realtime/client-secrets-route.ts
+++ b/apps/gateway/src/realtime/client-secrets-route.ts
@@ -6,9 +6,14 @@ import { extractApiToken } from "@/lib/extract-api-token.js";
 import { formatUsedModelForDisplay } from "@/lib/model-response-id.js";
 
 import { logger } from "@llmgateway/logger";
+import { estimateTokensFromText } from "@llmgateway/shared";
 
 import { findRealtimeTranscriptionMapping } from "./catalog.js";
-import { clampClientSecretTtl, createClientSecret } from "./client-secrets.js";
+import {
+	clampClientSecretTtl,
+	createClientSecret,
+	MAX_CLIENT_SECRET_INSTRUCTIONS_TOKENS,
+} from "./client-secrets.js";
 import { RealtimeConnectError } from "./errors.js";
 import { runRealtimePreflight } from "./preflight.js";
 
@@ -48,9 +53,16 @@ const sessionAudioInputSchema = z
 	})
 	.strict();
 
+const sessionAudioOutputSchema = z
+	.object({
+		voice: z.string().min(1).optional(),
+	})
+	.strict();
+
 const sessionAudioSchema = z
 	.object({
 		input: sessionAudioInputSchema.optional(),
+		output: sessionAudioOutputSchema.optional(),
 	})
 	.strict();
 
@@ -58,6 +70,9 @@ const clientSecretSessionSchema = z
 	.object({
 		type: z.literal("realtime"),
 		model: z.string().min(1),
+		// Locked for the session's lifetime once set; see instructions_locked in
+		// session.ts.
+		instructions: z.string().min(1).optional(),
 		audio: sessionAudioSchema.optional(),
 	})
 	.strict();
@@ -184,6 +199,32 @@ realtimeClientSecretsRoute.post("/client_secrets", async (c) => {
 		);
 	}
 
+	const instructions = body.session.instructions ?? null;
+	if (instructions !== null) {
+		const estimatedTokens = estimateTokensFromText(instructions);
+		if (estimatedTokens > MAX_CLIENT_SECRET_INSTRUCTIONS_TOKENS) {
+			return errorResponse(
+				c,
+				400,
+				"instructions_too_large",
+				`Session instructions are too large for a realtime session: roughly ${estimatedTokens} tokens, limit ${MAX_CLIENT_SECRET_INSTRUCTIONS_TOKENS}.`,
+			);
+		}
+	}
+
+	const voice = body.session.audio?.output?.voice ?? null;
+	if (voice !== null) {
+		const supportedVoices = preflight.match.mapping.supportedVoices ?? [];
+		if (supportedVoices.length > 0 && !supportedVoices.includes(voice)) {
+			return errorResponse(
+				c,
+				400,
+				"voice_not_supported",
+				`Unsupported voice '${voice}' for model ${preflight.match.modelId}. Supported voices: ${supportedVoices.join(", ")}.`,
+			);
+		}
+	}
+
 	const ttlSeconds = clampClientSecretTtl(body.expires_after?.seconds);
 	const responseModel = formatUsedModelForDisplay(
 		preflight.match.mapping.providerId,
@@ -198,6 +239,8 @@ realtimeClientSecretsRoute.post("/client_secrets", async (c) => {
 			token,
 			model: responseModel,
 			transcriptionModel,
+			instructions,
+			voice,
 			source,
 			ttlSeconds,
 		});

--- a/apps/gateway/src/realtime/client-secrets.spec.ts
+++ b/apps/gateway/src/realtime/client-secrets.spec.ts
@@ -74,6 +74,8 @@ describe("parseClientSecretRecord", () => {
 		token: "llmgtwy_test",
 		model: "openai/gpt-realtime-2.1-mini",
 		transcriptionModel: "gpt-4o-mini-transcribe",
+		instructions: "You are a support agent.",
+		voice: "marin",
 		source: "lounge.llmgateway.io",
 		createdAt: 1_784_800_000,
 		expiresAt: 1_784_800_060,
@@ -86,6 +88,28 @@ describe("parseClientSecretRecord", () => {
 	it("accepts null transcriptionModel and source", () => {
 		const record = { ...valid, transcriptionModel: null, source: null };
 		expect(parseClientSecretRecord(JSON.stringify(record))).toEqual(record);
+	});
+
+	it("reads a record minted before instructions existed as unpinned", () => {
+		// Secrets minted by an older build stay valid for their remaining TTL
+		// across a deploy, so absent keys must not invalidate the record.
+		const { instructions, voice, ...legacy } = valid;
+		expect(instructions).toBeDefined();
+		expect(voice).toBeDefined();
+		expect(parseClientSecretRecord(JSON.stringify(legacy))).toEqual({
+			...legacy,
+			instructions: null,
+			voice: null,
+		});
+	});
+
+	it("rejects non-string instructions and voice", () => {
+		expect(
+			parseClientSecretRecord(JSON.stringify({ ...valid, instructions: 42 })),
+		).toBeNull();
+		expect(
+			parseClientSecretRecord(JSON.stringify({ ...valid, voice: 42 })),
+		).toBeNull();
 	});
 
 	it("rejects malformed JSON", () => {

--- a/apps/gateway/src/realtime/client-secrets.ts
+++ b/apps/gateway/src/realtime/client-secrets.ts
@@ -11,6 +11,14 @@ export const MIN_CLIENT_SECRET_TTL_SECONDS = 10;
 export const MAX_CLIENT_SECRET_TTL_SECONDS = 300;
 
 /**
+ * Upper bound on pinned session instructions, in estimated tokens. 16,384 is
+ * OpenAI's realtime instructions cap, applied to every realtime provider as a
+ * single conservative guard. The estimate is chars/4 rather than a real
+ * tokenizer, so the provider stays authoritative for the exact boundary.
+ */
+export const MAX_CLIENT_SECRET_INSTRUCTIONS_TOKENS = 16_384;
+
+/**
  * Versioned record stored in Redis for one ephemeral client secret. The
  * bearer secret itself never appears in Redis keys or values — records are
  * addressed by the secret's SHA-256 fingerprint.
@@ -31,6 +39,16 @@ export interface RealtimeClientSecretRecord {
 	 * not authorize input transcription.
 	 */
 	transcriptionModel: string | null;
+	/**
+	 * Session instructions pinned at mint time, or null when the caller did not
+	 * pin any. Applied by the gateway on connect and locked thereafter.
+	 */
+	instructions: string | null;
+	/**
+	 * Output voice pinned at mint time, or null for the provider default. Only a
+	 * default, not a lock: the client may still change it via session.update.
+	 */
+	voice: string | null;
 	/**
 	 * Validated x-source header captured at mint time for billing attribution.
 	 */
@@ -74,6 +92,8 @@ export interface CreateClientSecretInput {
 	token: string;
 	model: string;
 	transcriptionModel: string | null;
+	instructions: string | null;
+	voice: string | null;
 	source: string | null;
 	ttlSeconds: number;
 }
@@ -95,6 +115,8 @@ export async function createClientSecret(
 		token: input.token,
 		model: input.model,
 		transcriptionModel: input.transcriptionModel,
+		instructions: input.instructions,
+		voice: input.voice,
 		source: input.source,
 		createdAt: Math.floor(now / 1000),
 		expiresAt,
@@ -163,6 +185,23 @@ export function parseClientSecretRecord(
 	) {
 		return null;
 	}
+	// instructions/voice postdate the v1 record shape. Secrets minted by an
+	// older build stay valid for their remaining TTL across a deploy, so an
+	// absent key is "not pinned" rather than a malformed record.
+	if (
+		record.instructions !== undefined &&
+		record.instructions !== null &&
+		typeof record.instructions !== "string"
+	) {
+		return null;
+	}
+	if (
+		record.voice !== undefined &&
+		record.voice !== null &&
+		typeof record.voice !== "string"
+	) {
+		return null;
+	}
 	if (record.source !== null && typeof record.source !== "string") {
 		return null;
 	}
@@ -177,6 +216,8 @@ export function parseClientSecretRecord(
 		token: record.token,
 		model: record.model,
 		transcriptionModel: record.transcriptionModel,
+		instructions: record.instructions ?? null,
+		voice: record.voice ?? null,
 		source: record.source,
 		createdAt: record.createdAt,
 		expiresAt: record.expiresAt,

--- a/apps/gateway/src/realtime/gemini-session.spec.ts
+++ b/apps/gateway/src/realtime/gemini-session.spec.ts
@@ -165,7 +165,10 @@ const validSetup = {
 	},
 };
 
-function createSession(preflightOverrides: Record<string, unknown> = {}) {
+function createSession(
+	preflightOverrides: Record<string, unknown> = {},
+	pinned: { instructions?: string | null; voice?: string | null } = {},
+) {
 	const client = new FakeSocket();
 	const upstream = new FakeSocket();
 	const session = new GeminiRealtimeProxySession({
@@ -182,6 +185,8 @@ function createSession(preflightOverrides: Record<string, unknown> = {}) {
 		lease: { sessionId: "rts_g1", organizationId: "org_1", apiKeyId: "key_1" },
 		source: "lounge.llmgateway.io",
 		userAgent: "vitest",
+		pinnedInstructions: pinned.instructions ?? null,
+		pinnedVoice: pinned.voice ?? null,
 		onClosed: () => {},
 	});
 	const clientSends = (message: Record<string, unknown>) => {
@@ -1012,5 +1017,134 @@ describe("GeminiRealtimeProxySession draining", () => {
 			"client_disconnected",
 			expect.anything(),
 		);
+	});
+});
+
+describe("GeminiRealtimeProxySession pinned instructions", () => {
+	const INSTRUCTIONS = "You are the operator's support agent.";
+
+	const baseSetup = {
+		model: "gemini-2.5-flash-native-audio-preview-12-2025",
+		generationConfig: { responseModalities: ["AUDIO"] },
+	};
+
+	it("applies pinned instructions to setup.systemInstruction", async () => {
+		const { upstream, session, clientSends } = createSession(
+			{},
+			{ instructions: INSTRUCTIONS },
+		);
+
+		clientSends({ setup: baseSetup });
+		await flush();
+
+		const forwarded = JSON.parse(upstream.sent[0]) as {
+			setup: { systemInstruction: { parts: { text: string }[] } };
+		};
+		expect(forwarded.setup.systemInstruction.parts[0].text).toBe(INSTRUCTIONS);
+
+		session.shutdown(1000, "test_done");
+	});
+
+	it("rejects a client systemInstruction when instructions are pinned", async () => {
+		const { upstream, session, clientSends, gatewayErrors } = createSession(
+			{},
+			{ instructions: INSTRUCTIONS },
+		);
+
+		clientSends({
+			setup: {
+				...baseSetup,
+				systemInstruction: { parts: [{ text: "You are a pirate." }] },
+			},
+		});
+		await flush();
+
+		expect(gatewayErrors()).toEqual(["instructions_locked"]);
+		expect(upstream.sent).toHaveLength(0);
+
+		session.shutdown(1000, "test_done");
+	});
+
+	it("leaves systemInstruction to the client when nothing is pinned", async () => {
+		const { upstream, session, clientSends } = createSession();
+
+		clientSends({
+			setup: {
+				...baseSetup,
+				systemInstruction: { parts: [{ text: "client owns this" }] },
+			},
+		});
+		await flush();
+
+		expect(upstream.sent[0]).toContain("client owns this");
+
+		session.shutdown(1000, "test_done");
+	});
+
+	it("fills in the pinned voice when the client chose none", async () => {
+		const { upstream, session, clientSends } = createSession(
+			{},
+			{ voice: "Kore" },
+		);
+
+		clientSends({ setup: baseSetup });
+		await flush();
+
+		const forwarded = JSON.parse(upstream.sent[0]) as {
+			setup: {
+				generationConfig: {
+					responseModalities: string[];
+					speechConfig: {
+						voiceConfig: { prebuiltVoiceConfig: { voiceName: string } };
+					};
+				};
+			};
+		};
+		expect(
+			forwarded.setup.generationConfig.speechConfig.voiceConfig
+				.prebuiltVoiceConfig.voiceName,
+		).toBe("Kore");
+		// Merging the voice must not drop the rest of generationConfig.
+		expect(forwarded.setup.generationConfig.responseModalities).toEqual([
+			"AUDIO",
+		]);
+
+		session.shutdown(1000, "test_done");
+	});
+
+	it("does not override a voice the client chose explicitly", async () => {
+		const { upstream, session, clientSends } = createSession(
+			{},
+			{ voice: "Kore" },
+		);
+
+		clientSends({
+			setup: {
+				...baseSetup,
+				generationConfig: {
+					responseModalities: ["AUDIO"],
+					speechConfig: {
+						voiceConfig: { prebuiltVoiceConfig: { voiceName: "Puck" } },
+					},
+				},
+			},
+		});
+		await flush();
+
+		const forwarded = JSON.parse(upstream.sent[0]) as {
+			setup: {
+				generationConfig: {
+					speechConfig: {
+						voiceConfig: { prebuiltVoiceConfig: { voiceName: string } };
+					};
+				};
+			};
+		};
+		expect(
+			forwarded.setup.generationConfig.speechConfig.voiceConfig
+				.prebuiltVoiceConfig.voiceName,
+		).toBe("Puck");
+
+		session.shutdown(1000, "test_done");
 	});
 });

--- a/apps/gateway/src/realtime/gemini-session.ts
+++ b/apps/gateway/src/realtime/gemini-session.ts
@@ -128,6 +128,16 @@ export interface GeminiRealtimeProxySessionOptions {
 	lease: RealtimeLease;
 	source: string | null;
 	userAgent: string | undefined;
+	/**
+	 * Instructions pinned by the client secret, applied to
+	 * setup.systemInstruction and locked against a client-supplied one.
+	 */
+	pinnedInstructions: string | null;
+	/**
+	 * Output voice pinned by the client secret, applied as the session default
+	 * (setup.generationConfig.speechConfig) when the client did not choose one.
+	 */
+	pinnedVoice: string | null;
 	onClosed: (session: GeminiRealtimeProxySession) => void;
 }
 
@@ -149,6 +159,8 @@ export class GeminiRealtimeProxySession {
 	private readonly lease: RealtimeLease;
 	private readonly source: string | null;
 	private readonly userAgent: string | undefined;
+	private readonly pinnedInstructions: string | null;
+	private readonly pinnedVoice: string | null;
 	private readonly onClosed: (session: GeminiRealtimeProxySession) => void;
 
 	private readonly openedAt = Date.now();
@@ -220,6 +232,8 @@ export class GeminiRealtimeProxySession {
 		this.lease = options.lease;
 		this.source = options.source;
 		this.userAgent = options.userAgent;
+		this.pinnedInstructions = options.pinnedInstructions;
+		this.pinnedVoice = options.pinnedVoice;
 		this.onClosed = options.onClosed;
 
 		this.client.on("message", (data, isBinary) => {
@@ -497,14 +511,74 @@ export class GeminiRealtimeProxySession {
 			return;
 		}
 
+		// Rejected rather than overwritten, so a caller that believes it
+		// configured the prompt learns that it did not.
+		if (
+			this.pinnedInstructions !== null &&
+			rawSetup.systemInstruction !== undefined
+		) {
+			this.sendToClientRaw(
+				buildGeminiError(
+					"instructions_locked",
+					"The session instructions were pinned when this session's client secret was created and cannot be changed via setup.systemInstruction.",
+				),
+			);
+			return;
+		}
+
 		// The model is pinned at connection time; whatever the caller sent is
 		// replaced with the mapping's upstream id.
-		const setup = {
+		const setup: Record<string, unknown> = {
 			...rawSetup,
 			model: `models/${this.preflight.match.mapping.externalId}`,
 		};
+		if (this.pinnedInstructions !== null) {
+			setup.systemInstruction = {
+				parts: [{ text: this.pinnedInstructions }],
+			};
+		}
+		if (this.pinnedVoice !== null) {
+			setup.generationConfig = this.withPinnedVoice(rawSetup.generationConfig);
+		}
 		this.setupSent = true;
 		this.forwardToUpstream(JSON.stringify({ setup }));
+	}
+
+	/**
+	 * Merge the pinned voice into setup.generationConfig.speechConfig. The voice
+	 * is a default rather than a lock, so an explicit client voiceName wins.
+	 */
+	private withPinnedVoice(
+		rawGenerationConfig: unknown,
+	): Record<string, unknown> {
+		const generationConfig: Record<string, unknown> = isPlainObject(
+			rawGenerationConfig,
+		)
+			? { ...rawGenerationConfig }
+			: {};
+		const speechConfig: Record<string, unknown> = isPlainObject(
+			generationConfig.speechConfig,
+		)
+			? { ...generationConfig.speechConfig }
+			: {};
+		const voiceConfig: Record<string, unknown> = isPlainObject(
+			speechConfig.voiceConfig,
+		)
+			? { ...speechConfig.voiceConfig }
+			: {};
+		const prebuiltVoiceConfig: Record<string, unknown> = isPlainObject(
+			voiceConfig.prebuiltVoiceConfig,
+		)
+			? { ...voiceConfig.prebuiltVoiceConfig }
+			: {};
+		if (typeof prebuiltVoiceConfig.voiceName === "string") {
+			return generationConfig;
+		}
+		prebuiltVoiceConfig.voiceName = this.pinnedVoice;
+		voiceConfig.prebuiltVoiceConfig = prebuiltVoiceConfig;
+		speechConfig.voiceConfig = voiceConfig;
+		generationConfig.speechConfig = speechConfig;
+		return generationConfig;
 	}
 
 	/**

--- a/apps/gateway/src/realtime/server.ts
+++ b/apps/gateway/src/realtime/server.ts
@@ -294,6 +294,8 @@ export function attachRealtimeServer(server: Server): RealtimeServer {
 			let requestedModel = url.searchParams.get("model") ?? undefined;
 			let source = extractSource(req);
 			let secretTranscriptionModel: string | null = null;
+			let pinnedInstructions: string | null = null;
+			let pinnedVoice: string | null = null;
 
 			if (subprotocolSecret) {
 				if (!subprotocolSecret.startsWith(CLIENT_SECRET_PREFIX)) {
@@ -340,6 +342,8 @@ export function attachRealtimeServer(server: Server): RealtimeServer {
 				token = record.token;
 				source = record.source;
 				secretTranscriptionModel = record.transcriptionModel;
+				pinnedInstructions = record.instructions;
+				pinnedVoice = record.voice;
 			}
 
 			// Full preflight runs against the WebSocket request's actual client IP:
@@ -545,6 +549,8 @@ export function attachRealtimeServer(server: Server): RealtimeServer {
 									sessionRecordId: sessionRecord.id,
 									lease,
 									source,
+									pinnedInstructions,
+									pinnedVoice,
 									userAgent: req.headers["user-agent"],
 									onClosed: (closed) => {
 										sessions.delete(closed);
@@ -560,6 +566,8 @@ export function attachRealtimeServer(server: Server): RealtimeServer {
 									lease,
 									source,
 									allowedTranscription,
+									pinnedInstructions,
+									pinnedVoice,
 									userAgent: req.headers["user-agent"],
 									onClosed: (closed) => {
 										sessions.delete(closed);

--- a/apps/gateway/src/realtime/session.spec.ts
+++ b/apps/gateway/src/realtime/session.spec.ts
@@ -218,15 +218,17 @@ beforeEach(() => {
 describe("RealtimeProxySession turn handling", () => {
 	it("accepts canonical model ids in session updates", async () => {
 		const preflight = buildPreflight();
-		const { client, upstream, session, clientSends } = createSession({
-			match: {
-				...preflight.match,
-				mapping: {
-					...preflight.match.mapping,
-					externalId: "upstream-deployment",
+		const { client, upstream, session, clientSends } = await openSession(
+			createSession({
+				match: {
+					...preflight.match,
+					mapping: {
+						...preflight.match.mapping,
+						externalId: "upstream-deployment",
+					},
 				},
-			},
-		});
+			}),
+		);
 
 		clientSends({
 			type: "session.update",
@@ -326,7 +328,8 @@ describe("RealtimeProxySession turn handling", () => {
 	});
 
 	it("does not queue an auto-response for commits when turn detection is disabled", async () => {
-		const { upstream, session, clientSends, upstreamSends } = createSession();
+		const { upstream, session, clientSends, upstreamSends } =
+			await openSession(createSession());
 
 		clientSends({
 			type: "session.update",
@@ -346,9 +349,11 @@ describe("RealtimeProxySession turn handling", () => {
 
 describe("RealtimeProxySession authorization", () => {
 	it("rejects a transcription model the key's IAM rules do not allow", async () => {
-		const { client, upstream, session, clientSends } = createSession({
-			allowedTranscriptionModelIds: ["gpt-4o-mini-transcribe"],
-		});
+		const { client, upstream, session, clientSends } = await openSession(
+			createSession({
+				allowedTranscriptionModelIds: ["gpt-4o-mini-transcribe"],
+			}),
+		);
 
 		clientSends({
 			type: "session.update",
@@ -416,7 +421,8 @@ describe("RealtimeProxySession authorization", () => {
 
 describe("RealtimeProxySession transcription", () => {
 	it("rejects unsupported transcription models in session.update", async () => {
-		const { client, upstream, session, clientSends } = createSession();
+		const { client, upstream, session, clientSends } =
+			await openSession(createSession());
 
 		clientSends({
 			type: "session.update",
@@ -436,7 +442,8 @@ describe("RealtimeProxySession transcription", () => {
 	});
 
 	it("pins the ASR mapping and rewrites the forwarded model to the upstream id", async () => {
-		const { client, upstream, session, clientSends } = createSession();
+		const { client, upstream, session, clientSends } =
+			await openSession(createSession());
 
 		clientSends({
 			type: "session.update",
@@ -480,7 +487,7 @@ describe("RealtimeProxySession transcription", () => {
 
 	it("drains a disconnect until the pending transcription is billed", async () => {
 		const { client, upstream, session, clientSends, upstreamSends } =
-			createSession();
+			await openSession(createSession());
 
 		clientSends({
 			type: "session.update",
@@ -605,7 +612,7 @@ describe("RealtimeProxySession transcription", () => {
 
 	it("does not start an auto-response while draining a disconnect", async () => {
 		const { client, upstream, session, clientSends, upstreamSends } =
-			createSession();
+			await openSession(createSession());
 
 		clientSends({
 			type: "session.update",
@@ -648,7 +655,8 @@ describe("RealtimeProxySession transcription", () => {
 	});
 
 	it("does not pin transcription when a later field of the same update is rejected", async () => {
-		const { client, upstream, session, clientSends } = createSession();
+		const { client, upstream, session, clientSends } =
+			await openSession(createSession());
 
 		clientSends({
 			type: "session.update",
@@ -687,7 +695,8 @@ describe("RealtimeProxySession transcription", () => {
 	});
 
 	it("does not track commits as pending when the enabling update was rejected", async () => {
-		const { client, session, clientSends, upstreamSends } = createSession();
+		const { client, session, clientSends, upstreamSends } =
+			await openSession(createSession());
 
 		clientSends({
 			type: "session.update",
@@ -725,7 +734,8 @@ describe("RealtimeProxySession transcription", () => {
 	});
 
 	it("closes the session when the API key is revoked between transcriptions", async () => {
-		const { client, session, clientSends, upstreamSends } = createSession();
+		const { client, session, clientSends, upstreamSends } =
+			await openSession(createSession());
 
 		clientSends({
 			type: "session.update",
@@ -774,7 +784,8 @@ describe("RealtimeProxySession transcription", () => {
 	});
 
 	it("fails closed on duration-based transcription usage", async () => {
-		const { session, clientSends, upstreamSends } = createSession();
+		const { session, clientSends, upstreamSends } =
+			await openSession(createSession());
 
 		clientSends({
 			type: "session.update",
@@ -856,9 +867,11 @@ describe("RealtimeProxySession pinned instructions", () => {
 	});
 
 	it("rejects a client session.update that changes instructions", async () => {
-		const { client, upstream, session, clientSends } = createSession({}, null, {
-			instructions: INSTRUCTIONS,
-		});
+		const { client, upstream, session, clientSends } = await openSession(
+			createSession({}, null, {
+				instructions: INSTRUCTIONS,
+			}),
+		);
 
 		clientSends({
 			type: "session.update",
@@ -894,9 +907,11 @@ describe("RealtimeProxySession pinned instructions", () => {
 	});
 
 	it("allows unrelated session updates while instructions are pinned", async () => {
-		const { client, upstream, session, clientSends } = createSession({}, null, {
-			instructions: INSTRUCTIONS,
-		});
+		const { client, upstream, session, clientSends } = await openSession(
+			createSession({}, null, {
+				instructions: INSTRUCTIONS,
+			}),
+		);
 
 		clientSends({
 			type: "session.update",
@@ -911,7 +926,8 @@ describe("RealtimeProxySession pinned instructions", () => {
 	});
 
 	it("leaves instructions to the client when nothing is pinned", async () => {
-		const { client, upstream, session, clientSends } = createSession();
+		const { client, upstream, session, clientSends } =
+			await openSession(createSession());
 
 		clientSends({
 			type: "session.update",
@@ -945,6 +961,41 @@ describe("RealtimeProxySession pinned instructions", () => {
 		expect(upstream.sent).toHaveLength(2);
 		expect(upstream.sent[0]).toContain(INSTRUCTIONS);
 		expect(JSON.parse(upstream.sent[1]).type).toBe("response.create");
+
+		session.shutdown(1000, "test_done");
+	});
+
+	it("keeps an early client voice update effective over the pinned default", async () => {
+		// Real clients configure on socket open rather than on session.created, so
+		// the client's own update must land after the gateway's control update —
+		// voice is a default, not a lock.
+		const { upstream, session, clientSends, upstreamSends } = createSession(
+			{},
+			null,
+			{ instructions: INSTRUCTIONS, voice: "marin" },
+		);
+
+		clientSends({
+			type: "session.update",
+			session: { type: "realtime", audio: { output: { voice: "cedar" } } },
+		});
+		await flush();
+		expect(upstream.sent).toHaveLength(0);
+
+		upstreamSends({ type: "session.created", session: { id: "sess_1" } });
+		await flush();
+
+		expect(upstream.sent).toHaveLength(2);
+		const control = JSON.parse(upstream.sent[0]) as {
+			session: { instructions: string; audio: { output: { voice: string } } };
+		};
+		const clientUpdate = JSON.parse(upstream.sent[1]) as {
+			session: { audio: { output: { voice: string } } };
+		};
+		expect(control.session.instructions).toBe(INSTRUCTIONS);
+		expect(control.session.audio.output.voice).toBe("marin");
+		// The client's choice is applied last, so it is the one in effect.
+		expect(clientUpdate.session.audio.output.voice).toBe("cedar");
 
 		session.shutdown(1000, "test_done");
 	});

--- a/apps/gateway/src/realtime/session.spec.ts
+++ b/apps/gateway/src/realtime/session.spec.ts
@@ -197,6 +197,20 @@ function createSession(
 	return { client, upstream, session, clientSends, upstreamSends };
 }
 
+/**
+ * Drive the upstream session.created handshake and clear the buffers, so the
+ * test starts from a configured session. Generation is held until the gateway's
+ * control session.update has been forwarded, so any test sending
+ * response.create needs this first.
+ */
+async function openSession(harness: ReturnType<typeof createSession>) {
+	harness.upstreamSends({ type: "session.created", session: { id: "sess_1" } });
+	await flush();
+	harness.upstream.sent.length = 0;
+	harness.client.sent.length = 0;
+	return harness;
+}
+
 beforeEach(() => {
 	vi.clearAllMocks();
 });
@@ -265,7 +279,8 @@ describe("RealtimeProxySession turn handling", () => {
 	});
 
 	it("starts the pending auto-response only after a commit-during-response's response.done is billed", async () => {
-		const { upstream, session, clientSends, upstreamSends } = createSession();
+		const { upstream, session, clientSends, upstreamSends } =
+			await openSession(createSession());
 
 		clientSends({ type: "response.create" });
 		await flush();
@@ -353,7 +368,8 @@ describe("RealtimeProxySession authorization", () => {
 	});
 
 	it("rejects stored prompt references in session.update and response.create", async () => {
-		const { client, upstream, session, clientSends } = createSession();
+		const { client, upstream, session, clientSends } =
+			await openSession(createSession());
 
 		clientSends({
 			type: "session.update",
@@ -375,7 +391,8 @@ describe("RealtimeProxySession authorization", () => {
 	});
 
 	it("closes the session when IAM revokes model access mid-session", async () => {
-		const { client, upstream, clientSends } = createSession();
+		const { client, upstream, clientSends } =
+			await openSession(createSession());
 
 		vi.mocked(validateRequestModelAccess).mockResolvedValueOnce({
 			allowed: false,
@@ -523,7 +540,8 @@ describe("RealtimeProxySession transcription", () => {
 	});
 
 	it("still bills a pending transcription after transcription is disabled", async () => {
-		const { upstream, session, clientSends, upstreamSends } = createSession();
+		const { upstream, session, clientSends, upstreamSends } =
+			await openSession(createSession());
 
 		clientSends({
 			type: "session.update",
@@ -857,9 +875,9 @@ describe("RealtimeProxySession pinned instructions", () => {
 	});
 
 	it("rejects per-response instructions that would bypass the lock", async () => {
-		const { client, upstream, session, clientSends } = createSession({}, null, {
-			instructions: INSTRUCTIONS,
-		});
+		const { client, upstream, session, clientSends } = await openSession(
+			createSession({}, null, { instructions: INSTRUCTIONS }),
+		);
 
 		clientSends({
 			type: "response.create",
@@ -904,6 +922,29 @@ describe("RealtimeProxySession pinned instructions", () => {
 		expect(client.sent).toHaveLength(0);
 		expect(upstream.sent).toHaveLength(1);
 		expect(upstream.sent[0]).toContain("client owns this");
+
+		session.shutdown(1000, "test_done");
+	});
+
+	it("holds generation until the pinned instructions reach the provider", async () => {
+		// A client that does not wait for session.created must not be able to
+		// generate a turn under the provider's defaults.
+		const { upstream, session, clientSends, upstreamSends } = createSession(
+			{},
+			null,
+			{ instructions: INSTRUCTIONS },
+		);
+
+		clientSends({ type: "response.create" });
+		await flush();
+		expect(upstream.sent).toHaveLength(0);
+
+		upstreamSends({ type: "session.created", session: { id: "sess_1" } });
+		await flush();
+
+		expect(upstream.sent).toHaveLength(2);
+		expect(upstream.sent[0]).toContain(INSTRUCTIONS);
+		expect(JSON.parse(upstream.sent[1]).type).toBe("response.create");
 
 		session.shutdown(1000, "test_done");
 	});

--- a/apps/gateway/src/realtime/session.spec.ts
+++ b/apps/gateway/src/realtime/session.spec.ts
@@ -166,6 +166,7 @@ async function flush(): Promise<void> {
 function createSession(
 	preflightOverrides: Record<string, unknown> = {},
 	allowedTranscription: RealtimeMappingMatch | null = null,
+	pinned: { instructions?: string | null; voice?: string | null } = {},
 ) {
 	const client = new FakeSocket();
 	const upstream = new FakeSocket();
@@ -183,6 +184,8 @@ function createSession(
 		source: "lounge.llmgateway.io",
 		userAgent: "vitest",
 		allowedTranscription,
+		pinnedInstructions: pinned.instructions ?? null,
+		pinnedVoice: pinned.voice ?? null,
 		onClosed: () => {},
 	});
 	const clientSends = (event: Record<string, unknown>) => {
@@ -783,6 +786,141 @@ describe("RealtimeProxySession transcription", () => {
 			expect.stringContaining("unpriceable_transcription"),
 			expect.anything(),
 		);
+
+		session.shutdown(1000, "test_done");
+	});
+});
+
+describe("RealtimeProxySession pinned instructions", () => {
+	const INSTRUCTIONS = "You are the operator's support agent.";
+
+	it("applies pinned instructions and voice in the control session.update", async () => {
+		const { upstream, session, upstreamSends } = createSession({}, null, {
+			instructions: INSTRUCTIONS,
+			voice: "marin",
+		});
+
+		upstreamSends({ type: "session.created", session: { id: "sess_1" } });
+		await flush();
+
+		const control = JSON.parse(upstream.sent[0]) as {
+			session: {
+				instructions: string;
+				audio: {
+					input: { turn_detection: { create_response: boolean } };
+					output: { voice: string };
+				};
+			};
+		};
+		expect(control.session.instructions).toBe(INSTRUCTIONS);
+		expect(control.session.audio.output.voice).toBe("marin");
+		// The auto-response control this message already carried still applies.
+		expect(control.session.audio.input.turn_detection.create_response).toBe(
+			false,
+		);
+
+		session.shutdown(1000, "test_done");
+	});
+
+	it("omits instructions from the control update when nothing is pinned", async () => {
+		const { upstream, session, upstreamSends } = createSession();
+
+		upstreamSends({ type: "session.created", session: { id: "sess_1" } });
+		await flush();
+
+		const control = JSON.parse(upstream.sent[0]) as {
+			session: Record<string, unknown>;
+		};
+		expect(control.session).not.toHaveProperty("instructions");
+		expect(control.session.audio).not.toHaveProperty("output");
+
+		session.shutdown(1000, "test_done");
+	});
+
+	it("rejects a client session.update that changes instructions", async () => {
+		const { client, upstream, session, clientSends } = createSession({}, null, {
+			instructions: INSTRUCTIONS,
+		});
+
+		clientSends({
+			type: "session.update",
+			session: { type: "realtime", instructions: "You are a pirate." },
+		});
+		await flush();
+
+		expect(client.sent.some((m) => m.includes("instructions_locked"))).toBe(
+			true,
+		);
+		expect(upstream.sent).toHaveLength(0);
+
+		session.shutdown(1000, "test_done");
+	});
+
+	it("rejects per-response instructions that would bypass the lock", async () => {
+		const { client, upstream, session, clientSends } = createSession({}, null, {
+			instructions: INSTRUCTIONS,
+		});
+
+		clientSends({
+			type: "response.create",
+			response: { instructions: "You are a pirate." },
+		});
+		await flush();
+
+		expect(client.sent.some((m) => m.includes("instructions_locked"))).toBe(
+			true,
+		);
+		expect(upstream.sent).toHaveLength(0);
+
+		session.shutdown(1000, "test_done");
+	});
+
+	it("allows unrelated session updates while instructions are pinned", async () => {
+		const { client, upstream, session, clientSends } = createSession({}, null, {
+			instructions: INSTRUCTIONS,
+		});
+
+		clientSends({
+			type: "session.update",
+			session: { type: "realtime", audio: { output: { voice: "cedar" } } },
+		});
+		await flush();
+
+		expect(client.sent).toHaveLength(0);
+		expect(upstream.sent).toHaveLength(1);
+
+		session.shutdown(1000, "test_done");
+	});
+
+	it("leaves instructions to the client when nothing is pinned", async () => {
+		const { client, upstream, session, clientSends } = createSession();
+
+		clientSends({
+			type: "session.update",
+			session: { type: "realtime", instructions: "client owns this" },
+		});
+		await flush();
+
+		expect(client.sent).toHaveLength(0);
+		expect(upstream.sent).toHaveLength(1);
+		expect(upstream.sent[0]).toContain("client owns this");
+
+		session.shutdown(1000, "test_done");
+	});
+
+	it("strips pinned instructions from session events echoed to the client", async () => {
+		const { client, session, upstreamSends } = createSession({}, null, {
+			instructions: INSTRUCTIONS,
+		});
+
+		// The provider echoes the whole session state, instructions included.
+		upstreamSends({
+			type: "session.updated",
+			session: { id: "sess_1", instructions: INSTRUCTIONS },
+		});
+		await flush();
+
+		expect(client.sent.join("")).not.toContain(INSTRUCTIONS);
 
 		session.shutdown(1000, "test_done");
 	});

--- a/apps/gateway/src/realtime/session.ts
+++ b/apps/gateway/src/realtime/session.ts
@@ -193,12 +193,15 @@ export class RealtimeProxySession {
 	private clientQueue: Promise<void> = Promise.resolve();
 	private upstreamQueue: Promise<void> = Promise.resolve();
 
-	// Client and upstream frames are chained separately, so a client that sends
-	// response.create without waiting for session.created can otherwise reach
-	// the provider before the control session.update below — generating a turn
-	// under the provider's defaults instead of the pinned instructions and the
-	// disabled auto-response. Generation waits on this; it is resolved once the
-	// control update is forwarded, and on teardown so nothing waits forever.
+	// Client and upstream frames are chained separately, so without a gate a
+	// client that configures on socket open rather than on session.created —
+	// which is the common shape — races the gateway's own control
+	// session.update. Losing that race means generating under the provider's
+	// defaults instead of the pinned instructions, or having the client's own
+	// session.update overwritten by the control update that lands after it. The
+	// whole client queue therefore starts behind this promise, which resolves
+	// once the control update is forwarded and on teardown so nothing waits
+	// forever.
 	private resolveUpstreamConfigured!: () => void;
 	private readonly upstreamConfigured = new Promise<void>((resolve) => {
 		this.resolveUpstreamConfigured = resolve;
@@ -218,6 +221,7 @@ export class RealtimeProxySession {
 		this.pinnedInstructions = options.pinnedInstructions;
 		this.pinnedVoice = options.pinnedVoice;
 		this.onClosed = options.onClosed;
+		this.clientQueue = this.upstreamConfigured;
 
 		this.client.on("message", (data, isBinary) => {
 			this.clientQueue = this.clientQueue
@@ -632,11 +636,6 @@ export class RealtimeProxySession {
 	private async handleResponseCreate(
 		message: Record<string, unknown>,
 	): Promise<void> {
-		// Never generate before the session's control update has reached the
-		// provider. Later client frames stay behind this one on clientQueue, so
-		// ordering is preserved for the audio that follows too.
-		await this.upstreamConfigured;
-
 		// response.create may carry inline input items and per-response tools;
 		// apply the same deferred-capability guards as session-level config.
 		const response =

--- a/apps/gateway/src/realtime/session.ts
+++ b/apps/gateway/src/realtime/session.ts
@@ -106,6 +106,16 @@ export interface RealtimeProxySessionOptions {
 	 * upstream provider.
 	 */
 	allowedTranscription: RealtimeMappingMatch | null;
+	/**
+	 * Instructions pinned by the client secret, applied on connect and locked
+	 * against any client change. Null leaves instructions to the client.
+	 */
+	pinnedInstructions: string | null;
+	/**
+	 * Output voice pinned by the client secret, applied as the session default.
+	 * Not locked, unlike instructions: the client may still change it.
+	 */
+	pinnedVoice: string | null;
 	onClosed: (session: RealtimeProxySession) => void;
 }
 
@@ -158,6 +168,8 @@ export class RealtimeProxySession {
 	// committed audio items will produce a billable transcription event.
 	private transcriptionEnabled = false;
 	private readonly allowedTranscription: RealtimeMappingMatch | null;
+	private readonly pinnedInstructions: string | null;
+	private readonly pinnedVoice: string | null;
 	// Committed user audio items whose billable transcription terminal event
 	// (completed or failed) has not arrived yet. Draining must wait for these
 	// so no billable transcription tail is dropped on disconnect.
@@ -192,6 +204,8 @@ export class RealtimeProxySession {
 		this.source = options.source;
 		this.userAgent = options.userAgent;
 		this.allowedTranscription = options.allowedTranscription;
+		this.pinnedInstructions = options.pinnedInstructions;
+		this.pinnedVoice = options.pinnedVoice;
 		this.onClosed = options.onClosed;
 
 		this.client.on("message", (data, isBinary) => {
@@ -373,6 +387,21 @@ export class RealtimeProxySession {
 				buildErrorEvent(
 					"model_locked",
 					"The session model is locked at connection time and cannot be changed via session.update.",
+				),
+			);
+			return;
+		}
+
+		// Rejected rather than ignored, so a caller that believes it configured
+		// the prompt learns that it did not.
+		if (
+			this.pinnedInstructions !== null &&
+			session.instructions !== undefined
+		) {
+			this.sendToClientRaw(
+				buildErrorEvent(
+					"instructions_locked",
+					"The session instructions were pinned when this session's client secret was created and cannot be changed via session.update.",
 				),
 			);
 			return;
@@ -630,6 +659,20 @@ export class RealtimeProxySession {
 				this.sendToClientRaw(buildErrorEvent(...PROMPT_NOT_SUPPORTED));
 				return;
 			}
+			// Per-response instructions override the session's, so the lock has to
+			// be enforced here as well as on session.update.
+			if (
+				this.pinnedInstructions !== null &&
+				response.instructions !== undefined
+			) {
+				this.sendToClientRaw(
+					buildErrorEvent(
+						"instructions_locked",
+						"The session instructions were pinned when this session's client secret was created and cannot be overridden per response.",
+					),
+				);
+				return;
+			}
 		}
 
 		const allowed = await this.runGenerationGates();
@@ -852,6 +895,17 @@ export class RealtimeProxySession {
 		);
 	}
 
+	/**
+	 * Strip pinned instructions from a session object on its way to the client.
+	 * The provider echoes the full session state on every session.updated, which
+	 * would otherwise hand the pinned prompt back to the client.
+	 */
+	private redactPinnedInstructions(session: Record<string, unknown>): void {
+		if (this.pinnedInstructions !== null && "instructions" in session) {
+			delete session.instructions;
+		}
+	}
+
 	private normalizeSessionModelIds(session: Record<string, unknown>): void {
 		session.model = this.canonicalModelId(this.preflight.match);
 		const audio =
@@ -921,10 +975,12 @@ export class RealtimeProxySession {
 					});
 				}
 				this.normalizeSessionModelIds(session);
+				this.redactPinnedInstructions(session);
 				this.sendToClientRaw(JSON.stringify(event));
 				// Disable the provider's automatic VAD response so every generation
-				// passes the gateway's authorization gates. The echoed
-				// session.updated for this control message is suppressed below.
+				// passes the gateway's authorization gates, and apply any pinned
+				// instructions and voice. The echoed session.updated for this
+				// control message is suppressed below.
 				this.suppressSessionUpdated += 1;
 				this.forwardToUpstream(
 					JSON.stringify({
@@ -932,6 +988,9 @@ export class RealtimeProxySession {
 						event_id: AUTO_RESPONSE_CONTROL_EVENT_ID,
 						session: {
 							type: "realtime",
+							...(this.pinnedInstructions !== null
+								? { instructions: this.pinnedInstructions }
+								: {}),
 							audio: {
 								input: {
 									turn_detection: {
@@ -939,6 +998,9 @@ export class RealtimeProxySession {
 										create_response: false,
 									},
 								},
+								...(this.pinnedVoice !== null
+									? { output: { voice: this.pinnedVoice } }
+									: {}),
 							},
 						},
 					}),
@@ -955,6 +1017,7 @@ export class RealtimeProxySession {
 						? (event.session as Record<string, unknown>)
 						: {};
 				this.normalizeSessionModelIds(session);
+				this.redactPinnedInstructions(session);
 				this.sendToClientRaw(JSON.stringify(event));
 				return;
 			}

--- a/apps/gateway/src/realtime/session.ts
+++ b/apps/gateway/src/realtime/session.ts
@@ -193,6 +193,17 @@ export class RealtimeProxySession {
 	private clientQueue: Promise<void> = Promise.resolve();
 	private upstreamQueue: Promise<void> = Promise.resolve();
 
+	// Client and upstream frames are chained separately, so a client that sends
+	// response.create without waiting for session.created can otherwise reach
+	// the provider before the control session.update below — generating a turn
+	// under the provider's defaults instead of the pinned instructions and the
+	// disabled auto-response. Generation waits on this; it is resolved once the
+	// control update is forwarded, and on teardown so nothing waits forever.
+	private resolveUpstreamConfigured!: () => void;
+	private readonly upstreamConfigured = new Promise<void>((resolve) => {
+		this.resolveUpstreamConfigured = resolve;
+	});
+
 	public constructor(options: RealtimeProxySessionOptions) {
 		this.client = options.clientSocket;
 		this.upstream = options.upstreamSocket;
@@ -621,6 +632,11 @@ export class RealtimeProxySession {
 	private async handleResponseCreate(
 		message: Record<string, unknown>,
 	): Promise<void> {
+		// Never generate before the session's control update has reached the
+		// provider. Later client frames stay behind this one on clientQueue, so
+		// ordering is preserved for the audio that follows too.
+		await this.upstreamConfigured;
+
 		// response.create may carry inline input items and per-response tools;
 		// apply the same deferred-capability guards as session-level config.
 		const response =
@@ -1005,6 +1021,7 @@ export class RealtimeProxySession {
 						},
 					}),
 				);
+				this.resolveUpstreamConfigured();
 				return;
 			}
 			case "session.updated": {
@@ -1416,6 +1433,9 @@ export class RealtimeProxySession {
 			return;
 		}
 		this.finalized = true;
+		// Release anything still waiting for the control update; the checks after
+		// it drop the frame once the session is finalized.
+		this.resolveUpstreamConfigured();
 
 		for (const timer of this.timers) {
 			clearInterval(timer);


### PR DESCRIPTION
Closes #3377.

Today `POST /v1/realtime/client_secrets` only accepts `{ type, model, audio.input.transcription }`, so an embedder whose server owns the prompt has to ship it to the browser and let the client apply it via `session.update` — exposing the prompt and leaving oversized-instruction failures to surface mid-call. This adds `session.instructions` and `session.audio.output.voice` to the mint schema: instructions are stored on the secret, applied by the gateway on connect (the OpenAI path reuses the control `session.update` already sent on `session.created`; the Gemini path rewrites `setup.systemInstruction`), and locked for the session's lifetime the same way `session.model` is. Size is validated at mint (`400 instructions_too_large`) and voice against the mapping's `supportedVoices` (`400 voice_not_supported`).

Three things worth a reviewer's attention:

- The lock is enforced on **`response.create` as well as `session.update`** — per-response `instructions` override the session's, so locking only `session.update` would be bypassable in one line.
- Pinned instructions are **stripped from the `session.created` / `session.updated` echoes**, which otherwise return full session state and would hand the prompt back to the client.
- Voice is a **default, not a lock** (no confidentiality or billing rationale), and the whole feature is opt-in: secrets minted without `instructions` behave exactly as before, and records predating the new keys parse as unpinned so in-flight secrets survive the deploy.

Verified with `pnpm format`, a full `pnpm build` (17/17), and the realtime suite (180 tests across 12 files, 31 new) run against an isolated per-worktree stack; the full unit suite passes except two failures reproducible on a clean tree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-controlled realtime instructions and default voice settings.
  * Pinned instructions are securely applied, hidden from session events, and protected from client overrides.
  * Added support for pinned instructions and voice settings in Gemini realtime sessions.
* **Bug Fixes**
  * Realtime responses now wait for session settings to be applied before generation.
* **Validation**
  * Added checks for instruction size, supported voices, and invalid session fields.
  * Existing sessions remain compatible when settings are omitted.
* **Documentation**
  * Documented server-authoritative realtime instructions and voice behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->