### PR TITLE
fix(gateway): bound provider image base64 fetch with a deadline

### DIFF
--- a/apps/gateway/src/chat/tools/convert-images-to-base64.spec.ts
+++ b/apps/gateway/src/chat/tools/convert-images-to-base64.spec.ts
@@ -41,7 +41,30 @@ describe("convertImagesToBase64 URL safety", () => {
 
 		expect(fetchSpy).toHaveBeenCalledWith("https://cdn.example.com/image.png", {
 			redirect: "error",
+			signal: expect.any(AbortSignal),
 		});
 		expect(result[0]?.image_url.url).toBe("data:image/png;base64,AQID");
+	});
+
+	it("bounds the image fetch with an abort signal and falls back when it aborts", async () => {
+		vi.stubEnv("ALLOW_INSECURE_PROVIDER_URLS", "true");
+		// Simulate the fetch deadline firing: reject as AbortSignal.timeout would.
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockImplementation((_url, init) => {
+				expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
+				return Promise.reject(
+					Object.assign(new Error("The operation was aborted"), {
+						name: "TimeoutError",
+					}),
+				);
+			});
+
+		const input = image("https://cdn.example.com/slow.png");
+		// Must resolve (fall back to the original image), never hang.
+		await expect(convertImagesToBase64([input])).resolves.toEqual([input]);
+		expect(fetchSpy).toHaveBeenCalled();
+		const firstCall = fetchSpy.mock.calls[0];
+		expect((firstCall?.[1] as RequestInit).signal).toBeInstanceOf(AbortSignal);
 	});
 });

--- a/apps/gateway/src/chat/tools/convert-images-to-base64.spec.ts
+++ b/apps/gateway/src/chat/tools/convert-images-to-base64.spec.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { convertImagesToBase64 } from "./convert-images-to-base64.js";
+import {
+	convertImagesToBase64,
+	resolveImageFetchTimeoutMs,
+} from "./convert-images-to-base64.js";
 
 function image(url: string) {
 	return { type: "image_url" as const, image_url: { url } };
@@ -66,5 +69,37 @@ describe("convertImagesToBase64 URL safety", () => {
 		expect(fetchSpy).toHaveBeenCalled();
 		const firstCall = fetchSpy.mock.calls[0];
 		expect((firstCall?.[1] as RequestInit).signal).toBeInstanceOf(AbortSignal);
+	});
+});
+
+describe("resolveImageFetchTimeoutMs", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("defaults to 15000 when unset", () => {
+		delete process.env.IMAGE_FETCH_TIMEOUT_MS;
+		expect(resolveImageFetchTimeoutMs()).toBe(15_000);
+	});
+
+	it.each(["-1", "Infinity", "1.5", "not-a-number"])(
+		"falls back to 15000 for invalid value %s (never throws)",
+		(value) => {
+			vi.stubEnv("IMAGE_FETCH_TIMEOUT_MS", value);
+			expect(resolveImageFetchTimeoutMs()).toBe(15_000);
+			expect(() =>
+				AbortSignal.timeout(resolveImageFetchTimeoutMs()),
+			).not.toThrow();
+		},
+	);
+
+	it("honours a valid integer value", () => {
+		vi.stubEnv("IMAGE_FETCH_TIMEOUT_MS", "5000");
+		expect(resolveImageFetchTimeoutMs()).toBe(5000);
+	});
+
+	it("honours 0", () => {
+		vi.stubEnv("IMAGE_FETCH_TIMEOUT_MS", "0");
+		expect(resolveImageFetchTimeoutMs()).toBe(0);
 	});
 });

--- a/apps/gateway/src/chat/tools/convert-images-to-base64.ts
+++ b/apps/gateway/src/chat/tools/convert-images-to-base64.ts
@@ -11,8 +11,23 @@ import type { ImageObject } from "./types.js";
  * fetch has no other timeout, so an unresponsive host would otherwise hang the
  * request indefinitely across every retry.
  */
