### PR TITLE
fix(gateway): track Together stream usage

### DIFF
--- a/apps/gateway/src/chat-prompt-caching.e2e.ts
+++ b/apps/gateway/src/chat-prompt-caching.e2e.ts
@@ -19,6 +19,7 @@ import {
 import { models } from "@llmgateway/models";
 
 import { app } from "./app.js";
+import { readAll } from "./test-utils/test-helpers.js";
 
 import type { ProviderModelMapping } from "@llmgateway/models";
 
@@ -126,6 +127,7 @@ describe("e2e prompt caching", getConcurrentTestOptions(), () => {
 					headers: {
 						"Content-Type": "application/json",
 						"x-request-id": firstRequestId,
+						"x-no-fallback": "true",
 						Authorization: `Bearer real-token`,
 					},
 					body: JSON.stringify({
@@ -178,6 +180,7 @@ describe("e2e prompt caching", getConcurrentTestOptions(), () => {
 						headers: {
 							"Content-Type": "application/json",
 							"x-request-id": secondRequestId,
+							"x-no-fallback": "true",
 							Authorization: `Bearer real-token`,
 						},
 						body: JSON.stringify({
@@ -273,6 +276,71 @@ describe("e2e prompt caching", getConcurrentTestOptions(), () => {
 					expect(Number(providerMapping.cachedInputPrice)).toBeLessThan(
 						Number(providerMapping.inputPrice),
 					);
+				}
+
+				if (provider.streaming) {
+					const sendStreamingCacheRequest = async () => {
+						const requestId = generateTestRequestId();
+						const res = await app.request("/v1/chat/completions", {
+							method: "POST",
+							headers: {
+								"Content-Type": "application/json",
+								"x-request-id": requestId,
+								"x-no-fallback": "true",
+								Authorization: `Bearer real-token`,
+							},
+							body: JSON.stringify({
+								model,
+								messages: [
+									{
+										role: "system",
+										content: longSystemPrompt,
+									},
+									{
+										role: "user",
+										content:
+											"Just reply with 'OK' to confirm you received the context.",
+									},
+								],
+								stream: true,
+							}),
+						});
+						const streamResult = await readAll(res.body);
+						const usage = streamResult.chunks
+							.filter((chunk) => chunk.usage)
+							.at(-1)?.usage;
+						return { res, requestId, streamResult, usage };
+					};
+
+					let streamAttempt = 0;
+					let streamResult: Awaited<
+						ReturnType<typeof sendStreamingCacheRequest>
+					>;
+					do {
+						streamAttempt++;
+						streamResult = await sendStreamingCacheRequest();
+						const cached =
+							streamResult.usage?.prompt_tokens_details?.cached_tokens ?? 0;
+						if (streamResult.res.status !== 200 || cached > 0) {
+							break;
+						}
+						if (streamAttempt < maxAttempts) {
+							await new Promise((r) => setTimeout(r, 750 * streamAttempt));
+						}
+					} while (streamAttempt < maxAttempts);
+
+					expect(streamResult.res.status).toBe(200);
+					expect(streamResult.streamResult.hasValidSSE).toBe(true);
+					expect(
+						streamResult.usage?.prompt_tokens_details?.cached_tokens,
+					).toBeGreaterThan(0);
+
+					const streamingLog = await validateLogByRequestId(
+						streamResult.requestId,
+					);
+					expect(streamingLog.streamed).toBe(true);
+					expect(Number(streamingLog.cachedTokens)).toBeGreaterThan(0);
+					expect(Number(streamingLog.cachedInputCost)).toBeGreaterThan(0);
 				}
 			},
 		);

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -6858,6 +6858,30 @@ describe("prepareRequestBody - max_tokens forwarding", () => {
 	});
 
 	describe("together-ai", () => {
+		test("requests usage details for streams", async () => {
+			const requestBody = (await prepareRequestBody(
+				"together-ai",
+				"kimi-k3",
+				null,
+				"moonshotai/Kimi-K3",
+				[{ role: "user", content: "Hello!" }],
+				true,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				true,
+				false,
+			)) as { stream_options?: { include_usage: boolean } };
+
+			expect(requestBody.stream_options).toEqual({ include_usage: true });
+		});
+
 		test("forwards caller-supplied max_tokens verbatim", async () => {
 			const requestBody = (await prepareRequestBody(
 				"together-ai",

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -4125,6 +4125,12 @@ export async function prepareRequestBody(
 		}
 		case "inference.net":
 		case "together-ai": {
+			if (stream && usedProvider === "together-ai") {
+				requestBody.stream_options = {
+					include_usage: true,
+				};
+			}
+
 			if (usedExternalId.startsWith(`${usedProvider}/`)) {
 				requestBody.model = usedExternalId.substring(usedProvider.length + 1);
 			}


### PR DESCRIPTION
## Summary

- request usage details for Together streaming responses
- pin prompt-cache E2E requests to the selected provider
- verify cached token usage and persisted cache costs for streams

## Root cause

Together only emits the final streaming usage frame when stream_options.include_usage is enabled. The gateway omitted that option, so it estimated tokens and could not recognize cached input. The opt-in cache E2E only exercised non-streaming requests, where Together returns usage without this option.

## Verification

- pnpm format
- pnpm exec vitest run --no-file-parallelism packages/actions/src/prepare-request-body.spec.ts
- TEST_MODELS=together-ai/kimi-k3 TEST_CACHE_MODE=true FULL_MODE=true LOG_MODE=true CONCURRENT_TESTS=false pnpm test:e2e
- pnpm build