### PR TITLE
feat(admin): add enterprise deal accounting

### DIFF
--- a/apps/api/src/routes/admin-enterprise-deals.spec.ts
+++ b/apps/api/src/routes/admin-enterprise-deals.spec.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db, tables } from "@llmgateway/db";
+
+const ORG_ID = "admin-enterprise-deals-org";
+
+interface AdminMetricsResponse {
+	totalRevenue: number;
+	totalProcessed: number;
+	totalToppedUp: number;
+	payingCustomers: number;
+	grossRevenue: number;
+	grossEnterpriseDealsRevenue: number;
+}
+
+describe("admin enterprise deals", () => {
+	let cookie: string;
+
+	beforeEach(async () => {
+		process.env.ADMIN_EMAILS = "admin@example.com";
+		cookie = await createTestUser();
+
+		await db.insert(tables.organization).values({
+			id: ORG_ID,
+			name: "Enterprise Deal Org",
+			billingEmail: "enterprise-deal@example.com",
+			credits: "10",
+		});
+	});
+
+	afterEach(async () => {
+		await deleteAll();
+	});
+
+	test("records and edits revenue without changing credits", async () => {
+		const createResponse = await app.request(
+			`/admin/organizations/${ORG_ID}/enterprise-deals`,
+			{
+				method: "POST",
+				headers: { Cookie: cookie, "Content-Type": "application/json" },
+				body: JSON.stringify({
+					amount: 1200,
+					paymentMethod: "wire",
+					externalReference: "INVOICE-42",
+					comment: "Annual agreement",
+				}),
+			},
+		);
+		expect(createResponse.status).toBe(200);
+		const createBody = (await createResponse.json()) as {
+			transactionId: string;
+		};
+
+		let org = await db.query.organization.findFirst({
+			where: { id: { eq: ORG_ID } },
+		});
+		expect(Number(org!.credits)).toBe(10);
+
+		let deal = await db.query.transaction.findFirst({
+			where: { id: { eq: createBody.transactionId } },
+		});
+		expect(deal).toMatchObject({
+			type: "enterprise_deal",
+			creditAmount: null,
+			paymentMethod: "wire",
+			externalReference: "INVOICE-42",
+			description: "Annual agreement",
+		});
+		expect(Number(deal!.amount)).toBe(1200);
+
+		const updateResponse = await app.request(
+			`/admin/organizations/${ORG_ID}/enterprise-deals/${createBody.transactionId}`,
+			{
+				method: "PATCH",
+				headers: { Cookie: cookie, "Content-Type": "application/json" },
+				body: JSON.stringify({
+					amount: 1500,
+					paymentMethod: "crypto",
+					externalReference: "INVOICE-43",
+					comment: "Updated agreement",
+				}),
+			},
+		);
+		expect(updateResponse.status).toBe(200);
+
+		org = await db.query.organization.findFirst({
+			where: { id: { eq: ORG_ID } },
+		});
+		expect(Number(org!.credits)).toBe(10);
+
+		deal = await db.query.transaction.findFirst({
+			where: { id: { eq: createBody.transactionId } },
+		});
+		expect(Number(deal!.amount)).toBe(1500);
+		expect(deal).toMatchObject({
+			creditAmount: null,
+			paymentMethod: "crypto",
+			externalReference: "INVOICE-43",
+			description: "Updated agreement",
+		});
+	});
+
+	test("reports enterprise revenue separately from credit flow", async () => {
+		await db.insert(tables.transaction).values({
+			organizationId: ORG_ID,
+			type: "enterprise_deal",
+			amount: "800",
+			creditAmount: null,
+			paymentMethod: "wire",
+			status: "completed",
+		});
+
+		const response = await app.request("/admin/metrics", {
+			headers: { Cookie: cookie },
+		});
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as AdminMetricsResponse;
+
+		expect(body.totalRevenue).toBe(0);
+		expect(body.totalProcessed).toBe(0);
+		expect(body.totalToppedUp).toBe(0);
+		expect(body.payingCustomers).toBe(1);
+		expect(body.grossEnterpriseDealsRevenue).toBe(800);
+		expect(body.grossRevenue).toBe(800);
+
+		const timeseriesResponse = await app.request(
+			"/admin/metrics/timeseries?range=7d",
+			{
+				headers: { Cookie: cookie },
+			},
+		);
+		expect(timeseriesResponse.status).toBe(200);
+		const timeseries = (await timeseriesResponse.json()) as {
+			totals: {
+				revenue: number;
+				processed: number;
+				net: number;
+				enterpriseRevenue: number;
+			};
+			data: Array<{ dailyNet: number; dailyEnterpriseRevenue: number }>;
+		};
+		expect(timeseries.totals).toMatchObject({
+			revenue: 0,
+			processed: 0,
+			net: 0,
+			enterpriseRevenue: 800,
+		});
+		expect(timeseries.data.at(-1)?.dailyNet).toBe(0);
+		expect(timeseries.data.at(-1)?.dailyEnterpriseRevenue).toBe(800);
+	});
+
+	test("rejects unsupported payment methods", async () => {
+		const response = await app.request(
+			`/admin/organizations/${ORG_ID}/enterprise-deals`,
+			{
+				method: "POST",
+				headers: { Cookie: cookie, "Content-Type": "application/json" },
+				body: JSON.stringify({ amount: 50, paymentMethod: "card" }),
+			},
+		);
+		expect(response.status).toBe(400);
+
+		const deals = await db.query.transaction.findMany({
+			where: {
+				organizationId: { eq: ORG_ID },
+				type: { eq: "enterprise_deal" },
+			},
+		});
+		expect(deals).toHaveLength(0);
+	});
+
+	test("only edits enterprise deal transactions in the organization", async () => {
+		const [creditTransaction] = await db
+			.insert(tables.transaction)
+			.values({
+				organizationId: ORG_ID,
+				type: "credit_topup",
+				amount: "100",
+				creditAmount: "95",
+				status: "completed",
+			})
+			.returning({ id: tables.transaction.id });
+
+		const response = await app.request(
+			`/admin/organizations/${ORG_ID}/enterprise-deals/${creditTransaction.id}`,
+			{
+				method: "PATCH",
+				headers: { Cookie: cookie, "Content-Type": "application/json" },
+				body: JSON.stringify({ amount: 50, paymentMethod: "wire" }),
+			},
+		);
+		expect(response.status).toBe(404);
+
+		const unchanged = await db.query.transaction.findFirst({
+			where: { id: { eq: creditTransaction.id } },
+		});
+		expect(Number(unchanged!.amount)).toBe(100);
+		expect(Number(unchanged!.creditAmount)).toBe(95);
+	});
+});

