### PR TITLE
fix(api): scope playground keys per user

### DIFF
--- a/apps/api/src/utils/playground-key.spec.ts
+++ b/apps/api/src/utils/playground-key.spec.ts
@@ -157,7 +157,7 @@ describe("resolvePlaygroundToken", () => {
 		).toBe(1);
 	});
 
-	test("provisions concurrent members without contending", async () => {
+	test("gives concurrent members one key each", async () => {
 		const project = await db.query.project.findFirst();
 		if (!project) {
 			throw new Error("Test project was not created");

--- a/apps/api/src/utils/playground-key.spec.ts
+++ b/apps/api/src/utils/playground-key.spec.ts
@@ -66,7 +66,7 @@ describe("resolvePlaygroundToken", () => {
 		await deleteAll();
 	});
 
-	test("rotates one stable key and invalidates another browser", async () => {
+	test("rotates the caller's own key when the cookie is missing", async () => {
 		const firstResponse = await resolver.request("/");
 		const firstBody = await firstResponse.json();
 		const firstCookie = firstResponse.headers.get("set-cookie");
@@ -155,6 +155,40 @@ describe("resolvePlaygroundToken", () => {
 				),
 			),
 		).toBe(1);
+	});
+
+	test("provisions concurrent members without contending", async () => {
+		const project = await db.query.project.findFirst();
+		if (!project) {
+			throw new Error("Test project was not created");
+		}
+		await db.insert(tables.user).values({
+			id: "other-playground-user",
+			name: "Other Playground User",
+			email: "other-playground@example.com",
+			emailVerified: true,
+		});
+
+		const [mine, theirs] = await Promise.all([
+			getOrCreatePlaygroundApiKey(project.id, "test-user-id"),
+			getOrCreatePlaygroundApiKey(project.id, "other-playground-user"),
+		]);
+
+		const keys = await db.query.apiKey.findMany({
+			where: {
+				projectId: { eq: project.id },
+				kind: { eq: "playground" },
+				status: { eq: "active" },
+			},
+		});
+		expect(keys).toHaveLength(2);
+		for (const [userId, result] of [
+			["test-user-id", mine],
+			["other-playground-user", theirs],
+		] as const) {
+			const key = keys.find((candidate) => candidate.createdBy === userId);
+			expect(getApiKeyFingerprints(result.token)).toContain(key?.tokenHash);
+		}
 	});
 
 	test("migrates a matching plaintext key without changing its token", async () => {
@@ -318,7 +352,7 @@ describe("resolvePlaygroundToken", () => {
 		).toBe(1);
 	});
 
-	test("preserves the original creator when another user rolls the row", async () => {
+	test("gives another member its own key instead of rotating", async () => {
 		const firstResponse = await resolver.request("/");
 		const firstBody = await firstResponse.json();
 		const key = await db.query.apiKey.findFirst({
@@ -337,13 +371,34 @@ describe("resolvePlaygroundToken", () => {
 		const result = await getOrCreatePlaygroundApiKey(
 			key.projectId,
 			"other-playground-user",
-			`${firstBody.token}-stale`,
+			firstBody.token,
 		);
-		const rolled = await db.query.apiKey.findFirst({
-			where: { id: { eq: key.id } },
-		});
 
 		expect(result.issued).toBe(true);
-		expect(rolled?.createdBy).toBe(key.createdBy);
+		expect(result.token).not.toBe(firstBody.token);
+
+		const untouched = await db.query.apiKey.findFirst({
+			where: { id: { eq: key.id } },
+		});
+		expect(untouched?.createdBy).toBe(key.createdBy);
+		expect(getApiKeyFingerprints(firstBody.token)).toContain(
+			untouched?.tokenHash,
+		);
+
+		const otherKey = await db.query.apiKey.findFirst({
+			where: { createdBy: { eq: "other-playground-user" } },
+		});
+		expect(otherKey?.id).not.toBe(key.id);
+		expect(getApiKeyFingerprints(result.token)).toContain(otherKey?.tokenHash);
+		expect(
+			await db.$count(
+				tables.apiKey,
+				and(
+					eq(tables.apiKey.projectId, key.projectId),
+					eq(tables.apiKey.kind, "playground"),
+					eq(tables.apiKey.status, "active"),
+				),
+			),
+		).toBe(2);
 	});
 });

--- a/apps/api/src/utils/playground-key.ts
+++ b/apps/api/src/utils/playground-key.ts
@@ -28,14 +28,23 @@ interface PlaygroundApiKeyResult {
 	cookieMaxAge: number;
 }
 
+// Playground keys are per (project, user): the row is provisioned lazily the
+// first time that member uses the playground, and is only ever rotated for the
+// member who owns it. Scoping by creator is what keeps two teammates on a
+// shared project from revoking each other's key on every visit; the token
+// itself is only stored hashed, so a caller without the secret still gets a
+// fresh one rather than the stored token.
 export async function getOrCreatePlaygroundApiKey(
 	projectId: string,
 	userId: string,
 	existingToken?: string,
 ): Promise<PlaygroundApiKeyResult> {
 	return await cdb.transaction(async (tx) => {
+		// Serialize concurrent first-use requests for this (project, user) pair
+		// only, so one member provisioning a key never blocks or rotates another
+		// member's key on the same project.
 		await tx.execute(
-			sql`SELECT ${tables.project.id} FROM ${tables.project} WHERE ${tables.project.id} = ${projectId} FOR UPDATE`,
+			sql`SELECT pg_advisory_xact_lock(hashtext(${projectId}), hashtext(${userId}))`,
 		);
 
 		const [key] = await tx
@@ -47,6 +56,7 @@ export async function getOrCreatePlaygroundApiKey(
 					eq(tables.apiKey.status, "active"),
 					eq(tables.apiKey.keyType, "user"),
 					eq(tables.apiKey.kind, "playground"),
+					eq(tables.apiKey.createdBy, userId),
 				),
 			)
 			.orderBy(asc(tables.apiKey.createdAt))

--- a/apps/api/src/utils/playground-key.ts
+++ b/apps/api/src/utils/playground-key.ts
@@ -40,11 +40,8 @@ export async function getOrCreatePlaygroundApiKey(
 	existingToken?: string,
 ): Promise<PlaygroundApiKeyResult> {
 	return await cdb.transaction(async (tx) => {
-		// Serialize concurrent first-use requests for this (project, user) pair
-		// only, so one member provisioning a key never blocks or rotates another
-		// member's key on the same project.
 		await tx.execute(
-			sql`SELECT pg_advisory_xact_lock(hashtext(${projectId}), hashtext(${userId}))`,
+			sql`SELECT ${tables.project.id} FROM ${tables.project} WHERE ${tables.project.id} = ${projectId} FOR UPDATE`,
 		);
 
 		const [key] = await tx


### PR DESCRIPTION
## Problem

The playground API key was a single project-wide row: `getOrCreatePlaygroundApiKey` looked up the oldest `kind: "playground"` key for the project, regardless of who created it. Since the token is only stored hashed, any caller arriving without the matching cookie fell through to the rotate branch and overwrote that shared row with a new hash.

On a project with more than one member — or a member with more than one browser — that means:

- Two teammates using the playground revoke each other's token on every visit, indefinitely.
- Concurrent first-use requests both return a token, but only the last writer's token actually works; the earlier caller's token is dead before it can be used.
- Every new browser session silently invalidates all other live playground tabs for that project.

## Approach

The lookup now also filters on `createdBy = userId`, so playground keys are per `(project, user)`: each member gets their own row, provisioned lazily the first time they use the playground. Rotation only ever touches the caller's own token — another member's key is never read or rewritten, even if the caller presents that member's secret.

That is the whole behavioural change; the existing `SELECT … FROM project … FOR UPDATE` still serializes concurrent first-use requests, so they continue to collapse to exactly one row per member.

A member using two browsers still gets a rotation on the second one — the token is stored hashed, so there is nothing to hand back and a fresh token is the only option. That is now confined to that member's own credential rather than a shared one, and each playground page re-runs `ensure-key` on mount, so the other browser recovers on its next load.

No schema change: playground keys are already excluded from key listings, developer-key quotas and team views, so more than one row per project is fine.

## Verification

- `apps/api/src/utils/playground-key.spec.ts` — two new cases (a second member gets its own key while the first member's hash stays untouched; two members provisioning concurrently get one key each) plus the existing suite, 10 passing. Confirmed the cross-member case fails without the `createdBy` filter.
- `apps/api/src/routes/keys-api.spec.ts`, `chat-projects.spec.ts`, `playground-realtime-history.spec.ts` — passing.
- `pnpm format` and a full `pnpm build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API keys are now scoped to the individual member who created them.
  * Members sharing a project no longer rotate or overwrite one another’s keys.
  * Concurrent first-time requests now create separate keys reliably without contention.
  * Existing keys are rotated only for the requesting member when required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->