-const IMAGE_FETCH_TIMEOUT_MS =
-	Number(process.env.IMAGE_FETCH_TIMEOUT_MS) || 15_000;
+const DEFAULT_IMAGE_FETCH_TIMEOUT_MS = 15_000;
+// Largest delay AbortSignal.timeout accepts; a bigger (or non-finite) value
+// throws and would break the retry loop, so we clamp to a safe range.
+const MAX_IMAGE_FETCH_TIMEOUT_MS = 2_147_483_647;
+
+/**
+ * Resolves the fetch deadline from IMAGE_FETCH_TIMEOUT_MS, guarding against
+ * values that would make AbortSignal.timeout throw. Only a finite integer in
+ * [0, 2_147_483_647] is honoured; anything else (NaN, negative, fractional,
+ * Infinity) falls back to the default.
+ */
+export function resolveImageFetchTimeoutMs(): number {
+	const raw = Number(process.env.IMAGE_FETCH_TIMEOUT_MS);
+	return Number.isInteger(raw) && raw >= 0 && raw <= MAX_IMAGE_FETCH_TIMEOUT_MS
+		? raw
+		: DEFAULT_IMAGE_FETCH_TIMEOUT_MS;
+}
 
 const MAX_RETRIES = 3;
 const RETRY_DELAY_MS = 1000;
@@ -36,7 +51,7 @@ async function fetchImageWithRetry(
 				redirect: "error",
 				// Bounds the whole download, headers and body. undici's bodyTimeout is
 				// refreshed on every chunk, so a host that trickles bytes never trips it.
-				signal: AbortSignal.timeout(IMAGE_FETCH_TIMEOUT_MS),
+				signal: AbortSignal.timeout(resolveImageFetchTimeoutMs()),
 			});
 			if (response.ok) {
 				const contentType = response.headers.get("content-type") ?? "image/png";

--- a/apps/gateway/src/chat/tools/convert-images-to-base64.ts
+++ b/apps/gateway/src/chat/tools/convert-images-to-base64.ts
@@ -3,6 +3,17 @@ import { assertSafeUserContentUrl } from "@llmgateway/shared/url-safety-node";
 
 import type { ImageObject } from "./types.js";
 
+/**
+ * Deadline for fetching a provider-returned image before converting it to a
+ * base64 data URL. These URLs come from the upstream provider response, which
+ * the SSRF guard below already treats as untrusted user-influenced input (a
+ * BYOK/custom-baseUrl tenant controls what the "provider" returns), and this
+ * fetch has no other timeout, so an unresponsive host would otherwise hang the
+ * request indefinitely across every retry.
+ */
+const IMAGE_FETCH_TIMEOUT_MS =
+	Number(process.env.IMAGE_FETCH_TIMEOUT_MS) || 15_000;
+
 const MAX_RETRIES = 3;
 const RETRY_DELAY_MS = 1000;
 
@@ -21,7 +32,12 @@ async function fetchImageWithRetry(
 
 	for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
 		try {
-			const response = await fetch(url, { redirect: "error" });
+			const response = await fetch(url, {
+				redirect: "error",
+				// Bounds the whole download, headers and body. undici's bodyTimeout is
+				// refreshed on every chunk, so a host that trickles bytes never trips it.
+				signal: AbortSignal.timeout(IMAGE_FETCH_TIMEOUT_MS),
+			});
 			if (response.ok) {
 				const contentType = response.headers.get("content-type") ?? "image/png";
 				const arrayBuffer = await response.arrayBuffer();


### PR DESCRIPTION
`convertImagesToBase64` in `apps/gateway/src/chat/tools/convert-images-to-base64.ts` downloads provider-returned image URLs to inline them as base64, but the `fetch` has no timeout and runs up to 3 times. There is no global undici dispatcher timeout, so an unresponsive host hangs the response path indefinitely.

These URLs are already treated as untrusted, SSRF-guarded input (the code refuses unsafe image URLs from provider responses), and a BYOK / custom-baseUrl tenant controls what the upstream returns — so this is reachable by any API-key holder and repeatable, i.e. a resource-exhaustion vector.

Fix: bound each attempt with `AbortSignal.timeout(IMAGE_FETCH_TIMEOUT_MS)` (default 15s, env-overridable), mirroring the existing remote image-fetch deadline. The retry loop already catches the abort and falls back to the original image. Adds a unit test asserting the fetch carries an `AbortSignal` and that a timing-out host falls back instead of hanging.

This is the sibling of the same pattern in #3780 (`process-image-url.ts`); different file/function, no overlap. Happy to consolidate with #3780 if you prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 15-second default timeout for image downloads.
  * Improved handling of configured image-fetch timeouts, including valid, zero, and invalid values.
  * Automatically falls back to the original image when a download is aborted or times out.
  * Preserved existing redirect and retry handling for image fetches.
  * Added coverage for timeout resolution and abort behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->