--- a/apps/api/src/routes/admin-enterprise-deals.spec.ts
+++ b/apps/api/src/routes/admin-enterprise-deals.spec.ts
@@ -44,6 +44,7 @@ describe("admin enterprise deals", () => {
 				body: JSON.stringify({
 					amount: 1200,
 					paymentMethod: "wire",
+					transactionDate: "2026-01-15",
 					externalReference: "INVOICE-42",
 					comment: "Annual agreement",
 				}),
@@ -70,6 +71,7 @@ describe("admin enterprise deals", () => {
 			description: "Annual agreement",
 		});
 		expect(Number(deal!.amount)).toBe(1200);
+		expect(deal!.createdAt.toISOString()).toBe("2026-01-15T00:00:00.000Z");
 
 		const updateResponse = await app.request(
 			`/admin/organizations/${ORG_ID}/enterprise-deals/${createBody.transactionId}`,
@@ -79,6 +81,7 @@ describe("admin enterprise deals", () => {
 				body: JSON.stringify({
 					amount: 1500,
 					paymentMethod: "crypto",
+					transactionDate: "2026-02-20",
 					externalReference: "INVOICE-43",
 					comment: "Updated agreement",
 				}),
@@ -95,12 +98,36 @@ describe("admin enterprise deals", () => {
 			where: { id: { eq: createBody.transactionId } },
 		});
 		expect(Number(deal!.amount)).toBe(1500);
+		expect(deal!.createdAt.toISOString()).toBe("2026-02-20T00:00:00.000Z");
 		expect(deal).toMatchObject({
 			creditAmount: null,
 			paymentMethod: "crypto",
 			externalReference: "INVOICE-43",
 			description: "Updated agreement",
 		});
+	});
+
+	test("defaults the transaction date to now when omitted", async () => {
+		const beforeCreate = Date.now();
+		const response = await app.request(
+			`/admin/organizations/${ORG_ID}/enterprise-deals`,
+			{
+				method: "POST",
+				headers: { Cookie: cookie, "Content-Type": "application/json" },
+				body: JSON.stringify({ amount: 50, paymentMethod: "other" }),
+			},
+		);
+		const afterCreate = Date.now();
+		expect(response.status).toBe(200);
+
+		const deal = await db.query.transaction.findFirst({
+			where: {
+				organizationId: { eq: ORG_ID },
+				type: { eq: "enterprise_deal" },
+			},
+		});
+		expect(deal!.createdAt.getTime()).toBeGreaterThanOrEqual(beforeCreate);
+		expect(deal!.createdAt.getTime()).toBeLessThanOrEqual(afterCreate);
 	});
 
 	test("reports enterprise revenue separately from credit flow", async () => {

--- a/apps/api/src/routes/admin-enterprise-deals.spec.ts
+++ b/apps/api/src/routes/admin-enterprise-deals.spec.ts
@@ -64,7 +64,7 @@ describe("admin enterprise deals", () => {
 			where: { id: { eq: createBody.transactionId } },
 		});
 		expect(deal).toMatchObject({
-			type: "enterprise_deal",
+			type: "enterprise_license_fee",
 			creditAmount: null,
 			paymentMethod: "wire",
 			externalReference: "INVOICE-42",
@@ -123,7 +123,7 @@ describe("admin enterprise deals", () => {
 		const deal = await db.query.transaction.findFirst({
 			where: {
 				organizationId: { eq: ORG_ID },
-				type: { eq: "enterprise_deal" },
+				type: { eq: "enterprise_license_fee" },
 			},
 		});
 		expect(deal!.createdAt.getTime()).toBeGreaterThanOrEqual(beforeCreate);
@@ -133,7 +133,7 @@ describe("admin enterprise deals", () => {
 	test("reports enterprise revenue separately from credit flow", async () => {
 		await db.insert(tables.transaction).values({
 			organizationId: ORG_ID,
-			type: "enterprise_deal",
+			type: "enterprise_license_fee",
 			amount: "800",
 			creditAmount: null,
 			paymentMethod: "wire",
@@ -193,7 +193,7 @@ describe("admin enterprise deals", () => {
 		const deals = await db.query.transaction.findMany({
 			where: {
 				organizationId: { eq: ORG_ID },
-				type: { eq: "enterprise_deal" },
+				type: { eq: "enterprise_license_fee" },
 			},
 		});
 		expect(deals).toHaveLength(0);

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -7422,12 +7422,26 @@ admin.openapi(manualCreditsRoute, async (c) => {
 
 const enterprisePaymentMethods = ["wire", "crypto", "other"] as const;
 
+const enterpriseTransactionDateSchema = z.string().refine((value) => {
+	const date = new Date(`${value}T00:00:00.000Z`);
+	return (
+		!Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value
+	);
+}, "Invalid transaction date");
+
 const enterpriseDealBodySchema = z.object({
 	amount: z.number().min(0.01, "Deal amount must be positive"),
 	paymentMethod: z.enum(enterprisePaymentMethods),
+	transactionDate: enterpriseTransactionDateSchema.optional(),
 	externalReference: z.string().trim().max(255).optional(),
 	comment: z.string().trim().max(2000).optional(),
 });
+
+function parseEnterpriseTransactionDate(transactionDate?: string) {
+	return transactionDate
+		? new Date(`${transactionDate}T00:00:00.000Z`)
+		: undefined;
+}
 
 const createEnterpriseDealRoute = createRoute({
 	method: "post",
@@ -7465,7 +7479,7 @@ const createEnterpriseDealRoute = createRoute({
 admin.openapi(createEnterpriseDealRoute, async (c) => {
 	const user = c.get("user");
 	const { orgId } = c.req.valid("param");
-	const { amount, paymentMethod, externalReference, comment } =
+	const { amount, paymentMethod, transactionDate, externalReference, comment } =
 		c.req.valid("json");
 
 	const org = await db.query.organization.findFirst({
@@ -7485,6 +7499,7 @@ admin.openapi(createEnterpriseDealRoute, async (c) => {
 		.values({
 			organizationId: orgId,
 			type: "enterprise_deal",
+			createdAt: parseEnterpriseTransactionDate(transactionDate),
 			amount: amount.toString(),
 			creditAmount: null,
 			currency: "USD",
@@ -7504,6 +7519,7 @@ admin.openapi(createEnterpriseDealRoute, async (c) => {
 		metadata: {
 			amount,
 			paymentMethod,
+			transactionDate,
 			externalReference,
 			comment,
 		},
@@ -7549,12 +7565,14 @@ const updateEnterpriseDealRoute = createRoute({
 admin.openapi(updateEnterpriseDealRoute, async (c) => {
 	const user = c.get("user");
 	const { orgId, transactionId } = c.req.valid("param");
-	const { amount, paymentMethod, externalReference, comment } =
+	const { amount, paymentMethod, transactionDate, externalReference, comment } =
 		c.req.valid("json");
+	const createdAt = parseEnterpriseTransactionDate(transactionDate);
 
 	const [updatedDeal] = await db
 		.update(tables.transaction)
 		.set({
+			...(createdAt ? { createdAt } : {}),
 			amount: amount.toString(),
 			creditAmount: null,
 			description: comment || null,
@@ -7585,6 +7603,7 @@ admin.openapi(updateEnterpriseDealRoute, async (c) => {
 		metadata: {
 			amount,
 			paymentMethod,
+			transactionDate,
 			externalReference,
 			comment,
 		},

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -397,6 +397,9 @@ const adminMetricsSchema = z.object({
 	// Credits paid for outside Stripe (wire, crypto, …) and credited manually by
 	// an administrator. Real revenue, just settled on another channel.
 	grossManualPaymentsRevenue: z.number(),
+	// Negotiated enterprise revenue recorded by an administrator. These rows do
+	// not grant credits and are kept separate from manual credit payments.
+	grossEnterpriseDealsRevenue: z.number(),
 });
 
 const timeseriesRangeSchema = z.enum(["7d", "30d", "90d", "365d", "all"]);
@@ -414,12 +417,16 @@ const timeseriesDataPointSchema = z.object({
 	devpassRevenue: z.number(),
 	devpassRefunds: z.number(),
 	devpassNet: z.number(),
+	// Enterprise deal revenue has no credits, Stripe fees, or provider cost
+	// attached, so its revenue and net profit are the same value.
+	enterpriseRevenue: z.number(),
 	// Per-day (non-cumulative) values. The cumulative series above start from a
 	// pre-range baseline, so clients cannot derive day-one deltas themselves.
 	dailySignups: z.number(),
 	dailyPaidCustomers: z.number(),
 	dailyNet: z.number(),
 	dailyDevpassNet: z.number(),
+	dailyEnterpriseRevenue: z.number(),
 });
 
 const adminTimeseriesSchema = z.object({
@@ -435,6 +442,7 @@ const adminTimeseriesSchema = z.object({
 		devpassRevenue: z.number(),
 		devpassRefunds: z.number(),
 		devpassNet: z.number(),
+		enterpriseRevenue: z.number(),
 	}),
 });
 
@@ -543,7 +551,8 @@ const transactionSchema = z.object({
 	currency: z.string(),
 	status: z.string(),
 	description: z.string().nullable(),
-	// Off-Stripe payment channel and its reference, set on manual payments only.
+	// Off-Stripe payment channel and its reference, set on manually recorded
+	// payments only.
 	paymentMethod: z.string().nullable(),
 	externalReference: z.string().nullable(),
 	stripePaymentIntentId: z.string().nullable(),
@@ -1043,10 +1052,8 @@ admin.openapi(getMetrics, async (c) => {
 
 	const payingCustomers = Number(payingRow?.count ?? 0);
 
-	// Total revenue: completed credit-purchase rows — org credit top-ups,
-	// manually credited off-Stripe payments (`credit_manual_payment`) AND
-	// end-user wallet top-ups (`end_user_topup`, reversed on refund) — using
-	// creditAmount to exclude Stripe fees. Excludes gifts, all plan rows
+	// Total credits revenue: completed credit-purchase rows use `creditAmount` to
+	// exclude Stripe fees. Excludes enterprise deals, gifts, all plan rows
 	// (DevPass/legacy subscription/Chat Plan), and the non-revenue end-user rows
 	// (developer margin + funded bonus).
 	const [revenueRow] = await db
@@ -1061,6 +1068,7 @@ admin.openapi(getMetrics, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
+				ne(tables.transaction.type, "enterprise_deal"),
 				notPlanFilter,
 				notEndUserNonRevenueFilter,
 				transactionDateFilter,
@@ -1160,8 +1168,9 @@ admin.openapi(getMetrics, async (c) => {
 	const totalApiKeysSpent = Number(spentRow?.apiKeysValue ?? 0);
 	const totalDebitedSpend = Number(spentRow?.debitedValue ?? 0);
 
-	// Total processed (gross payment amounts from completed non-gift, non-plan
-	// transactions — Stripe charges plus off-Stripe manual payments)
+	// Total processed credits (gross payment amounts from completed non-gift,
+	// non-plan transactions — Stripe charges plus off-Stripe manual payments).
+	// Enterprise deals are reported separately.
 	const [processedRow] = await db
 		.select({
 			value:
@@ -1174,6 +1183,7 @@ admin.openapi(getMetrics, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
+				ne(tables.transaction.type, "enterprise_deal"),
 				notPlanFilter,
 				notEndUserNonRevenueFilter,
 				transactionDateFilter,
@@ -1447,6 +1457,30 @@ admin.openapi(getMetrics, async (c) => {
 
 	const grossManualPaymentsRevenue = Number(grossManualPaymentsRow?.value ?? 0);
 
+	// Enterprise deals: negotiated contract revenue recorded outside the credits
+	// economy. `creditAmount` is always null, so this split never changes credit
+	// flow or balances.
+	const [grossEnterpriseDealsRow] = await db
+		.select({
+			value:
+				sql<number>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`.as(
+					"value",
+				),
+		})
+		.from(tables.transaction)
+		.where(
+			and(
+				eq(tables.transaction.status, "completed"),
+				eq(tables.transaction.type, "enterprise_deal"),
+				sql`CAST(${tables.transaction.amount} AS NUMERIC) > 0`,
+				transactionDateFilter,
+			),
+		);
+
+	const grossEnterpriseDealsRevenue = Number(
+		grossEnterpriseDealsRow?.value ?? 0,
+	);
+
 	const grossRevenue =
 		grossCreditsRevenue +
 		grossDevpassRevenue +
@@ -1454,7 +1488,8 @@ admin.openapi(getMetrics, async (c) => {
 		grossResetPassRevenue +
 		grossChatPlansRevenue +
 		grossProSubscriptionsRevenue +
-		grossManualPaymentsRevenue;
+		grossManualPaymentsRevenue +
+		grossEnterpriseDealsRevenue;
 
 	// Balance derivation must use debited spend, not blended cost: BYOK usage
 	// never drains purchased credits, so subtracting it would understate
@@ -1487,6 +1522,7 @@ admin.openapi(getMetrics, async (c) => {
 		grossChatPlansRevenue,
 		grossProSubscriptionsRevenue,
 		grossManualPaymentsRevenue,
+		grossEnterpriseDealsRevenue,
 	});
 });
 
@@ -1562,7 +1598,8 @@ admin.openapi(getTimeseries, async (c) => {
 		.groupBy(sql`DATE(${tables.user.createdAt})`)
 		.orderBy(asc(sql`DATE(${tables.user.createdAt})`));
 
-	// Revenue per day (creditAmount, post-fees; matches /admin/metrics totalRevenue)
+	// Revenue per day (post-fees credit revenue; matches /admin/metrics
+	// totalRevenue). Enterprise deals are a separate series below.
 	const revenuePerDay = await db
 		.select({
 			date: sql<string>`DATE(${tables.transaction.createdAt})`.as("date"),
@@ -1576,8 +1613,29 @@ admin.openapi(getTimeseries, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
+				ne(tables.transaction.type, "enterprise_deal"),
 				notPlanFilter,
 				notEndUserNonRevenueFilter,
+				gte(tables.transaction.createdAt, startDate),
+				lte(tables.transaction.createdAt, endDate),
+			),
+		)
+		.groupBy(sql`DATE(${tables.transaction.createdAt})`)
+		.orderBy(asc(sql`DATE(${tables.transaction.createdAt})`));
+
+	const enterpriseRevenuePerDay = await db
+		.select({
+			date: sql<string>`DATE(${tables.transaction.createdAt})`.as("date"),
+			total:
+				sql<number>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`.as(
+					"total",
+				),
+		})
+		.from(tables.transaction)
+		.where(
+			and(
+				eq(tables.transaction.status, "completed"),
+				eq(tables.transaction.type, "enterprise_deal"),
 				gte(tables.transaction.createdAt, startDate),
 				lte(tables.transaction.createdAt, endDate),
 			),
@@ -1599,6 +1657,7 @@ admin.openapi(getTimeseries, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
+				ne(tables.transaction.type, "enterprise_deal"),
 				notPlanFilter,
 				notEndUserNonRevenueFilter,
 				gte(tables.transaction.createdAt, startDate),
@@ -1716,12 +1775,32 @@ admin.openapi(getTimeseries, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
+				ne(tables.transaction.type, "enterprise_deal"),
 				notPlanFilter,
 				notEndUserNonRevenueFilter,
 				sql`${tables.transaction.createdAt} < ${startDate}`,
 			),
 		);
 	const preRangeRevenue = Number(preRangeRevenueRow?.total ?? 0);
+
+	const [preRangeEnterpriseRevenueRow] = await db
+		.select({
+			total:
+				sql<number>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`.as(
+					"total",
+				),
+		})
+		.from(tables.transaction)
+		.where(
+			and(
+				eq(tables.transaction.status, "completed"),
+				eq(tables.transaction.type, "enterprise_deal"),
+				sql`${tables.transaction.createdAt} < ${startDate}`,
+			),
+		);
+	const preRangeEnterpriseRevenue = Number(
+		preRangeEnterpriseRevenueRow?.total ?? 0,
+	);
 
 	const [preRangeProcessedRow] = await db
 		.select({
@@ -1735,6 +1814,7 @@ admin.openapi(getTimeseries, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
+				ne(tables.transaction.type, "enterprise_deal"),
 				notPlanFilter,
 				notEndUserNonRevenueFilter,
 				sql`${tables.transaction.createdAt} < ${startDate}`,
@@ -1904,6 +1984,11 @@ admin.openapi(getTimeseries, async (c) => {
 		devpassRefundsMap.set(row.date, Number(row.total));
 	}
 
+	const enterpriseRevenueMap = new Map<string, number>();
+	for (const row of enterpriseRevenuePerDay) {
+		enterpriseRevenueMap.set(row.date, Number(row.total));
+	}
+
 	const newPaidMap = new Map<string, number>();
 	for (const row of firstTransactionPerOrg) {
 		newPaidMap.set(row.date, Number(row.count));
@@ -1921,10 +2006,12 @@ admin.openapi(getTimeseries, async (c) => {
 		devpassRevenue: number;
 		devpassRefunds: number;
 		devpassNet: number;
+		enterpriseRevenue: number;
 		dailySignups: number;
 		dailyPaidCustomers: number;
 		dailyNet: number;
 		dailyDevpassNet: number;
+		dailyEnterpriseRevenue: number;
 	}> = [];
 	let cumulativePaid = preRangeCount;
 	let totalSignups = 0;
@@ -1933,6 +2020,7 @@ admin.openapi(getTimeseries, async (c) => {
 	let totalRefunds = preRangeRefunds;
 	let totalDevpassRevenue = preRangeDevpassRevenue;
 	let totalDevpassRefunds = preRangeDevpassRefunds;
+	let totalEnterpriseRevenue = preRangeEnterpriseRevenue;
 
 	const totalDays = Math.ceil(
 		(endDate.getTime() - startDate.getTime()) / (24 * 60 * 60 * 1000),
@@ -1947,6 +2035,7 @@ admin.openapi(getTimeseries, async (c) => {
 		const dailyRefunds = refundsMap.get(dateStr) ?? 0;
 		const dailyDevpassRevenue = devpassRevenueMap.get(dateStr) ?? 0;
 		const dailyDevpassRefunds = devpassRefundsMap.get(dateStr) ?? 0;
+		const dailyEnterpriseRevenue = enterpriseRevenueMap.get(dateStr) ?? 0;
 		const dailyPaidCustomers = newPaidMap.get(dateStr) ?? 0;
 		cumulativePaid += dailyPaidCustomers;
 
@@ -1956,6 +2045,7 @@ admin.openapi(getTimeseries, async (c) => {
 		totalRefunds += dailyRefunds;
 		totalDevpassRevenue += dailyDevpassRevenue;
 		totalDevpassRefunds += dailyDevpassRefunds;
+		totalEnterpriseRevenue += dailyEnterpriseRevenue;
 
 		data.push({
 			date: dateStr,
@@ -1968,10 +2058,12 @@ admin.openapi(getTimeseries, async (c) => {
 			devpassRevenue: totalDevpassRevenue,
 			devpassRefunds: totalDevpassRefunds,
 			devpassNet: totalDevpassRevenue - totalDevpassRefunds,
+			enterpriseRevenue: totalEnterpriseRevenue,
 			dailySignups,
 			dailyPaidCustomers,
 			dailyNet: dailyRevenue - dailyRefunds,
 			dailyDevpassNet: dailyDevpassRevenue - dailyDevpassRefunds,
+			dailyEnterpriseRevenue,
 		});
 	}
 
@@ -1988,6 +2080,7 @@ admin.openapi(getTimeseries, async (c) => {
 			devpassRevenue: totalDevpassRevenue,
 			devpassRefunds: totalDevpassRefunds,
 			devpassNet: totalDevpassRevenue - totalDevpassRefunds,
+			enterpriseRevenue: totalEnterpriseRevenue,
 		},
 	});
 });
@@ -7325,6 +7418,179 @@ admin.openapi(manualCreditsRoute, async (c) => {
 		message: "Credits added successfully",
 		credits: updatedCredits,
 	});
+});
+
+const enterprisePaymentMethods = ["wire", "crypto", "other"] as const;
+
+const enterpriseDealBodySchema = z.object({
+	amount: z.number().min(0.01, "Deal amount must be positive"),
+	paymentMethod: z.enum(enterprisePaymentMethods),
+	externalReference: z.string().trim().max(255).optional(),
+	comment: z.string().trim().max(2000).optional(),
+});
+
+const createEnterpriseDealRoute = createRoute({
+	method: "post",
+	path: "/organizations/{orgId}/enterprise-deals",
+	request: {
+		params: z.object({
+			orgId: z.string(),
+		}),
+		body: {
+			content: {
+				"application/json": {
+					schema: enterpriseDealBodySchema,
+				},
+			},
+		},
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({
+						message: z.string(),
+						transactionId: z.string(),
+					}),
+				},
+			},
+			description: "Enterprise deal recorded successfully.",
+		},
+		404: {
+			description: "Organization not found.",
+		},
+	},
+});
+
+admin.openapi(createEnterpriseDealRoute, async (c) => {
+	const user = c.get("user");
+	const { orgId } = c.req.valid("param");
+	const { amount, paymentMethod, externalReference, comment } =
+		c.req.valid("json");
+
+	const org = await db.query.organization.findFirst({
+		where: {
+			id: { eq: orgId },
+		},
+	});
+
+	if (!org || org.status === "deleted") {
+		throw new HTTPException(404, {
+			message: "Organization not found",
+		});
+	}
+
+	const [deal] = await db
+		.insert(tables.transaction)
+		.values({
+			organizationId: orgId,
+			type: "enterprise_deal",
+			amount: amount.toString(),
+			creditAmount: null,
+			currency: "USD",
+			status: "completed",
+			description: comment || null,
+			paymentMethod,
+			externalReference: externalReference || null,
+		})
+		.returning({ id: tables.transaction.id });
+
+	await logAuditEvent({
+		organizationId: orgId,
+		userId: user!.id,
+		action: "enterprise_deal.create",
+		resourceType: "transaction",
+		resourceId: deal.id,
+		metadata: {
+			amount,
+			paymentMethod,
+			externalReference,
+			comment,
+		},
+	});
+
+	return c.json({
+		message: "Enterprise deal recorded successfully",
+		transactionId: deal.id,
+	});
+});
+
+const updateEnterpriseDealRoute = createRoute({
+	method: "patch",
+	path: "/organizations/{orgId}/enterprise-deals/{transactionId}",
+	request: {
+		params: z.object({
+			orgId: z.string(),
+			transactionId: z.string(),
+		}),
+		body: {
+			content: {
+				"application/json": {
+					schema: enterpriseDealBodySchema,
+				},
+			},
+		},
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z.object({ message: z.string() }),
+				},
+			},
+			description: "Enterprise deal updated successfully.",
+		},
+		404: {
+			description: "Enterprise deal not found.",
+		},
+	},
+});
+
+admin.openapi(updateEnterpriseDealRoute, async (c) => {
+	const user = c.get("user");
+	const { orgId, transactionId } = c.req.valid("param");
+	const { amount, paymentMethod, externalReference, comment } =
+		c.req.valid("json");
+
+	const [updatedDeal] = await db
+		.update(tables.transaction)
+		.set({
+			amount: amount.toString(),
+			creditAmount: null,
+			description: comment || null,
+			paymentMethod,
+			externalReference: externalReference || null,
+		})
+		.where(
+			and(
+				eq(tables.transaction.id, transactionId),
+				eq(tables.transaction.organizationId, orgId),
+				eq(tables.transaction.type, "enterprise_deal"),
+			),
+		)
+		.returning({ id: tables.transaction.id });
+
+	if (!updatedDeal) {
+		throw new HTTPException(404, {
+			message: "Enterprise deal not found",
+		});
+	}
+
+	await logAuditEvent({
+		organizationId: orgId,
+		userId: user!.id,
+		action: "enterprise_deal.update",
+		resourceType: "transaction",
+		resourceId: updatedDeal.id,
+		metadata: {
+			amount,
+			paymentMethod,
+			externalReference,
+			comment,
+		},
+	});
+
+	return c.json({ message: "Enterprise deal updated successfully" });
 });
 
 // Configure the referral signup bonus for an organization

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -1067,7 +1067,7 @@ admin.openapi(getMetrics, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
-				ne(tables.transaction.type, "enterprise_deal"),
+				ne(tables.transaction.type, "enterprise_license_fee"),
 				notPlanFilter,
 				notEndUserNonRevenueFilter,
 				transactionDateFilter,
@@ -1182,7 +1182,7 @@ admin.openapi(getMetrics, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
-				ne(tables.transaction.type, "enterprise_deal"),
+				ne(tables.transaction.type, "enterprise_license_fee"),
 				notPlanFilter,
 				notEndUserNonRevenueFilter,
 				transactionDateFilter,
@@ -1470,7 +1470,7 @@ admin.openapi(getMetrics, async (c) => {
 		.where(
 			and(
 				eq(tables.transaction.status, "completed"),
-				eq(tables.transaction.type, "enterprise_deal"),
+				eq(tables.transaction.type, "enterprise_license_fee"),
 				sql`CAST(${tables.transaction.amount} AS NUMERIC) > 0`,
 				transactionDateFilter,
 			),
@@ -1612,7 +1612,7 @@ admin.openapi(getTimeseries, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
-				ne(tables.transaction.type, "enterprise_deal"),
+				ne(tables.transaction.type, "enterprise_license_fee"),
 				notPlanFilter,
 				notEndUserNonRevenueFilter,
 				gte(tables.transaction.createdAt, startDate),
@@ -1634,7 +1634,7 @@ admin.openapi(getTimeseries, async (c) => {
 		.where(
 			and(
 				eq(tables.transaction.status, "completed"),
-				eq(tables.transaction.type, "enterprise_deal"),
+				eq(tables.transaction.type, "enterprise_license_fee"),
 				gte(tables.transaction.createdAt, startDate),
 				lte(tables.transaction.createdAt, endDate),
 			),
@@ -1656,7 +1656,7 @@ admin.openapi(getTimeseries, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
-				ne(tables.transaction.type, "enterprise_deal"),
+				ne(tables.transaction.type, "enterprise_license_fee"),
 				notPlanFilter,
 				notEndUserNonRevenueFilter,
 				gte(tables.transaction.createdAt, startDate),
@@ -1774,7 +1774,7 @@ admin.openapi(getTimeseries, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
-				ne(tables.transaction.type, "enterprise_deal"),
+				ne(tables.transaction.type, "enterprise_license_fee"),
 				notPlanFilter,
 				notEndUserNonRevenueFilter,
 				sql`${tables.transaction.createdAt} < ${startDate}`,
@@ -1793,7 +1793,7 @@ admin.openapi(getTimeseries, async (c) => {
 		.where(
 			and(
 				eq(tables.transaction.status, "completed"),
-				eq(tables.transaction.type, "enterprise_deal"),
+				eq(tables.transaction.type, "enterprise_license_fee"),
 				sql`${tables.transaction.createdAt} < ${startDate}`,
 			),
 		);
@@ -1813,7 +1813,7 @@ admin.openapi(getTimeseries, async (c) => {
 			and(
 				eq(tables.transaction.status, "completed"),
 				ne(tables.transaction.type, "credit_gift"),
-				ne(tables.transaction.type, "enterprise_deal"),
+				ne(tables.transaction.type, "enterprise_license_fee"),
 				notPlanFilter,
 				notEndUserNonRevenueFilter,
 				sql`${tables.transaction.createdAt} < ${startDate}`,
@@ -7497,7 +7497,7 @@ admin.openapi(createEnterpriseDealRoute, async (c) => {
 		.insert(tables.transaction)
 		.values({
 			organizationId: orgId,
-			type: "enterprise_deal",
+			type: "enterprise_license_fee",
 			createdAt: parseEnterpriseTransactionDate(transactionDate),
 			amount: amount.toString(),
 			creditAmount: null,
@@ -7512,7 +7512,7 @@ admin.openapi(createEnterpriseDealRoute, async (c) => {
 	await logAuditEvent({
 		organizationId: orgId,
 		userId: user!.id,
-		action: "enterprise_deal.create",
+		action: "enterprise_license_fee.create",
 		resourceType: "transaction",
 		resourceId: deal.id,
 		metadata: {
@@ -7582,7 +7582,7 @@ admin.openapi(updateEnterpriseDealRoute, async (c) => {
 			and(
 				eq(tables.transaction.id, transactionId),
 				eq(tables.transaction.organizationId, orgId),
-				eq(tables.transaction.type, "enterprise_deal"),
+				eq(tables.transaction.type, "enterprise_license_fee"),
 			),
 		)
 		.returning({ id: tables.transaction.id });
@@ -7596,7 +7596,7 @@ admin.openapi(updateEnterpriseDealRoute, async (c) => {
 	await logAuditEvent({
 		organizationId: orgId,
 		userId: user!.id,
-		action: "enterprise_deal.update",
+		action: "enterprise_license_fee.update",
 		resourceType: "transaction",
 		resourceId: updatedDeal.id,
 		metadata: {

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -417,8 +417,7 @@ const timeseriesDataPointSchema = z.object({
 	devpassRevenue: z.number(),
 	devpassRefunds: z.number(),
 	devpassNet: z.number(),
-	// Enterprise deal revenue has no credits, Stripe fees, or provider cost
-	// attached, so its revenue and net profit are the same value.
+	// Enterprise deal revenue is recorded gross and has no credit amount attached.
 	enterpriseRevenue: z.number(),
 	// Per-day (non-cumulative) values. The cumulative series above start from a
 	// pre-range baseline, so clients cannot derive day-one deltas themselves.

--- a/apps/api/src/routes/organization.ts
+++ b/apps/api/src/routes/organization.ts
@@ -303,6 +303,7 @@ const transactionSchema = z.object({
 		"credit_refund",
 		"credit_gift",
 		"credit_manual_payment",
+		"enterprise_deal",
 		"dev_plan_start",
 		"dev_plan_upgrade",
 		"dev_plan_downgrade",

--- a/apps/api/src/routes/organization.ts
+++ b/apps/api/src/routes/organization.ts
@@ -303,7 +303,7 @@ const transactionSchema = z.object({
 		"credit_refund",
 		"credit_gift",
 		"credit_manual_payment",
-		"enterprise_deal",
+		"enterprise_license_fee",
 		"dev_plan_start",
 		"dev_plan_upgrade",
 		"dev_plan_downgrade",

--- a/apps/api/src/utils/devpass-filter.ts
+++ b/apps/api/src/utils/devpass-filter.ts
@@ -132,7 +132,7 @@ export function firstRowPerInvoiceFilter(dedupTypes: readonly string[]) {
 export const paidTransactionTypes = [
 	"credit_topup",
 	"credit_manual_payment",
-	"enterprise_deal",
+	"enterprise_license_fee",
 	"subscription_start",
 	"dev_plan_start",
 	"dev_plan_upgrade",

--- a/apps/api/src/utils/devpass-filter.ts
+++ b/apps/api/src/utils/devpass-filter.ts
@@ -124,14 +124,15 @@ export function firstRowPerInvoiceFilter(dedupTypes: readonly string[]) {
 }
 
 // Transaction types that represent an actual customer payment: org credit
-// purchases (Stripe or manually credited off-Stripe payments), dev/chat plan
-// charges (start/upgrade/renewal — cancel, end and downgrade rows are
-// bookkeeping, not payments), legacy subscriptions, and end-user wallet
-// top-ups. Used to count "paid customers", so gifts, refunds and margin
-// bookkeeping never qualify an org as paying.
+// purchases (Stripe or manually credited off-Stripe payments), enterprise
+// deals, dev/chat plan charges (start/upgrade/renewal — cancel, end and
+// downgrade rows are bookkeeping, not payments), legacy subscriptions, and
+// end-user wallet top-ups. Used to count "paid customers", so gifts, refunds
+// and margin bookkeeping never qualify an org as paying.
 export const paidTransactionTypes = [
 	"credit_topup",
 	"credit_manual_payment",
+	"enterprise_deal",
 	"subscription_start",
 	"dev_plan_start",
 	"dev_plan_upgrade",

--- a/ee/admin/src/app/organizations/[orgId]/page.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/page.tsx
@@ -141,7 +141,7 @@ function getTransactionTypeBadgeVariant(type: string) {
 		type.includes("topup") ||
 		type.includes("gift") ||
 		type.includes("manual_payment") ||
-		type === "enterprise_deal"
+		type === "enterprise_license_fee"
 	) {
 		return "default";
 	}
@@ -682,7 +682,7 @@ export default async function OrganizationPage({
 														)}
 													</TableCell>
 													<TableCell className="text-right">
-														{transaction.type === "enterprise_deal" ? (
+														{transaction.type === "enterprise_license_fee" ? (
 															<EnterpriseDealDialog
 																orgName={org.name}
 																deal={transaction}

--- a/ee/admin/src/app/organizations/[orgId]/page.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/page.tsx
@@ -18,6 +18,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { BlockOrgButton } from "@/components/block-org-button";
+import { EnterpriseDealDialog } from "@/components/enterprise-deal-dialog";
 import { GiftCreditsDialog } from "@/components/gift-credits-dialog";
 import { ManualCreditsDialog } from "@/components/manual-credits-dialog";
 import { PlanTermBadge } from "@/components/plan-term-badge";
@@ -33,11 +34,13 @@ import {
 } from "@/components/ui/table";
 import { TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
+	addEnterpriseDealToOrganization,
 	addManualCreditsToOrganization,
 	blockOrganization,
 	deleteOrganizationPaymentMethod,
 	giftCreditsToOrganization,
 	manageOrganization,
+	updateEnterpriseDeal,
 	updateReferralBonus,
 } from "@/lib/admin-organizations";
 import { KEY_STATUS_DEFAULT, parseKeyStatus } from "@/lib/key-status";
@@ -137,7 +140,8 @@ function getTransactionTypeBadgeVariant(type: string) {
 		type.includes("start") ||
 		type.includes("topup") ||
 		type.includes("gift") ||
-		type.includes("manual_payment")
+		type.includes("manual_payment") ||
+		type === "enterprise_deal"
 	) {
 		return "default";
 	}
@@ -454,6 +458,13 @@ export default async function OrganizationPage({
 							return await addManualCreditsToOrganization(orgId, data);
 						}}
 					/>
+					<EnterpriseDealDialog
+						orgName={org.name}
+						onSave={async (data) => {
+							"use server";
+							return await addEnterpriseDealToOrganization(orgId, data);
+						}}
+					/>
 					<ReferralBonusDialog
 						orgName={org.name}
 						enabled={org.referralBonusEnabled ?? false}
@@ -592,13 +603,14 @@ export default async function OrganizationPage({
 										<TableHead>Reference</TableHead>
 										<TableHead>Description</TableHead>
 										<TableHead>Stripe</TableHead>
+										<TableHead className="text-right">Actions</TableHead>
 									</TableRow>
 								</TableHeader>
 								<TableBody>
 									{transactions.length === 0 ? (
 										<TableRow>
 											<TableCell
-												colSpan={8}
+												colSpan={9}
 												className="h-24 text-center text-muted-foreground"
 											>
 												No transactions found
@@ -668,6 +680,22 @@ export default async function OrganizationPage({
 														) : (
 															<span className="text-muted-foreground">—</span>
 														)}
+													</TableCell>
+													<TableCell className="text-right">
+														{transaction.type === "enterprise_deal" ? (
+															<EnterpriseDealDialog
+																orgName={org.name}
+																deal={transaction}
+																onSave={async (data) => {
+																	"use server";
+																	return await updateEnterpriseDeal(
+																		orgId,
+																		transaction.id,
+																		data,
+																	);
+																}}
+															/>
+														) : null}
 													</TableCell>
 												</TableRow>
 											);

--- a/ee/admin/src/app/page.tsx
+++ b/ee/admin/src/app/page.tsx
@@ -361,7 +361,7 @@ export default async function Page({
 								...(metrics.grossEnterpriseDealsRevenue > 0
 									? [
 											{
-												label: "Enterprise deals",
+												label: "Enterprise licensing",
 												value: currencyFormatter.format(
 													metrics.grossEnterpriseDealsRevenue,
 												),

--- a/ee/admin/src/app/page.tsx
+++ b/ee/admin/src/app/page.tsx
@@ -358,6 +358,16 @@ export default async function Page({
 											},
 										]
 									: []),
+								...(metrics.grossEnterpriseDealsRevenue > 0
+									? [
+											{
+												label: "Enterprise deals",
+												value: currencyFormatter.format(
+													metrics.grossEnterpriseDealsRevenue,
+												),
+											},
+										]
+									: []),
 							]}
 						/>
 						<MetricCell
@@ -505,6 +515,7 @@ export default async function Page({
 								totals={{
 									credits: timeseries.totals.net,
 									devpass: timeseries.totals.devpassNet,
+									enterprise: timeseries.totals.enterpriseRevenue,
 								}}
 							/>
 						</div>

--- a/ee/admin/src/components/enterprise-deal-dialog.tsx
+++ b/ee/admin/src/components/enterprise-deal-dialog.tsx
@@ -145,8 +145,8 @@ export function EnterpriseDealDialog({
 						{editing ? "Edit Enterprise Deal" : "Add Enterprise Deal"}
 					</DialogTitle>
 					<DialogDescription>
-						Record contract revenue for {orgName}. It counts toward total
-						revenue and net profit without adding credits to the organization.
+						Record contract revenue for {orgName}. It counts toward total gross
+						revenue without adding credits to the organization.
 					</DialogDescription>
 				</DialogHeader>
 

--- a/ee/admin/src/components/enterprise-deal-dialog.tsx
+++ b/ee/admin/src/components/enterprise-deal-dialog.tsx
@@ -27,6 +27,7 @@ import { Textarea } from "@/components/ui/textarea";
 
 interface EnterpriseDeal {
 	id: string;
+	createdAt: string;
 	amount: string | null;
 	paymentMethod: string | null;
 	externalReference: string | null;
@@ -47,6 +48,7 @@ interface EnterpriseDealDialogProps {
 	onSave: (data: {
 		amount: number;
 		paymentMethod: EnterprisePaymentMethod;
+		transactionDate?: string;
 		externalReference?: string;
 		comment?: string;
 	}) => Promise<{ success: boolean; error?: string }>;
@@ -74,6 +76,9 @@ export function EnterpriseDealDialog({
 	const [paymentMethod, setPaymentMethod] = useState<EnterprisePaymentMethod>(
 		toPaymentMethod(deal?.paymentMethod),
 	);
+	const [transactionDate, setTransactionDate] = useState(
+		deal?.createdAt.slice(0, 10) ?? "",
+	);
 	const [externalReference, setExternalReference] = useState(
 		deal?.externalReference ?? "",
 	);
@@ -92,6 +97,7 @@ export function EnterpriseDealDialog({
 		const result = await onSave({
 			amount: parsedAmount,
 			paymentMethod,
+			transactionDate: transactionDate || undefined,
 			externalReference: externalReference.trim() || undefined,
 			comment: comment.trim() || undefined,
 		});
@@ -103,6 +109,7 @@ export function EnterpriseDealDialog({
 			if (!editing) {
 				setAmount("");
 				setPaymentMethod("wire");
+				setTransactionDate("");
 				setExternalReference("");
 				setComment("");
 			}
@@ -159,6 +166,21 @@ export function EnterpriseDealDialog({
 						/>
 						<p className="text-xs text-muted-foreground">
 							Booked as revenue only; no credits are granted
+						</p>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor={`enterpriseDate-${deal?.id ?? "new"}`}>
+							Transaction Date (Optional)
+						</Label>
+						<Input
+							id={`enterpriseDate-${deal?.id ?? "new"}`}
+							type="date"
+							value={transactionDate}
+							onChange={(event) => setTransactionDate(event.target.value)}
+						/>
+						<p className="text-xs text-muted-foreground">
+							Leave empty to use the current date
 						</p>
 					</div>
 

--- a/ee/admin/src/components/enterprise-deal-dialog.tsx
+++ b/ee/admin/src/components/enterprise-deal-dialog.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { Handshake, Loader2, Pencil } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+
+interface EnterpriseDeal {
+	id: string;
+	amount: string | null;
+	paymentMethod: string | null;
+	externalReference: string | null;
+	description: string | null;
+}
+
+type EnterprisePaymentMethod = "wire" | "crypto" | "other";
+
+const PAYMENT_METHOD_LABELS: Record<EnterprisePaymentMethod, string> = {
+	wire: "Wire transfer",
+	crypto: "Crypto",
+	other: "Other",
+};
+
+interface EnterpriseDealDialogProps {
+	orgName: string;
+	deal?: EnterpriseDeal;
+	onSave: (data: {
+		amount: number;
+		paymentMethod: EnterprisePaymentMethod;
+		externalReference?: string;
+		comment?: string;
+	}) => Promise<{ success: boolean; error?: string }>;
+}
+
+function toPaymentMethod(
+	value: string | null | undefined,
+): EnterprisePaymentMethod {
+	return value && value in PAYMENT_METHOD_LABELS
+		? (value as EnterprisePaymentMethod)
+		: "wire";
+}
+
+export function EnterpriseDealDialog({
+	orgName,
+	deal,
+	onSave,
+}: EnterpriseDealDialogProps) {
+	const router = useRouter();
+	const editing = Boolean(deal);
+	const [open, setOpen] = useState(false);
+	const [loading, setLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [amount, setAmount] = useState(deal?.amount ?? "");
+	const [paymentMethod, setPaymentMethod] = useState<EnterprisePaymentMethod>(
+		toPaymentMethod(deal?.paymentMethod),
+	);
+	const [externalReference, setExternalReference] = useState(
+		deal?.externalReference ?? "",
+	);
+	const [comment, setComment] = useState(deal?.description ?? "");
+
+	const handleSubmit = async () => {
+		const parsedAmount = parseFloat(amount);
+		if (isNaN(parsedAmount) || parsedAmount <= 0) {
+			setError("Deal amount must be a positive number");
+			return;
+		}
+
+		setLoading(true);
+		setError(null);
+
+		const result = await onSave({
+			amount: parsedAmount,
+			paymentMethod,
+			externalReference: externalReference.trim() || undefined,
+			comment: comment.trim() || undefined,
+		});
+
+		setLoading(false);
+
+		if (result.success) {
+			setOpen(false);
+			if (!editing) {
+				setAmount("");
+				setPaymentMethod("wire");
+				setExternalReference("");
+				setComment("");
+			}
+			router.refresh();
+		} else {
+			setError(result.error ?? "Failed to save enterprise deal");
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger asChild>
+				{editing ? (
+					<Button
+						variant="ghost"
+						size="icon"
+						className="h-8 w-8"
+						aria-label="Edit enterprise deal"
+						title="Edit enterprise deal"
+					>
+						<Pencil className="h-3.5 w-3.5" />
+					</Button>
+				) : (
+					<Button variant="outline" size="sm">
+						<Handshake className="mr-1.5 h-4 w-4" />
+						Add Enterprise Deal
+					</Button>
+				)}
+			</DialogTrigger>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>
+						{editing ? "Edit Enterprise Deal" : "Add Enterprise Deal"}
+					</DialogTitle>
+					<DialogDescription>
+						Record contract revenue for {orgName}. It counts toward total
+						revenue and net profit without adding credits to the organization.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-4 py-4">
+					<div className="space-y-2">
+						<Label htmlFor={`enterpriseDealAmount-${deal?.id ?? "new"}`}>
+							Amount Paid (USD)
+						</Label>
+						<Input
+							id={`enterpriseDealAmount-${deal?.id ?? "new"}`}
+							type="number"
+							min="0.01"
+							step="0.01"
+							value={amount}
+							onChange={(event) => setAmount(event.target.value)}
+							placeholder="e.g. 5000"
+						/>
+						<p className="text-xs text-muted-foreground">
+							Booked as revenue only; no credits are granted
+						</p>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor={`enterprisePaymentMethod-${deal?.id ?? "new"}`}>
+							Payment Method
+						</Label>
+						<Select
+							value={paymentMethod}
+							onValueChange={(value) =>
+								setPaymentMethod(value as EnterprisePaymentMethod)
+							}
+						>
+							<SelectTrigger
+								id={`enterprisePaymentMethod-${deal?.id ?? "new"}`}
+								className="w-full"
+							>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{(
+									Object.keys(
+										PAYMENT_METHOD_LABELS,
+									) as EnterprisePaymentMethod[]
+								).map((method) => (
+									<SelectItem key={method} value={method}>
+										{PAYMENT_METHOD_LABELS[method]}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor={`enterpriseReference-${deal?.id ?? "new"}`}>
+							Transaction ID / Reference (Optional)
+						</Label>
+						<Input
+							id={`enterpriseReference-${deal?.id ?? "new"}`}
+							value={externalReference}
+							onChange={(event) => setExternalReference(event.target.value)}
+							placeholder="e.g. invoice or bank reference"
+							maxLength={255}
+						/>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor={`enterpriseComment-${deal?.id ?? "new"}`}>
+							Comment (Optional)
+						</Label>
+						<Textarea
+							id={`enterpriseComment-${deal?.id ?? "new"}`}
+							value={comment}
+							onChange={(event) => setComment(event.target.value)}
+							placeholder="e.g. Annual platform agreement"
+							maxLength={2000}
+							rows={3}
+						/>
+					</div>
+
+					{error && <p className="text-sm text-destructive">{error}</p>}
+				</div>
+
+				<DialogFooter>
+					<Button
+						variant="outline"
+						onClick={() => setOpen(false)}
+						disabled={loading}
+					>
+						Cancel
+					</Button>
+					<Button onClick={handleSubmit} disabled={loading}>
+						{loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+						{editing ? "Save Changes" : "Add Deal"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/ee/admin/src/components/revenue-chart.tsx
+++ b/ee/admin/src/components/revenue-chart.tsx
@@ -50,7 +50,7 @@ const chartConfig = {
 		color: "hsl(142 71% 45%)",
 	},
 	enterpriseRevenue: {
-		label: "Net profit",
+		label: "Enterprise licensing fees",
 		color: "hsl(271 81% 56%)",
 	},
 } satisfies ChartConfig;
@@ -60,18 +60,21 @@ const revenueViews = {
 		label: "Credits Net",
 		description:
 			"Cumulative processed, revenue (after fees), and net (after fees & refunds) for credit purchases",
+		dailyLabel: "Net gain",
 		lines: ["processed", "revenue", "net"],
 	},
 	devpass: {
 		label: "DevPass Net",
 		description:
 			"Cumulative gross and net (after refunds) DevPass plan revenue",
+		dailyLabel: "Net gain",
 		lines: ["devpassRevenue", "devpassNet"],
 	},
 	enterprise: {
-		label: "Enterprise",
+		label: "Enterprise Gross",
 		description:
-			"Cumulative enterprise deal revenue and net profit; these deals do not grant credits",
+			"Cumulative gross revenue from enterprise licensing deals; these deals do not grant credits",
+		dailyLabel: "Enterprise licensing fees",
 		lines: ["enterpriseRevenue"],
 	},
 } as const;
@@ -195,7 +198,7 @@ export function RevenueChart({
 				</ChartContainer>
 				<div className="mt-2 px-2 sm:px-0">
 					<p className="mb-1 px-2 text-xs text-muted-foreground sm:px-3">
-						Net gain per day
+						{revenueViews[activeView].dailyLabel} per day
 					</p>
 					<ChartContainer
 						config={chartConfig}
@@ -214,7 +217,9 @@ export function RevenueChart({
 										}}
 										formatter={(value) => (
 											<>
-												<span className="text-muted-foreground">Net gain</span>
+												<span className="text-muted-foreground">
+													{revenueViews[activeView].dailyLabel}
+												</span>
 												<span className="ml-auto font-mono font-medium tabular-nums">
 													{currencyFormatter.format(Number(value))}
 												</span>

--- a/ee/admin/src/components/revenue-chart.tsx
+++ b/ee/admin/src/components/revenue-chart.tsx
@@ -49,6 +49,10 @@ const chartConfig = {
 		label: "Net",
 		color: "hsl(142 71% 45%)",
 	},
+	enterpriseRevenue: {
+		label: "Net profit",
+		color: "hsl(271 81% 56%)",
+	},
 } satisfies ChartConfig;
 
 const revenueViews = {
@@ -63,6 +67,12 @@ const revenueViews = {
 		description:
 			"Cumulative gross and net (after refunds) DevPass plan revenue",
 		lines: ["devpassRevenue", "devpassNet"],
+	},
+	enterprise: {
+		label: "Enterprise",
+		description:
+			"Cumulative enterprise deal revenue and net profit; these deals do not grant credits",
+		lines: ["enterpriseRevenue"],
 	},
 } as const;
 
@@ -84,7 +94,7 @@ export function RevenueChart({
 	totals,
 }: {
 	data: TimeseriesDataPoint[];
-	totals: { credits: number; devpass: number };
+	totals: { credits: number; devpass: number; enterprise: number };
 }) {
 	const [activeView, setActiveView] = useState<ActiveView>("credits");
 
@@ -93,7 +103,11 @@ export function RevenueChart({
 			data.map((point) => ({
 				date: point.date,
 				dailyNet:
-					activeView === "credits" ? point.dailyNet : point.dailyDevpassNet,
+					activeView === "credits"
+						? point.dailyNet
+						: activeView === "devpass"
+							? point.dailyDevpassNet
+							: point.dailyEnterpriseRevenue,
 			})),
 		[data, activeView],
 	);
@@ -103,14 +117,14 @@ export function RevenueChart({
 			<CardHeader className="flex flex-col items-stretch space-y-0 border-b p-0 sm:flex-row">
 				<div className="flex flex-1 flex-col justify-center gap-1.5 px-6 py-5 sm:py-6">
 					<CardTitle className="font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
-						Credits & DevPass Revenue
+						Credits, DevPass & Enterprise Revenue
 					</CardTitle>
 					<CardDescription className="text-xs">
 						{revenueViews[activeView].description}
 					</CardDescription>
 				</div>
 				<div className="flex">
-					{(["credits", "devpass"] as const).map((key) => (
+					{(["credits", "devpass", "enterprise"] as const).map((key) => (
 						<button
 							key={key}
 							data-active={activeView === key}

--- a/ee/admin/src/lib/admin-organizations.ts
+++ b/ee/admin/src/lib/admin-organizations.ts
@@ -97,6 +97,54 @@ export async function addManualCreditsToOrganization(
 	return { success: true };
 }
 
+export interface EnterpriseDealInput {
+	amount: number;
+	paymentMethod: "wire" | "crypto" | "other";
+	externalReference?: string;
+	comment?: string;
+}
+
+export async function addEnterpriseDealToOrganization(
+	orgId: string,
+	body: EnterpriseDealInput,
+): Promise<{ success: boolean; error?: string }> {
+	const $api = await createServerApiClient();
+	const { data, error } = await $api.POST(
+		"/admin/organizations/{orgId}/enterprise-deals",
+		{
+			params: { path: { orgId } },
+			body,
+		},
+	);
+
+	if (error || !data) {
+		return { success: false, error: "Failed to add enterprise deal" };
+	}
+
+	return { success: true };
+}
+
+export async function updateEnterpriseDeal(
+	orgId: string,
+	transactionId: string,
+	body: EnterpriseDealInput,
+): Promise<{ success: boolean; error?: string }> {
+	const $api = await createServerApiClient();
+	const { data, error } = await $api.PATCH(
+		"/admin/organizations/{orgId}/enterprise-deals/{transactionId}",
+		{
+			params: { path: { orgId, transactionId } },
+			body,
+		},
+	);
+
+	if (error || !data) {
+		return { success: false, error: "Failed to update enterprise deal" };
+	}
+
+	return { success: true };
+}
+
 export async function updateReferralBonus(
 	orgId: string,
 	body: { enabled: boolean; percent: number },

--- a/ee/admin/src/lib/admin-organizations.ts
+++ b/ee/admin/src/lib/admin-organizations.ts
@@ -100,6 +100,7 @@ export async function addManualCreditsToOrganization(
 export interface EnterpriseDealInput {
 	amount: number;
 	paymentMethod: "wire" | "crypto" | "other";
+	transactionDate?: string;
 	externalReference?: string;
 	comment?: string;
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -513,6 +513,10 @@ export const transaction = pgTable(
 				// received) and `creditAmount` (credits granted) are set and the row
 				// counts toward revenue. `paymentMethod` records the channel.
 				"credit_manual_payment",
+				// Revenue from a negotiated enterprise contract. This is accounting
+				// only: `amount` records the payment while `creditAmount` stays null,
+				// so the deal never changes the organization's credit balance.
+				"enterprise_deal",
 				"dev_plan_start",
 				"dev_plan_upgrade",
 				"dev_plan_downgrade",
@@ -569,15 +573,15 @@ export const transaction = pgTable(
 		description: text(),
 		relatedTransactionId: text(),
 		refundReason: text(),
-		// Off-Stripe payment channel, set only on `credit_manual_payment` rows so
-		// manually credited revenue can be reconciled per channel. Stripe-settled
-		// rows leave this null — the payment method lives in Stripe.
+		// Off-Stripe payment channel, set on `credit_manual_payment` and
+		// `enterprise_deal` rows so revenue can be reconciled per channel.
+		// Stripe-settled rows leave this null — the payment method lives in Stripe.
 		paymentMethod: text({
 			enum: ["wire", "crypto", "paypal", "other"],
 		}),
 		// Free-form identifier for the payment on its own channel — a bank wire
 		// reference, an on-chain transaction hash, a PayPal transaction id. Set
-		// only on `credit_manual_payment` rows, so a credit can be traced back to
+		// only on manually recorded payment rows, so revenue can be traced back to
 		// the money that paid for it without digging through the description.
 		externalReference: text(),
 	},
@@ -3716,6 +3720,9 @@ export const auditLogActions = [
 	// Credits
 	"credits.gift",
 	"credits.manual_payment",
+	// Enterprise deals
+	"enterprise_deal.create",
+	"enterprise_deal.update",
 	// Referral
 	"referral_bonus.update",
 	// Dev Plan
@@ -3776,6 +3783,7 @@ export const auditLogResourceTypes = [
 	"subscription",
 	"payment_method",
 	"payment",
+	"transaction",
 	"dev_plan",
 	"chat_plan",
 	"sso_provider",

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -516,7 +516,7 @@ export const transaction = pgTable(
 				// Revenue from a negotiated enterprise contract. This is accounting
 				// only: `amount` records the payment while `creditAmount` stays null,
 				// so the deal never changes the organization's credit balance.
-				"enterprise_deal",
+				"enterprise_license_fee",
 				"dev_plan_start",
 				"dev_plan_upgrade",
 				"dev_plan_downgrade",
@@ -574,7 +574,7 @@ export const transaction = pgTable(
 		relatedTransactionId: text(),
 		refundReason: text(),
 		// Off-Stripe payment channel, set on `credit_manual_payment` and
-		// `enterprise_deal` rows so revenue can be reconciled per channel.
+		// `enterprise_license_fee` rows so revenue can be reconciled per channel.
 		// Stripe-settled rows leave this null — the payment method lives in Stripe.
 		paymentMethod: text({
 			enum: ["wire", "crypto", "paypal", "other"],
@@ -3720,9 +3720,9 @@ export const auditLogActions = [
 	// Credits
 	"credits.gift",
 	"credits.manual_payment",
-	// Enterprise deals
-	"enterprise_deal.create",
-	"enterprise_deal.update",
+	// Enterprise license fees
+	"enterprise_license_fee.create",
+	"enterprise_license_fee.update",
 	// Referral
 	"referral_bonus.update",
 	// Dev Plan


### PR DESCRIPTION
## Summary

- record enterprise licensing revenue as `enterprise_license_fee` transactions without changing organization credits
- optionally backdate fees while defaulting new entries to the current time
- include enterprise licensing fees in total gross revenue and paying-customer metrics
- show gross enterprise licensing revenue as a separate dashboard series
- limit enterprise payment methods to wire, crypto, or other

## Validation

- `pnpm migrations` (no SQL migration required for the text-backed transaction type)
- `pnpm format`
- `pnpm build`
- `pnpm exec vitest run --no-file-parallelism apps/api/src/routes/admin-enterprise-deals.spec.ts` (5 tests)
- verified a backdated fee against the seeded isolated stack, including the stored timestamp and unchanged credits
- verified the Enterprise Gross dashboard and enterprise licensing labels in the seeded admin UI

## Screenshots

### Organization before adding a fee (light)

![Organization before adding a fee](https://raw.githubusercontent.com/theopenco/llmgateway/4b000c287e967b950b262ba63cadac17f13d89c7/enterprise-org-before-light.png)

### Add a backdated enterprise fee (light)

![Add enterprise fee dialog with optional transaction date and gross revenue copy](https://raw.githubusercontent.com/theopenco/llmgateway/6577f1f8b079766516feb8318545e84571268b54/enterprise-dialog-gross-light.png)

### Organization after editing the fee (dark)

![Organization after editing the fee](https://raw.githubusercontent.com/theopenco/llmgateway/4b000c287e967b950b262ba63cadac17f13d89c7/enterprise-org-after-dark.png)

### Gross enterprise licensing view (light)

![Gross enterprise licensing revenue view](https://raw.githubusercontent.com/theopenco/llmgateway/6577f1f8b079766516feb8318545e84571268b54/enterprise-gross-light.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enterprise deal creation and editing from organization administration pages.
  * Supports wire, crypto, and other payment methods, optional dates, references, and comments.
  * Added enterprise deals as a distinct transaction type with audit tracking.
  * Added enterprise revenue totals and dedicated chart views to the admin dashboard.

* **Bug Fixes**
  * Enterprise payments are correctly included when identifying paid customers.
  * Enterprise revenue is separated from credit revenue and does not add organization credits.
  * Added validation for positive amounts and supported payment methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->