### PR TITLE
feat(admin): expand DevPass KPIs

### DIFF
--- a/apps/api/src/routes/admin-devpass-subscriber-kpis.spec.ts
+++ b/apps/api/src/routes/admin-devpass-subscriber-kpis.spec.ts
@@ -10,6 +10,8 @@ const originalAdminEmails = process.env.ADMIN_EMAILS;
 interface KpisResponse {
 	totalSubscribers: number;
 	totalSubscribersExcludingRefunded: number;
+	grossSubscriptionRevenue: number;
+	subscriptionRevenueExcludingRefunds: number;
 }
 
 async function insertOrg(id: string, kind: "default" | "devpass" = "devpass") {
@@ -46,6 +48,9 @@ describe("admin devpass subscriber KPIs", () => {
 			insertOrg("payment-without-start"),
 			insertOrg("failed-refund"),
 			insertOrg("unrelated-refund"),
+			insertOrg("upgrade-subscriber"),
+			insertOrg("downgrade-subscriber"),
+			insertOrg("renewal-subscriber"),
 			insertOrg("non-devpass", "default"),
 		]);
 
@@ -118,6 +123,42 @@ describe("admin devpass subscriber KPIs", () => {
 				relatedTransactionId: "reset-pass",
 			},
 			{
+				organizationId: "upgrade-subscriber",
+				type: "dev_plan_start",
+				amount: "0",
+				status: "completed",
+			},
+			{
+				organizationId: "upgrade-subscriber",
+				type: "dev_plan_upgrade",
+				amount: "49",
+				status: "completed",
+			},
+			{
+				organizationId: "downgrade-subscriber",
+				type: "dev_plan_start",
+				amount: "0",
+				status: "completed",
+			},
+			{
+				organizationId: "downgrade-subscriber",
+				type: "dev_plan_downgrade",
+				amount: "19",
+				status: "completed",
+			},
+			{
+				organizationId: "renewal-subscriber",
+				type: "dev_plan_start",
+				amount: "0",
+				status: "completed",
+			},
+			{
+				organizationId: "renewal-subscriber",
+				type: "dev_plan_renewal",
+				amount: "79",
+				status: "completed",
+			},
+			{
 				organizationId: "non-devpass",
 				type: "subscription_start",
 				amount: "99",
@@ -131,7 +172,9 @@ describe("admin devpass subscriber KPIs", () => {
 		expect(res.status).toBe(200);
 		const body = (await res.json()) as KpisResponse;
 
-		expect(body.totalSubscribers).toBe(4);
-		expect(body.totalSubscribersExcludingRefunded).toBe(3);
+		expect(body.totalSubscribers).toBe(7);
+		expect(body.totalSubscribersExcludingRefunded).toBe(6);
+		expect(body.grossSubscriptionRevenue).toBe(413);
+		expect(body.subscriptionRevenueExcludingRefunds).toBe(334);
 	});
 });

--- a/apps/api/src/routes/admin-devpass-subscriber-kpis.spec.ts
+++ b/apps/api/src/routes/admin-devpass-subscriber-kpis.spec.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db, tables } from "@llmgateway/db";
+
+const originalAdminEmails = process.env.ADMIN_EMAILS;
+
+interface KpisResponse {
+	totalSubscribers: number;
+	totalSubscribersExcludingRefunded: number;
+}
+
+async function insertOrg(id: string, kind: "default" | "devpass" = "devpass") {
+	await db.insert(tables.organization).values({
+		id,
+		name: id,
+		billingEmail: `${id}@example.com`,
+		kind,
+	});
+}
+
+describe("admin devpass subscriber KPIs", () => {
+	let cookie: string;
+
+	beforeEach(async () => {
+		process.env.ADMIN_EMAILS = "admin@example.com";
+		cookie = await createTestUser();
+	});
+
+	afterEach(async () => {
+		if (originalAdminEmails === undefined) {
+			delete process.env.ADMIN_EMAILS;
+		} else {
+			process.env.ADMIN_EMAILS = originalAdminEmails;
+		}
+		await deleteAll();
+	});
+
+	it("counts paid subscribers and excludes plan-payment refunds", async () => {
+		await Promise.all([
+			insertOrg("paid-subscriber"),
+			insertOrg("refunded-subscriber"),
+			insertOrg("unpaid-subscriber"),
+			insertOrg("payment-without-start"),
+			insertOrg("failed-refund"),
+			insertOrg("unrelated-refund"),
+			insertOrg("non-devpass", "default"),
+		]);
+
+		await db.insert(tables.transaction).values([
+			{
+				id: "paid-start",
+				organizationId: "paid-subscriber",
+				type: "dev_plan_start",
+				amount: "29",
+				status: "completed",
+			},
+			{
+				id: "refunded-start",
+				organizationId: "refunded-subscriber",
+				type: "dev_plan_start",
+				amount: "79",
+				status: "completed",
+			},
+			{
+				organizationId: "refunded-subscriber",
+				type: "credit_refund",
+				amount: "79",
+				status: "completed",
+				relatedTransactionId: "refunded-start",
+			},
+			{
+				organizationId: "unpaid-subscriber",
+				type: "dev_plan_start",
+				amount: "0",
+				status: "completed",
+			},
+			{
+				organizationId: "payment-without-start",
+				type: "dev_plan_renewal",
+				amount: "79",
+				status: "completed",
+			},
+			{
+				id: "failed-refund-start",
+				organizationId: "failed-refund",
+				type: "dev_plan_start",
+				amount: "79",
+				status: "completed",
+			},
+			{
+				organizationId: "failed-refund",
+				type: "credit_refund",
+				amount: "79",
+				status: "failed",
+				relatedTransactionId: "failed-refund-start",
+			},
+			{
+				organizationId: "unrelated-refund",
+				type: "dev_plan_start",
+				amount: "79",
+				status: "completed",
+			},
+			{
+				id: "reset-pass",
+				organizationId: "unrelated-refund",
+				type: "dev_plan_reset_pass",
+				amount: "29",
+				status: "completed",
+			},
+			{
+				organizationId: "unrelated-refund",
+				type: "credit_refund",
+				amount: "29",
+				status: "completed",
+				relatedTransactionId: "reset-pass",
+			},
+			{
+				organizationId: "non-devpass",
+				type: "subscription_start",
+				amount: "99",
+				status: "completed",
+			},
+		]);
+
+		const res = await app.request("/admin/devpass/kpis", {
+			headers: { Cookie: cookie },
+		});
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as KpisResponse;
+
+		expect(body.totalSubscribers).toBe(4);
+		expect(body.totalSubscribersExcludingRefunded).toBe(3);
+	});
+});

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -13505,6 +13505,8 @@ const devpassKpisSchema = z.object({
 		pro: z.number(),
 		max: z.number(),
 	}),
