### PR TITLE
fix(actions): bound remote image fetch with a deadline

### DIFF
--- a/packages/actions/src/process-image-url.spec.ts
+++ b/packages/actions/src/process-image-url.spec.ts
@@ -27,6 +27,23 @@ function imageResponseWithBody(bytes: number): Response {
 	return new Response(stream, { headers: { "content-type": "image/png" } });
 }
 
+function stalledImageResponse(signal?: AbortSignal): Response {
+	// Models undici: the body stream is errored when the fetch signal aborts
+	// mid-download. With no signal the reader never settles, which is exactly
+	// the hang this test is about.
+	const stream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			signal?.addEventListener("abort", () => {
+				controller.error(signal.reason);
+			});
+		},
+		pull() {
+			return new Promise<void>(() => {});
+		},
+	});
+	return new Response(stream, { headers: { "content-type": "image/png" } });
+}
+
 describe("processImageUrl size limits", () => {
 	beforeEach(() => {
 		// The message gains an upsell sentence under HOSTED + PAID_MODE, so pin
@@ -215,8 +232,30 @@ describe("processImageUrl size limits", () => {
 
 		await processImageUrl(REMOTE_URL);
 
-		expect(fetchSpy).toHaveBeenCalledWith(REMOTE_URL, { redirect: "error" });
+		expect(fetchSpy).toHaveBeenCalledWith(REMOTE_URL, {
+			redirect: "error",
+			signal: expect.any(AbortSignal),
+		});
 	});
+
+	it("gives up on a server that never finishes sending the image", async () => {
+		// A remote host that trickles bytes (or simply never sends the last one)
+		// keeps undici's bodyTimeout alive forever: client-h1 refreshes the timer
+		// on every chunk, so the 300s default is an inactivity timeout, not a
+		// deadline. Only a signal on the fetch bounds the whole download.
+		vi.stubEnv("IMAGE_FETCH_TIMEOUT_MS", "50");
+		vi.resetModules();
+		const { processImageUrl: freshProcessImageUrl } =
+			await import("./process-image-url.js");
+
+		vi.spyOn(globalThis, "fetch").mockImplementation((_url, init) =>
+			Promise.resolve(stalledImageResponse(init?.signal ?? undefined)),
+		);
+
+		await expect(
+			freshProcessImageUrl(REMOTE_URL, false, MAX_SIZE_MB, "free"),
+		).rejects.toThrow("Failed to process image from URL");
+	}, 2000);
 });
 
 describe("processImageUrl data URLs", () => {

--- a/packages/actions/src/process-image-url.spec.ts
+++ b/packages/actions/src/process-image-url.spec.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ImageSizeLimitError, processImageUrl } from "./process-image-url.js";
+import {
+	ImageSizeLimitError,
+	processImageUrl,
+	resolveImageFetchTimeoutMs,
+} from "./process-image-url.js";
 import { RequestError } from "./request-error.js";
 
 const MAX_SIZE_MB = 1;
@@ -296,5 +300,37 @@ describe("processImageUrl data URLs", () => {
 		expect(Buffer.from(data, "base64").byteLength).toBe(
 			MAX_SIZE_MB * 1024 * 1024,
 		);
+	});
+});
+
+describe("resolveImageFetchTimeoutMs", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("defaults to 15000 when unset", () => {
+		delete process.env.IMAGE_FETCH_TIMEOUT_MS;
+		expect(resolveImageFetchTimeoutMs()).toBe(15_000);
+	});
+
+	it.each(["-1", "Infinity", "1.5", "not-a-number"])(
+		"falls back to 15000 for invalid value %s (never throws)",
+		(value) => {
+			vi.stubEnv("IMAGE_FETCH_TIMEOUT_MS", value);
+			expect(resolveImageFetchTimeoutMs()).toBe(15_000);
+			expect(() =>
+				AbortSignal.timeout(resolveImageFetchTimeoutMs()),
+			).not.toThrow();
+		},
+	);
+
+	it("honours a valid integer value", () => {
+		vi.stubEnv("IMAGE_FETCH_TIMEOUT_MS", "5000");
+		expect(resolveImageFetchTimeoutMs()).toBe(5000);
+	});
+
+	it("honours 0", () => {
+		vi.stubEnv("IMAGE_FETCH_TIMEOUT_MS", "0");
+		expect(resolveImageFetchTimeoutMs()).toBe(0);
 	});
 });

