### PR TITLE
docs(devpass): document usage API

### DIFF
--- a/apps/docs/content/developers/devpass-usage.mdx
+++ b/apps/docs/content/developers/devpass-usage.mdx
@@ -1,0 +1,84 @@
+---
+title: DevPass Usage API
+description: Read DevPass monthly and weekly usage limits from an application using its gateway API key
+icon: Gauge
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+# DevPass Usage API
+
+Use `GET /v1/key` to show DevPass allowance meters in a coding tool or other
+trusted application. The endpoint uses the application's existing gateway API
+key, so it does not require a dashboard session.
+
+<Callout type="warning">
+	A regular gateway API key is a secret. Do not embed it in public browser code
+	or distribute it with an application. Read it from the user's secure local
+	configuration or call the endpoint from a trusted backend.
+</Callout>
+
+## Request
+
+```bash
+curl https://api.llmgateway.io/v1/key \
+  -H "Authorization: Bearer llmgtwy_your_api_key_here"
+```
+
+Only regular gateway API keys can use this endpoint. Platform publishable keys
+and end-user sessions receive `403 Forbidden` because they cannot read
+organization-level plan state.
+
+## Response
+
+```json
+{
+	"data": {
+		"label": "My coding tool",
+		"usage": "31.42",
+		"limit": null,
+		"devPlan": "pro",
+		"devPlanCreditsUsed": "25",
+		"devPlanCreditsLimit": "237",
+		"devPlanCreditsRemaining": "212.00",
+		"devPlanPremiumWeeklyLimit": "35.55",
+		"devPlanPremiumCreditsUsed": "5.00",
+		"devPlanPremiumWeekResetsAt": "2026-08-28T12:00:00.000Z"
+	}
+}
+```
+
+| Field                        | Meaning                                                        |
+| ---------------------------- | -------------------------------------------------------------- |
+| `label`                      | Description of the key                                         |
+| `usage`                      | All-time usage attributed to the key, in USD                   |
+| `limit`                      | All-time key usage limit in USD, or `null`                     |
+| `devPlan`                    | `lite`, `pro`, `max`, or `none`                                |
+| `devPlanCreditsUsed`         | Plan credits used in the current billing cycle                 |
+| `devPlanCreditsLimit`        | Plan credit allowance for the current billing cycle            |
+| `devPlanCreditsRemaining`    | Remaining plan credits, clamped to zero                        |
+| `devPlanPremiumWeeklyLimit`  | Weekly premium-model allowance                                 |
+| `devPlanPremiumCreditsUsed`  | Premium-model credits used in the current weekly window        |
+| `devPlanPremiumWeekResetsAt` | ISO 8601 reset time, or `null` when no weekly window is active |
+
+All USD values are decimal strings. Parse them before calculating percentages
+or remaining premium allowance.
+
+## Weekly window behavior
+
+The premium window starts with the first premium-model request and lasts seven
+days. When it expires, the endpoint returns `"0.00"` for
+`devPlanPremiumCreditsUsed` and `null` for `devPlanPremiumWeekResetsAt`; the
+full weekly allowance is already available, and the next premium request starts
+a new window.
+
+Pay-as-you-go keys return `"none"` for `devPlan` and zero for every DevPass
+field. This lets one integration support both key types without a separate
+account lookup.
+
+The endpoint remains readable when the key has exceeded its own usage limit,
+so an integration can explain why requests stopped. Invalid or inactive keys
+receive `401 Unauthorized`.
+
+See [Retrieve key status](/v1_key_retrieve) for the generated API reference and
+complete response schema.

--- a/apps/docs/content/developers/index.mdx
+++ b/apps/docs/content/developers/index.mdx
@@ -8,6 +8,7 @@ This section is for developers building applications on top of LLM Gateway — w
 
 ## Guides
 
+- [**DevPass Usage API**](/developers/devpass-usage) — Show monthly and weekly DevPass allowance meters in your application
 - [**LLM Gateway CLI**](/developers/cli) — Launch coding agents, scaffold projects from templates, generate agent configs, and manage keys, budgets, and usage from the terminal
 - [**Model Context Protocol (MCP)**](/developers/mcp) — Use LLM Gateway as an MCP server from Claude Code, Cursor, and other MCP clients
 - [**Using the AI SDK**](/developers/ai-sdk) — Install the provider, generate and stream text, call tools, and wire up Next.js routes