+	totalSubscribers: z.number(),
+	totalSubscribersExcludingRefunded: z.number(),
 	totalActive: z.number(),
 	cancelledPending: z.number(),
 	churned: z.number(),
@@ -14612,11 +14614,90 @@ admin.openapi(getDevpassKpis, async (c) => {
 		tables.transaction,
 		"reset_pass_refund_original_tx",
 	);
+	const subscriberStartTx = aliasedTable(
+		tables.transaction,
+		"subscriber_start_tx",
+	);
+	const subscriberPaymentTx = aliasedTable(
+		tables.transaction,
+		"subscriber_payment_tx",
+	);
+	const subscriberRefundTx = aliasedTable(
+		tables.transaction,
+		"subscriber_refund_tx",
+	);
+	const subscriberRefundOriginalTx = aliasedTable(
+		tables.transaction,
+		"subscriber_refund_original_tx",
+	);
+
+	const subscriberStartsSub = db
+		.select({ organizationId: subscriberStartTx.organizationId })
+		.from(subscriberStartTx)
+		.where(
+			and(
+				eq(subscriberStartTx.status, "completed"),
+				inArray(subscriberStartTx.type, [
+					"dev_plan_start",
+					"subscription_start",
+				]),
+			),
+		)
+		.groupBy(subscriberStartTx.organizationId)
+		.as("subscriber_starts");
+	const subscriberPaymentsSub = db
+		.select({ organizationId: subscriberPaymentTx.organizationId })
+		.from(subscriberPaymentTx)
+		.where(
+			and(
+				eq(subscriberPaymentTx.status, "completed"),
+				inArray(subscriberPaymentTx.type, [
+					...DEV_PLAN_SUBSCRIPTION_TX_TYPES,
+					"subscription_start",
+				]),
+				isNotNull(subscriberPaymentTx.amount),
+				sql`CAST(${subscriberPaymentTx.amount} AS NUMERIC) > 0`,
+			),
+		)
+		.groupBy(subscriberPaymentTx.organizationId)
+		.as("subscriber_payments");
+	const subscriberRefundsSub = db
+		.select({ organizationId: subscriberRefundTx.organizationId })
+		.from(subscriberRefundTx)
+		.innerJoin(
+			subscriberRefundOriginalTx,
+			eq(
+				subscriberRefundTx.relatedTransactionId,
+				subscriberRefundOriginalTx.id,
+			),
+		)
+		.where(
+			and(
+				eq(subscriberRefundTx.type, "credit_refund"),
+				eq(subscriberRefundTx.status, "completed"),
+				isNotNull(subscriberRefundTx.amount),
+				sql`CAST(${subscriberRefundTx.amount} AS NUMERIC) > 0`,
+				eq(
+					subscriberRefundOriginalTx.organizationId,
+					subscriberRefundTx.organizationId,
+				),
+				eq(subscriberRefundOriginalTx.status, "completed"),
+				inArray(subscriberRefundOriginalTx.type, [
+					...DEV_PLAN_SUBSCRIPTION_TX_TYPES,
+					"subscription_start",
+				]),
+				isNotNull(subscriberRefundOriginalTx.amount),
+				sql`CAST(${subscriberRefundOriginalTx.amount} AS NUMERIC) > 0`,
+			),
+		)
+		.groupBy(subscriberRefundTx.organizationId)
+		.as("subscriber_refunds");
 
 	// Every KPI is an independent aggregate over the same universe, so they run
 	// concurrently rather than serially.
 	const [
 		activeRows,
+		[subscriberCountsRow],
 		[churnedRow],
 		[startsRow],
 		[endsRow],
@@ -14644,6 +14725,28 @@ admin.openapi(getDevpassKpis, async (c) => {
 				tables.organization.devPlan,
 				tables.organization.devPlanCancelled,
 			),
+		// Historical subscribers must have both a completed plan start and a
+		// completed, positive plan payment. The secondary count drops anyone with
+		// a completed refund against one of those payments.
+		db
+			.select({
+				total: sql<number>`COUNT(*)`,
+				excludingRefunded: sql<number>`COUNT(*) FILTER (WHERE ${subscriberRefundsSub.organizationId} IS NULL)`,
+			})
+			.from(tables.organization)
+			.innerJoin(
+				subscriberStartsSub,
+				eq(tables.organization.id, subscriberStartsSub.organizationId),
+			)
+			.innerJoin(
+				subscriberPaymentsSub,
+				eq(tables.organization.id, subscriberPaymentsSub.organizationId),
+			)
+			.leftJoin(
+				subscriberRefundsSub,
+				eq(tables.organization.id, subscriberRefundsSub.organizationId),
+			)
+			.where(eq(tables.organization.kind, "devpass")),
 		db
 			.select({
 				count: sql<number>`COUNT(DISTINCT ${tables.transaction.organizationId})`,
@@ -14853,6 +14956,10 @@ admin.openapi(getDevpassKpis, async (c) => {
 
 	return c.json({
 		activeByTier,
+		totalSubscribers: Number(subscriberCountsRow?.total ?? 0),
+		totalSubscribersExcludingRefunded: Number(
+			subscriberCountsRow?.excludingRefunded ?? 0,
+		),
 		totalActive,
 		cancelledPending,
 		churned: Number(churnedRow?.count ?? 0),

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -13507,6 +13507,8 @@ const devpassKpisSchema = z.object({
 	}),
 	totalSubscribers: z.number(),
 	totalSubscribersExcludingRefunded: z.number(),
+	grossSubscriptionRevenue: z.number(),
+	subscriptionRevenueExcludingRefunds: z.number(),
 	totalActive: z.number(),
 	cancelledPending: z.number(),
 	churned: z.number(),
@@ -14618,10 +14620,6 @@ admin.openapi(getDevpassKpis, async (c) => {
 		tables.transaction,
 		"subscriber_start_tx",
 	);
-	const subscriberPaymentTx = aliasedTable(
-		tables.transaction,
-		"subscriber_payment_tx",
-	);
 	const subscriberRefundTx = aliasedTable(
 		tables.transaction,
 		"subscriber_refund_tx",
@@ -14630,6 +14628,10 @@ admin.openapi(getDevpassKpis, async (c) => {
 		tables.transaction,
 		"subscriber_refund_original_tx",
 	);
+	const subscriberPaymentTypes = [
+		...DEV_PLAN_SUBSCRIPTION_TX_TYPES,
+		"subscription_start",
+	] as const;
 
 	const subscriberStartsSub = db
 		.select({ organizationId: subscriberStartTx.organizationId })
@@ -14646,23 +14648,33 @@ admin.openapi(getDevpassKpis, async (c) => {
 		.groupBy(subscriberStartTx.organizationId)
 		.as("subscriber_starts");
 	const subscriberPaymentsSub = db
-		.select({ organizationId: subscriberPaymentTx.organizationId })
-		.from(subscriberPaymentTx)
+		.select({
+			organizationId: tables.transaction.organizationId,
+			grossRevenue:
+				sql<string>`SUM(CAST(${tables.transaction.amount} AS NUMERIC))`.as(
+					"gross_subscription_revenue",
+				),
+		})
+		.from(tables.transaction)
 		.where(
 			and(
-				eq(subscriberPaymentTx.status, "completed"),
-				inArray(subscriberPaymentTx.type, [
-					...DEV_PLAN_SUBSCRIPTION_TX_TYPES,
-					"subscription_start",
-				]),
-				isNotNull(subscriberPaymentTx.amount),
-				sql`CAST(${subscriberPaymentTx.amount} AS NUMERIC) > 0`,
+				eq(tables.transaction.status, "completed"),
+				inArray(tables.transaction.type, subscriberPaymentTypes),
+				isNotNull(tables.transaction.amount),
+				sql`CAST(${tables.transaction.amount} AS NUMERIC) > 0`,
+				firstRowPerInvoiceFilter(subscriberPaymentTypes),
 			),
 		)
-		.groupBy(subscriberPaymentTx.organizationId)
+		.groupBy(tables.transaction.organizationId)
 		.as("subscriber_payments");
 	const subscriberRefundsSub = db
-		.select({ organizationId: subscriberRefundTx.organizationId })
+		.select({
+			organizationId: subscriberRefundTx.organizationId,
+			refundedAmount:
+				sql<string>`SUM(CAST(${subscriberRefundTx.amount} AS NUMERIC))`.as(
+					"subscriber_refunded_amount",
+				),
+		})
 		.from(subscriberRefundTx)
 		.innerJoin(
 			subscriberRefundOriginalTx,
@@ -14682,10 +14694,7 @@ admin.openapi(getDevpassKpis, async (c) => {
 					subscriberRefundTx.organizationId,
 				),
 				eq(subscriberRefundOriginalTx.status, "completed"),
-				inArray(subscriberRefundOriginalTx.type, [
-					...DEV_PLAN_SUBSCRIPTION_TX_TYPES,
-					"subscription_start",
-				]),
+				inArray(subscriberRefundOriginalTx.type, subscriberPaymentTypes),
 				isNotNull(subscriberRefundOriginalTx.amount),
 				sql`CAST(${subscriberRefundOriginalTx.amount} AS NUMERIC) > 0`,
 			),
@@ -14732,6 +14741,12 @@ admin.openapi(getDevpassKpis, async (c) => {
 			.select({
 				total: sql<number>`COUNT(*)`,
 				excludingRefunded: sql<number>`COUNT(*) FILTER (WHERE ${subscriberRefundsSub.organizationId} IS NULL)`,
+				grossRevenue: sql<string>`COALESCE(SUM(CAST(${subscriberPaymentsSub.grossRevenue} AS NUMERIC)), 0)`,
+				revenueExcludingRefunds: sql<string>`GREATEST(
+						COALESCE(SUM(CAST(${subscriberPaymentsSub.grossRevenue} AS NUMERIC)), 0)
+						- COALESCE(SUM(CAST(${subscriberRefundsSub.refundedAmount} AS NUMERIC)), 0),
+						0
+					)`,
 			})
 			.from(tables.organization)
 			.innerJoin(
@@ -14959,6 +14974,10 @@ admin.openapi(getDevpassKpis, async (c) => {
 		totalSubscribers: Number(subscriberCountsRow?.total ?? 0),
 		totalSubscribersExcludingRefunded: Number(
 			subscriberCountsRow?.excludingRefunded ?? 0,
+		),
+		grossSubscriptionRevenue: Number(subscriberCountsRow?.grossRevenue ?? 0),
+		subscriptionRevenueExcludingRefunds: Number(
+			subscriberCountsRow?.revenueExcludingRefunds ?? 0,
 		),
 		totalActive,
 		cancelledPending,

--- a/ee/admin/src/components/devpass-kpis.tsx
+++ b/ee/admin/src/components/devpass-kpis.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+	CircleDollarSign,
 	Info,
 	RotateCcw,
 	Ticket,
@@ -139,6 +140,20 @@ export function DevpassKpis({ from, to }: { from?: string; to?: string }) {
 							</div>
 						</KpiCard>
 						<KpiCard
+							icon={<CircleDollarSign className="h-3.5 w-3.5" />}
+							label="All-time plan revenue"
+						>
+							<div className="mt-2 text-2xl font-semibold tabular-nums">
+								{currencyFormatter.format(kpis.grossSubscriptionRevenue)}
+							</div>
+							<div className="mt-1 text-xs text-muted-foreground">
+								{currencyFormatter.format(
+									kpis.subscriptionRevenueExcludingRefunds,
+								)}{" "}
+								excluding refunds
+							</div>
+						</KpiCard>
+						<KpiCard
 							icon={<Wallet className="h-3.5 w-3.5" />}
 							label="Gross MRR"
 						>
@@ -208,6 +223,14 @@ export function DevpassKpis({ from, to }: { from?: string; to?: string }) {
 								({kpis.startsThisMonth} starts / {kpis.endsThisMonth} ends)
 							</div>
 						</KpiCard>
+					</>
+				)}
+			</div>
+			<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+				{kpisError ? null : !kpis ? (
+					<KpiSkeleton count={5} />
+				) : (
+					<>
 						<KpiCard
 							icon={
 								kpis.totalMargin >= 0 ? (
@@ -256,14 +279,6 @@ export function DevpassKpis({ from, to }: { from?: string; to?: string }) {
 								) : null}
 							</div>
 						</KpiCard>
-					</>
-				)}
-			</div>
-			<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
-				{kpisError ? null : !kpis ? (
-					<KpiSkeleton count={4} />
-				) : (
-					<>
 						<KpiCard
 							icon={<RotateCcw className="h-3.5 w-3.5" />}
 							label="Refunds this month"

--- a/ee/admin/src/components/devpass-kpis.tsx
+++ b/ee/admin/src/components/devpass-kpis.tsx
@@ -99,11 +99,11 @@ export function DevpassKpis({ from, to }: { from?: string; to?: string }) {
 
 	return (
 		<section className="space-y-3">
-			<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+			<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
 				{kpisError ? (
 					<KpiError label="DevPass KPIs" />
 				) : !kpis ? (
-					<KpiSkeleton count={3} />
+					<KpiSkeleton count={4} />
 				) : (
 					<>
 						<KpiCard
@@ -125,6 +125,17 @@ export function DevpassKpis({ from, to }: { from?: string; to?: string }) {
 										</span>
 									</>
 								) : null}
+							</div>
+						</KpiCard>
+						<KpiCard
+							icon={<Users className="h-3.5 w-3.5" />}
+							label="Total subscribers"
+						>
+							<div className="mt-2 text-2xl font-semibold tabular-nums">
+								{kpis.totalSubscribers}
+							</div>
+							<div className="mt-1 text-xs text-muted-foreground">
+								{kpis.totalSubscribersExcludingRefunded} excluding refunded
 							</div>
 						</KpiCard>
 						<KpiCard

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -10,7 +10,7 @@ import {
 	models as allModels,
 	providers as allProviders,
 } from "@llmgateway/models";
-import { getDevPlanCreditsLimit } from "@llmgateway/shared";
+import { DEV_PLAN_PRICES, getDevPlanCreditsLimit } from "@llmgateway/shared";
 
 import { closeDatabase, db, tables } from "./index.js";
 import { logs } from "./logs.js";
@@ -700,6 +700,13 @@ const TRANSACTION_TYPES = [
 	"dev_plan_renewal",
 ] as const;
 
+// DevPass subscription history is seeded deterministically below so its
+// subscriber and revenue KPIs stay internally consistent across seed runs.
+const DEV_PASS_RANDOM_TRANSACTION_TYPES = [
+	"credit_topup",
+	"credit_refund",
+] as const;
+
 function generateTransactions() {
 	const transactions = [];
 	let txIdx = 0;
@@ -711,7 +718,11 @@ function generateTransactions() {
 					? randomInt(4, 8)
 					: randomInt(1, 3);
 		for (let i = 0; i < numTx; i++) {
-			const type = randomChoice([...TRANSACTION_TYPES]);
+			const type = randomChoice([
+				...(org.kind === "devpass"
+					? DEV_PASS_RANDOM_TRANSACTION_TYPES
+					: TRANSACTION_TYPES),
+			]);
 			const isCredit = type === "credit_topup";
 			const isRefund = type === "credit_refund";
 			const isSub =
@@ -2349,6 +2360,22 @@ async function seed() {
 		description: "Test credit top-up for referral eligibility",
 	});
 
+	const devpassStartCreatedAt = daysAgo(36);
+	await upsert(tables.transaction, {
+		id: "test-devpass-start-transaction-id",
+		organizationId: "test-personal-org-id",
+		createdAt: devpassStartCreatedAt,
+		updatedAt: devpassStartCreatedAt,
+		type: "dev_plan_start",
+		amount: String(DEV_PLAN_PRICES.pro),
+		creditAmount: String(getDevPlanCreditsLimit("pro")),
+		currency: "USD",
+		status: "completed",
+		stripePaymentIntentId: "pi_seed_devpass_start",
+		stripeInvoiceId: "in_seed_devpass_start",
+		description: "Seeded DevPass Pro start for admin dashboard",
+	});
+
 	const devpassRenewalCreatedAt = daysAgo(6);
 	await upsert(tables.transaction, {
 		id: "test-devpass-renewal-transaction-id",
@@ -2709,6 +2736,29 @@ async function seed() {
 
 	const transactions = generateTransactions();
 	await bulkInsert(tables.transaction, transactions);
+
+	const devpassSubscriptionStarts = EXTRA_ORGS.flatMap((org) => {
+		if (org.kind !== "devpass" || org.devPlan === "none") {
+			return [];
+		}
+		return [
+			{
+				id: `seed-devpass-start-${org.id}`,
+				organizationId: org.id,
+				createdAt: org.createdAt,
+				updatedAt: org.createdAt,
+				type: "dev_plan_start" as const,
+				amount: String(DEV_PLAN_PRICES[org.devPlan]),
+				creditAmount: String(getDevPlanCreditsLimit(org.devPlan)),
+				currency: "USD",
+				status: "completed" as const,
+				stripePaymentIntentId: `pi_seed_devpass_start_${org.id}`,
+				stripeInvoiceId: `in_seed_devpass_start_${org.id}`,
+				description: `Seeded DevPass ${org.devPlan.toUpperCase()} start for admin dashboard`,
+			},
+		];
+	});
+	await bulkInsert(tables.transaction, devpassSubscriptionStarts);
 
 	const discounts = generateDiscounts();
 	await bulkInsert(tables.discount, discounts);


### PR DESCRIPTION
## Summary

- count historical DevPass subscribers with a completed plan start and at least one completed paid plan transaction
- show a secondary subscriber count excluding organizations with a completed linked plan refund
- show all-time gross plan revenue and revenue after refunds, with invoice-level payment deduplication
- make DevPass subscription seed history deterministic so active and historical KPIs stay consistent
- rebalance the KPI cards across the two summary rows

## Screenshots

### Light

Before:

<img width="1440" alt="DevPass admin KPIs before the change in light mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/38c391c1d855494f16d0e95f282c8b2ae994d171/devpass-before-light.png" />

After:

<img width="1440" alt="DevPass admin subscriber and revenue KPIs in light mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/38c391c1d855494f16d0e95f282c8b2ae994d171/devpass-final-light.png" />

### Dark

Before:

<img width="1440" alt="DevPass admin KPIs before the change in dark mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/38c391c1d855494f16d0e95f282c8b2ae994d171/devpass-before-dark.png" />

After:

<img width="1440" alt="DevPass admin subscriber and revenue KPIs in dark mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/38c391c1d855494f16d0e95f282c8b2ae994d171/devpass-final-dark.png" />

## Verification

- `pnpm format`
- `pnpm test:unit apps/api/src/routes/admin-devpass-subscriber-kpis.spec.ts`
- `pnpm build`
- verified the seeded DevPass page in light and dark modes
