### PR TITLE
fix(actions): use Azure Anthropic resource

### DIFF
--- a/apps/api/src/routes/admin-provider-credentials.spec.ts
+++ b/apps/api/src/routes/admin-provider-credentials.spec.ts
@@ -1702,4 +1702,27 @@ describe("managed credential allowed models", () => {
 		expect(res.status).toBe(200);
 		expect(((await res.json()) as { allValid: boolean }).allValid).toBe(true);
 	});
+
+	test("verify-models passes managed Azure Anthropic settings", async () => {
+		vi.stubEnv("E2E_TEST", "true");
+		validateProviderKeyMock.mockResolvedValueOnce({ valid: true });
+		const [model] = await catalogModels("azure-anthropic");
+
+		const res = await post("/admin/provider-credentials/verify-models", {
+			provider: "azure-anthropic",
+			token: "azure-anthropic-key",
+			config: { resource: "managed-resource" },
+			models: [model],
+		});
+
+		expect(res.status).toBe(200);
+		expect(validateProviderKeyMock).toHaveBeenCalledWith(
+			"azure-anthropic",
+			"azure-anthropic-key",
+			undefined,
+			false,
+			{ env_config: { resource: "managed-resource" } },
+			model,
+		);
+	});
 });

--- a/packages/actions/src/get-provider-endpoint.spec.ts
+++ b/packages/actions/src/get-provider-endpoint.spec.ts
@@ -510,6 +510,29 @@ describe("getProviderEndpoint", () => {
 			);
 		});
 
+		it("uses the managed credential resource", () => {
+			delete process.env.LLM_AZURE_ANTHROPIC_RESOURCE;
+
+			const endpoint = getProviderEndpoint(
+				"azure-anthropic",
+				undefined,
+				"claude-sonnet-5",
+				undefined,
+				false,
+				undefined,
+				undefined,
+				{ env_config: { resource: "managed-resource" } },
+				undefined,
+				undefined,
+				undefined,
+				true,
+			);
+
+			expect(endpoint).toBe(
+				"https://managed-resource.services.ai.azure.com/anthropic/v1/messages",
+			);
+		});
+
 		it("throws when no resource is configured", () => {
 			delete process.env.LLM_AZURE_ANTHROPIC_RESOURCE;
 

--- a/packages/actions/src/get-provider-endpoint.ts
+++ b/packages/actions/src/get-provider-endpoint.ts
@@ -636,6 +636,7 @@ export function getProviderEndpoint(
 			}
 			case "azure-anthropic": {
 				const resource =
+					credentialConfig?.resource ??
 					providerKeyOptions?.azure_anthropic_resource ??
 					(skipEnvVars
 						? undefined


### PR DESCRIPTION
## Problem

Azure Anthropic managed credentials stored their resource setting correctly, but endpoint resolution ignored managed `env_config`. Self-test and model verification therefore reported that the resource was missing.

## Fix

- resolve Azure Anthropic resources from managed credential config before legacy provider options and environment variables
- cover endpoint resolution with environment fallback disabled
- cover the admin model-verification path forwarding managed settings

## Verification

- `pnpm exec vitest run packages/actions/src/get-provider-endpoint.spec.ts apps/api/src/routes/admin-provider-credentials.spec.ts --no-file-parallelism` (149 tests)
- `pnpm format`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure Anthropic configuration handling by correctly prioritizing the managed credential’s resource setting.
  * Model verification and endpoint resolution now work when the resource is configured through managed credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->