--- a/packages/actions/src/process-image-url.ts
+++ b/packages/actions/src/process-image-url.ts
@@ -9,8 +9,23 @@ import { RequestError } from "./request-error.js";
  * behind `image_url.url`, and this fetch happens before the provider call, so
  * it is not covered by the provider request timeout.
  */
-const IMAGE_FETCH_TIMEOUT_MS =
-	Number(process.env.IMAGE_FETCH_TIMEOUT_MS) || 15_000;
+const DEFAULT_IMAGE_FETCH_TIMEOUT_MS = 15_000;
+// Largest delay AbortSignal.timeout accepts; a bigger (or non-finite) value
+// throws and would break the fetch, so we clamp to a safe range.
+const MAX_IMAGE_FETCH_TIMEOUT_MS = 2_147_483_647;
+
+/**
+ * Resolves the fetch deadline from IMAGE_FETCH_TIMEOUT_MS, guarding against
+ * values that would make AbortSignal.timeout throw. Only a finite integer in
+ * [0, 2_147_483_647] is honoured; anything else (NaN, negative, fractional,
+ * Infinity) falls back to the default.
+ */
+export function resolveImageFetchTimeoutMs(): number {
+	const raw = Number(process.env.IMAGE_FETCH_TIMEOUT_MS);
+	return Number.isInteger(raw) && raw >= 0 && raw <= MAX_IMAGE_FETCH_TIMEOUT_MS
+		? raw
+		: DEFAULT_IMAGE_FETCH_TIMEOUT_MS;
+}
 
 /**
  * Thrown when an image exceeds the caller's size limit. A `RequestError` so the
@@ -202,7 +217,7 @@ export async function processImageUrl(
 			redirect: "error",
 			// Bounds the whole download, headers and body. undici's bodyTimeout is
 			// refreshed on every chunk, so a host that trickles bytes never trips it.
-			signal: AbortSignal.timeout(IMAGE_FETCH_TIMEOUT_MS),
+			signal: AbortSignal.timeout(resolveImageFetchTimeoutMs()),
 		});
 
 		if (!response.ok) {

--- a/packages/actions/src/process-image-url.ts
+++ b/packages/actions/src/process-image-url.ts
@@ -5,6 +5,14 @@ import { parseDataUrl } from "./parse-data-url.js";
 import { RequestError } from "./request-error.js";
 
 /**
+ * Deadline for fetching a remote image. Any API-key holder controls the URL
+ * behind `image_url.url`, and this fetch happens before the provider call, so
+ * it is not covered by the provider request timeout.
+ */
+const IMAGE_FETCH_TIMEOUT_MS =
+	Number(process.env.IMAGE_FETCH_TIMEOUT_MS) || 15_000;
+
+/**
  * Thrown when an image exceeds the caller's size limit. A `RequestError` so the
  * gateway maps it to a 400 and writes a client_error log row: the chat path
  * only preserves `RequestError`, so a plain `Error` here would still reach the
@@ -190,7 +198,12 @@ export async function processImageUrl(
 	await assertSafeUserContentUrl(url);
 
 	try {
-		const response = await fetch(url, { redirect: "error" });
+		const response = await fetch(url, {
+			redirect: "error",
+			// Bounds the whole download, headers and body. undici's bodyTimeout is
+			// refreshed on every chunk, so a host that trickles bytes never trips it.
+			signal: AbortSignal.timeout(IMAGE_FETCH_TIMEOUT_MS),
+		});
 
 		if (!response.ok) {
 			logger.warn(`Failed to fetch image from URL (${response.status})`, {


### PR DESCRIPTION
## What

`processImageUrl` fetches a caller-supplied URL with no `AbortSignal`:

```ts
// packages/actions/src/process-image-url.ts:193
const response = await fetch(url, { redirect: "error" });
```

This PR adds a deadline: `signal: AbortSignal.timeout(IMAGE_FETCH_TIMEOUT_MS)`, defaulting to 15s and overridable via `IMAGE_FETCH_TIMEOUT_MS`.

## Reachability from an ordinary, unprivileged request

This is not a defense-in-depth patch on an admin path — the URL is caller-controlled on the main product surface, and I traced the whole chain:

1. `POST /v1/chat/completions` is declared with `security: [{ bearerAuth: [] }]` (`apps/gateway/src/chat/chat.ts:1363-1372`). Any holder of a normal API key reaches it. There is no admin or role gate.
2. The handler calls `prepareRequestBody` (`apps/gateway/src/chat/chat.ts:7190`, and `apps/gateway/src/chat/tools/resolve-provider-context.ts:943`).
3. `prepareRequestBody` passes `part.image_url.url` — a raw string straight off the request JSON — into `processImageUrl` at `packages/actions/src/prepare-request-body.ts:1967`, `:2184` and `:3618`. Same for `transform-anthropic-messages.ts:147` and `transform-google-messages.ts:374`.
4. The SSRF guard (`assertSafeUserContentUrl`) blocks internal hosts, but the caller's own public host passes it — which is the case that matters here.
5. `prepare-request-body.ts:1967` sits inside two nested `Promise.all`s (messages × content parts), so a single request carrying N `image_url` parts opens N concurrent sockets, each pinned by the same unbounded fetch.

The whole thing runs **before** the provider call, so `createTimeoutSignal()` — which bounds the provider request — does not cover this phase at all.

## Why the undici defaults are not enough

`bodyTimeout` and `headersTimeout` default to 300s, but they are **inactivity** timeouts, not deadlines. `lib/dispatcher/client-h1.js` calls `this.timeout.refresh()` on every parsed chunk (lines 273, 293, 661, 741 in undici 8.9.0; the same pattern is present in the undici bundled into Node — `process.versions.undici` is 7.29.0 on Node 24 — and in undici 6.28.0). A server that emits one byte every two seconds refreshes the timer forever.

The `readBodyWithLimit` size cap does not rescue this either: at one byte every two seconds, reaching the 20MB default cap takes on the order of a year.

## Fix

A signal on the `fetch` bounds headers *and* body as one deadline. It also propagates to `response.body`, so the `reader.read()` loop inside `readBodyWithLimit` unwinds with an error instead of hanging — the added test asserts exactly that.

## Two variants — pick whichever you prefer

**(A) Targeted patch (what this PR does).** One constant plus one `signal:` in `process-image-url.ts`. No new module, no other call site touched.

**(B) Centralized `fetchWithDeadline` helper.** A small wrapper composing a caller-supplied signal with `AbortSignal.timeout` via `AbortSignal.any`, adopted here and at any other outbound fetch of user-controlled URLs.

Say the word and I will convert this branch to (B). I did not want to pre-empt that call with a repo-wide refactor.

## Notes

- The timeout currently surfaces as the generic `Error("Failed to process image from URL")` and is logged at `error` level, so a caller-triggered condition becomes a 500 plus error-level noise. Mapping it to a `RequestError` (400, or 504) would be a one-line follow-up — left out to keep this diff focused, happy to fold it in.
- `IMAGE_FETCH_TIMEOUT_MS` is read once at module load, which is what lets the test exercise the real code path with a short deadline.

## Tests

- The existing redirect assertion now pins the new options object (`{ redirect: "error", signal: expect.any(AbortSignal) }`).
- A new behavioral test drives a `ReadableStream` whose `pull` never settles — the exact trickle/stall shape — and asserts the call rejects. Before the fix it hangs until the test's own 2s timeout; after the fix it rejects in ~50ms.

`process-image-url.spec.ts`: 14/14 passing. `packages/actions`: 746/750 — the only failures are in `provider-key/env-inventory.spec.ts`, which requires Redis (unavailable in my environment) and is unrelated to this change. `tsc --noEmit` on the package is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Remote image downloads now use a validated timeout, defaulting to 15 seconds when no valid setting is provided.
  - A timeout value of zero is now honored correctly.
  - Stalled or timed-out downloads fail cleanly instead of hanging processing.
  - Existing redirect protections and response handling remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->