### PR TITLE
fix(actions): cap remote images fetched for OpenAI image edits

### DIFF
--- a/packages/actions/src/prepare-request-body.image-edits.spec.ts
+++ b/packages/actions/src/prepare-request-body.image-edits.spec.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { prepareRequestBody } from "./prepare-request-body.js";
+
+import type { BaseMessage } from "@llmgateway/models";
+
+const MODEL_ID = "gpt-image-2";
+
+const originalFetch = globalThis.fetch;
+
+/**
+ * A remote image whose body is streamed in 1MB chunks up to `totalMB`, with the
+ * Content-Length deliberately understated so only a running cap can catch it —
+ * exactly what a hostile (or merely broken) image host looks like.
+ */
+function respondWithImageOfSize(totalMB: number): void {
+	globalThis.fetch = vi.fn(async () => {
+		let sent = 0;
+		const body = new ReadableStream<Uint8Array>({
+			pull(controller) {
+				if (sent >= totalMB) {
+					controller.close();
+					return;
+				}
+				sent += 1;
+				controller.enqueue(new Uint8Array(1024 * 1024));
+			},
+		});
+		return new Response(body, {
+			status: 200,
+			headers: {
+				"content-type": "image/png",
+				"content-length": "1024",
+			},
+		});
+	}) as unknown as typeof fetch;
+}
+
+function prepareEdit(url: string) {
+	return prepareRequestBody(
+		"openai",
+		MODEL_ID,
+		null,
+		MODEL_ID,
+		[
+			{
+				role: "user",
+				content: [
+					{ type: "text", text: "make it blue" },
+					{ type: "image_url", image_url: { url } },
+				],
+			},
+		] as unknown as BaseMessage[],
+		false, // stream
+		undefined, // temperature
+		undefined, // max_tokens
+		undefined, // top_p
+		undefined, // frequency_penalty
+		undefined, // presence_penalty
+		undefined, // response_format
+		undefined, // tools
+		undefined, // tool_choice
+		undefined, // reasoning_effort
+		false, // supportsReasoning
+		false, // isProd
+		2, // maxImageSizeMB
+		"free", // userPlan
+		undefined, // sensitive_word_check
+		undefined, // image_config
+		undefined, // effort
+		true, // imageGenerations
+	);
+}
+
+describe("prepareRequestBody - OpenAI image edits", () => {
+	beforeEach(() => {
+		process.env.ALLOW_INSECURE_PROVIDER_URLS = "true";
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		vi.restoreAllMocks();
+	});
+
+	test("rejects a remote edit image that exceeds the caller size limit", async () => {
+		respondWithImageOfSize(8);
+
+		await expect(
+			prepareEdit("https://cdn.example.com/huge.png"),
+		).rejects.toThrow(/exceeds/i);
+	});
+
+	test("rejects a remote edit image that is not an image", async () => {
+		globalThis.fetch = vi.fn(
+			async () =>
+				new Response("<html>nope</html>", {
+					status: 200,
+					headers: { "content-type": "text/html" },
+				}),
+		) as unknown as typeof fetch;
+
+		await expect(
+			prepareEdit("https://cdn.example.com/not-an-image"),
+		).rejects.toThrow(/does not point to a valid image/i);
+	});
+
+	test("uploads an in-limit remote image as a multipart image part", async () => {
+		respondWithImageOfSize(1);
+
+		const body = (await prepareEdit(
+			"https://cdn.example.com/small.png",
+		)) as FormData;
+
+		expect(body).toBeInstanceOf(FormData);
+		const file = body.get("image") as File;
+		expect(file).toBeInstanceOf(File);
+		expect(file.type).toBe("image/png");
+		expect(file.name).toBe("image-0.png");
+		expect(file.size).toBe(1024 * 1024);
+	});
+});

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -27,7 +27,6 @@ import {
 	type WebSearchTool,
 } from "@llmgateway/models";
 import { getApiKeyHashSecret } from "@llmgateway/shared/api-key-hash";
