### PR TITLE
fix(gateway): keep DB open while draining

### DIFF
--- a/apps/gateway/src/lib/pending-work.spec.ts
+++ b/apps/gateway/src/lib/pending-work.spec.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { describe, expect, test } from "vitest";
 
 import {
+	drainPendingWork,
 	pendingWorkCount,
 	streamSSE,
 	trackPendingWork,
@@ -45,6 +46,29 @@ describe("pending-work registry", () => {
 
 		work.resolve();
 		expect(await waitForPendingWork(1000)).toBe(0);
+	});
+
+	test("drainPendingWork keeps dependencies alive after the warning threshold", async () => {
+		const work = deferred();
+		const delayed = deferred();
+		void trackPendingWork(work.promise);
+
+		let reportedRemaining = 0;
+		let drained = false;
+		const drain = drainPendingWork(0, (remaining) => {
+			reportedRemaining = remaining;
+			delayed.resolve();
+		}).then(() => {
+			drained = true;
+		});
+
+		await delayed.promise;
+		expect(reportedRemaining).toBe(1);
+		expect(drained).toBe(false);
+
+		work.resolve();
+		await drain;
+		expect(drained).toBe(true);
 	});
 
 	test("streamSSE tail work stays tracked after the response is fully consumed", async () => {

--- a/apps/gateway/src/lib/pending-work.ts
+++ b/apps/gateway/src/lib/pending-work.ts
@@ -44,6 +44,26 @@ export async function waitForPendingWork(timeoutMs: number): Promise<number> {
 }
 
 /**
+ * Waits for all tracked work before shutdown closes shared dependencies.
+ * The timeout is only a diagnostic threshold: closing the database or Redis
+ * while work remains would make the pending handlers fail by construction.
+ */
+export async function drainPendingWork(
+	warnAfterMs: number,
+	onDelayed: (remaining: number) => void,
+): Promise<void> {
+	const remaining = await waitForPendingWork(warnAfterMs);
+	if (remaining === 0) {
+		return;
+	}
+
+	onDelayed(remaining);
+	while (pending.size > 0) {
+		await Promise.all([...pending]);
+	}
+}
+
+/**
  * Drop-in replacement for hono/streaming's streamSSE that tracks the stream
  * callback in the pending-work registry for its full duration. Gateway routes
  * must use this instead of importing from hono/streaming directly, or their

--- a/apps/gateway/src/serve.ts
+++ b/apps/gateway/src/serve.ts
@@ -11,7 +11,7 @@ import { logger, toError } from "@llmgateway/logger";
 import { getEnterpriseLicenseStatus } from "@llmgateway/shared/enterprise-license";
 
 import { app } from "./app.js";
-import { pendingWorkCount, waitForPendingWork } from "./lib/pending-work.js";
+import { drainPendingWork, pendingWorkCount } from "./lib/pending-work.js";
 import {
 	closeUpstreamDispatcher,
 	installUpstreamDispatcher,
@@ -148,9 +148,10 @@ const realtimeShutdownGracePeriodMs =
 	Number(process.env.REALTIME_SHUTDOWN_GRACE_PERIOD_MS) ||
 	((Number(process.env.REALTIME_MAX_SESSION_SECONDS) || 3600) + 60) * 1000;
 
-// How long to wait for handler tails (billing, log insertion) that outlive
-// their HTTP connection before closing the database pool and Redis. These are
-// a few DB/Redis round-trips, so 20s is generous.
+// Warn when handler tails (billing, log insertion) outlive their HTTP
+// connection longer than expected. Shutdown continues waiting after this
+// threshold because closing shared dependencies underneath live handlers is
+// guaranteed to make them fail; the orchestrator owns the hard deadline.
 const pendingWorkTimeoutMs =
 	Number(process.env.SHUTDOWN_PENDING_WORK_TIMEOUT_MS) || 20000;
 
@@ -252,13 +253,12 @@ const gracefulShutdown = async (signal: string, server: ServerType) => {
 			logger.info("Waiting for pending request work", {
 				pending: pendingAtClose,
 			});
-			const remaining = await waitForPendingWork(pendingWorkTimeoutMs);
-			if (remaining > 0) {
-				logger.warn("Pending request work did not finish before shutdown", {
+			await drainPendingWork(pendingWorkTimeoutMs, (remaining) => {
+				logger.warn("Pending request work is still draining", {
 					remaining,
-					timeoutMs: pendingWorkTimeoutMs,
+					warningThresholdMs: pendingWorkTimeoutMs,
 				});
-			}
+			});
 		}
 
 		logger.info("Closing upstream dispatcher");


### PR DESCRIPTION
## Problem

Gateway shutdown tracked streaming billing and logging tails, but only waited 20 seconds before closing PostgreSQL and Redis even when tracked work remained. A slow tail could therefore query a pool that shutdown had already ended.

## Approach

- Treat the existing pending-work timeout as a diagnostic threshold.
- Continue draining tracked handlers after the warning instead of closing shared dependencies underneath them.
- Leave the orchestrator responsible for the hard shutdown deadline.
- Cover the delayed-drain path with a regression test.

## Verification

- `pnpm exec vitest run apps/gateway/src/lib/pending-work.spec.ts --no-file-parallelism`
- `pnpm format`
- `pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling so pending work continues completing after the warning threshold.
  * Added periodic visibility into remaining pending work during shutdown.
  * Updated timeout messaging to clarify it is a warning threshold, not a hard limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->