--- a/apps/docs/content/developers/meta.json
+++ b/apps/docs/content/developers/meta.json
@@ -5,6 +5,7 @@
 	"defaultOpen": true,
 	"pages": [
 		"index",
+		"devpass-usage",
 		"cli",
 		"mcp",
 		"ai-sdk",

--- a/apps/docs/content/features/api-keys.mdx
+++ b/apps/docs/content/features/api-keys.mdx
@@ -90,6 +90,9 @@ curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
   }'
 ```
 
+To show DevPass allowance meters in an integration, see the [DevPass Usage
+API](/developers/devpass-usage).
+
 ## Renaming API Keys
 
 A key's name is only a label, so you can change it at any time — from the

--- a/apps/docs/content/resources/rate-limits.mdx
+++ b/apps/docs/content/resources/rate-limits.mdx
@@ -20,24 +20,24 @@ Every API endpoint is rate limited per organization using a rolling 60-second wi
 
 The default limits (requests per minute, per organization) are:
 
-| Endpoint             | Path                       | Requests / min |
-| -------------------- | -------------------------- | -------------- |
-| Chat completions     | `/v1/chat/completions`     | 600            |
-| Messages (Anthropic) | `/v1/messages`             | 600            |
-| Responses            | `/v1/responses`            | 600            |
-| Embeddings           | `/v1/embeddings`           | 1200           |
-| Moderations          | `/v1/moderations`          | 1200           |
-| Rerank               | `/v1/rerank`               | 1200           |
-| Models               | `/v1/models`               | 1200           |
-| OCR                  | `/v1/ocr`                  | 300            |
-| Images               | `/v1/images`               | 300            |
-| Speech               | `/v1/audio/speech`         | 300            |
-| Transcriptions       | `/v1/audio/transcriptions` | 300            |
-| Videos               | `/v1/videos`               | 120            |
-| Realtime (mint)      | `/v1/realtime`             | 120            |
-| Key info             | `/v1/key`                  | 1200           |
-| Credits              | `/v1/credits`              | 300            |
-| AI SDK protocol      | `/v*/ai`                   | 600            |
+| Endpoint                                           | Path                       | Requests / min |
+| -------------------------------------------------- | -------------------------- | -------------- |
+| Chat completions                                   | `/v1/chat/completions`     | 600            |
+| Messages (Anthropic)                               | `/v1/messages`             | 600            |
+| Responses                                          | `/v1/responses`            | 600            |
+| Embeddings                                         | `/v1/embeddings`           | 1200           |
+| Moderations                                        | `/v1/moderations`          | 1200           |
+| Rerank                                             | `/v1/rerank`               | 1200           |
+| Models                                             | `/v1/models`               | 1200           |
+| OCR                                                | `/v1/ocr`                  | 300            |
+| Images                                             | `/v1/images`               | 300            |
+| Speech                                             | `/v1/audio/speech`         | 300            |
+| Transcriptions                                     | `/v1/audio/transcriptions` | 300            |
+| Videos                                             | `/v1/videos`               | 120            |
+| Realtime (mint)                                    | `/v1/realtime`             | 120            |
+| [Key and DevPass usage](/developers/devpass-usage) | `/v1/key`                  | 1200           |
+| Credits                                            | `/v1/credits`              | 300            |
+| AI SDK protocol                                    | `/v*/ai`                   | 600            |
 
 <Callout type="info">
 	**[Enterprise](https://llmgateway.io/enterprise) organizations are exempt**

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -102,6 +102,11 @@ const nextConfig: NextConfig = {
 				permanent: true,
 			},
 			{
+				source: "/v1/key",
+				destination: "/v1_key_retrieve",
+				permanent: true,
+			},
+			{
 				source: "/v1/videos",
 				destination: "/v1_videos_create",
 				permanent: true,


### PR DESCRIPTION
## Problem

The API-key-authenticated DevPass usage endpoint was only discoverable through the generated API reference and an integration-specific guide. Developers lacked a focused explanation of its allowance fields and weekly-window behavior.

## Approach

- add a dedicated DevPass Usage API page under Developers
- document authentication, response fields, PAYG behavior, and key restrictions
- link the page from the developer overview, API-key guide, and rate-limit table
- keep the existing `/v1/key` route and add a docs redirect to its generated reference

## Verification

- `pnpm format`
- `pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added documentation for the DevPass Usage API, including authentication, response fields, usage windows, limits, and error behavior.
  - Added guidance for displaying monthly and weekly DevPass allowance meters in integrations.
  - Added the API to the Developers documentation navigation.

- **Documentation**
  - Updated rate-limit documentation with Key and DevPass usage details.
  - Added a permanent redirect from the legacy `/v1/key` documentation path to the generated API reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->