### PR TITLE
fix(icons): size the Empryo mark like its siblings

### DIFF
--- a/apps/docs/lib/custom-icons.tsx
+++ b/apps/docs/lib/custom-icons.tsx
@@ -1,4 +1,4 @@
-import type { ComponentType, CSSProperties, SVGProps } from "react";
+import type { ComponentType, SVGProps } from "react";
 
 type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
 
@@ -152,21 +152,23 @@ export const customIcons: Record<string, IconComponent> = {
 			/>
 		</svg>
 	),
-	Empryo: ({ className, style }) => (
-		// Raster mark hosted at /integrations/empryo.png in the docs public dir.
-		<img
-			src="/integrations/empryo.png"
-			alt="Empryo"
-			width={24}
-			height={24}
-			className={className as string | undefined}
-			style={
-				{
-					objectFit: "contain",
-					...(style as CSSProperties | undefined),
-				} as CSSProperties
-			}
-		/>
+	Empryo: (props) => (
+		// Raster mark hosted at /integrations/empryo.png in the docs public dir,
+		// wrapped in an <svg> shell so the sidebar's svg sizing rules apply to it
+		// exactly as they do to every sibling icon.
+		<svg
+			style={{ flex: "none", lineHeight: "1" }}
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			{...props}
+		>
+			<image
+				href="/integrations/empryo.png"
+				width="24"
+				height="24"
+				preserveAspectRatio="xMidYMid meet"
+			/>
+		</svg>
 	),
 	OpenClaw: (props) => (
 		<svg

--- a/packages/shared/src/components/integration-icons.tsx
+++ b/packages/shared/src/components/integration-icons.tsx
@@ -226,22 +226,18 @@ export const SoulForgeIcon: React.FC<React.SVGProps<SVGSVGElement>> = ({
 	/>
 );
 
-// Empryo Icon — raster mark hosted at /integrations/empryo.png in each app's public dir.
-export const EmpryoIcon: React.FC<React.SVGProps<SVGSVGElement>> = ({
-	className,
-	style,
-}) => (
-	<img
-		src="/integrations/empryo.png"
-		alt="Empryo"
-		className={className as string | undefined}
-		style={
-			{
-				objectFit: "contain",
-				...(style as React.CSSProperties | undefined),
-			} as React.CSSProperties
-		}
-	/>
+// Empryo Icon — raster mark hosted at /integrations/empryo.png in each app's
+// public dir, wrapped in an <svg> shell so every rule that sizes and aligns
+// the sibling icons (they are all svg elements) applies to this one too.
+export const EmpryoIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" {...props}>
+		<image
+			href="/integrations/empryo.png"
+			width="24"
+			height="24"
+			preserveAspectRatio="xMidYMid meet"
+		/>
+	</svg>
 );
 
 // Continue CLI Icon


### PR DESCRIPTION
## What

Wraps the Empryo raster mark in an `<svg><image>` shell in `packages/shared/src/components/integration-icons.tsx` and `apps/docs/lib/custom-icons.tsx`. The logo itself is unchanged — same `/integrations/empryo.png`.

## Why

Every sibling icon is an `svg` element, and the sidebar/grid sizing rules target `svg` — a bare `<img>` never receives them, so the Empryo icon rendered at a different size and alignment than the rest (visible on docs.llmgateway.io/guides). Fixed `width`/`height` on the img (the earlier attempt) can't follow those per-context rules either. Follow-up to #3779.

## Notes

- Same component signature (`React.SVGProps<SVGSVGElement>`) — all existing call sites unchanged.
- Prettier-formatted; drops one now-unused `CSSProperties` import.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Empryo integration icon rendering for consistent sizing and alignment with other integration icons.
  - Preserved the existing Empryo image asset while improving compatibility with shared icon styling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->