### PR TITLE
fix(admin): show deleted org usage

### DIFF
--- a/apps/api/src/routes/admin-metrics-mode-split.spec.ts
+++ b/apps/api/src/routes/admin-metrics-mode-split.spec.ts
@@ -287,6 +287,41 @@ describe("admin — credits vs BYOK mode split", () => {
 		expect(gpt4!.apiKeysRequestCount).toBe(1);
 	});
 
+	test("organization cost charts retain soft-deleted usage", async () => {
+		await db
+			.update(tables.organization)
+			.set({ status: "deleted" })
+			.where(eq(tables.organization.id, ORG_ID));
+
+		const breakdownRes = await app.request(
+			`/admin/organizations/${ORG_ID}/cost-by-model?window=1d`,
+			{ headers: { Cookie: cookie } },
+		);
+		expect(breakdownRes.status).toBe(200);
+		const breakdown = (await breakdownRes.json()) as {
+			models: { model: string; cost: number }[];
+			totalCost: number;
+		};
+		expect(breakdown.models).toHaveLength(1);
+		expect(breakdown.totalCost).toBeCloseTo(50, 3);
+
+		const timeseriesRes = await app.request(
+			`/admin/organizations/${ORG_ID}/cost-by-model-timeseries?window=1d`,
+			{ headers: { Cookie: cookie } },
+		);
+		expect(timeseriesRes.status).toBe(200);
+		const timeseries = (await timeseriesRes.json()) as {
+			models: string[];
+			data: { entries: { cost: number }[] }[];
+		};
+		expect(timeseries.models).toHaveLength(1);
+		expect(
+			timeseries.data
+				.flatMap((point) => point.entries)
+				.reduce((sum, entry) => sum + entry.cost, 0),
+		).toBeCloseTo(50, 3);
+	});
+
 	test("cost breakdown totals include rows beyond the top 20", async () => {
 		const hourTimestamp = new Date();
 		hourTimestamp.setUTCMinutes(0, 0, 0);

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -10170,7 +10170,7 @@ admin.openapi(getOrgCostByModel, async (c) => {
 		where: { id: { eq: orgId } },
 	});
 
-	if (!org || org.status === "deleted") {
+	if (!org) {
 		throw new HTTPException(404, { message: "Organization not found" });
 	}
 
@@ -10459,7 +10459,7 @@ admin.openapi(getOrgCostByModelTimeseries, async (c) => {
 		where: { id: { eq: orgId } },
 	});
 
-	if (!org || org.status === "deleted") {
+	if (!org) {
 		throw new HTTPException(404, { message: "Organization not found" });
 	}
 


### PR DESCRIPTION
## Problem

Admin usage cards remained available for soft-deleted organizations, but the cost breakdown and time-series endpoints returned 404. This made retained project-hourly usage disappear from both charts.

## Approach

Allow authenticated admin analytics endpoints to read retained usage for soft-deleted organizations while preserving 404 responses for unknown IDs.

Add regression coverage for both chart responses after an organization is soft-deleted.

## Verification

- `pnpm format`
- `pnpm build`
- `pnpm test:unit apps/api/src/routes/admin-metrics-mode-split.spec.ts` (16 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Organization cost breakdown and timeseries reports now remain available after an organization is soft-deleted.
  * Deleted organizations are no longer incorrectly reported as missing when viewing usage metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->