### PR TITLE
feat(admin): show DevPass LTV on subscribers card

### DIFF
--- a/ee/admin/src/components/devpass-kpis.tsx
+++ b/ee/admin/src/components/devpass-kpis.tsx
@@ -98,6 +98,19 @@ export function DevpassKpis({ from, to }: { from?: string; to?: string }) {
 		? kpis.grossMrr - kpis.refundedAmountThisMonth
 		: 0;
 
+	// Lifetime value per subscriber, gross and net of refunds. Both use the same
+	// denominator so the pair is directly comparable and the gap is purely the
+	// refund effect — totalSubscribersExcludingRefunded drops an org for any
+	// refund, even a partial one whose remaining revenue still counts.
+	const ltv =
+		kpis && kpis.totalSubscribers > 0
+			? kpis.grossSubscriptionRevenue / kpis.totalSubscribers
+			: 0;
+	const ltvAfterRefunds =
+		kpis && kpis.totalSubscribers > 0
+			? kpis.subscriptionRevenueExcludingRefunds / kpis.totalSubscribers
+			: 0;
+
 	return (
 		<section className="space-y-3">
 			<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
@@ -137,6 +150,35 @@ export function DevpassKpis({ from, to }: { from?: string; to?: string }) {
 							</div>
 							<div className="mt-1 text-xs text-muted-foreground">
 								{kpis.totalSubscribersExcludingRefunded} excluding refunded
+							</div>
+							<div className="mt-1 text-xs text-muted-foreground">
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<span className="cursor-help underline decoration-dotted underline-offset-2">
+											LTV
+										</span>
+									</TooltipTrigger>
+									<TooltipContent className="max-w-xs">
+										All-time plan revenue per subscriber. Both figures divide by
+										total subscribers, so the difference is purely the refund
+										effect.
+									</TooltipContent>
+								</Tooltip>{" "}
+								<span className="font-medium tabular-nums text-foreground">
+									{currencyFormatter.format(ltv)}
+								</span>{" "}
+								·{" "}
+								<span
+									className={cn(
+										"font-medium tabular-nums",
+										ltvAfterRefunds < ltv
+											? "text-rose-600 dark:text-rose-400"
+											: "",
+									)}
+								>
+									{currencyFormatter.format(ltvAfterRefunds)}
+								</span>{" "}
+								post-refund
 							</div>
 						</KpiCard>
 						<KpiCard


### PR DESCRIPTION
The DevPass KPI strip shows total subscribers and all-time plan revenue side by side, but never the ratio between them — the lifetime value of a subscriber had to be worked out by hand off two cards.

This adds it to the existing "Total subscribers" card as a third line: gross LTV plus a post-refund figure.

## Approach

Both values are derived in the component from data already in the `/admin/devpass/kpis` payload, so there is no API, schema, or generated-client change:

- **LTV** = `grossSubscriptionRevenue / totalSubscribers`
- **post-refund** = `subscriptionRevenueExcludingRefunds / totalSubscribers`, tinted rose when it sits below gross

### Why both divide by the same denominator

The tempting alternative is to pair the net numerator with `totalSubscribersExcludingRefunded`, but those two are not consistent definitions. That count drops an organization entirely as soon as it has *any* refund, including a partial one whose remaining revenue is still counted in `subscriptionRevenueExcludingRefunds` — so the net LTV would come out inflated, and could even exceed gross LTV.

Holding the denominator fixed makes the pair directly comparable: the gap between the two numbers is purely the refund effect. This is noted in a code comment and surfaced to admins in the tooltip on the "LTV" label.

## Verification

Run against a locally seeded stack (seeded DevPass organizations with refunds), so the figures below are fixture data:

- $445.00 all-time plan revenue / 4 subscribers = **$111.25** gross LTV
- $430.00 excluding refunds / 4 subscribers = **$107.50** post-refund

`pnpm format` clean, full `pnpm build` passes, and `apps/api/src/routes/admin-devpass-subscriber-kpis.spec.ts` passes.

## Screenshots

**Before — light**

<img width="1440" alt="DevPass KPI strip before, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/5f0856cc0e7d408f7709a465c48118f0b3bb9e22/before-light-kpis.png" />

**After — light**

<img width="1440" alt="DevPass KPI strip after, light theme, showing LTV on the Total subscribers card" src="https://raw.githubusercontent.com/theopenco/llmgateway/5f0856cc0e7d408f7709a465c48118f0b3bb9e22/light-kpis.png" />

**Before — dark**

<img width="1440" alt="DevPass KPI strip before, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/5f0856cc0e7d408f7709a465c48118f0b3bb9e22/before-dark-kpis.png" />

**After — dark**

<img width="1440" alt="DevPass KPI strip after, dark theme, showing LTV on the Total subscribers card" src="https://raw.githubusercontent.com/theopenco/llmgateway/5f0856cc0e7d408f7709a465c48118f0b3bb9e22/dark-kpis.png" />

---
_Generated by [Claude Code](https://claude.ai/code/session_01D82DTfpB4qmupC418rqnqa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gross and post-refund lifetime value metrics per subscriber.
  * The Total Subscribers KPI now displays both LTV figures with explanatory tooltips.
  * Post-refund LTV is highlighted when it is lower than gross LTV.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->