### PR TITLE
chore: extend Runware promo until September 9

### DIFF
--- a/apps/ui/src/content/changelog/2026-07-27-runware-launch-discount.md
+++ b/apps/ui/src/content/changelog/2026-07-27-runware-launch-discount.md
@@ -6,7 +6,7 @@ title: "Runware Launch: 30% Off Open-Source Models"
 summary: "We partnered with Runware.ai to serve six open-source flagships — gpt-oss-120b, Gemma 4, DeepSeek V4 Pro and Flash, Kimi K2.6, and GLM 5.2 — at 30% off. The discount applies automatically to everything routed through Runware until September 9."
 image:
   src: "/changelog/runware-launch-discount.png"
-  alt: "LLM Gateway and Runware logos beside a large 30% and a one-month calendar, announcing the launch discount"
+  alt: "LLM Gateway and Runware logos beside a large 30% and a calendar, announcing the launch discount"
   width: 1536
   height: 1024
 ---

--- a/apps/ui/src/content/changelog/2026-07-27-runware-launch-discount.md
+++ b/apps/ui/src/content/changelog/2026-07-27-runware-launch-discount.md
@@ -3,7 +3,7 @@ id: "71"
 slug: "runware-launch-discount"
 date: "2026-07-27"
 title: "Runware Launch: 30% Off Open-Source Models"
-summary: "We partnered with Runware.ai to serve six open-source flagships — gpt-oss-120b, Gemma 4, DeepSeek V4 Pro and Flash, Kimi K2.6, and GLM 5.2 — at 30% off for 30 days. The discount applies automatically to everything routed through Runware until August 26."
+summary: "We partnered with Runware.ai to serve six open-source flagships — gpt-oss-120b, Gemma 4, DeepSeek V4 Pro and Flash, Kimi K2.6, and GLM 5.2 — at 30% off. The discount applies automatically to everything routed through Runware until September 9."
 image:
   src: "/changelog/runware-launch-discount.png"
   alt: "LLM Gateway and Runware logos beside a large 30% and a one-month calendar, announcing the launch discount"
@@ -11,9 +11,11 @@ image:
   height: 1024
 ---
 
-Open-source flagships now carry serious production workloads, which makes the per-token price of serving them the number that matters. We partnered with **[Runware.ai](https://llmgateway.io/providers/runware)** to bring their fast, OpenAI-compatible inference for open models to the gateway — and to launch it, **every Runware model is 30% off for 30 days**.
+> **Update (August 25):** the promo has been extended by two weeks — the discount now runs until **September 9, 2026**.
 
-## Six Models, 30% Off Until August 26
+Open-source flagships now carry serious production workloads, which makes the per-token price of serving them the number that matters. We partnered with **[Runware.ai](https://llmgateway.io/providers/runware)** to bring their fast, OpenAI-compatible inference for open models to the gateway — and to launch it, **every Runware model is 30% off**.
+
+## Six Models, 30% Off Until September 9
 
 | Model                                                                       | Context | Input $/M | Output $/M |
 | --------------------------------------------------------------------------- | ------- | --------- | ---------- |
@@ -41,7 +43,7 @@ curl https://api.llmgateway.io/v1/chat/completions \
 
 - Discounted pricing shows directly on the model pages while the promo runs.
 - Automatic fallback keeps working as usual — only requests actually served by Runware get the discount.
-- The promo ends **August 26, 2026**; list prices apply after that.
+- The promo ends **September 9, 2026**; list prices apply after that.
 
 Runware serves these models through the same unified API as every other provider, with streaming support and no training on your API traffic.
 

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -1892,7 +1892,7 @@ export const providers: ProviderDefinition[] = [
 		color: "#a8f399",
 		website: "https://runware.ai",
 		statusPageUrl: "https://status.runware.ai/",
-		announcement: "Launch offer: 30% off all Runware models until August 26",
+		announcement: "Launch offer: 30% off all Runware models until September 9",
 		termsUrl: "https://runware.ai/terms",
 		privacyPolicyUrl: "https://runware.ai/privacy",
 		headquarters: "GB",

--- a/packages/shared/src/marketing.ts
+++ b/packages/shared/src/marketing.ts
@@ -14,13 +14,13 @@ export const MARKETING_STATS = {
 	githubStars: "20K+",
 } as const;
 
-// Runware launch partnership: 30% off all Runware-served OSS models for 30
-// days from the 2026-07-27 launch. The promo banners in apps/ui and apps/code
-// hide themselves automatically once `endsAt` passes; the banner code can be
-// removed entirely after that date.
+// Runware launch partnership: 30% off all Runware-served OSS models from the
+// 2026-07-27 launch, extended by two weeks on 2026-08-25. The promo banners in
+// apps/ui and apps/code hide themselves automatically once `endsAt` passes;
+// the banner code can be removed entirely after that date.
 export const RUNWARE_PROMO = {
 	discountPercent: 30,
-	endsAt: "2026-08-26T23:59:59Z",
+	endsAt: "2026-09-09T23:59:59Z",
 	providerPath: "/providers/runware",
 	providerUrl: "https://llmgateway.io/providers/runware",
 } as const;


### PR DESCRIPTION
## Problem

The Runware launch discount (30% off Runware-served OSS models) was set to end on August 26. We're extending it by two weeks.

## Approach

New end date: **September 9, 2026** (23:59:59 UTC), applied everywhere the date lives in code:

- `RUNWARE_PROMO.endsAt` in `packages/shared/src/marketing.ts` — the promo banners in `apps/ui` and `apps/code` read this and keep auto-hiding after the new date.
- The Runware provider `announcement` in `packages/models/src/providers.ts`.
- The launch changelog entry: dates updated plus a short extension note, and the "for 30 days" phrasing dropped since the promo now runs longer.

## Notes for the reviewer

- The billing discount itself is runtime config (a `discount` table row managed via the admin dashboard), not code — its `expiresAt` must be extended to the same date in the deployed environment for the pricing to actually keep applying. This PR only covers the banners, announcement, and changelog.
- No visual changes: the banner components are untouched and only read the shared constant, so no screenshots.
- `pnpm format` and full `pnpm build` pass.

https://claude.ai/code/session_014ABC6hitaK4kEyxym96YMH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended the Runware launch promotion through September 9, 2026.
  * Updated promotional announcements and introductory messaging to reflect the new end date.
  * Added notice of the August 25 promotion extension.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->