-import { assertSafeUserContentUrl } from "@llmgateway/shared/url-safety-node";
 
 import {
 	isToolSearchTool,
@@ -212,6 +211,9 @@ function normalizeImageQuality(
 async function fetchImageAsBlob(
 	url: string,
 	index: number,
+	isProd: boolean,
+	maxSizeMB: number,
+	userPlan: "free" | "pro" | "enterprise" | null,
 ): Promise<{ blob: Blob; filename: string }> {
 	const parsed = parseDataUrl(url);
 	if (parsed) {
@@ -230,21 +232,28 @@ async function fetchImageAsBlob(
 		};
 	}
 
-	// SSRF: the URL comes from the request body, so validate it does not resolve
-	// to an internal host and refuse redirects before fetching.
-	await assertSafeUserContentUrl(url);
-	const response = await fetch(url, { redirect: "error" });
-	if (!response.ok) {
-		throw new Error(
-			`Failed to fetch image ${url}: ${response.status} ${response.statusText}`,
-		);
-	}
-	const mimeType =
-		response.headers.get("content-type")?.split(";")[0]?.trim() || "image/png";
-	const buffer = await response.arrayBuffer();
-	const ext = mimeType.split("/")[1]?.split("+")[0] ?? "png";
+	// Load the remote image through `processImageUrl` instead of fetching inline.
+	// It keeps the SSRF validation and the redirect refusal, and it additionally
+	// rejects non-image content types and enforces the caller size cap *while* the
+	// body downloads. The inline `arrayBuffer()` this replaces had no cap at all,
+	// so an edits request pointing at an oversized (or endless) response buffered
+	// the whole thing in memory before anything looked at it.
+	const { data, mimeType } = await processImageUrl(
+		url,
+		isProd,
+		maxSizeMB,
+		userPlan,
+	);
+	// `processImageUrl` returns the raw Content-Type for remote fetches, which can
+	// carry parameters (e.g. "image/png; charset=binary"). The multipart part type
+	// and the filename extension both need the bare type.
+	const baseMimeType = mimeType.split(";", 1)[0].trim() || "image/png";
+	const raw = Buffer.from(data, "base64");
+	const buffer = new ArrayBuffer(raw.byteLength);
+	new Uint8Array(buffer).set(raw);
+	const ext = baseMimeType.split("/")[1]?.split("+")[0] ?? "png";
 	return {
-		blob: new Blob([buffer], { type: mimeType }),
+		blob: new Blob([buffer], { type: baseMimeType }),
 		filename: `image-${index}.${ext}`,
 	};
 }
@@ -1474,7 +1483,9 @@ export async function prepareRequestBody(
 			}
 
 			const decoded = await Promise.all(
-				imageUrls.map((url, index) => fetchImageAsBlob(url, index)),
+				imageUrls.map((url, index) =>
+					fetchImageAsBlob(url, index, isProd, maxImageSizeMB, userPlan),
+				),
 			);
 			const fieldName = decoded.length === 1 ? "image" : "image[]";
 			for (const { blob, filename } of decoded) {


### PR DESCRIPTION
The OpenAI/Azure image-edits path decoded each caller-supplied `image_url` with its own inline `fetch` plus `response.arrayBuffer()`. That path had no size cap and no content-type check, so a tenant API key could point an edits request at an oversized or endless response and the gateway would buffer the whole body in memory before anything inspected it — while every other image input in the codebase goes through `processImageUrl`, which refuses redirects, requires an `image/*` content type, and enforces the caller size cap as the body downloads.

Reachable with an ordinary tenant key: `POST /v1/chat/completions` against an OpenAI/Azure image model with an `image_url` in the last user message switches to `/v1/images/edits`, and `prepareRequestBody` calls `fetchImageAsBlob(url)` on the URL from the request body.

Route the edits path through the same helper and pass the `isProd`, `maxImageSizeMB` and `userPlan` values the surrounding function already receives. The bare content type is still used for the multipart part type and the filename extension, so upstream requests are unchanged for images that were within the limit. The `data:` branch is untouched. Net effect is 16 fewer lines of source.

Covered by `prepare-request-body.image-edits.spec.ts`: an 8MB body served with an understated `Content-Length` against a 2MB cap, a `text/html` body, and an in-limit image that must still upload as `image-0.png`. The two rejection tests fail before the change (the oversized body resolves as an 8388608-byte `File`) and pass after. `packages/actions`: 748 passed; the 4 failures in `provider-key/env-inventory*` are identical on a clean `main` (they need Redis).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image editing with stronger validation for remote image URLs.
  - Rejects unsupported content, unsafe redirects, and images exceeding the configured size limit.
  - Preserves support for valid images within the allowed size limit.
  - Improved handling of image file types and metadata when preparing edits.

- **Tests**
  - Added coverage for oversized images, invalid content responses, and valid in-limit images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->