### PR TITLE
fix: guard playground keys in master IAM routes

### DIFF
--- a/apps/api/src/routes/keys-api.ts
+++ b/apps/api/src/routes/keys-api.ts
@@ -45,7 +45,7 @@ export function isPlaygroundApiKey(apiKey: {
 	return apiKey.kind === "playground";
 }
 
-function assertApiKeyIsUserManaged(apiKey: {
+export function assertApiKeyIsUserManaged(apiKey: {
 	kind: "regular" | "playground";
 }): void {
 	if (isPlaygroundApiKey(apiKey)) {

--- a/apps/api/src/routes/v1-master.spec.ts
+++ b/apps/api/src/routes/v1-master.spec.ts
@@ -181,6 +181,60 @@ describe("v1/master cache invalidation", () => {
 		expect(remove.status).toBe(403);
 	});
 
+	test("managed playground keys reject master-key IAM mutations", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "playground-key",
+			token: "playground-token",
+			projectId: "test-project-id",
+			description: "Playground",
+			kind: "playground",
+			createdBy: "test-user-id",
+		});
+		const [rule] = await db
+			.insert(tables.apiKeyIamRule)
+			.values({
+				apiKeyId: "playground-key",
+				ruleType: "allow_models",
+				ruleValue: { models: ["openai/gpt-4o-mini"] },
+			})
+			.returning();
+
+		const create = await app.request("/v1/master/keys/playground-key/iam", {
+			method: "POST",
+			headers: authHeaders({ "Content-Type": "application/json" }),
+			body: JSON.stringify({
+				ruleType: "deny_models",
+				ruleValue: { models: ["openai/gpt-4o-mini"] },
+			}),
+		});
+		expect(create.status).toBe(403);
+
+		const update = await app.request(
+			`/v1/master/keys/playground-key/iam/${rule.id}`,
+			{
+				method: "PATCH",
+				headers: authHeaders({ "Content-Type": "application/json" }),
+				body: JSON.stringify({ status: "inactive" }),
+			},
+		);
+		expect(update.status).toBe(403);
+
+		const remove = await app.request(
+			`/v1/master/keys/playground-key/iam/${rule.id}`,
+			{
+				method: "DELETE",
+				headers: authHeaders(),
+			},
+		);
+		expect(remove.status).toBe(403);
+
+		const rules = await db.query.apiKeyIamRule.findMany({
+			where: { apiKeyId: { eq: "playground-key" } },
+		});
+		expect(rules).toHaveLength(1);
+		expect(rules[0]?.status).toBe("active");
+	});
+
 	test("PATCH /keys allows the playground description on a regular key", async () => {
 		const res = await app.request("/v1/master/keys/test-api-key-id", {
 			method: "PATCH",

--- a/apps/api/src/routes/v1-master.ts
+++ b/apps/api/src/routes/v1-master.ts
@@ -33,6 +33,7 @@ import {
 	updateCustomModelSchema,
 } from "@/routes/custom-models.js";
 import {
+	assertApiKeyIsUserManaged,
 	buildApiKeyLimitAuditChanges,
 	createApiKeyForProject,
 	hasPeriodConfigChanged,
@@ -685,11 +686,7 @@ v1Master.openapi(updateApiKey, async (c) => {
 
 	const existing = await loadApiKeyForOrg(id, masterKey.organizationId);
 
-	if (isPlaygroundApiKey(existing)) {
-		throw new HTTPException(403, {
-			message: "The playground API key is managed automatically.",
-		});
-	}
+	assertApiKeyIsUserManaged(existing);
 
 	const limitUpdate: PartialApiKeyLimitConfig = {};
 	if ("usageLimit" in updates) {
@@ -999,6 +996,8 @@ v1Master.openapi(createIamRule, async (c) => {
 
 	const apiKey = await loadApiKeyForOrg(id, masterKey.organizationId);
 
+	assertApiKeyIsUserManaged(apiKey);
+
 	const [rule] = await cdb
 		.insert(tables.apiKeyIamRule)
 		.values({
@@ -1098,6 +1097,8 @@ v1Master.openapi(updateIamRule, async (c) => {
 
 	const apiKey = await loadApiKeyForOrg(id, masterKey.organizationId);
 
+	assertApiKeyIsUserManaged(apiKey);
+
 	const existingRule = await db.query.apiKeyIamRule.findFirst({
 		where: { id: { eq: ruleId }, apiKeyId: { eq: apiKey.id } },
 	});
@@ -1170,6 +1171,8 @@ v1Master.openapi(deleteIamRule, async (c) => {
 	const { id, ruleId } = c.req.param();
 
 	const apiKey = await loadApiKeyForOrg(id, masterKey.organizationId);
+
+	assertApiKeyIsUserManaged(apiKey);
 
 	const existingRule = await db.query.apiKeyIamRule.findFirst({
 		where: { id: { eq: ruleId }, apiKeyId: { eq: apiKey.id } },


### PR DESCRIPTION
## Problem

`PATCH /v1/master/keys/{id}` and `DELETE /v1/master/keys/{id}` reject the automatically managed playground API key, but the IAM mutation handlers on the same router — `POST`, `PATCH` and `DELETE /v1/master/keys/{id}/iam[/{ruleId}]` — loaded the key via `loadApiKeyForOrg` without that check.

Playground rows still carry `keyType: "user"`, so the gateway enforces their IAM rules. A master-key client that knows the playground key's id could therefore attach a deny rule and break the credential the playground depends on, even though the dashboard IAM endpoints (`/keys/api/{id}/iam*`) reject the exact same operation.

## Change

- Export `assertApiKeyIsUserManaged` from `apps/api/src/routes/keys-api.ts` and call it in all three master IAM mutation handlers.
- Replace the inline duplicate of that guard in the master `PATCH /keys/{id}` handler with the shared helper.

Read paths (`GET /keys/{id}`, `GET /keys/{id}/iam`) are unchanged, matching the dashboard routes, which also only guard mutations.

## Test

New spec in `apps/api/src/routes/v1-master.spec.ts` asserts the three IAM mutations return 403 for a playground key and that the pre-existing rule is left untouched. Verified it fails without the handler change and passes with it; `apps/api/src/routes/v1-master.spec.ts` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NJTEXHPZHfGwiUpuxmQbK

---
_Generated by [Claude Code](https://claude.ai/code/session_014NJTEXHPZHfGwiUpuxmQbK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted API key updates and IAM rule changes to user-managed keys.
  * Prevented managed playground keys from being modified through master API endpoints.
  * Preserved existing IAM rules when unauthorized changes are attempted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->