### PR TITLE
feat(admin): add usage breakdown toggles

### DIFF
--- a/apps/api/src/routes/admin-metrics-mode-split.spec.ts
+++ b/apps/api/src/routes/admin-metrics-mode-split.spec.ts
@@ -283,6 +283,52 @@ describe("admin — credits vs BYOK mode split", () => {
 		expect(gpt4!.apiKeysRequestCount).toBe(1);
 	});
 
+	test.each([
+		["project", "Mode Split Project"],
+		["api-key", "Mode Split Key"],
+		["user", "admin@example.com"],
+	] as const)(
+		"GET organization cost breakdown groups by %s",
+		async (groupBy, expectedLabel) => {
+			const res = await app.request(
+				`/admin/organizations/${ORG_ID}/cost-by-model?window=1d&groupBy=${groupBy}`,
+				{ headers: { Cookie: cookie } },
+			);
+			expect(res.status).toBe(200);
+			const body = (await res.json()) as {
+				models: { model: string; cost: number }[];
+			};
+
+			expect(body.models).toHaveLength(1);
+			expect(body.models[0]?.model).toContain(expectedLabel);
+			expect(body.models[0]?.cost).toBeCloseTo(50, 3);
+		},
+	);
+
+	test.each(["project", "api-key", "user"] as const)(
+		"GET organization cost timeseries groups by %s",
+		async (groupBy) => {
+			const res = await app.request(
+				`/admin/organizations/${ORG_ID}/cost-by-model-timeseries?window=1d&groupBy=${groupBy}`,
+				{ headers: { Cookie: cookie } },
+			);
+			expect(res.status).toBe(200);
+			const body = (await res.json()) as {
+				groupBy: string;
+				models: string[];
+				data: { entries: { cost: number }[] }[];
+			};
+
+			expect(body.groupBy).toBe(groupBy);
+			expect(body.models).toHaveLength(1);
+			expect(
+				body.data
+					.flatMap((point) => point.entries)
+					.reduce((sum, entry) => sum + entry.cost, 0),
+			).toBeCloseTo(50, 3);
+		},
+	);
+
 	test("DevPass real provider cost excludes BYOK usage", async () => {
 		const res = await app.request(`/admin/devpass/${DEVPASS_ORG_ID}`, {
 			headers: { Cookie: cookie },

--- a/apps/api/src/routes/admin-metrics-mode-split.spec.ts
+++ b/apps/api/src/routes/admin-metrics-mode-split.spec.ts
@@ -7,7 +7,7 @@ import {
 	deleteAll,
 } from "@/testing.js";
 
-import { db, tables } from "@llmgateway/db";
+import { db, eq, tables } from "@llmgateway/db";
 
 const ORG_ID = "mode-split-org";
 const PROJECT_ID = "mode-split-project";
@@ -267,11 +267,15 @@ describe("admin — credits vs BYOK mode split", () => {
 				apiKeysRequestCount: number;
 			}[];
 			totalCost: number;
+			totalCreditsRequests: number;
+			totalApiKeysRequests: number;
 			totalCreditsCost: number;
 			totalApiKeysCost: number;
 		};
 
 		expect(body.totalCost).toBeCloseTo(50, 3);
+		expect(body.totalCreditsRequests).toBe(1);
+		expect(body.totalApiKeysRequests).toBe(1);
 		expect(body.totalCreditsCost).toBeCloseTo(10, 3);
 		expect(body.totalApiKeysCost).toBeCloseTo(40, 3);
 
@@ -281,6 +285,42 @@ describe("admin — credits vs BYOK mode split", () => {
 		expect(gpt4!.apiKeysCost).toBeCloseTo(40, 3);
 		expect(gpt4!.creditsRequestCount).toBe(1);
 		expect(gpt4!.apiKeysRequestCount).toBe(1);
+	});
+
+	test("cost breakdown totals include rows beyond the top 20", async () => {
+		const hourTimestamp = new Date();
+		hourTimestamp.setUTCMinutes(0, 0, 0);
+		await db.insert(tables.projectHourlyModelStats).values(
+			Array.from({ length: 20 }, (_, index) => ({
+				projectId: PROJECT_ID,
+				hourTimestamp,
+				usedModel: `extra-model-${index}`,
+				usedProvider: "test-provider",
+				requestCount: 1,
+				totalTokens: "1",
+				cost: 1,
+				creditsRequestCount: 1,
+				creditsCost: 1,
+			})),
+		);
+
+		const res = await app.request(
+			`/admin/organizations/${ORG_ID}/cost-by-model?window=1d`,
+			{ headers: { Cookie: cookie } },
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			models: { creditsRequestCount: number }[];
+			totalCreditsRequests: number;
+			totalApiKeysRequests: number;
+		};
+
+		expect(body.models).toHaveLength(20);
+		expect(
+			body.models.reduce((sum, model) => sum + model.creditsRequestCount, 0),
+		).toBe(20);
+		expect(body.totalCreditsRequests).toBe(21);
+		expect(body.totalApiKeysRequests).toBe(1);
 	});
 
 	test.each([
@@ -302,6 +342,45 @@ describe("admin — credits vs BYOK mode split", () => {
 			expect(body.models).toHaveLength(1);
 			expect(body.models[0]?.model).toContain(expectedLabel);
 			expect(body.models[0]?.cost).toBeCloseTo(50, 3);
+		},
+	);
+
+	test.each([
+		["api-key", API_KEY_ID],
+		["user", "Deleted user"],
+	] as const)(
+		"organization %s breakdown retains deleted-key usage",
+		async (groupBy, expectedLabel) => {
+			await db.delete(tables.apiKey).where(eq(tables.apiKey.id, API_KEY_ID));
+
+			const breakdownRes = await app.request(
+				`/admin/organizations/${ORG_ID}/cost-by-model?window=1d&groupBy=${groupBy}`,
+				{ headers: { Cookie: cookie } },
+			);
+			expect(breakdownRes.status).toBe(200);
+			const breakdown = (await breakdownRes.json()) as {
+				models: { model: string; cost: number }[];
+			};
+			expect(breakdown.models).toHaveLength(1);
+			expect(breakdown.models[0]?.model).toContain(expectedLabel);
+			expect(breakdown.models[0]?.cost).toBeCloseTo(50, 3);
+
+			const timeseriesRes = await app.request(
+				`/admin/organizations/${ORG_ID}/cost-by-model-timeseries?window=1d&groupBy=${groupBy}`,
+				{ headers: { Cookie: cookie } },
+			);
+			expect(timeseriesRes.status).toBe(200);
+			const timeseries = (await timeseriesRes.json()) as {
+				models: string[];
+				data: { entries: { cost: number }[] }[];
+			};
+			expect(timeseries.models).toHaveLength(1);
+			expect(timeseries.models[0]).toContain(expectedLabel);
+			expect(
+				timeseries.data
+					.flatMap((point) => point.entries)
+					.reduce((sum, entry) => sum + entry.cost, 0),
+			).toBeCloseTo(50, 3);
 		},
 	);
 

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -9942,6 +9942,35 @@ const costByModelResponseSchema = z.object({
 	totalApiKeysCost: z.number(),
 });
 
+const costByModelViewSchema = z.enum(["mapping", "canonical"]);
+const organizationCostGroupBySchema = z.enum([
+	"model",
+	"project",
+	"api-key",
+	"user",
+]);
+
+type CostBreakdownRow = z.infer<typeof costByModelEntrySchema>;
+
+function summarizeCostBreakdown(
+	rows: CostBreakdownRow[],
+	window: z.infer<typeof tokenWindowSchema>,
+) {
+	const sorted = [...rows].sort((a, b) => b.cost - a.cost);
+	return {
+		window,
+		models: sorted.slice(0, 20),
+		totalCost: sorted.reduce((sum, row) => sum + row.cost, 0),
+		totalRequests: sorted.reduce((sum, row) => sum + row.requestCount, 0),
+		totalCreditsCost: sorted.reduce((sum, row) => sum + row.creditsCost, 0),
+		totalApiKeysCost: sorted.reduce((sum, row) => sum + row.apiKeysCost, 0),
+	};
+}
+
+function dimensionLabel(label: string | null, id: string): string {
+	return label && label !== id ? `${label} · ${id.slice(-6)}` : id;
+}
+
 // Global cost by model
 const getGlobalCostByModel = createRoute({
 	method: "get",
@@ -10052,6 +10081,8 @@ const getOrgCostByModel = createRoute({
 		params: z.object({ orgId: z.string() }),
 		query: z.object({
 			window: tokenWindowSchema.default("7d").optional(),
+			modelView: costByModelViewSchema.default("mapping").optional(),
+			groupBy: organizationCostGroupBySchema.default("model").optional(),
 		}),
 	},
 	responses: {
@@ -10061,7 +10092,8 @@ const getOrgCostByModel = createRoute({
 					schema: costByModelResponseSchema.openapi({}),
 				},
 			},
-			description: "Organization cost breakdown by model.",
+			description:
+				"Organization cost breakdown by model, project, API key, or user.",
 		},
 		404: {
 			description: "Organization not found.",
@@ -10073,6 +10105,8 @@ admin.openapi(getOrgCostByModel, async (c) => {
 	const { orgId } = c.req.valid("param");
 	const query = c.req.valid("query");
 	const window = query.window ?? "7d";
+	const modelView = query.modelView ?? "mapping";
+	const groupBy = query.groupBy ?? "model";
 	const startDate = getTokenWindowStartDate(window);
 
 	const org = await db.query.organization.findFirst({
@@ -10101,6 +10135,107 @@ admin.openapi(getOrgCostByModel, async (c) => {
 		});
 	}
 
+	if (groupBy === "project") {
+		const rows = await db
+			.select({
+				id: projectHourlyStats.projectId,
+				label: tables.project.name,
+				cost: sql<number>`SUM(cast(${projectHourlyStats.cost} as double precision))`.as(
+					"cost",
+				),
+				requestCount: sql<number>`SUM(${projectHourlyStats.requestCount})`.as(
+					"request_count",
+				),
+				totalTokens:
+					sql<number>`SUM(CAST(${projectHourlyStats.totalTokens} AS NUMERIC))`.as(
+						"total_tokens",
+					),
+				...modeSplitFields(projectHourlyStats),
+			})
+			.from(projectHourlyStats)
+			.innerJoin(
+				tables.project,
+				eq(tables.project.id, projectHourlyStats.projectId),
+			)
+			.where(
+				and(
+					inArray(projectHourlyStats.projectId, ids),
+					gte(projectHourlyStats.hourTimestamp, startDate),
+				),
+			)
+			.groupBy(projectHourlyStats.projectId, tables.project.name);
+
+		return c.json(
+			summarizeCostBreakdown(
+				rows.map((row) => ({
+					model: dimensionLabel(row.label, row.id),
+					cost: Number(row.cost),
+					requestCount: Number(row.requestCount),
+					totalTokens: Number(row.totalTokens),
+					creditsRequestCount: Number(row.creditsRequestCount),
+					apiKeysRequestCount: Number(row.apiKeysRequestCount),
+					creditsCost: Number(row.creditsCost),
+					apiKeysCost: Number(row.apiKeysCost),
+				})),
+				window,
+			),
+		);
+	}
+
+	if (groupBy === "api-key" || groupBy === "user") {
+		const rows = await db
+			.select({
+				id: groupBy === "user" ? tables.user.id : tables.apiKey.id,
+				label:
+					groupBy === "user" ? tables.user.email : tables.apiKey.description,
+				cost: sql<number>`SUM(cast(${tables.apiKeyHourlyStats.cost} as double precision))`.as(
+					"cost",
+				),
+				requestCount:
+					sql<number>`SUM(${tables.apiKeyHourlyStats.requestCount})`.as(
+						"request_count",
+					),
+				totalTokens:
+					sql<number>`SUM(CAST(${tables.apiKeyHourlyStats.totalTokens} AS NUMERIC))`.as(
+						"total_tokens",
+					),
+				...modeSplitFields(tables.apiKeyHourlyStats),
+			})
+			.from(tables.apiKeyHourlyStats)
+			.innerJoin(
+				tables.apiKey,
+				eq(tables.apiKey.id, tables.apiKeyHourlyStats.apiKeyId),
+			)
+			.innerJoin(tables.user, eq(tables.user.id, tables.apiKey.createdBy))
+			.where(
+				and(
+					inArray(tables.apiKeyHourlyStats.projectId, ids),
+					gte(tables.apiKeyHourlyStats.hourTimestamp, startDate),
+				),
+			)
+			.groupBy(
+				groupBy === "user" ? tables.user.id : tables.apiKey.id,
+				groupBy === "user" ? tables.user.email : tables.apiKey.description,
+			);
+
+		return c.json(
+			summarizeCostBreakdown(
+				rows.map((row) => ({
+					model:
+						groupBy === "user" ? row.label : dimensionLabel(row.label, row.id),
+					cost: Number(row.cost),
+					requestCount: Number(row.requestCount),
+					totalTokens: Number(row.totalTokens),
+					creditsRequestCount: Number(row.creditsRequestCount),
+					apiKeysRequestCount: Number(row.apiKeysRequestCount),
+					creditsCost: Number(row.creditsCost),
+					apiKeysCost: Number(row.apiKeysCost),
+				})),
+				window,
+			),
+		);
+	}
+
 	const rows = await db
 		.select({
 			usedModel: projectHourlyModelStats.usedModel,
@@ -10124,50 +10259,47 @@ admin.openapi(getOrgCostByModel, async (c) => {
 				gte(projectHourlyModelStats.hourTimestamp, startDate),
 			),
 		)
-		.groupBy(projectHourlyModelStats.usedModel)
-		.orderBy(
-			desc(sql`SUM(cast(${projectHourlyModelStats.cost} as double precision))`),
-		)
-		.limit(20);
+		.groupBy(projectHourlyModelStats.usedModel);
 
-	const totalCost = rows.reduce((sum, r) => sum + Number(r.cost), 0);
-	const totalRequests = rows.reduce(
-		(sum, r) => sum + Number(r.requestCount),
-		0,
-	);
-	const totalCreditsCost = rows.reduce(
-		(sum, r) => sum + Number(r.creditsCost),
-		0,
-	);
-	const totalApiKeysCost = rows.reduce(
-		(sum, r) => sum + Number(r.apiKeysCost),
-		0,
-	);
+	const byModel = new Map<string, CostBreakdownRow>();
+	for (const row of rows) {
+		const model =
+			modelView === "canonical"
+				? extractCanonicalModelId(row.usedModel)
+				: row.usedModel;
+		const current = byModel.get(model) ?? {
+			model,
+			cost: 0,
+			requestCount: 0,
+			totalTokens: 0,
+			creditsRequestCount: 0,
+			apiKeysRequestCount: 0,
+			creditsCost: 0,
+			apiKeysCost: 0,
+		};
+		current.cost += Number(row.cost);
+		current.requestCount += Number(row.requestCount);
+		current.totalTokens += Number(row.totalTokens);
+		current.creditsRequestCount += Number(row.creditsRequestCount);
+		current.apiKeysRequestCount += Number(row.apiKeysRequestCount);
+		current.creditsCost += Number(row.creditsCost);
+		current.apiKeysCost += Number(row.apiKeysCost);
+		byModel.set(model, current);
+	}
 
-	return c.json({
-		window,
-		models: rows.map((r) => ({
-			model: r.usedModel,
-			cost: Number(r.cost),
-			requestCount: Number(r.requestCount),
-			totalTokens: Number(r.totalTokens),
-			creditsRequestCount: Number(r.creditsRequestCount),
-			apiKeysRequestCount: Number(r.apiKeysRequestCount),
-			creditsCost: Number(r.creditsCost),
-			apiKeysCost: Number(r.apiKeysCost),
-		})),
-		totalCost,
-		totalRequests,
-		totalCreditsCost,
-		totalApiKeysCost,
-	});
+	return c.json(summarizeCostBreakdown([...byModel.values()], window));
 });
 
 // --- Cost by model time-series endpoints ---
 
-const costByModelTimeseriesModelViewSchema = z.enum(["mapping", "canonical"]);
-
 const costTimeseriesGroupBySchema = z.enum(["model", "source"]);
+
+const organizationCostTimeseriesGroupBySchema = z.enum([
+	"model",
+	"project",
+	"api-key",
+	"user",
+]);
 
 const TOP_TIMESERIES_SERIES = 10;
 
@@ -10190,8 +10322,8 @@ const costByModelTimeseriesPointSchema = z.object({
 const costByModelTimeseriesResponseSchema = z.object({
 	window: tokenWindowSchema,
 	bucket: z.enum(["hour", "day"]),
-	modelView: costByModelTimeseriesModelViewSchema,
-	groupBy: costTimeseriesGroupBySchema,
+	modelView: costByModelViewSchema,
+	groupBy: z.enum(["model", "source", "project", "api-key", "user"]),
 	models: z.array(z.string()),
 	data: z.array(costByModelTimeseriesPointSchema),
 });
@@ -10234,8 +10366,9 @@ const getOrgCostByModelTimeseries = createRoute({
 		params: z.object({ orgId: z.string() }),
 		query: z.object({
 			window: tokenWindowSchema.default("7d").optional(),
-			modelView: costByModelTimeseriesModelViewSchema
-				.default("mapping")
+			modelView: costByModelViewSchema.default("mapping").optional(),
+			groupBy: organizationCostTimeseriesGroupBySchema
+				.default("model")
 				.optional(),
 		}),
 	},
@@ -10246,7 +10379,8 @@ const getOrgCostByModelTimeseries = createRoute({
 					schema: costByModelTimeseriesResponseSchema.openapi({}),
 				},
 			},
-			description: "Organization cost breakdown by model over time.",
+			description:
+				"Organization cost breakdown by model, project, API key, or user over time.",
 		},
 		404: {
 			description: "Organization not found.",
@@ -10259,6 +10393,7 @@ admin.openapi(getOrgCostByModelTimeseries, async (c) => {
 	const query = c.req.valid("query");
 	const window = query.window ?? "7d";
 	const modelView = query.modelView ?? "mapping";
+	const groupBy = query.groupBy ?? "model";
 	const startDate = getTokenWindowStartDate(window);
 	const bucketUnit = getBucketUnitForWindow(window);
 
@@ -10282,27 +10417,41 @@ admin.openapi(getOrgCostByModelTimeseries, async (c) => {
 			window,
 			bucket: bucketUnit,
 			modelView,
-			groupBy: "model" as const,
+			groupBy,
 			models: [],
 			data: [],
 		});
 	}
 
-	const result = await buildCostByModelTimeseries({
-		modelView,
-		bucketUnit,
-		startDate,
-		baseFilter: and(
-			inArray(projectHourlyModelStats.projectId, ids),
-			gte(projectHourlyModelStats.hourTimestamp, startDate),
-		),
-	});
+	const result =
+		groupBy === "project"
+			? await buildCostByProjectTimeseries({
+					bucketUnit,
+					startDate,
+					projectIds: ids,
+				})
+			: groupBy === "api-key" || groupBy === "user"
+				? await buildCostByApiKeyDimensionTimeseries({
+						bucketUnit,
+						startDate,
+						projectIds: ids,
+						groupBy,
+					})
+				: await buildCostByModelTimeseries({
+						modelView,
+						bucketUnit,
+						startDate,
+						baseFilter: and(
+							inArray(projectHourlyModelStats.projectId, ids),
+							gte(projectHourlyModelStats.hourTimestamp, startDate),
+						),
+					});
 
 	return c.json({
 		window,
 		bucket: bucketUnit,
 		modelView,
-		groupBy: "model" as const,
+		groupBy,
 		models: result.models,
 		data: result.data,
 	});
@@ -10315,9 +10464,7 @@ const getProjectCostByModelTimeseries = createRoute({
 		params: z.object({ orgId: z.string(), projectId: z.string() }),
 		query: z.object({
 			window: tokenWindowSchema.default("7d").optional(),
-			modelView: costByModelTimeseriesModelViewSchema
-				.default("mapping")
-				.optional(),
+			modelView: costByModelViewSchema.default("mapping").optional(),
 			groupBy: costTimeseriesGroupBySchema.default("model").optional(),
 		}),
 	},
@@ -10386,13 +10533,203 @@ admin.openapi(getProjectCostByModelTimeseries, async (c) => {
 	});
 });
 
+async function buildCostByProjectTimeseries({
+	bucketUnit,
+	startDate,
+	projectIds,
+}: {
+	bucketUnit: "hour" | "day";
+	startDate: Date;
+	projectIds: string[];
+}): Promise<{
+	models: string[];
+	data: z.infer<typeof costByModelTimeseriesPointSchema>[];
+}> {
+	const totals = await db
+		.select({
+			id: projectHourlyStats.projectId,
+			label: tables.project.name,
+			cost: sql<number>`SUM(cast(${projectHourlyStats.cost} as double precision))`.as(
+				"cost",
+			),
+		})
+		.from(projectHourlyStats)
+		.innerJoin(
+			tables.project,
+			eq(tables.project.id, projectHourlyStats.projectId),
+		)
+		.where(
+			and(
+				inArray(projectHourlyStats.projectId, projectIds),
+				gte(projectHourlyStats.hourTimestamp, startDate),
+			),
+		)
+		.groupBy(projectHourlyStats.projectId, tables.project.name);
+
+	const top = [...totals]
+		.sort((a, b) => Number(b.cost) - Number(a.cost))
+		.slice(0, TOP_TIMESERIES_SERIES)
+		.map((row) => ({
+			id: row.id,
+			label: dimensionLabel(row.label, row.id),
+		}));
+	if (top.length === 0) {
+		return { models: [], data: [] };
+	}
+
+	const labels = new Map(top.map((item) => [item.id, item.label]));
+	const topIds = top.map((item) => item.id);
+	const bucketExpr = sql<string>`to_char(date_trunc(${sql.raw(`'${bucketUnit}'`)}, ${projectHourlyStats.hourTimestamp}), 'YYYY-MM-DD"T"HH24:MI:SS"Z"')`;
+	const rows = await db
+		.select({
+			bucket: bucketExpr.as("bucket"),
+			id: projectHourlyStats.projectId,
+			cost: sql<number>`SUM(cast(${projectHourlyStats.cost} as double precision))`.as(
+				"cost",
+			),
+			requestCount: sql<number>`SUM(${projectHourlyStats.requestCount})`.as(
+				"request_count",
+			),
+			totalTokens:
+				sql<number>`SUM(CAST(${projectHourlyStats.totalTokens} AS NUMERIC))`.as(
+					"total_tokens",
+				),
+			...modeSplitFields(projectHourlyStats),
+		})
+		.from(projectHourlyStats)
+		.where(
+			and(
+				inArray(projectHourlyStats.projectId, topIds),
+				gte(projectHourlyStats.hourTimestamp, startDate),
+			),
+		)
+		.groupBy(bucketExpr, projectHourlyStats.projectId)
+		.orderBy(asc(bucketExpr));
+
+	return {
+		models: top.map((item) => item.label),
+		data: assembleCostTimeseriesPoints({
+			allBuckets: generateBucketTimestamps(startDate, new Date(), bucketUnit),
+			rows: rows.map((row) => ({
+				bucket: row.bucket,
+				key: labels.get(row.id) ?? row.id,
+				cost: Number(row.cost),
+				requestCount: Number(row.requestCount),
+				totalTokens: Number(row.totalTokens),
+				creditsRequestCount: Number(row.creditsRequestCount),
+				apiKeysRequestCount: Number(row.apiKeysRequestCount),
+				creditsCost: Number(row.creditsCost),
+				apiKeysCost: Number(row.apiKeysCost),
+			})),
+		}),
+	};
+}
+
+async function buildCostByApiKeyDimensionTimeseries({
+	bucketUnit,
+	startDate,
+	projectIds,
+	groupBy,
+}: {
+	bucketUnit: "hour" | "day";
+	startDate: Date;
+	projectIds: string[];
+	groupBy: "api-key" | "user";
+}): Promise<{
+	models: string[];
+	data: z.infer<typeof costByModelTimeseriesPointSchema>[];
+}> {
+	const idColumn = groupBy === "user" ? tables.user.id : tables.apiKey.id;
+	const labelColumn =
+		groupBy === "user" ? tables.user.email : tables.apiKey.description;
+	const baseFilter = and(
+		inArray(tables.apiKeyHourlyStats.projectId, projectIds),
+		gte(tables.apiKeyHourlyStats.hourTimestamp, startDate),
+	);
+	const totals = await db
+		.select({
+			id: idColumn,
+			label: labelColumn,
+			cost: sql<number>`SUM(cast(${tables.apiKeyHourlyStats.cost} as double precision))`.as(
+				"cost",
+			),
+		})
+		.from(tables.apiKeyHourlyStats)
+		.innerJoin(
+			tables.apiKey,
+			eq(tables.apiKey.id, tables.apiKeyHourlyStats.apiKeyId),
+		)
+		.innerJoin(tables.user, eq(tables.user.id, tables.apiKey.createdBy))
+		.where(baseFilter)
+		.groupBy(idColumn, labelColumn);
+
+	const top = [...totals]
+		.sort((a, b) => Number(b.cost) - Number(a.cost))
+		.slice(0, TOP_TIMESERIES_SERIES)
+		.map((row) => ({
+			id: row.id,
+			label: groupBy === "user" ? row.label : dimensionLabel(row.label, row.id),
+		}));
+	if (top.length === 0) {
+		return { models: [], data: [] };
+	}
+
+	const labels = new Map(top.map((item) => [item.id, item.label]));
+	const topIds = top.map((item) => item.id);
+	const bucketExpr = sql<string>`to_char(date_trunc(${sql.raw(`'${bucketUnit}'`)}, ${tables.apiKeyHourlyStats.hourTimestamp}), 'YYYY-MM-DD"T"HH24:MI:SS"Z"')`;
+	const rows = await db
+		.select({
+			bucket: bucketExpr.as("bucket"),
+			id: idColumn,
+			cost: sql<number>`SUM(cast(${tables.apiKeyHourlyStats.cost} as double precision))`.as(
+				"cost",
+			),
+			requestCount:
+				sql<number>`SUM(${tables.apiKeyHourlyStats.requestCount})`.as(
+					"request_count",
+				),
+			totalTokens:
+				sql<number>`SUM(CAST(${tables.apiKeyHourlyStats.totalTokens} AS NUMERIC))`.as(
+					"total_tokens",
+				),
+			...modeSplitFields(tables.apiKeyHourlyStats),
+		})
+		.from(tables.apiKeyHourlyStats)
+		.innerJoin(
+			tables.apiKey,
+			eq(tables.apiKey.id, tables.apiKeyHourlyStats.apiKeyId),
+		)
+		.innerJoin(tables.user, eq(tables.user.id, tables.apiKey.createdBy))
+		.where(and(baseFilter, inArray(idColumn, topIds)))
+		.groupBy(bucketExpr, idColumn)
+		.orderBy(asc(bucketExpr));
+
+	return {
+		models: top.map((item) => item.label),
+		data: assembleCostTimeseriesPoints({
+			allBuckets: generateBucketTimestamps(startDate, new Date(), bucketUnit),
+			rows: rows.map((row) => ({
+				bucket: row.bucket,
+				key: labels.get(row.id) ?? row.id,
+				cost: Number(row.cost),
+				requestCount: Number(row.requestCount),
+				totalTokens: Number(row.totalTokens),
+				creditsRequestCount: Number(row.creditsRequestCount),
+				apiKeysRequestCount: Number(row.apiKeysRequestCount),
+				creditsCost: Number(row.creditsCost),
+				apiKeysCost: Number(row.apiKeysCost),
+			})),
+		}),
+	};
+}
+
 async function buildCostByModelTimeseries({
 	modelView,
 	bucketUnit,
 	startDate,
 	baseFilter,
 }: {
-	modelView: z.infer<typeof costByModelTimeseriesModelViewSchema>;
+	modelView: z.infer<typeof costByModelViewSchema>;
 	bucketUnit: "hour" | "day";
 	startDate: Date;
 	baseFilter: ReturnType<typeof and>;

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -9938,6 +9938,8 @@ const costByModelResponseSchema = z.object({
 	models: z.array(costByModelEntrySchema),
 	totalCost: z.number(),
 	totalRequests: z.number(),
+	totalCreditsRequests: z.number(),
+	totalApiKeysRequests: z.number(),
 	totalCreditsCost: z.number(),
 	totalApiKeysCost: z.number(),
 });
@@ -9962,6 +9964,14 @@ function summarizeCostBreakdown(
 		models: sorted.slice(0, 20),
 		totalCost: sorted.reduce((sum, row) => sum + row.cost, 0),
 		totalRequests: sorted.reduce((sum, row) => sum + row.requestCount, 0),
+		totalCreditsRequests: sorted.reduce(
+			(sum, row) => sum + row.creditsRequestCount,
+			0,
+		),
+		totalApiKeysRequests: sorted.reduce(
+			(sum, row) => sum + row.apiKeysRequestCount,
+			0,
+		),
 		totalCreditsCost: sorted.reduce((sum, row) => sum + row.creditsCost, 0),
 		totalApiKeysCost: sorted.reduce((sum, row) => sum + row.apiKeysCost, 0),
 	};
@@ -9969,6 +9979,18 @@ function summarizeCostBreakdown(
 
 function dimensionLabel(label: string | null, id: string): string {
 	return label && label !== id ? `${label} · ${id.slice(-6)}` : id;
+}
+
+function apiKeyDimensionColumns(groupBy: "api-key" | "user") {
+	return groupBy === "user"
+		? {
+				id: sql<string>`COALESCE(${tables.user.id}, 'deleted-user')`,
+				label: sql<string>`COALESCE(${tables.user.email}, 'Deleted user')`,
+			}
+		: {
+				id: sql<string>`COALESCE(${tables.apiKey.id}, ${tables.apiKeyHourlyStats.apiKeyId})`,
+				label: tables.apiKey.description,
+			};
 }
 
 // Global cost by model
@@ -10037,40 +10059,23 @@ admin.openapi(getGlobalCostByModel, async (c) => {
 		.groupBy(projectHourlyModelStats.usedModel)
 		.orderBy(
 			desc(sql`SUM(cast(${projectHourlyModelStats.cost} as double precision))`),
-		)
-		.limit(20);
+		);
 
-	const totalCost = rows.reduce((sum, r) => sum + Number(r.cost), 0);
-	const totalRequests = rows.reduce(
-		(sum, r) => sum + Number(r.requestCount),
-		0,
+	return c.json(
+		summarizeCostBreakdown(
+			rows.map((r) => ({
+				model: r.usedModel,
+				cost: Number(r.cost),
+				requestCount: Number(r.requestCount),
+				totalTokens: Number(r.totalTokens),
+				creditsRequestCount: Number(r.creditsRequestCount),
+				apiKeysRequestCount: Number(r.apiKeysRequestCount),
+				creditsCost: Number(r.creditsCost),
+				apiKeysCost: Number(r.apiKeysCost),
+			})),
+			window,
+		),
 	);
-	const totalCreditsCost = rows.reduce(
-		(sum, r) => sum + Number(r.creditsCost),
-		0,
-	);
-	const totalApiKeysCost = rows.reduce(
-		(sum, r) => sum + Number(r.apiKeysCost),
-		0,
-	);
-
-	return c.json({
-		window,
-		models: rows.map((r) => ({
-			model: r.usedModel,
-			cost: Number(r.cost),
-			requestCount: Number(r.requestCount),
-			totalTokens: Number(r.totalTokens),
-			creditsRequestCount: Number(r.creditsRequestCount),
-			apiKeysRequestCount: Number(r.apiKeysRequestCount),
-			creditsCost: Number(r.creditsCost),
-			apiKeysCost: Number(r.apiKeysCost),
-		})),
-		totalCost,
-		totalRequests,
-		totalCreditsCost,
-		totalApiKeysCost,
-	});
 });
 
 // Org cost by model
@@ -10130,6 +10135,8 @@ admin.openapi(getOrgCostByModel, async (c) => {
 			models: [],
 			totalCost: 0,
 			totalRequests: 0,
+			totalCreditsRequests: 0,
+			totalApiKeysRequests: 0,
 			totalCreditsCost: 0,
 			totalApiKeysCost: 0,
 		});
@@ -10183,11 +10190,11 @@ admin.openapi(getOrgCostByModel, async (c) => {
 	}
 
 	if (groupBy === "api-key" || groupBy === "user") {
+		const dimension = apiKeyDimensionColumns(groupBy);
 		const rows = await db
 			.select({
-				id: groupBy === "user" ? tables.user.id : tables.apiKey.id,
-				label:
-					groupBy === "user" ? tables.user.email : tables.apiKey.description,
+				id: dimension.id,
+				label: dimension.label,
 				cost: sql<number>`SUM(cast(${tables.apiKeyHourlyStats.cost} as double precision))`.as(
 					"cost",
 				),
@@ -10202,27 +10209,26 @@ admin.openapi(getOrgCostByModel, async (c) => {
 				...modeSplitFields(tables.apiKeyHourlyStats),
 			})
 			.from(tables.apiKeyHourlyStats)
-			.innerJoin(
+			.leftJoin(
 				tables.apiKey,
 				eq(tables.apiKey.id, tables.apiKeyHourlyStats.apiKeyId),
 			)
-			.innerJoin(tables.user, eq(tables.user.id, tables.apiKey.createdBy))
+			.leftJoin(tables.user, eq(tables.user.id, tables.apiKey.createdBy))
 			.where(
 				and(
 					inArray(tables.apiKeyHourlyStats.projectId, ids),
 					gte(tables.apiKeyHourlyStats.hourTimestamp, startDate),
 				),
 			)
-			.groupBy(
-				groupBy === "user" ? tables.user.id : tables.apiKey.id,
-				groupBy === "user" ? tables.user.email : tables.apiKey.description,
-			);
+			.groupBy(dimension.id, dimension.label);
 
 		return c.json(
 			summarizeCostBreakdown(
 				rows.map((row) => ({
 					model:
-						groupBy === "user" ? row.label : dimensionLabel(row.label, row.id),
+						groupBy === "user"
+							? (row.label ?? "Deleted user")
+							: dimensionLabel(row.label, row.id),
 					cost: Number(row.cost),
 					requestCount: Number(row.requestCount),
 					totalTokens: Number(row.totalTokens),
@@ -10639,36 +10645,37 @@ async function buildCostByApiKeyDimensionTimeseries({
 	models: string[];
 	data: z.infer<typeof costByModelTimeseriesPointSchema>[];
 }> {
-	const idColumn = groupBy === "user" ? tables.user.id : tables.apiKey.id;
-	const labelColumn =
-		groupBy === "user" ? tables.user.email : tables.apiKey.description;
+	const dimension = apiKeyDimensionColumns(groupBy);
 	const baseFilter = and(
 		inArray(tables.apiKeyHourlyStats.projectId, projectIds),
 		gte(tables.apiKeyHourlyStats.hourTimestamp, startDate),
 	);
 	const totals = await db
 		.select({
-			id: idColumn,
-			label: labelColumn,
+			id: dimension.id,
+			label: dimension.label,
 			cost: sql<number>`SUM(cast(${tables.apiKeyHourlyStats.cost} as double precision))`.as(
 				"cost",
 			),
 		})
 		.from(tables.apiKeyHourlyStats)
-		.innerJoin(
+		.leftJoin(
 			tables.apiKey,
 			eq(tables.apiKey.id, tables.apiKeyHourlyStats.apiKeyId),
 		)
-		.innerJoin(tables.user, eq(tables.user.id, tables.apiKey.createdBy))
+		.leftJoin(tables.user, eq(tables.user.id, tables.apiKey.createdBy))
 		.where(baseFilter)
-		.groupBy(idColumn, labelColumn);
+		.groupBy(dimension.id, dimension.label);
 
 	const top = [...totals]
 		.sort((a, b) => Number(b.cost) - Number(a.cost))
 		.slice(0, TOP_TIMESERIES_SERIES)
 		.map((row) => ({
 			id: row.id,
-			label: groupBy === "user" ? row.label : dimensionLabel(row.label, row.id),
+			label:
+				groupBy === "user"
+					? (row.label ?? "Deleted user")
+					: dimensionLabel(row.label, row.id),
 		}));
 	if (top.length === 0) {
 		return { models: [], data: [] };
@@ -10680,7 +10687,7 @@ async function buildCostByApiKeyDimensionTimeseries({
 	const rows = await db
 		.select({
 			bucket: bucketExpr.as("bucket"),
-			id: idColumn,
+			id: dimension.id,
 			cost: sql<number>`SUM(cast(${tables.apiKeyHourlyStats.cost} as double precision))`.as(
 				"cost",
 			),
@@ -10695,13 +10702,13 @@ async function buildCostByApiKeyDimensionTimeseries({
 			...modeSplitFields(tables.apiKeyHourlyStats),
 		})
 		.from(tables.apiKeyHourlyStats)
-		.innerJoin(
+		.leftJoin(
 			tables.apiKey,
 			eq(tables.apiKey.id, tables.apiKeyHourlyStats.apiKeyId),
 		)
-		.innerJoin(tables.user, eq(tables.user.id, tables.apiKey.createdBy))
-		.where(and(baseFilter, inArray(idColumn, topIds)))
-		.groupBy(bucketExpr, idColumn)
+		.leftJoin(tables.user, eq(tables.user.id, tables.apiKey.createdBy))
+		.where(and(baseFilter, inArray(dimension.id, topIds)))
+		.groupBy(bucketExpr, dimension.id)
 		.orderBy(asc(bucketExpr));
 
 	return {

--- a/ee/admin/src/app/organizations/[orgId]/org-cost-by-model-timeseries.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/org-cost-by-model-timeseries.tsx
@@ -1,12 +1,17 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback } from "react";
 
 import { CostByModelTimeseriesChart } from "@/components/cost-by-model-timeseries-chart";
 import { getOrgCostByModelTimeseries } from "@/lib/admin-history";
 
-import type { ModelView, TokenWindow } from "@/lib/types";
+import type {
+	CostTimeseriesGroupBy,
+	ModelView,
+	OrganizationCostGroupBy,
+	TokenWindow,
+} from "@/lib/types";
 
 const validWindows = new Set<TokenWindow>([
 	"1h",
@@ -19,6 +24,27 @@ const validWindows = new Set<TokenWindow>([
 	"365d",
 ]);
 
+const groupByOptions: CostTimeseriesGroupBy[] = [
+	"model",
+	"project",
+	"api-key",
+	"user",
+];
+
+const breakdownNouns: Record<OrganizationCostGroupBy, string> = {
+	model: "models",
+	project: "projects",
+	"api-key": "API keys",
+	user: "users",
+};
+
+const breakdownTitles: Record<OrganizationCostGroupBy, string> = {
+	model: "Model",
+	project: "Project",
+	"api-key": "API Key",
+	user: "User",
+};
+
 function parseWindow(value: string | null): TokenWindow {
 	if (value && validWindows.has(value as TokenWindow)) {
 		return value as TokenWindow;
@@ -26,23 +52,75 @@ function parseWindow(value: string | null): TokenWindow {
 	return "1d";
 }
 
+function parseGroupBy(value: string | null): OrganizationCostGroupBy {
+	return value === "project" || value === "api-key" || value === "user"
+		? value
+		: "model";
+}
+
+function parseModelView(value: string | null): ModelView {
+	return value === "canonical" ? "canonical" : "mapping";
+}
+
 export function OrgCostByModelTimeseries({ orgId }: { orgId: string }) {
 	const searchParams = useSearchParams();
+	const router = useRouter();
+	const pathname = usePathname();
 	const window = parseWindow(searchParams.get("window"));
+	const groupBy = parseGroupBy(searchParams.get("breakdown"));
+	const modelView = parseModelView(searchParams.get("modelView"));
+	const breakdownNoun = breakdownNouns[groupBy];
 
 	const fetchData = useCallback(
-		async (w: TokenWindow, modelView: ModelView) => {
-			return await getOrgCostByModelTimeseries(orgId, w, modelView);
+		async (w: TokenWindow, view: ModelView, group: CostTimeseriesGroupBy) => {
+			return await getOrgCostByModelTimeseries(
+				orgId,
+				w,
+				view,
+				group === "source" ? "model" : group,
+			);
 		},
 		[orgId],
 	);
 
+	const updateView = useCallback(
+		(updates: { groupBy?: OrganizationCostGroupBy; modelView?: ModelView }) => {
+			const params = new URLSearchParams(searchParams.toString());
+			if (updates.groupBy) {
+				if (updates.groupBy === "model") {
+					params.delete("breakdown");
+				} else {
+					params.set("breakdown", updates.groupBy);
+				}
+			}
+			if (updates.modelView) {
+				if (updates.modelView === "mapping") {
+					params.delete("modelView");
+				} else {
+					params.set("modelView", updates.modelView);
+				}
+			}
+			const query = params.toString();
+			router.push(query ? `${pathname}?${query}` : pathname);
+		},
+		[pathname, router, searchParams],
+	);
+
 	return (
 		<CostByModelTimeseriesChart
-			title="Cost by Model Over Time"
-			description="Stacked breakdown of top 10 models over the selected window"
+			title={`Cost by ${breakdownTitles[groupBy]} Over Time`}
+			description={`Stacked breakdown of top 10 ${breakdownNoun} over the selected window`}
 			fetchData={fetchData}
 			externalWindow={window}
+			groupBy={groupBy}
+			onGroupByChange={(value) =>
+				updateView({
+					groupBy: value === "source" ? "model" : value,
+				})
+			}
+			groupByOptions={groupByOptions}
+			modelView={modelView}
+			onModelViewChange={(value) => updateView({ modelView: value })}
 		/>
 	);
 }

--- a/ee/admin/src/app/organizations/[orgId]/org-cost-by-model.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/org-cost-by-model.tsx
@@ -1,12 +1,17 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback } from "react";
 
 import { CostByModelChart } from "@/components/cost-by-model-chart";
 import { getOrgCostByModel } from "@/lib/admin-history";
 
-import type { TokenWindow } from "@/lib/types";
+import type {
+	GlobalStatsModelView,
+	ModelView,
+	OrganizationCostGroupBy,
+	TokenWindow,
+} from "@/lib/types";
 
 const validWindows = new Set<TokenWindow>([
 	"1h",
@@ -19,6 +24,16 @@ const validWindows = new Set<TokenWindow>([
 	"365d",
 ]);
 
+const breakdownNouns: Record<
+	OrganizationCostGroupBy,
+	{ singular: string; plural: string }
+> = {
+	model: { singular: "Model", plural: "models" },
+	project: { singular: "Project", plural: "projects" },
+	"api-key": { singular: "API Key", plural: "API keys" },
+	user: { singular: "User", plural: "users" },
+};
+
 function parseWindow(value: string | null): TokenWindow {
 	if (value && validWindows.has(value as TokenWindow)) {
 		return value as TokenWindow;
@@ -26,23 +41,79 @@ function parseWindow(value: string | null): TokenWindow {
 	return "1d";
 }
 
+function parseGroupBy(value: string | null): OrganizationCostGroupBy {
+	return value === "project" || value === "api-key" || value === "user"
+		? value
+		: "model";
+}
+
+function parseModelView(value: string | null): ModelView {
+	return value === "canonical" ? "canonical" : "mapping";
+}
+
 export function OrgCostByModel({ orgId }: { orgId: string }) {
 	const searchParams = useSearchParams();
+	const router = useRouter();
+	const pathname = usePathname();
 	const window = parseWindow(searchParams.get("window"));
+	const groupBy = parseGroupBy(searchParams.get("breakdown"));
+	const modelView = parseModelView(searchParams.get("modelView"));
+	const breakdownNoun = breakdownNouns[groupBy];
 
 	const fetchData = useCallback(
-		async (w: TokenWindow) => {
-			return await getOrgCostByModel(orgId, w);
+		async (
+			w: TokenWindow,
+			view: GlobalStatsModelView,
+			group: OrganizationCostGroupBy,
+		) => {
+			return await getOrgCostByModel(
+				orgId,
+				w,
+				view === "canonical" ? "canonical" : "mapping",
+				group,
+			);
 		},
 		[orgId],
 	);
 
+	const updateView = useCallback(
+		(updates: { groupBy?: OrganizationCostGroupBy; modelView?: ModelView }) => {
+			const params = new URLSearchParams(searchParams.toString());
+			if (updates.groupBy) {
+				if (updates.groupBy === "model") {
+					params.delete("breakdown");
+				} else {
+					params.set("breakdown", updates.groupBy);
+				}
+			}
+			if (updates.modelView) {
+				if (updates.modelView === "mapping") {
+					params.delete("modelView");
+				} else {
+					params.set("modelView", updates.modelView);
+				}
+			}
+			const query = params.toString();
+			router.push(query ? `${pathname}?${query}` : pathname);
+		},
+		[pathname, router, searchParams],
+	);
+
 	return (
 		<CostByModelChart
-			title="Cost by Model"
-			description="Top 20 models by cost for this organization"
+			title={`Cost by ${breakdownNoun.singular}`}
+			description={`Top 20 ${breakdownNoun.plural} by cost for this organization`}
 			fetchData={fetchData}
 			externalWindow={window}
+			showModelView
+			modelView={modelView}
+			onModelViewChange={(view) =>
+				updateView({ modelView: view === "canonical" ? view : "mapping" })
+			}
+			allowedModelViews={["mapping", "canonical"]}
+			showGroupBy
+			groupBy={groupBy}
+			onGroupByChange={(value) => updateView({ groupBy: value })}
 		/>
 	);
 }

--- a/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/project-cost-by-model-timeseries.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/project-cost-by-model-timeseries.tsx
@@ -9,6 +9,7 @@ import { getProjectCostByModelTimeseries } from "@/lib/admin-history";
 import type {
 	CostTimeseriesGroupBy,
 	ModelView,
+	ProjectCostTimeseriesGroupBy,
 	TokenWindow,
 } from "@/lib/types";
 
@@ -30,7 +31,7 @@ function parseWindow(value: string | null): TokenWindow {
 	return "1d";
 }
 
-function parseGroupBy(value: string | null): CostTimeseriesGroupBy {
+function parseGroupBy(value: string | null): ProjectCostTimeseriesGroupBy {
 	return value === "source" ? "source" : "model";
 }
 
@@ -55,14 +56,14 @@ export function ProjectCostByModelTimeseries({
 				projectId,
 				w,
 				modelView,
-				g,
+				g === "source" ? "source" : "model",
 			);
 		},
 		[orgId, projectId],
 	);
 
 	const handleGroupByChange = useCallback(
-		(next: CostTimeseriesGroupBy) => {
+		(next: ProjectCostTimeseriesGroupBy) => {
 			const params = new URLSearchParams(searchParams.toString());
 			if (next === "model") {
 				params.delete("breakdown");
@@ -90,7 +91,10 @@ export function ProjectCostByModelTimeseries({
 			fetchData={fetchData}
 			externalWindow={window}
 			groupBy={groupBy}
-			onGroupByChange={handleGroupByChange}
+			onGroupByChange={(value) =>
+				handleGroupByChange(value === "source" ? "source" : "model")
+			}
+			groupByOptions={["model", "source"]}
 		/>
 	);
 }

--- a/ee/admin/src/components/cost-by-model-chart.tsx
+++ b/ee/admin/src/components/cost-by-model-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Cpu, Layers, Server } from "lucide-react";
+import { Cpu, FolderOpen, KeyRound, Layers, Server, User } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 
@@ -24,7 +24,11 @@ import {
 import { cn } from "@/lib/utils";
 
 import type { ChartConfig } from "@/components/ui/chart";
-import type { GlobalStatsModelView, TokenWindow } from "@/lib/types";
+import type {
+	GlobalStatsModelView,
+	OrganizationCostGroupBy,
+	TokenWindow,
+} from "@/lib/types";
 
 export interface CostByModelEntry {
 	model: string;
@@ -70,6 +74,17 @@ const modelViewOptions: {
 	{ value: "provider", label: "Providers", icon: Server },
 ];
 
+const groupByOptions: {
+	value: OrganizationCostGroupBy;
+	label: string;
+	icon: typeof Cpu;
+}[] = [
+	{ value: "model", label: "Model", icon: Cpu },
+	{ value: "project", label: "Project", icon: FolderOpen },
+	{ value: "api-key", label: "API key", icon: KeyRound },
+	{ value: "user", label: "User", icon: User },
+];
+
 const currencyFormatter = new Intl.NumberFormat("en-US", {
 	style: "currency",
 	currency: "USD",
@@ -85,6 +100,10 @@ export function CostByModelChart({
 	showModelView = false,
 	modelView: controlledModelView,
 	onModelViewChange,
+	showGroupBy = false,
+	groupBy: controlledGroupBy,
+	onGroupByChange,
+	allowedModelViews,
 	forceRange = false,
 	from,
 	to,
@@ -94,6 +113,7 @@ export function CostByModelChart({
 	fetchData?: (
 		window: TokenWindow,
 		modelView: GlobalStatsModelView,
+		groupBy: OrganizationCostGroupBy,
 	) => Promise<CostByModelData | null>;
 	fetchDataRange?: (
 		from: string | undefined,
@@ -104,6 +124,10 @@ export function CostByModelChart({
 	showModelView?: boolean;
 	modelView?: GlobalStatsModelView;
 	onModelViewChange?: (value: GlobalStatsModelView) => void;
+	showGroupBy?: boolean;
+	groupBy?: OrganizationCostGroupBy;
+	onGroupByChange?: (value: OrganizationCostGroupBy) => void;
+	allowedModelViews?: GlobalStatsModelView[];
 	forceRange?: boolean;
 	from?: string;
 	to?: string;
@@ -116,6 +140,10 @@ export function CostByModelChart({
 		useState<GlobalStatsModelView>("mapping");
 	const modelView = controlledModelView ?? internalModelView;
 	const setModelView = onModelViewChange ?? setInternalModelView;
+	const [internalGroupBy, setInternalGroupBy] =
+		useState<OrganizationCostGroupBy>("model");
+	const groupBy = controlledGroupBy ?? internalGroupBy;
+	const setGroupBy = onGroupByChange ?? setInternalGroupBy;
 	const useRange = forceRange || Boolean(from && to);
 	const requestIdRef = useRef(0);
 
@@ -127,7 +155,7 @@ export function CostByModelChart({
 			if (useRange && fetchDataRange) {
 				result = await fetchDataRange(from, to, modelView);
 			} else if (fetchData) {
-				result = await fetchData(window, modelView);
+				result = await fetchData(window, modelView, groupBy);
 			}
 			if (requestId === requestIdRef.current) {
 				setData(result);
@@ -142,7 +170,16 @@ export function CostByModelChart({
 				setLoading(false);
 			}
 		}
-	}, [fetchData, fetchDataRange, window, modelView, from, to, useRange]);
+	}, [
+		fetchData,
+		fetchDataRange,
+		window,
+		modelView,
+		groupBy,
+		from,
+		to,
+		useRange,
+	]);
 
 	useEffect(() => {
 		void loadData();
@@ -217,10 +254,16 @@ export function CostByModelChart({
 					</div>
 				</div>
 				<div className="flex flex-wrap items-center justify-between gap-2 border-b pb-2">
-					<div className="flex items-center gap-1">
+					<div
+						className="flex items-center gap-1"
+						role="group"
+						aria-label="Metric"
+					>
 						{viewTabs.map((tab) => (
 							<button
 								key={tab.key}
+								type="button"
+								aria-pressed={activeView === tab.key}
 								className={cn(
 									"rounded-md px-3 py-1 text-xs font-medium transition-colors",
 									activeView === tab.key
@@ -233,26 +276,61 @@ export function CostByModelChart({
 							</button>
 						))}
 					</div>
-					<UsageModeSelector />
-					{showModelView && (
-						<div className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-1">
-							{modelViewOptions.map((opt) => {
-								const Icon = opt.icon;
-								return (
-									<Button
-										key={opt.value}
-										variant={modelView === opt.value ? "default" : "ghost"}
-										size="sm"
-										className="h-7 gap-1.5 px-3 text-xs"
-										onClick={() => setModelView(opt.value)}
-									>
-										<Icon className="h-3.5 w-3.5" />
-										{opt.label}
-									</Button>
-								);
-							})}
-						</div>
-					)}
+					<div className="flex flex-wrap items-center justify-end gap-2">
+						<UsageModeSelector />
+						{showGroupBy && (
+							<div
+								className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-1"
+								role="group"
+								aria-label="Break down by"
+							>
+								{groupByOptions.map((opt) => {
+									const Icon = opt.icon;
+									return (
+										<Button
+											key={opt.value}
+											variant={groupBy === opt.value ? "default" : "ghost"}
+											size="sm"
+											className="h-7 gap-1.5 px-3 text-xs"
+											onClick={() => setGroupBy(opt.value)}
+										>
+											<Icon className="h-3.5 w-3.5" />
+											{opt.label}
+										</Button>
+									);
+								})}
+							</div>
+						)}
+						{showModelView && groupBy === "model" && (
+							<div
+								className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-1"
+								role="group"
+								aria-label="Model view"
+							>
+								{modelViewOptions
+									.filter(
+										(opt) =>
+											!allowedModelViews ||
+											allowedModelViews.includes(opt.value),
+									)
+									.map((opt) => {
+										const Icon = opt.icon;
+										return (
+											<Button
+												key={opt.value}
+												variant={modelView === opt.value ? "default" : "ghost"}
+												size="sm"
+												className="h-7 gap-1.5 px-3 text-xs"
+												onClick={() => setModelView(opt.value)}
+											>
+												<Icon className="h-3.5 w-3.5" />
+												{opt.label}
+											</Button>
+										);
+									})}
+							</div>
+						)}
+					</div>
 				</div>
 			</CardHeader>
 			<CardContent className="px-2 pb-4 sm:px-6">
@@ -274,6 +352,7 @@ export function CostByModelChart({
 					>
 						<BarChart
 							data={displayModels}
+							accessibilityLayer
 							layout="vertical"
 							margin={{ left: 8, right: 8, top: 20, bottom: 4 }}
 						>

--- a/ee/admin/src/components/cost-by-model-chart.tsx
+++ b/ee/admin/src/components/cost-by-model-chart.tsx
@@ -46,6 +46,8 @@ export interface CostByModelData {
 	models: CostByModelEntry[];
 	totalCost: number;
 	totalRequests: number;
+	totalCreditsRequests?: number;
+	totalApiKeysRequests?: number;
 	totalCreditsCost?: number;
 	totalApiKeysCost?: number;
 }
@@ -209,7 +211,10 @@ export function CostByModelChart({
 	const displayTotalRequests =
 		usageMode === "total"
 			? (data?.totalRequests ?? 0)
-			: displayModels.reduce((sum, m) => sum + m.requestCount, 0);
+			: ((usageMode === "credits"
+					? data?.totalCreditsRequests
+					: data?.totalApiKeysRequests) ??
+				displayModels.reduce((sum, m) => sum + m.requestCount, 0));
 
 	const config = viewConfigs[activeView];
 	const dataKey = Object.keys(config)[0];
@@ -289,6 +294,7 @@ export function CostByModelChart({
 									return (
 										<Button
 											key={opt.value}
+											aria-pressed={groupBy === opt.value}
 											variant={groupBy === opt.value ? "default" : "ghost"}
 											size="sm"
 											className="h-7 gap-1.5 px-3 text-xs"

--- a/ee/admin/src/components/cost-by-model-timeseries-chart.tsx
+++ b/ee/admin/src/components/cost-by-model-timeseries-chart.tsx
@@ -255,6 +255,7 @@ export function CostByModelTimeseriesChart({
 									return (
 										<Button
 											key={option}
+											aria-pressed={activeGroupBy === option}
 											variant={activeGroupBy === option ? "default" : "ghost"}
 											size="sm"
 											className="h-7 gap-1.5 px-3 text-xs"

--- a/ee/admin/src/components/cost-by-model-timeseries-chart.tsx
+++ b/ee/admin/src/components/cost-by-model-timeseries-chart.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { format } from "date-fns";
+import { Cpu, FolderOpen, KeyRound, Layers, User } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 
+import { Button } from "@/components/ui/button";
 import {
 	Card,
 	CardContent,
@@ -43,10 +45,16 @@ const modelViewTabs: { key: ModelView; label: string }[] = [
 	{ key: "canonical", label: "Canonical" },
 ];
 
-const groupByTabs: { key: CostTimeseriesGroupBy; label: string }[] = [
-	{ key: "model", label: "By model" },
-	{ key: "source", label: "By source" },
-];
+const groupByConfig: Record<
+	CostTimeseriesGroupBy,
+	{ label: string; icon: typeof Cpu }
+> = {
+	model: { label: "Model", icon: Cpu },
+	source: { label: "Source", icon: Layers },
+	project: { label: "Project", icon: FolderOpen },
+	"api-key": { label: "API key", icon: KeyRound },
+	user: { label: "User", icon: User },
+};
 
 const seriesColors = [
 	"hsl(221 83% 53%)",
@@ -67,10 +75,6 @@ const currencyFormatter = new Intl.NumberFormat("en-US", {
 	maximumFractionDigits: 4,
 });
 
-function sanitizeKey(model: string): string {
-	return model.replace(/[^a-zA-Z0-9]/g, "_");
-}
-
 export function CostByModelTimeseriesChart({
 	title,
 	description,
@@ -78,6 +82,9 @@ export function CostByModelTimeseriesChart({
 	externalWindow,
 	groupBy,
 	onGroupByChange,
+	groupByOptions = ["model", "source"],
+	modelView: controlledModelView,
+	onModelViewChange,
 }: {
 	title: string;
 	description?: string;
@@ -89,11 +96,17 @@ export function CostByModelTimeseriesChart({
 	externalWindow: TokenWindow;
 	groupBy?: CostTimeseriesGroupBy;
 	onGroupByChange?: (groupBy: CostTimeseriesGroupBy) => void;
+	groupByOptions?: CostTimeseriesGroupBy[];
+	modelView?: ModelView;
+	onModelViewChange?: (modelView: ModelView) => void;
 }) {
 	const [data, setData] = useState<CostByModelTimeseriesResponse | null>(null);
 	const [loading, setLoading] = useState(true);
 	const [activeMetric, setActiveMetric] = useState<ActiveMetric>("cost");
-	const [modelView, setModelView] = useState<ModelView>("mapping");
+	const [internalModelView, setInternalModelView] =
+		useState<ModelView>("mapping");
+	const modelView = controlledModelView ?? internalModelView;
+	const setModelView = onModelViewChange ?? setInternalModelView;
 	const latestRequestRef = useRef(0);
 	const activeGroupBy = groupBy ?? "model";
 
@@ -125,19 +138,22 @@ export function CostByModelTimeseriesChart({
 
 	const usageMode = useUsageMode();
 
-	const { chartData, config, keyToModel } = useMemo(() => {
+	const { chartData, config, keyToModel, modelToKey } = useMemo(() => {
 		if (!data) {
 			return {
 				chartData: [],
 				config: {} as ChartConfig,
 				keyToModel: new Map<string, string>(),
+				modelToKey: new Map<string, string>(),
 			};
 		}
 		const keyToModelLocal = new Map<string, string>();
+		const modelToKeyLocal = new Map<string, string>();
 		const cfg: ChartConfig = {};
 		data.models.forEach((model, index) => {
-			const key = sanitizeKey(model);
+			const key = `series_${index}`;
 			keyToModelLocal.set(key, model);
+			modelToKeyLocal.set(model, key);
 			cfg[key] = {
 				label: model,
 				color: seriesColors[index % seriesColors.length],
@@ -160,15 +176,25 @@ export function CostByModelTimeseriesChart({
 				timestamp: point.timestamp,
 			};
 			for (const model of data.models) {
-				row[sanitizeKey(model)] = 0;
+				const key = modelToKeyLocal.get(model);
+				if (key) {
+					row[key] = 0;
+				}
 			}
 			for (const entry of point.entries) {
-				const key = sanitizeKey(entry.model);
-				row[key] = Number(entry[metricKey] ?? 0);
+				const key = modelToKeyLocal.get(entry.model);
+				if (key) {
+					row[key] = Number(entry[metricKey] ?? 0);
+				}
 			}
 			return row;
 		});
-		return { chartData: rows, config: cfg, keyToModel: keyToModelLocal };
+		return {
+			chartData: rows,
+			config: cfg,
+			keyToModel: keyToModelLocal,
+			modelToKey: modelToKeyLocal,
+		};
 	}, [data, activeMetric, usageMode]);
 
 	const bucket = data?.bucket ?? "day";
@@ -194,10 +220,16 @@ export function CostByModelTimeseriesChart({
 					</div>
 				</div>
 				<div className="flex flex-wrap items-center justify-between gap-2 border-b pb-2">
-					<div className="flex items-center gap-1">
+					<div
+						className="flex items-center gap-1"
+						role="group"
+						aria-label="Metric"
+					>
 						{metricTabs.map((tab) => (
 							<button
 								key={tab.key}
+								type="button"
+								aria-pressed={activeMetric === tab.key}
 								className={cn(
 									"rounded-md px-3 py-1 text-xs font-medium transition-colors",
 									activeMetric === tab.key
@@ -213,28 +245,39 @@ export function CostByModelTimeseriesChart({
 					<div className="flex flex-wrap items-center gap-2">
 						<UsageModeSelector />
 						{onGroupByChange && (
-							<div className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-0.5">
-								{groupByTabs.map((tab) => (
-									<button
-										key={tab.key}
-										className={cn(
-											"rounded-sm px-2.5 py-1 text-xs font-medium transition-colors",
-											activeGroupBy === tab.key
-												? "bg-primary text-primary-foreground"
-												: "text-muted-foreground hover:text-foreground",
-										)}
-										onClick={() => onGroupByChange(tab.key)}
-									>
-										{tab.label}
-									</button>
-								))}
+							<div
+								className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-0.5"
+								role="group"
+								aria-label="Break down by"
+							>
+								{groupByOptions.map((option) => {
+									const { label, icon: Icon } = groupByConfig[option];
+									return (
+										<Button
+											key={option}
+											variant={activeGroupBy === option ? "default" : "ghost"}
+											size="sm"
+											className="h-7 gap-1.5 px-3 text-xs"
+											onClick={() => onGroupByChange(option)}
+										>
+											<Icon className="h-3.5 w-3.5" />
+											{label}
+										</Button>
+									);
+								})}
 							</div>
 						)}
 						{activeGroupBy === "model" && (
-							<div className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-0.5">
+							<div
+								className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-0.5"
+								role="group"
+								aria-label="Model view"
+							>
 								{modelViewTabs.map((tab) => (
 									<button
 										key={tab.key}
+										type="button"
+										aria-pressed={modelView === tab.key}
 										className={cn(
 											"rounded-sm px-2.5 py-1 text-xs font-medium transition-colors",
 											modelView === tab.key
@@ -266,8 +309,9 @@ export function CostByModelTimeseriesChart({
 							config={config}
 							className="aspect-auto h-[300px] w-full"
 						>
-							<AreaChart
+							<BarChart
 								data={chartData}
+								accessibilityLayer
 								margin={{ left: 0, right: 8, top: 4, bottom: 0 }}
 							>
 								<CartesianGrid vertical={false} strokeDasharray="3 3" />
@@ -331,21 +375,20 @@ export function CostByModelTimeseriesChart({
 									}}
 								/>
 								{data.models.map((model) => {
-									const key = sanitizeKey(model);
+									const key = modelToKey.get(model);
+									if (!key) {
+										return null;
+									}
 									return (
-										<Area
+										<Bar
 											key={key}
 											dataKey={key}
-											type="monotone"
-											stackId="1"
-											stroke={`var(--color-${key})`}
+											stackId="breakdown"
 											fill={`var(--color-${key})`}
-											fillOpacity={0.5}
-											strokeWidth={1}
 										/>
 									);
 								})}
-							</AreaChart>
+							</BarChart>
 						</ChartContainer>
 						<div className="mt-3 flex flex-wrap gap-x-3 gap-y-1 text-xs">
 							{data.models.map((model, i) => (

--- a/ee/admin/src/lib/admin-history.ts
+++ b/ee/admin/src/lib/admin-history.ts
@@ -3,9 +3,10 @@
 import { createServerApiClient } from "./server-api";
 
 import type {
-	CostTimeseriesGroupBy,
 	GlobalStatsModelView,
 	ModelView,
+	OrganizationCostGroupBy,
+	ProjectCostTimeseriesGroupBy,
 	TokenWindow,
 } from "./types";
 import type { HistoryWindow } from "@/components/history-chart";
@@ -160,12 +161,17 @@ export async function getGlobalCostByModel(
 	return mapGlobalStatsToCostByModel(data, "30d");
 }
 
-export async function getOrgCostByModel(orgId: string, window: TokenWindow) {
+export async function getOrgCostByModel(
+	orgId: string,
+	window: TokenWindow,
+	modelView: ModelView = "mapping",
+	groupBy: OrganizationCostGroupBy = "model",
+) {
 	const $api = await createServerApiClient();
 	const { data } = await $api.GET(
 		"/admin/organizations/{orgId}/cost-by-model",
 		{
-			params: { path: { orgId }, query: { window } },
+			params: { path: { orgId }, query: { window, modelView, groupBy } },
 		},
 	);
 	return data ?? null;
@@ -175,12 +181,13 @@ export async function getOrgCostByModelTimeseries(
 	orgId: string,
 	window: TokenWindow,
 	modelView: ModelView = "mapping",
+	groupBy: OrganizationCostGroupBy = "model",
 ) {
 	const $api = await createServerApiClient();
 	const { data } = await $api.GET(
 		"/admin/organizations/{orgId}/cost-by-model-timeseries",
 		{
-			params: { path: { orgId }, query: { window, modelView } },
+			params: { path: { orgId }, query: { window, modelView, groupBy } },
 		},
 	);
 	return data ?? null;
@@ -191,7 +198,7 @@ export async function getProjectCostByModelTimeseries(
 	projectId: string,
 	window: TokenWindow,
 	modelView: ModelView = "mapping",
-	groupBy: CostTimeseriesGroupBy = "model",
+	groupBy: ProjectCostTimeseriesGroupBy = "model",
 ) {
 	const $api = await createServerApiClient();
 	const { data } = await $api.GET(

--- a/ee/admin/src/lib/types.ts
+++ b/ee/admin/src/lib/types.ts
@@ -108,6 +108,14 @@ export type CostByModelTimeseriesResponse =
 	GetJsonResponse<"/admin/organizations/{orgId}/cost-by-model-timeseries">;
 export type ModelView = CostByModelTimeseriesResponse["modelView"];
 export type CostTimeseriesGroupBy = CostByModelTimeseriesResponse["groupBy"];
+export type OrganizationCostGroupBy = Extract<
+	CostTimeseriesGroupBy,
+	"model" | "project" | "api-key" | "user"
+>;
+export type ProjectCostTimeseriesGroupBy = Extract<
+	CostTimeseriesGroupBy,
+	"model" | "source"
+>;
 
 // Global stats
 export type GlobalStatsResponse = GetJsonResponse<"/admin/global-stats">;


### PR DESCRIPTION
## Problem

Organization usage charts only supported model breakdowns, and the time-series chart used an area presentation.

## Changes

- add model, project, API key, and user breakdowns to both organization charts
- keep mapping/canonical selection for model breakdowns and sync chart state through the URL
- render the time series as stacked bars and query hourly aggregation tables
- preserve historical API-key and user usage when metadata is deleted
- calculate mode-specific request totals before limiting displayed rows

## Verification

- `pnpm format`
- `pnpm build`
- `pnpm exec vitest run --no-file-parallelism apps/api/src/routes/admin-metrics-mode-split.spec.ts`
- seeded desktop and mobile checks in light and dark themes

## Screenshots

| Theme and chart | Before | After |
| --- | --- | --- |
| Light — summary | <img src="https://raw.githubusercontent.com/theopenco/llmgateway/6f48f87915d23b68b5eaad47bca496bd165d6cf8/before-light-summary.png" width="420" alt="Organization cost summary before"> | <img src="https://raw.githubusercontent.com/theopenco/llmgateway/6f48f87915d23b68b5eaad47bca496bd165d6cf8/after-light-summary.png" width="420" alt="Organization cost summary with project breakdown toggle"> |
| Light — time series | <img src="https://raw.githubusercontent.com/theopenco/llmgateway/6f48f87915d23b68b5eaad47bca496bd165d6cf8/before-light-timeseries.png" width="420" alt="Organization time series before"> | <img src="https://raw.githubusercontent.com/theopenco/llmgateway/6f48f87915d23b68b5eaad47bca496bd165d6cf8/after-light-timeseries.png" width="420" alt="Organization stacked time series with project breakdown toggle"> |
| Dark — summary | <img src="https://raw.githubusercontent.com/theopenco/llmgateway/6f48f87915d23b68b5eaad47bca496bd165d6cf8/before-dark-summary.png" width="420" alt="Organization cost summary before in dark theme"> | <img src="https://raw.githubusercontent.com/theopenco/llmgateway/6f48f87915d23b68b5eaad47bca496bd165d6cf8/after-dark-summary.png" width="420" alt="Organization cost summary with project breakdown toggle in dark theme"> |
| Dark — time series | <img src="https://raw.githubusercontent.com/theopenco/llmgateway/6f48f87915d23b68b5eaad47bca496bd165d6cf8/before-dark-timeseries.png" width="420" alt="Organization time series before in dark theme"> | <img src="https://raw.githubusercontent.com/theopenco/llmgateway/6f48f87915d23b68b5eaad47bca496bd165d6cf8/after-dark-timeseries.png" width="420" alt="Organization stacked time series with project breakdown toggle in dark theme"> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Organization cost reports can be grouped by model, project, API key, or user.
  - Choose mapped or canonical model views for model-based analysis.
  - Cost timeseries charts support additional breakdowns and stacked bars.
  - Charts show the top 10 series and fill missing time periods for clearer trends.
  - Reports now include total credit and API-key request counts.
  - Usage remains attributable when API keys or users are deleted.
  - Added accessible controls for grouping and model-view selection.

- **Bug Fixes**
  - Improved consistency between organization- and project-level cost reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->