### PR TITLE
fix(ui): refresh user after profile edits

### DIFF
--- a/apps/code/src/hooks/useUser.ts
+++ b/apps/code/src/hooks/useUser.ts
@@ -78,10 +78,11 @@ export function useUser(options?: UseUserOptions) {
 export function useUpdateUser() {
 	const queryClient = useQueryClient();
 	const api = useApi();
+	const userQueryKey = api.queryOptions("get", "/user/me", {}).queryKey;
 
 	return api.useMutation("patch", "/user/me", {
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["user"] });
+			void queryClient.invalidateQueries({ queryKey: userQueryKey });
 			void queryClient.invalidateQueries({ queryKey: ["session"] });
 		},
 	});

--- a/apps/ui/src/hooks/useUser.ts
+++ b/apps/ui/src/hooks/useUser.ts
@@ -125,10 +125,11 @@ export function useUser(options?: UseUserOptions) {
 export function useUpdateUser() {
 	const queryClient = useQueryClient();
 	const api = useApi();
+	const userQueryKey = api.queryOptions("get", "/user/me", {}).queryKey;
 
 	return api.useMutation("patch", "/user/me", {
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["user"] });
+			void queryClient.invalidateQueries({ queryKey: userQueryKey });
 			void queryClient.invalidateQueries({ queryKey: ["session"] });
 		},
 	});


### PR DESCRIPTION
## Problem

Profile updates invalidated a legacy `["user"]` query key, which did not match the OpenAPI React Query cache entry for `GET /user/me`. Updated profile data therefore stayed stale.

## Approach

Derive the `GET /user/me` query key from the generated API client and invalidate it after successful user updates in both dashboard apps.

## Verification

- `pnpm format`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user profile updates so refreshed account information appears reliably after changes.
  * Ensured cached user data is refreshed correctly following successful profile updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->