### PR TITLE
fix(docs): constrain Empryo guide icon

### DIFF
--- a/apps/docs/lib/custom-icons.tsx
+++ b/apps/docs/lib/custom-icons.tsx
@@ -157,6 +157,8 @@ export const customIcons: Record<string, IconComponent> = {
 		<img
 			src="/integrations/empryo.png"
 			alt="Empryo"
+			width={24}
+			height={24}
 			className={className as string | undefined}
 			style={
 				{


### PR DESCRIPTION
## What

Sets the Empryo guide icon to 24×24 so it matches the other sidebar icons instead of rendering at the image's intrinsic size.

## Verification

- `pnpm --filter docs lint`
- `pnpm --filter docs build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Empryo icon to consistently render at 24×24 pixels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->