### PR TITLE
perf: weekly react best-practices audit fixes

### DIFF
--- a/apps/code/src/app/coding-models/page.tsx
+++ b/apps/code/src/app/coding-models/page.tsx
@@ -6,6 +6,7 @@ import { Footer } from "@/components/Footer";
 import { GetDevPassButton } from "@/components/GetDevPassButton";
 import { Header } from "@/components/Header";
 import { Button } from "@/components/ui/button";
+import { codingModelCards } from "@/lib/coding-models";
 
 import type { Metadata } from "next";
 
@@ -95,7 +96,7 @@ export default function CodingModelsPage() {
 							We recommend the latest models from open-weight-first labs — the
 							full standard and premium catalogue is one tab away.
 						</p>
-						<CodingModelsShowcase showCTA showTabs />
+						<CodingModelsShowcase models={codingModelCards} showCTA showTabs />
 					</div>
 				</section>
 

--- a/apps/code/src/app/page.tsx
+++ b/apps/code/src/app/page.tsx
@@ -18,6 +18,7 @@ import { FlickeringGrid } from "@/components/ui/flickering-grid";
 import { Marquee } from "@/components/ui/marquee";
 import { NumberTicker } from "@/components/ui/number-ticker";
 import { marqueeTools } from "@/lib/agent-tools";
+import { codingModelCards } from "@/lib/coding-models";
 import { getConfig } from "@/lib/config-server";
 import { buildDevPassProductSchema } from "@/lib/product-schema";
 
@@ -450,7 +451,7 @@ export default function LandingPage() {
 								instead.
 							</p>
 						</div>
-						<CodingModelsShowcase />
+						<CodingModelsShowcase models={codingModelCards} />
 					</div>
 				</section>
 

--- a/apps/code/src/components/CodingModelsShowcase.tsx
+++ b/apps/code/src/components/CodingModelsShowcase.tsx
@@ -15,70 +15,19 @@ import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 
-import { models, type ModelDefinition } from "@llmgateway/models";
-import { isCodingModel, isPremiumModel } from "@llmgateway/shared";
-import {
-	getModelFamilyIcon,
-	OPEN_WEIGHT_LAB_FAMILIES,
-} from "@llmgateway/shared/components";
+import { getModelFamilyIcon } from "@llmgateway/shared/components";
+
+import type { CodingModelCard } from "@/lib/coding-models";
 
 export type CodingModelsView = "recommended" | "standard" | "premium" | "all";
 
 interface CodingModelsShowcaseProps {
+	models: CodingModelCard[];
 	showCTA?: boolean;
 	className?: string;
 	showTabs?: boolean;
 	defaultView?: CodingModelsView;
 }
-
-type ModelProvider = ModelDefinition["providers"][number];
-
-function isActiveMapping(provider: ModelProvider): boolean {
-	const now = new Date();
-	return (
-		(!provider.deprecatedAt || provider.deprecatedAt > now) &&
-		(!provider.deactivatedAt || provider.deactivatedAt > now)
-	);
-}
-
-// The gateway's DevPass gate, minus mappings that have already been retired.
-function isShowcaseCodingModel(model: ModelDefinition): boolean {
-	return isCodingModel({
-		...model,
-		providers: model.providers.filter(isActiveMapping),
-	});
-}
-
-// Newest release first; models without a release date sink to the end.
-function byNewestRelease(a: ModelDefinition, b: ModelDefinition): number {
-	const aTime = a.releasedAt?.getTime() ?? 0;
-	const bTime = b.releasedAt?.getTime() ?? 0;
-	return bTime - aTime;
-}
-
-const codingModels = (models as ModelDefinition[])
-	.filter(isShowcaseCodingModel)
-	.sort(byNewestRelease);
-
-// Recommended = the latest coding model from each open-weight lab, derived
-// from release dates so new catalogue entries surface without curation.
-const recommendedIds: ReadonlySet<string> = (() => {
-	const latestPerFamily = new Map<string, ModelDefinition>();
-	for (const model of codingModels) {
-		if (!OPEN_WEIGHT_LAB_FAMILIES.has(model.family) || !model.releasedAt) {
-			continue;
-		}
-		const current = latestPerFamily.get(model.family);
-		if (!current || model.releasedAt > current.releasedAt!) {
-			latestPerFamily.set(model.family, model);
-		}
-	}
-	return new Set(Array.from(latestPerFamily.values()).map((model) => model.id));
-})();
-
-const premiumIds: ReadonlySet<string> = new Set(
-	codingModels.filter((m) => isPremiumModel(m.id)).map((m) => m.id),
-);
 
 function formatContextSize(size: number): string {
 	if (size >= 1000000) {
@@ -88,29 +37,6 @@ function formatContextSize(size: number): string {
 		return `${(size / 1000).toFixed(0)}K`;
 	}
 	return size.toString();
-}
-
-// Pick the provider with the lowest combined input + output price so the card
-// advertises the best ("starting from") rate available for the model. Providers
-// without pricing are ranked last so we still fall back to a usable mapping.
-function getCheapestProvider(
-	providers: readonly ModelProvider[],
-): ModelProvider | undefined {
-	const cost = (p: ModelProvider): number => {
-		const input = p.inputPrice !== undefined ? Number(p.inputPrice) : undefined;
-		const output =
-			p.outputPrice !== undefined ? Number(p.outputPrice) : undefined;
-		if (input === undefined && output === undefined) {
-			return Number.POSITIVE_INFINITY;
-		}
-		return (input ?? 0) + (output ?? 0);
-	};
-	return providers.reduce<ModelProvider | undefined>((cheapest, p) => {
-		if (!cheapest) {
-			return p;
-		}
-		return cost(p) < cost(cheapest) ? p : cheapest;
-	}, undefined);
 }
 
 function formatPrice(price: number): string {
@@ -159,6 +85,7 @@ const TAB_DEFINITIONS: {
 ];
 
 export function CodingModelsShowcase({
+	models,
 	showCTA,
 	className,
 	showTabs = false,
@@ -167,15 +94,15 @@ export function CodingModelsShowcase({
 	const [copiedModel, setCopiedModel] = useState<string | null>(null);
 	const [view, setView] = useState<CodingModelsView>(defaultView);
 
-	const visibleModels = codingModels.filter((model) => {
+	const visibleModels = models.filter((model) => {
 		if (view === "recommended") {
-			return recommendedIds.has(model.id);
+			return model.recommended;
 		}
 		if (view === "standard") {
-			return !premiumIds.has(model.id);
+			return !model.premium;
 		}
 		if (view === "premium") {
-			return premiumIds.has(model.id);
+			return model.premium;
 		}
 		return true;
 	});
@@ -234,9 +161,6 @@ export function CodingModelsShowcase({
 			</p>
 			<div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
 				{visibleModels.map((model) => {
-					const provider = getCheapestProvider(
-						model.providers.filter(isActiveMapping),
-					);
 					const FamilyIcon = getModelFamilyIcon(model.family);
 
 					return (
@@ -244,7 +168,7 @@ export function CodingModelsShowcase({
 							key={model.id}
 							className="group relative flex flex-col gap-2 rounded-lg border p-4 transition-all hover:border-primary/50 hover:shadow-sm"
 						>
-							{premiumIds.has(model.id) ? (
+							{model.premium ? (
 								<span className="absolute right-3 top-3 inline-flex items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-600 dark:text-amber-400">
 									<Gem className="h-2.5 w-2.5" />
 									Premium
@@ -257,7 +181,7 @@ export function CodingModelsShowcase({
 											<FamilyIcon className="h-4 w-4" />
 										</div>
 										<span className="font-medium text-sm truncate">
-											{model.name ?? model.id}
+											{model.name}
 										</span>
 									</div>
 								</div>
@@ -292,35 +216,37 @@ export function CodingModelsShowcase({
 								</button>
 							</div>
 
-							{provider && (
+							{(model.contextSize !== null ||
+								model.inputPrice !== null ||
+								model.outputPrice !== null) && (
 								<div className="text-xs text-muted-foreground space-y-1 mt-1">
-									{provider.contextSize && (
+									{model.contextSize !== null && (
 										<p>
 											Context:{" "}
 											<span className="font-mono font-medium text-foreground">
-												{formatContextSize(provider.contextSize)}
+												{formatContextSize(model.contextSize)}
 											</span>
 										</p>
 									)}
-									{(provider.inputPrice !== undefined ||
-										provider.outputPrice !== undefined) && (
+									{(model.inputPrice !== null ||
+										model.outputPrice !== null) && (
 										<p>
 											<span className="text-muted-foreground mr-1">
 												starting from
 											</span>
-											{provider.inputPrice !== undefined && (
+											{model.inputPrice !== null && (
 												<>
 													<span className="font-mono font-medium text-foreground">
-														${formatPrice(Number(provider.inputPrice))}
+														${formatPrice(model.inputPrice)}
 													</span>
 													<span className="text-muted-foreground"> in</span>
 												</>
 											)}
-											{provider.outputPrice !== undefined && (
+											{model.outputPrice !== null && (
 												<>
 													<span className="text-muted-foreground mx-1">/</span>
 													<span className="font-mono font-medium text-foreground">
-														${formatPrice(Number(provider.outputPrice))}
+														${formatPrice(model.outputPrice)}
 													</span>
 													<span className="text-muted-foreground"> out</span>
 												</>

--- a/apps/code/src/components/ui/number-ticker.tsx
+++ b/apps/code/src/components/ui/number-ticker.tsx
@@ -46,18 +46,21 @@ export function NumberTicker({
 		};
 	}, [motionValue, isInView, delay, value, direction, startValue]);
 
-	useEffect(
-		() =>
-			springValue.on("change", (latest) => {
-				if (ref.current) {
-					ref.current.textContent = Intl.NumberFormat("en-US", {
-						minimumFractionDigits: decimalPlaces,
-						maximumFractionDigits: decimalPlaces,
-					}).format(Number(latest.toFixed(decimalPlaces)));
-				}
-			}),
-		[springValue, decimalPlaces],
-	);
+	useEffect(() => {
+		// One formatter per subscription — the spring change handler fires every
+		// animation frame, so it must not construct an Intl.NumberFormat each call.
+		const format = new Intl.NumberFormat("en-US", {
+			minimumFractionDigits: decimalPlaces,
+			maximumFractionDigits: decimalPlaces,
+		});
+		return springValue.on("change", (latest) => {
+			if (ref.current) {
+				ref.current.textContent = format.format(
+					Number(latest.toFixed(decimalPlaces)),
+				);
+			}
+		});
+	}, [springValue, decimalPlaces]);
 
 	return (
 		<span

--- a/apps/code/src/lib/coding-models.ts
+++ b/apps/code/src/lib/coding-models.ts
@@ -1,0 +1,101 @@
+import { models, type ModelDefinition } from "@llmgateway/models";
+import { isCodingModel, isPremiumModel } from "@llmgateway/shared";
+import { OPEN_WEIGHT_LAB_FAMILIES } from "@llmgateway/shared/components";
+
+// Server-side derivation of the coding-model showcase cards. Only this
+// trimmed shape crosses the RSC boundary — the full catalogue never ships
+// to the client.
+export interface CodingModelCard {
+	id: string;
+	name: string;
+	family: string;
+	premium: boolean;
+	recommended: boolean;
+	contextSize: number | null;
+	inputPrice: number | null;
+	outputPrice: number | null;
+}
+
+type ModelProvider = ModelDefinition["providers"][number];
+
+function isActiveMapping(provider: ModelProvider): boolean {
+	const now = new Date();
+	return (
+		(!provider.deprecatedAt || provider.deprecatedAt > now) &&
+		(!provider.deactivatedAt || provider.deactivatedAt > now)
+	);
+}
+
+// The gateway's DevPass gate, minus mappings that have already been retired.
+function isShowcaseCodingModel(model: ModelDefinition): boolean {
+	return isCodingModel({
+		...model,
+		providers: model.providers.filter(isActiveMapping),
+	});
+}
+
+// Newest release first; models without a release date sink to the end.
+function byNewestRelease(a: ModelDefinition, b: ModelDefinition): number {
+	const aTime = a.releasedAt?.getTime() ?? 0;
+	const bTime = b.releasedAt?.getTime() ?? 0;
+	return bTime - aTime;
+}
+
+// Pick the provider with the lowest combined input + output price so the card
+// advertises the best ("starting from") rate available for the model. Providers
+// without pricing are ranked last so we still fall back to a usable mapping.
+function getCheapestProvider(
+	providers: readonly ModelProvider[],
+): ModelProvider | undefined {
+	const cost = (p: ModelProvider): number => {
+		const input = p.inputPrice !== undefined ? Number(p.inputPrice) : undefined;
+		const output =
+			p.outputPrice !== undefined ? Number(p.outputPrice) : undefined;
+		if (input === undefined && output === undefined) {
+			return Number.POSITIVE_INFINITY;
+		}
+		return (input ?? 0) + (output ?? 0);
+	};
+	return providers.reduce<ModelProvider | undefined>((cheapest, p) => {
+		if (!cheapest) {
+			return p;
+		}
+		return cost(p) < cost(cheapest) ? p : cheapest;
+	}, undefined);
+}
+
+const codingModels = (models as ModelDefinition[])
+	.filter(isShowcaseCodingModel)
+	.sort(byNewestRelease);
+
+// Recommended = the latest coding model from each open-weight lab, derived
+// from release dates so new catalogue entries surface without curation.
+const recommendedIds: ReadonlySet<string> = (() => {
+	const latestPerFamily = new Map<string, ModelDefinition>();
+	for (const model of codingModels) {
+		if (!OPEN_WEIGHT_LAB_FAMILIES.has(model.family) || !model.releasedAt) {
+			continue;
+		}
+		const current = latestPerFamily.get(model.family);
+		if (!current || model.releasedAt > current.releasedAt!) {
+			latestPerFamily.set(model.family, model);
+		}
+	}
+	return new Set(Array.from(latestPerFamily.values()).map((model) => model.id));
+})();
+
+export const codingModelCards: CodingModelCard[] = codingModels.map((model) => {
+	const provider = getCheapestProvider(model.providers.filter(isActiveMapping));
+	return {
+		id: model.id,
+		name: model.name ?? model.id,
+		family: model.family,
+		premium: isPremiumModel(model.id),
+		recommended: recommendedIds.has(model.id),
+		contextSize: provider?.contextSize ?? null,
+		inputPrice:
+			provider?.inputPrice !== undefined ? Number(provider.inputPrice) : null,
+		outputPrice:
+			provider?.outputPrice !== undefined ? Number(provider.outputPrice) : null,
+	};
+});

--- a/apps/docs/app/api/chat/route.ts
+++ b/apps/docs/app/api/chat/route.ts
@@ -96,7 +96,19 @@ export type ChatUIMessage = UIMessage<
 	}
 >;
 
-const searchServer = createSearchServer();
+// Built lazily on first search: indexing reads every docs page, which should
+// not run at import time (nor when the route only ever answers 503 because
+// Ask AI is unconfigured). An eager module-scope promise would also be an
+// unhandled rejection if indexing fails before the first request.
+let searchServerPromise: Promise<Document<CustomDocument>> | undefined;
+
+function getSearchServer(): Promise<Document<CustomDocument>> {
+	searchServerPromise ??= createSearchServer().catch((error: unknown) => {
+		searchServerPromise = undefined;
+		throw error;
+	});
+	return searchServerPromise;
+}
 
 async function createSearchServer() {
 	const search = new Document<CustomDocument>({
@@ -158,7 +170,7 @@ const searchTool = tool({
 		limit: z.number().int().min(1).max(100).default(10),
 	}),
 	async execute({ query, limit }: { query: string; limit: number }) {
-		const search = await searchServer;
+		const search = await getSearchServer();
 		return await search.searchAsync(query, {
 			limit,
 			merge: true,

--- a/apps/docs/components/ai-tooling-cards.tsx
+++ b/apps/docs/components/ai-tooling-cards.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import {
 	ArrowRight,
 	Bot,
@@ -8,8 +6,8 @@ import {
 	ScrollText,
 	Sparkles,
 } from "lucide-react";
-import Link from "next/link";
-import { usePostHog } from "posthog-js/react";
+
+import { TrackedLink } from "@/components/tracked-link";
 
 import type { ReactNode } from "react";
 
@@ -59,20 +57,14 @@ const tools: Tool[] = [
 ];
 
 export function AIToolingCards() {
-	const posthog = usePostHog();
-
 	return (
 		<div className="not-prose grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
 			{tools.map((tool) => (
-				<Link
+				<TrackedLink
 					key={tool.href}
 					href={tool.href}
-					onClick={() => {
-						posthog.capture("docs_ai_tooling_card_click", {
-							tool: tool.title,
-							href: tool.href,
-						});
-					}}
+					event="docs_ai_tooling_card_click"
+					properties={{ tool: tool.title, href: tool.href }}
 					className="group relative flex flex-col gap-3 rounded-xl border border-fd-border bg-fd-card p-4 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md hover:border-fd-primary/40"
 				>
 					<div className="flex items-center justify-between">
@@ -89,7 +81,7 @@ export function AIToolingCards() {
 					<p className="text-[13px] leading-relaxed text-fd-muted-foreground">
 						{tool.description}
 					</p>
-				</Link>
+				</TrackedLink>
 			))}
 		</div>
 	);

--- a/apps/docs/components/ai/page-actions.tsx
+++ b/apps/docs/components/ai/page-actions.tsx
@@ -15,7 +15,21 @@ import { cn } from "@/lib/cn";
 
 import { Logo } from "../logo";
 
+// Bounded: each entry holds a full page's markdown for the lifetime of the
+// tab, so evict the oldest entries instead of growing with every page copied.
+const CACHE_MAX_ENTRIES = 16;
 const cache = new Map<string, string>();
+
+function cachePage(url: string, content: string) {
+	cache.set(url, content);
+	while (cache.size > CACHE_MAX_ENTRIES) {
+		const oldest = cache.keys().next().value;
+		if (oldest === undefined) {
+			break;
+		}
+		cache.delete(oldest);
+	}
+}
 
 export function LLMCopyButton({
 	/**
@@ -40,7 +54,7 @@ export function LLMCopyButton({
 				new ClipboardItem({
 					"text/plain": fetch(markdownUrl).then(async (res) => {
 						const content = await res.text();
-						cache.set(markdownUrl, content);
+						cachePage(markdownUrl, content);
 
 						return content;
 					}),

--- a/apps/docs/components/ai/search.tsx
+++ b/apps/docs/components/ai/search.tsx
@@ -17,7 +17,6 @@ import {
 	type SyntheticEvent,
 	use,
 	useEffect,
-	useMemo,
 	useRef,
 	useState,
 } from "react";
@@ -117,6 +116,17 @@ export function AISearchInputActions() {
 }
 
 const StorageKeyInput = "__ai_search_input";
+// localStorage writes are synchronous main-thread I/O, so debounce the
+// per-keystroke draft persistence instead of writing on every input event.
+let persistTimer: ReturnType<typeof setTimeout> | undefined;
+
+function persistInput(value: string) {
+	clearTimeout(persistTimer);
+	persistTimer = setTimeout(() => {
+		localStorage.setItem(StorageKeyInput, value);
+	}, 300);
+}
+
 export function AISearchInput(props: ComponentProps<"form">) {
 	const { status, sendMessage, stop } = useChatContext();
 	const [input, setInput] = useState(
@@ -146,6 +156,7 @@ export function AISearchInput(props: ComponentProps<"form">) {
 			],
 		});
 		setInput("");
+		clearTimeout(persistTimer);
 		localStorage.removeItem(StorageKeyInput);
 	};
 
@@ -169,7 +180,7 @@ export function AISearchInput(props: ComponentProps<"form">) {
 				disabled={status === "streaming" || status === "submitted"}
 				onChange={(e) => {
 					setInput(e.target.value);
-					localStorage.setItem(StorageKeyInput, e.target.value);
+					persistInput(e.target.value);
 				}}
 				onKeyDown={(event) => {
 					if (!event.shiftKey && event.key === "Enter") {
@@ -365,9 +376,7 @@ export default function AISearchPanel({
 	});
 
 	return (
-		<Context
-			value={useMemo(() => ({ chat, open, setOpen }), [chat, open, setOpen])}
-		>
+		<Context value={{ chat, open, setOpen }}>
 			<style>
 				{`
         @keyframes ask-ai-open {

--- a/apps/docs/components/enterprise-cta.tsx
+++ b/apps/docs/components/enterprise-cta.tsx
@@ -1,22 +1,15 @@
-"use client";
-
 import { ArrowRight, Shield } from "lucide-react";
-import Link from "next/link";
-import { usePostHog } from "posthog-js/react";
+
+import { TrackedLink } from "@/components/tracked-link";
 
 export function EnterpriseCTA() {
-	const posthog = usePostHog();
-
 	return (
-		<Link
+		<TrackedLink
+			event="docs_enterprise_cta_click"
+			properties={{ location: "toc" }}
 			href="https://llmgateway.io/enterprise"
 			target="_blank"
 			rel="noopener noreferrer"
-			onClick={() => {
-				posthog.capture("docs_enterprise_cta_click", {
-					location: "toc",
-				});
-			}}
 			className="group relative flex flex-col gap-3 rounded-xl border border-fd-border bg-fd-card p-4 transition-all duration-200 hover:border-fd-primary/40 hover:shadow-md"
 		>
 			<div className="flex items-center gap-2.5">
@@ -35,6 +28,6 @@ export function EnterpriseCTA() {
 				Explore Enterprise
 				<ArrowRight className="size-3" />
 			</span>
-		</Link>
+		</TrackedLink>
 	);
 }

--- a/apps/docs/components/self-host-cards.tsx
+++ b/apps/docs/components/self-host-cards.tsx
@@ -1,8 +1,6 @@
-"use client";
-
 import { ArrowRight, Cloud, Container, Layers, Ship } from "lucide-react";
-import Link from "next/link";
-import { usePostHog } from "posthog-js/react";
+
+import { TrackedLink } from "@/components/tracked-link";
 
 import type { ReactNode } from "react";
 
@@ -72,8 +70,6 @@ const groups: Group[] = [
 ];
 
 export function SelfHostCards() {
-	const posthog = usePostHog();
-
 	return (
 		<div className="not-prose flex flex-col gap-8">
 			{groups.map((group) => (
@@ -83,15 +79,11 @@ export function SelfHostCards() {
 					</h3>
 					<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
 						{group.options.map((option) => (
-							<Link
+							<TrackedLink
 								key={option.href}
 								href={option.href}
-								onClick={() => {
-									posthog.capture("docs_self_host_card_click", {
-										option: option.title,
-										href: option.href,
-									});
-								}}
+								event="docs_self_host_card_click"
+								properties={{ option: option.title, href: option.href }}
 								className="group relative flex flex-col gap-3 rounded-xl border border-fd-border bg-fd-card p-4 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md hover:border-fd-primary/40"
 							>
 								<div className="flex items-center justify-between">
@@ -108,7 +100,7 @@ export function SelfHostCards() {
 								<p className="text-[13px] leading-relaxed text-fd-muted-foreground">
 									{option.description}
 								</p>
-							</Link>
+							</TrackedLink>
 						))}
 					</div>
 				</div>

--- a/apps/docs/components/tracked-link.tsx
+++ b/apps/docs/components/tracked-link.tsx
@@ -11,6 +11,7 @@ import type { ComponentProps } from "react";
 export function TrackedLink({
 	event,
 	properties,
+	onClick,
 	...props
 }: ComponentProps<typeof Link> & {
 	event: string;
@@ -21,7 +22,8 @@ export function TrackedLink({
 	return (
 		<Link
 			{...props}
-			onClick={() => {
+			onClick={(clickEvent) => {
+				onClick?.(clickEvent);
 				posthog.capture(event, properties);
 			}}
 		/>

--- a/apps/docs/components/tracked-link.tsx
+++ b/apps/docs/components/tracked-link.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import Link from "next/link";
+import { usePostHog } from "posthog-js/react";
+
+import type { ComponentProps } from "react";
+
+// Thin client boundary for PostHog click tracking, so purely presentational
+// cards can stay server components instead of shipping their whole markup as
+// client JS.
+export function TrackedLink({
+	event,
+	properties,
+	...props
+}: ComponentProps<typeof Link> & {
+	event: string;
+	properties?: Record<string, string>;
+}) {
+	const posthog = usePostHog();
+
+	return (
+		<Link
+			{...props}
+			onClick={() => {
+				posthog.capture(event, properties);
+			}}
+		/>
+	);
+}

--- a/apps/playground/src/app/realtime/page.tsx
+++ b/apps/playground/src/app/realtime/page.tsx
@@ -31,11 +31,23 @@ export default async function RealtimePage({
 		cookieStore.get(REALTIME_MODEL_COOKIE)?.value,
 	);
 
-	const [models, providers, initialOrganizationsData] = await Promise.all([
-		fetchModels(),
-		fetchProviders(),
-		fetchServerData("GET", "/orgs"),
-	]);
+	const [models, providers, initialOrganizationsData, orgIdProjectsData] =
+		await Promise.all([
+			fetchModels(),
+			fetchProviders(),
+			fetchServerData("GET", "/orgs"),
+			// Start the projects fetch for the URL's org eagerly; it is discarded
+			// below when that org doesn't end up selected.
+			orgId
+				? fetchServerData("GET", "/orgs/{id}/projects", {
+						params: {
+							path: {
+								id: orgId,
+							},
+						},
+					})
+				: null,
+		]);
 
 	const allOrganizations = (
 		initialOrganizationsData &&
@@ -54,8 +66,11 @@ export default async function RealtimePage({
 		organizations[0] ??
 		null;
 
-	let initialProjectsData: { projects: Project[] } | null = null;
-	if (selectedOrganization?.id) {
+	let initialProjectsData: { projects: Project[] } | null =
+		selectedOrganization?.id === orgId && orgIdProjectsData
+			? (orgIdProjectsData as { projects: Project[] })
+			: null;
+	if (!initialProjectsData && selectedOrganization?.id) {
 		try {
 			initialProjectsData = (await fetchServerData(
 				"GET",

--- a/apps/playground/src/components/ai-elements/code-block.tsx
+++ b/apps/playground/src/components/ai-elements/code-block.tsx
@@ -127,8 +127,32 @@ const highlighterCache = new Map<
 	Promise<HighlighterGeneric<BundledLanguage, BundledTheme>>
 >();
 
-// Token cache
+// Token cache, bounded: a long chat renders many code blocks (and streaming
+// produces one entry per intermediate snapshot), so evict the least recently
+// used entries instead of retaining every token array for the tab's lifetime.
+const TOKENS_CACHE_MAX_ENTRIES = 200;
 const tokensCache = new Map<string, TokenizedCode>();
+
+function setCachedTokens(key: string, tokens: TokenizedCode) {
+	tokensCache.set(key, tokens);
+	while (tokensCache.size > TOKENS_CACHE_MAX_ENTRIES) {
+		const oldest = tokensCache.keys().next().value;
+		if (oldest === undefined) {
+			break;
+		}
+		tokensCache.delete(oldest);
+	}
+}
+
+function getCachedTokens(key: string): TokenizedCode | undefined {
+	const cached = tokensCache.get(key);
+	if (cached) {
+		// Re-insert so recently used entries sit at the back of the eviction order.
+		tokensCache.delete(key);
+		tokensCache.set(key, cached);
+	}
+	return cached;
+}
 
 // Subscribers for async token updates
 const subscribers = new Map<string, Set<(result: TokenizedCode) => void>>();
@@ -196,7 +220,7 @@ export const highlightCode = (
 	const tokensCacheKey = getTokensCacheKey(code, language);
 
 	// Return cached result if available
-	const cached = tokensCache.get(tokensCacheKey);
+	const cached = getCachedTokens(tokensCacheKey);
 	if (cached) {
 		return cached;
 	}
@@ -231,7 +255,7 @@ export const highlightCode = (
 			};
 
 			// Cache the result
-			tokensCache.set(tokensCacheKey, tokenized);
+			setCachedTokens(tokensCacheKey, tokenized);
 
 			// Notify all subscribers
 			const subs = subscribers.get(tokensCacheKey);

--- a/apps/playground/src/components/credits/top-up-credits-dialog.tsx
+++ b/apps/playground/src/components/credits/top-up-credits-dialog.tsx
@@ -73,7 +73,9 @@ export function TopUpCreditsDialog({
 	>(null);
 	const api = useApi();
 	const queryClient = useQueryClient();
-	const { stripe, isLoading: stripeLoading } = useStripe();
+	// Stripe.js is only needed once the dialog is open; don't load it on the
+	// pages that merely mount this dialog closed.
+	const { stripe, isLoading: stripeLoading } = useStripe(open);
 
 	const { data: paymentMethodsData, isLoading: paymentMethodsLoading } =
 		api.useQuery(

--- a/apps/playground/src/lib/stripe.ts
+++ b/apps/playground/src/lib/stripe.ts
@@ -15,12 +15,17 @@ function getStripePromise() {
 	return stripePromise;
 }
 
-export function useStripe() {
+// Pass enabled: false to skip loading Stripe.js entirely until the caller
+// actually needs it — the script is ~200KB and phones home on load.
+export function useStripe(enabled = true) {
 	const [stripe, setStripe] = useState<Stripe | null>(null);
 	const [isLoading, setIsLoading] = useState(true);
 	const [error, setError] = useState<Error | null>(null);
 
 	useEffect(() => {
+		if (!enabled) {
+			return;
+		}
 		getStripePromise()
 			.then((stripeInstance) => {
 				setStripe(stripeInstance);
@@ -30,7 +35,7 @@ export function useStripe() {
 				setError(err);
 				setIsLoading(false);
 			});
-	}, []);
+	}, [enabled]);
 
 	return { stripe, isLoading, error };
 }

--- a/apps/ui/src/app/dashboard/[orgId]/layout.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/layout.tsx
@@ -1,3 +1,5 @@
+import { cookies } from "next/headers";
+
 import { DashboardLayoutClient } from "@/components/dashboard/dashboard-layout-client";
 import { UnauthorizedView } from "@/components/dashboard/unauthorized-view";
 import { UserProvider } from "@/components/providers/user-provider";
@@ -72,9 +74,13 @@ export default async function OrgLayout({ children, params }: OrgLayoutProps) {
 	// Recent changelog + blog entries for the notifications bell
 	const announcementEntries = await getAnnouncementEntries();
 
+	const cookieStore = await cookies();
+	const sidebarDefaultOpen =
+		cookieStore.get("sidebar_state")?.value !== "false";
+
 	return (
 		<UserProvider initialUserData={initialUserData}>
-			<SidebarProvider>
+			<SidebarProvider defaultOpen={sidebarDefaultOpen}>
 				<DashboardLayoutClient
 					initialOrganizationsData={initialOrganizationsData}
 					initialProjectsData={initialProjectsData}

--- a/apps/ui/src/app/dashboard/page.tsx
+++ b/apps/ui/src/app/dashboard/page.tsx
@@ -1,16 +1,13 @@
 import { redirect } from "next/navigation";
 
 import { getLastUsedProjectId } from "@/lib/last-used-project-server";
-import { fetchServerData } from "@/lib/server-api";
-
-import type { User } from "@/lib/types";
+import { getOrganizations, getOrgProjects, getUserMe } from "@/lib/server-api";
 
 export default async function DashboardPage() {
-	// Fetch user and organization data server-side in parallel
-	const initialUserDataPromise = fetchServerData<
-		{ user: User } | undefined | null
-	>("GET", "/user/me");
-	const initialOrganizationsDataPromise = fetchServerData("GET", "/orgs");
+	// Fetch user and organization data server-side in parallel, through the
+	// request-deduped helpers shared with the dashboard layouts.
+	const initialUserDataPromise = getUserMe();
+	const initialOrganizationsDataPromise = getOrganizations();
 
 	const initialUserData = await initialUserDataPromise;
 
@@ -29,52 +26,34 @@ export default async function DashboardPage() {
 
 	// Determine default organization and project for redirect
 	if (
-		initialOrganizationsData &&
-		typeof initialOrganizationsData === "object"
+		initialOrganizationsData.organizations &&
+		initialOrganizationsData.organizations.length > 0
 	) {
-		const data = initialOrganizationsData as {
-			organizations?: Array<{ id: string; name: string }>;
-		};
+		const defaultOrgId = initialOrganizationsData.organizations[0].id;
 
-		if (data.organizations && data.organizations.length > 0) {
-			const defaultOrgId = data.organizations[0].id;
+		// Fetch projects for the default organization
+		const projectsData = await getOrgProjects(defaultOrgId);
 
-			// Fetch projects for the default organization
-			const projectsData = await fetchServerData("GET", "/orgs/{id}/projects", {
-				params: {
-					path: {
-						id: defaultOrgId,
-					},
-				},
-			});
-
-			// Check if projects data is null (API error)
-			if (!projectsData) {
-				redirect(`/dashboard/${defaultOrgId}`);
-			}
-
-			if (projectsData && typeof projectsData === "object") {
-				const projects = projectsData as {
-					projects?: Array<{ id: string; name: string }>;
-				};
-
-				if (projects.projects && projects.projects.length > 0) {
-					// Check for last used project first, fallback to first project
-					const lastUsedProjectId = await getLastUsedProjectId(defaultOrgId);
-					const defaultProjectId =
-						lastUsedProjectId &&
-						projects.projects.some((p) => p.id === lastUsedProjectId)
-							? lastUsedProjectId
-							: projects.projects[0].id;
-
-					// Redirect to the proper route structure
-					redirect(`/dashboard/${defaultOrgId}/${defaultProjectId}`);
-				}
-			}
-
-			// If no projects found, redirect to organization level
+		// Check if projects data is null (API error)
+		if (!projectsData) {
 			redirect(`/dashboard/${defaultOrgId}`);
 		}
+
+		if (projectsData.projects && projectsData.projects.length > 0) {
+			// Check for last used project first, fallback to first project
+			const lastUsedProjectId = await getLastUsedProjectId(defaultOrgId);
+			const defaultProjectId =
+				lastUsedProjectId &&
+				projectsData.projects.some((p) => p.id === lastUsedProjectId)
+					? lastUsedProjectId
+					: projectsData.projects[0].id;
+
+			// Redirect to the proper route structure
+			redirect(`/dashboard/${defaultOrgId}/${defaultProjectId}`);
+		}
+
+		// If no projects found, redirect to organization level
+		redirect(`/dashboard/${defaultOrgId}`);
 	}
 
 	// If no organizations found, redirect to onboarding

--- a/apps/ui/src/components/api-keys/api-key-limit-fields.tsx
+++ b/apps/ui/src/components/api-keys/api-key-limit-fields.tsx
@@ -204,6 +204,13 @@ export function formatPeriodLimitSummary(
 	return `${formatCurrencyAmount(apiKey.periodUsageLimit)} / ${formatPeriodWindowLabel(apiKey.periodUsageDurationValue, apiKey.periodUsageDurationUnit)}`;
 }
 
+const periodResetFormat = new Intl.DateTimeFormat(undefined, {
+	month: "short",
+	day: "numeric",
+	hour: "2-digit",
+	minute: "2-digit",
+});
+
 export function formatApiKeyPeriodResetLabel(
 	resetAt: string | Date | null | undefined,
 ): string | null {
@@ -216,12 +223,7 @@ export function formatApiKeyPeriodResetLabel(
 		return null;
 	}
 
-	return Intl.DateTimeFormat(undefined, {
-		month: "short",
-		day: "numeric",
-		hour: "2-digit",
-		minute: "2-digit",
-	}).format(date);
+	return periodResetFormat.format(date);
 }
 
 export function formatCurrentPeriodUsageSummary(

--- a/apps/ui/src/components/api-keys/api-key-ttl-fields.tsx
+++ b/apps/ui/src/components/api-keys/api-key-ttl-fields.tsx
@@ -27,6 +27,14 @@ const ttlMaxValues: Record<ApiKeyTtlUnit, number> = {
 	day: 365,
 };
 
+const expiryDateFormat = new Intl.DateTimeFormat(undefined, {
+	month: "short",
+	day: "numeric",
+	year: "numeric",
+	hour: "2-digit",
+	minute: "2-digit",
+});
+
 export interface ApiKeyTtlFormValue {
 	enabled: boolean;
 	unit: ApiKeyTtlUnit;
@@ -73,13 +81,7 @@ export function formatApiKeyExpiry(
 
 	return {
 		expired: date.getTime() <= Date.now(),
-		label: Intl.DateTimeFormat(undefined, {
-			month: "short",
-			day: "numeric",
-			year: "numeric",
-			hour: "2-digit",
-			minute: "2-digit",
-		}).format(date),
+		label: expiryDateFormat.format(date),
 	};
 }
 
@@ -110,13 +112,7 @@ export function ApiKeyTtlFields({
 	const preview = buildApiKeyTtlExpiresAt(value);
 	const previewLabel =
 		value.enabled && preview.expiresAt
-			? Intl.DateTimeFormat(undefined, {
-					month: "short",
-					day: "numeric",
-					year: "numeric",
-					hour: "2-digit",
-					minute: "2-digit",
-				}).format(new Date(preview.expiresAt))
+			? expiryDateFormat.format(new Date(preview.expiresAt))
 			: null;
 
 	return (

--- a/apps/ui/src/components/api-keys/api-keys-list.tsx
+++ b/apps/ui/src/components/api-keys/api-keys-list.tsx
@@ -92,6 +92,19 @@ type LimitFilter = "all" | "approaching" | "reached";
 
 const PLAYGROUND_KEY_DESCRIPTION = "Auto-generated playground key";
 
+const createdDateFormat = new Intl.DateTimeFormat(undefined, {
+	month: "short",
+	day: "numeric",
+	year: "numeric",
+});
+const createdDateTimeFormat = new Intl.DateTimeFormat(undefined, {
+	month: "short",
+	day: "numeric",
+	year: "numeric",
+	hour: "2-digit",
+	minute: "2-digit",
+});
+
 function PlaygroundKeyNote() {
 	return (
 		<>
@@ -812,22 +825,14 @@ export function ApiKeysList({
 										<Tooltip>
 											<TooltipTrigger asChild>
 												<span className="text-muted-foreground cursor-help border-b border-dotted border-muted-foreground/50 hover:border-muted-foreground">
-													{Intl.DateTimeFormat(undefined, {
-														month: "short",
-														day: "numeric",
-														year: "numeric",
-													}).format(new Date(key.createdAt))}
+													{createdDateFormat.format(new Date(key.createdAt))}
 												</span>
 											</TooltipTrigger>
 											<TooltipContent>
 												<p className="max-w-xs text-xs whitespace-nowrap">
-													{Intl.DateTimeFormat(undefined, {
-														month: "short",
-														day: "numeric",
-														year: "numeric",
-														hour: "2-digit",
-														minute: "2-digit",
-													}).format(new Date(key.createdAt))}
+													{createdDateTimeFormat.format(
+														new Date(key.createdAt),
+													)}
 												</p>
 											</TooltipContent>
 										</Tooltip>
@@ -1020,13 +1025,7 @@ export function ApiKeysList({
 									{renderExpiry(key)}
 									<div className="flex items-center gap-2 mt-1">
 										<span className="text-xs text-muted-foreground">
-											{Intl.DateTimeFormat(undefined, {
-												month: "short",
-												day: "numeric",
-												year: "numeric",
-												hour: "2-digit",
-												minute: "2-digit",
-											}).format(new Date(key.createdAt))}
+											{createdDateTimeFormat.format(new Date(key.createdAt))}
 										</span>
 									</div>
 								</div>

--- a/apps/ui/src/components/master-keys/master-keys-list.tsx
+++ b/apps/ui/src/components/master-keys/master-keys-list.tsx
@@ -45,6 +45,19 @@ interface MasterKeysListProps {
 	organizationId: string;
 }
 
+const createdDateFormat = new Intl.DateTimeFormat(undefined, {
+	month: "short",
+	day: "numeric",
+	year: "numeric",
+});
+const createdDateTimeFormat = new Intl.DateTimeFormat(undefined, {
+	month: "short",
+	day: "numeric",
+	year: "numeric",
+	hour: "2-digit",
+	minute: "2-digit",
+});
+
 export function MasterKeysList({ organizationId }: MasterKeysListProps) {
 	const api = useApi();
 	const queryClient = useQueryClient();
@@ -212,22 +225,12 @@ export function MasterKeysList({ organizationId }: MasterKeysListProps) {
 									<Tooltip>
 										<TooltipTrigger asChild>
 											<span className="text-muted-foreground cursor-help border-b border-dotted border-muted-foreground/50 hover:border-muted-foreground">
-												{Intl.DateTimeFormat(undefined, {
-													month: "short",
-													day: "numeric",
-													year: "numeric",
-												}).format(new Date(key.createdAt))}
+												{createdDateFormat.format(new Date(key.createdAt))}
 											</span>
 										</TooltipTrigger>
 										<TooltipContent>
 											<p className="max-w-xs text-xs whitespace-nowrap">
-												{Intl.DateTimeFormat(undefined, {
-													month: "short",
-													day: "numeric",
-													year: "numeric",
-													hour: "2-digit",
-													minute: "2-digit",
-												}).format(new Date(key.createdAt))}
+												{createdDateTimeFormat.format(new Date(key.createdAt))}
 											</p>
 										</TooltipContent>
 									</Tooltip>
@@ -239,13 +242,7 @@ export function MasterKeysList({ organizationId }: MasterKeysListProps) {
 								</TableCell>
 								<TableCell className="text-muted-foreground text-sm">
 									{key.lastUsedAt
-										? Intl.DateTimeFormat(undefined, {
-												month: "short",
-												day: "numeric",
-												year: "numeric",
-												hour: "2-digit",
-												minute: "2-digit",
-											}).format(new Date(key.lastUsedAt))
+										? createdDateTimeFormat.format(new Date(key.lastUsedAt))
 										: "Never"}
 								</TableCell>
 								<TableCell className="text-right">
@@ -314,11 +311,7 @@ export function MasterKeysList({ organizationId }: MasterKeysListProps) {
 									<StatusBadge status={key.status} />
 								</div>
 								<div className="text-xs text-muted-foreground mt-1">
-									{Intl.DateTimeFormat(undefined, {
-										month: "short",
-										day: "numeric",
-										year: "numeric",
-									}).format(new Date(key.createdAt))}
+									{createdDateFormat.format(new Date(key.createdAt))}
 								</div>
 							</div>
 							<DropdownMenu>
@@ -378,13 +371,7 @@ export function MasterKeysList({ organizationId }: MasterKeysListProps) {
 							</div>
 							<div className="text-sm">
 								{key.lastUsedAt
-									? Intl.DateTimeFormat(undefined, {
-											month: "short",
-											day: "numeric",
-											year: "numeric",
-											hour: "2-digit",
-											minute: "2-digit",
-										}).format(new Date(key.lastUsedAt))
+									? createdDateTimeFormat.format(new Date(key.lastUsedAt))
 									: "Never"}
 							</div>
 						</div>

--- a/apps/ui/src/lib/components/number-ticker.tsx
+++ b/apps/ui/src/lib/components/number-ticker.tsx
@@ -43,18 +43,21 @@ export function NumberTicker({
 		return () => {};
 	}, [motionValue, isInView, delay, value, direction, startValue]);
 
-	useEffect(
-		() =>
-			springValue.on("change", (latest) => {
-				if (ref.current) {
-					ref.current.textContent = Intl.NumberFormat("en-US", {
-						minimumFractionDigits: decimalPlaces,
-						maximumFractionDigits: decimalPlaces,
-					}).format(Number(latest.toFixed(decimalPlaces)));
-				}
-			}),
-		[springValue, decimalPlaces],
-	);
+	useEffect(() => {
+		// One formatter per subscription — the spring change handler fires every
+		// animation frame, so it must not construct an Intl.NumberFormat each call.
+		const format = new Intl.NumberFormat("en-US", {
+			minimumFractionDigits: decimalPlaces,
+			maximumFractionDigits: decimalPlaces,
+		});
+		return springValue.on("change", (latest) => {
+			if (ref.current) {
+				ref.current.textContent = format.format(
+					Number(latest.toFixed(decimalPlaces)),
+				);
+			}
+		});
+	}, [springValue, decimalPlaces]);
 
 	return (
 		<span

--- a/apps/ui/src/lib/components/sidebar.tsx
+++ b/apps/ui/src/lib/components/sidebar.tsx
@@ -38,7 +38,8 @@ import { randomInt } from "@llmgateway/shared/random";
 
 import type { VariantProps } from "class-variance-authority";
 
-const SIDEBAR_STORAGE_KEY = "sidebar_state";
+const SIDEBAR_COOKIE_NAME = "sidebar_state";
+const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = "16rem";
 const SIDEBAR_WIDTH_MOBILE = "18rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
@@ -80,26 +81,13 @@ function SidebarProvider({
 }) {
 	const isMobile = useIsMobile();
 	const [openMobile, setOpenMobile] = useState(false);
-	const [mounted, setMounted] = useState(false);
-
-	// Track if component has mounted to prevent hydration issues
-	useEffect(() => {
-		setMounted(true);
-	}, []);
 
 	// This is the internal state of the sidebar.
 	// We use openProp and setOpenProp for control from outside the component.
+	// The server layout reads the cookie and passes it as defaultOpen, so the
+	// first client render already matches the persisted state (no post-mount
+	// snap).
 	const [_open, _setOpen] = useState(defaultOpen);
-
-	// Update internal state from localStorage after mounting
-	useEffect(() => {
-		if (mounted && !openProp) {
-			const savedState = localStorage.getItem(SIDEBAR_STORAGE_KEY);
-			if (savedState !== null) {
-				_setOpen(savedState === "true");
-			}
-		}
-	}, [mounted, openProp]);
 
 	const open = openProp ?? _open;
 	const setOpen = useCallback(
@@ -111,10 +99,8 @@ function SidebarProvider({
 				_setOpen(openState);
 			}
 
-			// Save the state to localStorage
-			if (typeof window !== "undefined") {
-				localStorage.setItem(SIDEBAR_STORAGE_KEY, String(openState));
-			}
+			// This sets the cookie to keep the sidebar state.
+			document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
 		},
 		[setOpenProp, open],
 	);

--- a/apps/ui/src/lib/utils/markdown.tsx
+++ b/apps/ui/src/lib/utils/markdown.tsx
@@ -1,6 +1,12 @@
+import dynamic from "next/dynamic";
+
 import { BlogCta } from "@/components/blog/blog-cta";
 
-import { SyntaxHighlightedPre } from "./markdown-code-block";
+// Defer the prism-based highlighter chunk until a markdown document actually
+// renders a fenced code block.
+const SyntaxHighlightedPre = dynamic(() =>
+	import("./markdown-code-block").then((mod) => mod.SyntaxHighlightedPre),
+);
 
 export interface ChangelogFrontmatter {
 	id: string;


### PR DESCRIPTION
Weekly React/Next.js best-practices audit of the four Next.js apps (`apps/ui`, `apps/code`, `apps/playground`, `apps/docs`) against [Vercel's react-best-practices guide](https://github.com/vercel-labs/agent-skills/blob/main/skills/react-best-practices/AGENTS.md). The three previous audits (#3391, #3518, #3647) are all merged, so this week covers code merged since then plus remaining findings, including two items those audits explicitly deferred that turned out to have surgical fixes. No routing changes, no user-visible behavior changes, nothing touching `export const dynamic`.

## Fixes

### apps/ui

- **Prevent Hydration Mismatch Without Flickering (rule 6.5)** — `lib/components/sidebar.tsx`, `app/dashboard/[orgId]/layout.tsx`. The sidebar open state was read from localStorage in a post-mount effect (behind a `mounted` flag), so every dashboard load rendered the default state and then snapped to the persisted one — a layout shift on every navigation for anyone with a collapsed sidebar. Deferred by the last two audits as needing prop threading; it doesn't: the provider's only mount point is the org server layout, which already reads cookies. The state now persists in a `sidebar_state` cookie (the pattern the playground's sidebar already uses) and the layout passes it as `defaultOpen`, so the first paint is correct and both effects plus the `mounted` state are gone. One-time migration cost: a previously saved localStorage value is ignored, so a collapsed sidebar renders expanded once until the user toggles again.
- **Per-Request Deduplication with React.cache() (rule 3.9)** — `app/dashboard/page.tsx`. The dashboard entry page fetched `/user/me`, `/orgs`, and `/orgs/{id}/projects` through the raw fetcher while `dashboard/layout.tsx` fetches `/user/me` through the deduped `getUserMe()` in the same render pass — a duplicate round-trip on every `/dashboard` hit. All three now go through the existing `cache()`-backed helpers, which also lets the redirect target's org layout share them.
- **Dynamic Imports for Heavy Components (rule 2.4)** — `lib/utils/markdown.tsx`. The prism-based `SyntaxHighlightedPre` (prism-react-renderer plus its full `themes` barrel) was statically wired into the markdown options used by the blog, guides, changelog, legal, use-cases, and migration routes, shipping the highlighter on articles with zero code blocks. Now `next/dynamic`, mirroring the identical fix `apps/code` got in #3518.
- **Cache Repeated Function Calls / Hoist Constructors (rules 7.4/7.10)** — `components/api-keys/api-keys-list.tsx`, `api-key-limit-fields.tsx`, `api-key-ttl-fields.tsx`, `components/master-keys/master-keys-list.tsx`, `lib/components/number-ticker.tsx`. The API-keys table constructed 3–4 `Intl.DateTimeFormat` instances per row per render (creation date, tooltip, expiry, period reset), the master-keys list the same, and `NumberTicker` constructed one per spring animation frame (×3 tickers on pages using it). All formatters are hoisted to module scope (or, for the ticker, created once per subscription).

### apps/code

- **Minimize Serialization at RSC Boundaries / bundle size (rules 3.6, 2.x)** — new `lib/coding-models.ts`, `components/CodingModelsShowcase.tsx`, `app/page.tsx`, `app/coding-models/page.tsx`. The showcase — rendered on the landing page and `/coding-models` — imported the entire `@llmgateway/models` catalogue (~800K of source: every model with all provider mappings) into a client component, then derived a few fields per coding model in the browser. Flagged as the app's biggest bundle finding in #3518 and deferred twice as "needs an interface redesign"; the redesign is small. All derivation (DevPass coding gate, recommended/premium sets, cheapest-provider pricing) now runs server-side and only a trimmed card array (8 scalar fields per model) crosses the RSC boundary. The client keeps just the tab state and copy button; rendered UI is unchanged.
- **NumberTicker per-frame `Intl.NumberFormat`** — `components/ui/number-ticker.tsx`, same fix as the ui copy above.

### apps/playground

- **Promise.all() for Independent Operations (rule 1.5)** — `app/realtime/page.tsx`. Realtime was the only media page still awaiting `/orgs/{id}/projects` serially after models/providers/orgs; the siblings (`image`, `video`, `audio`, `canvas`) all start it eagerly in the same `Promise.all` when the URL carries an `orgId`. Realtime now does the same, with the eager result used only when that org actually ends up selected.
- **Defer Non-Critical Third-Party Libraries (rule 2.3)** — `lib/stripe.ts`, `components/credits/top-up-credits-dialog.tsx`. `useStripe()` loaded Stripe.js (~200KB, phones home on load) in an unconditional mount effect, and the top-up dialog mounts closed on the chat, image, video, and audio pages — so every playground visit fetched Stripe. Ported the `enabled` gate `apps/code` got in #3647; the dialog passes its `open` state, so Stripe.js loads only when the dialog is actually opened.
- **Bounded module cache (rule 4.4-adjacent)** — `components/ai-elements/code-block.tsx`. The shiki `tokensCache` retained the full `ThemedToken[][]` of every code block ever rendered (including one entry per streaming snapshot) for the tab's lifetime; its sibling caches were already bounded/cleaned. Now LRU-capped at 200 entries.

### apps/docs

- **Defer Await Until Needed (rule 1.2)** — `app/api/chat/route.ts`. The Ask-AI FlexSearch index was built eagerly at module scope: importing the route read and indexed the processed text of all ~131 MDX pages even when `DOCS_AI_SUPPORT_CHAT_API_KEY` is unset and the handler always 503s — and the module-scope promise had no rejection handler until the first tool call, so an indexing failure at boot would crash the standalone server as an unhandled rejection. The index is now built lazily and memoized on first search, with failed builds dropped so a transient error doesn't stick.
- **Unnecessary `"use client"` on static components** — new `components/tracked-link.tsx`; `components/enterprise-cta.tsx`, `ai-tooling-cards.tsx`, `self-host-cards.tsx`. Three purely presentational card components were client components solely to fire a PostHog click capture — `EnterpriseCTA` renders in the TOC footer of every docs page, so its markup shipped as client JS everywhere. A thin `TrackedLink` client wrapper now owns the capture, and the cards (icons, copy, layout) are server components.
- **Bounded module cache** — `components/ai/page-actions.tsx`. The "Copy Markdown" cache stored each copied page's entire raw markdown in an unbounded module `Map`; now capped with oldest-entry eviction, matching the treatment `markdown.tsx` got in #3518.
- **Cache Storage API Calls (rule 7.5)** — `components/ai/search.tsx`. The Ask-AI input wrote its draft to localStorage synchronously on every keystroke; now debounced (300ms), flushed/cleared on submit.
- **Remove always-missing `useMemo`** — `components/ai/search.tsx`. The context value was memoized on `[chat, open, setOpen]`, but `useChat` returns a fresh object every render, so the memo allocated every time and never hit; removed (React Compiler covers the rest).

## Considered and deliberately skipped

- **Anything involving `export const dynamic`** — intentional (runtime env loading); excluded per repo policy.
- **docs: `APIPage` in `mdx-components.tsx`** pulls the fumadocs OpenAPI playground into the client manifest of every docs page — the largest remaining docs bundle item, but the app has a single catch-all page route serving both prose and API reference, so splitting it needs a route restructure. Deferred.
- **docs: static `posthog-js` import in the root provider** — the init is already idle-deferred; deferring the import itself requires reworking how `PostHogProvider` receives its client instance. Deferred as behavior-sensitive.
- **ui: `posthog.identify()` inside `getUser()`** runs on every dashboard layout render (server-side twin of the client issue fixed in #3518/#3647) — relocating identification to the auth path is an analytics-behavior decision, not a perf-only diff.
- **ui: security-events page hand-rolls `useEffect` fetching** (same class as the already-deferred audit-logs/routing-config pages) — the right fix is a `useInfiniteQuery` rewrite; too invasive for this pass.
- **ui: millisecond-precision `new Date()` in the agents-view query key** defeats its `staleTime` — real, but truncating the window boundary changes the queried range semantics slightly; left for a deliberate change.
- **playground: chat route's project retrieval serialized ahead of MCP connects** — parallelizing changes error-ordering on the hottest route; same reasoning as #3518's deferral of that route's auth/body ordering.
- **playground: `@streamdown/mermaid` statically registered for every assistant message** — potentially the largest chat-chunk item, but needs bundle analysis to confirm the plugin doesn't lazy-load internally before acting.
- **Manual memoization nits** — all four apps run the React Compiler; only issues the compiler cannot fix (effects, module caches, per-frame constructors, RSC boundaries) were touched.

## Verification

- `pnpm build`: 15 of 17 workspaces green, including docs, code, and playground. `ui#build` compiles and type-checks, but static export fails on `/compare/litellm/opengraph-image` with `SELF_SIGNED_CERT_IN_CHAIN` — the same pre-existing build-environment artifact documented and reproduced on clean main in #3647 (TLS-intercepting proxy breaking a build-time `next/og` fetch), unrelated to this diff.
- `pnpm exec tsc --noEmit` in `apps/ui` passes.
- `pnpm format` clean.
- No visual changes intended: the sidebar renders in its persisted state without the previous post-hydration snap, and the showcase/dialog/card changes render identical UI — so no before/after screenshots.

Note: this session pushes to its designated branch, so the head branch is `claude/upbeat-johnson-mc6akz` rather than the `chore/react-bp-audit-2026-08-24` naming convention (same situation as #3518); future audits should locate this PR by title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQLYmwthWTnfTLViZsfYKM

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQLYmwthWTnfTLViZsfYKM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated coding-model showcases with refreshed model details, pricing, context limits, and recommendation badges.
  - Sidebar preferences now persist across sessions.
  - Realtime views load projects for the selected workspace more reliably.
  - Added consistent click tracking for documentation and promotional links.

- **Bug Fixes**
  - Improved documentation search reliability and retry behavior.
  - Preserved AI search drafts more reliably while typing.
  - Deferred Stripe loading until the credit top-up dialog opens.

- **Performance**
  - Improved code highlighting, markdown rendering, number formatting, and dashboard data loading.
  - Added bounded caching to keep documentation and code previews responsive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->