### PR TITLE
fix(gateway): handle MCP timeouts

### DIFF
--- a/apps/gateway/src/mcp/mcp.spec.ts
+++ b/apps/gateway/src/mcp/mcp.spec.ts
@@ -140,7 +140,7 @@ describe("MCP endpoint", () => {
 		expect(json.error.code).toBe(-32001);
 	});
 
-	test("returns a gateway timeout without logging a server error", async () => {
+	test("returns correlated timeouts without logging a server error", async () => {
 		await seedActiveKey();
 
 		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
@@ -154,35 +154,65 @@ describe("MCP endpoint", () => {
 			);
 
 		try {
-			const responsePromise = app.request("/mcp", {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-					Authorization: "Bearer real-token",
-				},
-				body: JSON.stringify({
-					jsonrpc: "2.0",
-					id: 1,
-					method: "tools/call",
-					params: {
-						name: "chat",
-						arguments: {
-							model: "gpt-4o-mini",
-							messages: [{ role: "user", content: "hello" }],
-						},
+			const makeRequest = (id: string | number) => ({
+				jsonrpc: "2.0",
+				id,
+				method: "tools/call",
+				params: {
+					name: "chat",
+					arguments: {
+						model: "gpt-4o-mini",
+						messages: [{ role: "user", content: "hello" }],
 					},
-				}),
+				},
 			});
+			const request = (body: unknown) =>
+				app.request("/mcp", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: "Bearer real-token",
+					},
+					body: JSON.stringify(body),
+				});
 
-			const response = await responsePromise;
+			const response = await request(makeRequest(1));
 			const json = await response.json();
 
-			expect(response.status).toBe(504);
-			expect(json.error).toMatchObject({
-				code: -32001,
-				message: "Request timed out",
-				data: { timeout: 60_000 },
+			expect(response.status).toBe(200);
+			expect(json).toMatchObject({
+				id: 1,
+				error: {
+					code: -32001,
+					message: "Request timed out",
+					data: { timeout: 60_000 },
+				},
 			});
+
+			const batchResponse = await request([
+				makeRequest(2),
+				makeRequest("three"),
+			]);
+			const batchJson = await batchResponse.json();
+
+			expect(batchResponse.status).toBe(200);
+			expect(batchJson).toMatchObject([
+				{
+					id: 2,
+					error: {
+						code: -32001,
+						message: "Request timed out",
+					},
+				},
+				{
+					id: "three",
+					error: {
+						code: -32001,
+						message: "Request timed out",
+					},
+				},
+			]);
+			expect(warnSpy).toHaveBeenCalledTimes(3);
 			expect(warnSpy).toHaveBeenCalledWith("MCP request timeout", {
 				message: "MCP error -32001: Request timed out",
 				data: { timeout: 60_000 },

--- a/apps/gateway/src/mcp/mcp.spec.ts
+++ b/apps/gateway/src/mcp/mcp.spec.ts
@@ -1,11 +1,14 @@
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { app } from "@/app.js";
 import { clearCache } from "@/test-utils/test-helpers.js";
 
 import { db, eq, tables } from "@llmgateway/db";
+import { logger } from "@llmgateway/logger";
 
-describe("MCP endpoint authentication", () => {
+describe("MCP endpoint", () => {
 	async function seedActiveKey() {
 		await db
 			.insert(tables.user)
@@ -135,5 +138,60 @@ describe("MCP endpoint authentication", () => {
 		expect(res.status).toBe(401);
 		const json = await res.json();
 		expect(json.error.code).toBe(-32001);
+	});
+
+	test("returns a gateway timeout without logging a server error", async () => {
+		await seedActiveKey();
+
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		const callToolSpy = vi
+			.spyOn(Client.prototype, "callTool")
+			.mockRejectedValue(
+				new McpError(ErrorCode.RequestTimeout, "Request timed out", {
+					timeout: 60_000,
+				}),
+			);
+
+		try {
+			const responsePromise = app.request("/mcp", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					jsonrpc: "2.0",
+					id: 1,
+					method: "tools/call",
+					params: {
+						name: "chat",
+						arguments: {
+							model: "gpt-4o-mini",
+							messages: [{ role: "user", content: "hello" }],
+						},
+					},
+				}),
+			});
+
+			const response = await responsePromise;
+			const json = await response.json();
+
+			expect(response.status).toBe(504);
+			expect(json.error).toMatchObject({
+				code: -32001,
+				message: "Request timed out",
+				data: { timeout: 60_000 },
+			});
+			expect(warnSpy).toHaveBeenCalledWith("MCP request timeout", {
+				message: "MCP error -32001: Request timed out",
+				data: { timeout: 60_000 },
+			});
+			expect(errorSpy).not.toHaveBeenCalled();
+		} finally {
+			callToolSpy.mockRestore();
+			warnSpy.mockRestore();
+			errorSpy.mockRestore();
+		}
 	});
 });

--- a/apps/gateway/src/mcp/mcp.ts
+++ b/apps/gateway/src/mcp/mcp.ts
@@ -1066,6 +1066,23 @@ async function processMcpRequest(
 					},
 				};
 		}
+	} catch (error) {
+		if (error instanceof McpError && error.code === -32001) {
+			logger.warn("MCP request timeout", {
+				message: error.message,
+				data: error.data,
+			});
+			return {
+				jsonrpc: "2.0",
+				id: request.id ?? null,
+				error: {
+					code: error.code,
+					message: "Request timed out",
+					data: error.data,
+				},
+			};
+		}
+		throw error;
 	} finally {
 		await client.close();
 	}
@@ -1325,25 +1342,6 @@ export async function mcpHandler(c: Context): Promise<Response> {
 				"mcp-session-id": sessionId,
 			});
 		} catch (error) {
-			if (error instanceof McpError && error.code === -32001) {
-				logger.warn("MCP request timeout", {
-					message: error.message,
-					data: error.data,
-				});
-				return c.json(
-					{
-						jsonrpc: "2.0",
-						error: {
-							code: error.code,
-							message: "Request timed out",
-							data: error.data,
-						},
-						id: null,
-					},
-					504,
-				);
-			}
-
 			// Check if this is a JSON parse error (-32700 Parse error)
 			const isParseError =
 				error instanceof SyntaxError ||

--- a/apps/gateway/src/mcp/mcp.ts
+++ b/apps/gateway/src/mcp/mcp.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { McpError } from "@modelcontextprotocol/sdk/types.js";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
@@ -1324,6 +1325,25 @@ export async function mcpHandler(c: Context): Promise<Response> {
 				"mcp-session-id": sessionId,
 			});
 		} catch (error) {
+			if (error instanceof McpError && error.code === -32001) {
+				logger.warn("MCP request timeout", {
+					message: error.message,
+					data: error.data,
+				});
+				return c.json(
+					{
+						jsonrpc: "2.0",
+						error: {
+							code: error.code,
+							message: "Request timed out",
+							data: error.data,
+						},
+						id: null,
+					},
+					504,
+				);
+			}
+
 			// Check if this is a JSON parse error (-32700 Parse error)
 			const isParseError =
 				error instanceof SyntaxError ||


### PR DESCRIPTION
## Problem

Expected MCP SDK request timeouts fell through to the generic request-error path, producing an error-level log and a transport failure.

## Changes

- detect SDK request timeouts per JSON-RPC request
- log timeouts as operational warnings
- return parseable HTTP 200 responses with JSON-RPC timeout code `-32001`
- preserve request IDs for single and batch timeout responses
- add regression coverage for transport status, correlation, and log severity

## Verification

- `pnpm exec vitest run apps/gateway/src/mcp/mcp.spec.ts --no-file-parallelism`
- `pnpm format`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MCP request timeouts now return HTTP 200 responses with clear, per-request JSON-RPC timeout errors.
  * Batch requests preserve response correlation, reporting timeouts independently for each request.
  * Timeout events are logged as warnings rather than server errors.
  * Parsing failures and unexpected errors continue to receive appropriate error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->