### PR TITLE
chore(models): retire Nebius mappings

### DIFF
--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -571,6 +571,7 @@ export const alibabaModels = [
 				providerId: "nebius",
 				stability: "unstable",
 				externalId: "Qwen/Qwen3-235B-A22B-Instruct-2507",
+				deactivatedAt: new Date("2026-08-31"),
 				inputPrice: "0.2e-6",
 				outputPrice: "0.6e-6",
 				requestPrice: "0",
@@ -1120,6 +1121,7 @@ export const alibabaModels = [
 			{
 				providerId: "nebius",
 				externalId: "Qwen/Qwen3-30B-A3B-Instruct-2507",
+				deactivatedAt: new Date("2026-08-31"),
 				inputPrice: "0.1e-6",
 				outputPrice: "0.3e-6",
 				requestPrice: "0",
@@ -3945,6 +3947,7 @@ export const alibabaModels = [
 			{
 				providerId: "nebius",
 				externalId: "Qwen/Qwen3-Embedding-8B",
+				deactivatedAt: new Date("2026-08-31"),
 				inputPrice: "0.01e-6",
 				outputPrice: "0",
 				requestPrice: "0",

--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -480,6 +480,7 @@ export const deepseekModels = [
 			{
 				providerId: "nebius",
 				externalId: "deepseek-ai/DeepSeek-V4-Pro",
+				deactivatedAt: new Date("2026-08-31"),
 				inputPrice: "1.75e-6",
 				outputPrice: "3.5e-6",
 				requestPrice: "0",

--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -2377,6 +2377,7 @@ export const googleModels = [
 			{
 				providerId: "nebius",
 				externalId: "google/gemma-3-27b-it",
+				deactivatedAt: new Date("2026-08-31"),
 				inputPrice: "0.1e-6",
 				outputPrice: "0.3e-6",
 				requestPrice: "0",

--- a/packages/models/src/models/minimax.ts
+++ b/packages/models/src/models/minimax.ts
@@ -62,6 +62,7 @@ export const minimaxModels = [
 			{
 				providerId: "nebius",
 				externalId: "MiniMaxAI/MiniMax-M3",
+				deactivatedAt: new Date("2026-08-31"),
 				inputPrice: "0.3e-6",
 				outputPrice: "1.2e-6",
 				requestPrice: "0",

--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -546,6 +546,7 @@ export const moonshotModels = [
 			{
 				providerId: "nebius",
 				externalId: "moonshotai/Kimi-K2.6",
+				deactivatedAt: new Date("2026-08-31"),
 				// Streaming tool calls are unreliable on this deployment: required
 				// choices can end without a tool call, while named choices can leak raw
 				// control tokens into argument deltas (verified 2026-07-22).
@@ -660,6 +661,7 @@ export const moonshotModels = [
 			{
 				providerId: "nebius",
 				externalId: "moonshotai/Kimi-K2.7-Code",
+				deactivatedAt: new Date("2026-08-31"),
 				inputPrice: "0.95e-6",
 				outputPrice: "4.0e-6",
 				requestPrice: "0",
@@ -804,6 +806,7 @@ export const moonshotModels = [
 			{
 				providerId: "nebius",
 				externalId: "moonshotai/Kimi-K3",
+				deactivatedAt: new Date("2026-08-31"),
 				// Named tool choice is rejected with a 400 ("Named tool choice is not
 				// supported for Kimi K3"), and "required" is silently broken: the
 				// upstream emits the call as text in `reasoning_content` and returns

--- a/packages/models/src/models/nousresearch.ts
+++ b/packages/models/src/models/nousresearch.ts
@@ -12,6 +12,7 @@ export const nousresearchModels = [
 			{
 				providerId: "nebius",
 				externalId: "NousResearch/Hermes-4-405B",
+				deactivatedAt: new Date("2026-08-31"),
 				inputPrice: "1.0e-6",
 				outputPrice: "3.0e-6",
 				requestPrice: "0",

--- a/packages/models/src/models/nvidia.ts
+++ b/packages/models/src/models/nvidia.ts
@@ -54,6 +54,7 @@ export const nvidiaModels = [
 			{
 				providerId: "nebius",
 				externalId: "nvidia/nemotron-3-super-120b-a12b",
+				deactivatedAt: new Date("2026-08-31"),
 				// The deployment rejects tool_choice="required" with a 400, but
 				// named function choices work (verified 2026-07-22).
 				supportedToolChoices: ["auto", "none", "function"],

--- a/packages/models/src/models/openai.ts
+++ b/packages/models/src/models/openai.ts
@@ -766,6 +766,7 @@ export const openaiModels = [
 			{
 				providerId: "nebius",
 				externalId: "openai/gpt-oss-120b",
+				deactivatedAt: new Date("2026-08-31"),
 				// Streaming tool calls arrive malformed from nebius (vLLM emits a
 				// bogus tool_call index on the final argument fragment)
 				stability: "unstable",

--- a/packages/models/src/models/openbmb.ts
+++ b/packages/models/src/models/openbmb.ts
@@ -12,6 +12,7 @@ export const openbmbModels = [
 			{
 				providerId: "nebius",
 				externalId: "openbmb/MiniCPM-V-4_5",
+				deactivatedAt: new Date("2026-08-31"),
 				inputPrice: "0.658e-6",
 				outputPrice: "1.11e-6",
 				requestPrice: "0",

--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -250,6 +250,7 @@ export const zaiModels = [
 			{
 				providerId: "nebius",
 				externalId: "zai-org/GLM-5.2",
+				deactivatedAt: new Date("2026-08-31"),
 				inputPrice: "1.4e-6",
 				outputPrice: "4.4e-6",
 				requestPrice: "0",
@@ -464,6 +465,7 @@ export const zaiModels = [
 			{
 				providerId: "nebius",
 				externalId: "zai-org/GLM-5.1",
+				deactivatedAt: new Date("2026-08-31"),
 				inputPrice: "1.4e-6",
 				outputPrice: "4.4e-6",
 				requestPrice: "0",


### PR DESCRIPTION
## Summary

- schedule the 15 remaining active Nebius mappings for deactivation on August 31, 2026
- preserve existing historical deactivation dates
- ensure every Nebius mapping now has a deactivation date

## Verification

- `pnpm format`
- `pnpm exec vitest run --no-file-parallelism packages/models/src/model-metadata.spec.ts packages/models/src/providers.spec.ts packages/models/src/realtime-models.spec.ts apps/gateway/src/lib/costs.spec.ts`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Added a scheduled deactivation date of August 31, 2026, for several models available through the Nebius provider.
  * Affected models include Qwen3, DeepSeek V4 Pro, Gemma 3 27B, MiniMax M3, Kimi, Hermes 4 405B, Nemotron 3 Super 120B, GPT-OSS 120B, MiniCPM-V 4.5, and GLM models.
  * Model availability information now reflects these planned deactivations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->