### PR TITLE
feat(models): add status filter chips

### DIFF
--- a/apps/ui/src/components/models/model-status-badge-auto.tsx
+++ b/apps/ui/src/components/models/model-status-badge-auto.tsx
@@ -29,7 +29,10 @@ export function ModelStatusBadgeAuto({ providers }: ModelStatusBadgeAutoProps) {
 
 	if (showDeactivationStatus) {
 		const allPast = providers.every((p) => new Date(p.deactivatedAt!) <= now);
-		return <ModelStatusBadge status="deactivated" isPast={allPast} />;
+		if (allPast) {
+			return <ModelStatusBadge status="deactivated" isPast />;
+		}
+		return <ModelStatusBadge status="scheduled" />;
 	}
 
 	if (allHaveDeprecatedAt) {

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -75,6 +75,7 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import {
+	getMappingStatus,
 	isModelMappingStatus,
 	shouldShowDeactivationNotice,
 	type ModelMappingStatus,
@@ -86,6 +87,7 @@ import { matchesCapability } from "./capability-filters";
 import { formatDeprecationDate, formatPerImagePriceRange } from "./format";
 import { ModelCard } from "./model-card";
 import { applyCategoryFilter } from "./model-category-filters";
+import { ModelStatusBadge } from "./model-status-badge";
 import { isVisibleMapping } from "./status-filters";
 import {
 	applyUseCaseFilter,
@@ -174,6 +176,9 @@ interface FlattenedModelRow {
 	rowKey: string;
 	capabilities: CapabilityIcon[];
 	ProviderIcon: React.ComponentType<{ className?: string }> | null;
+	isAllDeactivated: boolean;
+	isAllScheduled: boolean;
+	isAllDeprecated: boolean;
 }
 
 // Helper to compute capabilities (moved outside component for performance).
@@ -331,6 +336,8 @@ const ModelTableRow = React.memo(
 		const blockedReasons = row.provider.blockedReasons ?? [];
 		const isBlocked = blockedReasons.length > 0;
 		const showDeactivationNotice = shouldShowDeactivationNotice(row.provider);
+		const mappingStatus = getMappingStatus(row.provider);
+		const isScheduled = mappingStatus === "scheduled";
 
 		return (
 			<>
@@ -436,7 +443,11 @@ const ModelTableRow = React.memo(
 								<Tooltip>
 									<TooltipTrigger asChild>
 										<span className="shrink-0 cursor-help">
-											<AlertCircle className="h-3.5 w-3.5 text-red-500" />
+											{isScheduled ? (
+												<Clock className="h-3.5 w-3.5 text-amber-500" />
+											) : (
+												<AlertCircle className="h-3.5 w-3.5 text-red-500" />
+											)}
 										</span>
 									</TooltipTrigger>
 									<TooltipContent>
@@ -502,6 +513,13 @@ const ModelTableRow = React.memo(
 										</p>
 									</TooltipContent>
 								</Tooltip>
+							)}
+							{row.isAllDeactivated && (
+								<ModelStatusBadge status="deactivated" isPast />
+							)}
+							{row.isAllScheduled && <ModelStatusBadge status="scheduled" />}
+							{row.isAllDeprecated && (
+								<ModelStatusBadge status="deprecated" isPast />
 							)}
 							<button
 								onClick={(e) => {
@@ -1433,6 +1451,27 @@ export function AllModels({
 				: null;
 
 		for (const model of modelsWithProviders) {
+			// Model-level retirement state — all visible mappings share a
+			// status. The filter (any-mapping) decides *whether* a model
+			// appears; this decides *how* its name badge renders.
+			const isAllDeactivated =
+				model.providerDetails.length > 0 &&
+				model.providerDetails.every(
+					({ provider }) => getMappingStatus(provider) === "deactivated",
+				);
+			const isAllScheduled =
+				!isAllDeactivated &&
+				model.providerDetails.length > 0 &&
+				model.providerDetails.every(
+					({ provider }) => getMappingStatus(provider) === "scheduled",
+				);
+			const isAllDeprecated =
+				!isAllDeactivated &&
+				!isAllScheduled &&
+				model.providerDetails.length > 0 &&
+				model.providerDetails.every(
+					({ provider }) => getMappingStatus(provider) === "deprecated",
+				);
 			for (const { provider, providerInfo } of model.providerDetails) {
 				// Single source of truth for which rows belong in the filtered
 				// table: provider, capability, category, and use-case filters
@@ -1474,6 +1513,9 @@ export function AllModels({
 					rowKey: `${provider.providerId}-${model.id}-${provider.region ?? ""}`,
 					capabilities: computeCapabilities(provider, model),
 					ProviderIcon: getProviderIcon(provider.providerId),
+					isAllDeactivated,
+					isAllScheduled,
+					isAllDeprecated,
 				});
 			}
 		}

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -75,7 +75,9 @@ import {
 } from "@/components/ui/tooltip";
 import {
 	isMappingDeactivated,
+	isModelMappingStatus,
 	shouldShowDeactivationNotice,
+	type ModelMappingStatus,
 } from "@/deactivation";
 import { discountFraction } from "@/lib/discount";
 import { cn } from "@/lib/utils";
@@ -846,6 +848,20 @@ export function AllModels({
 				: "asc",
 	);
 	const urlCategory = searchParams.get("category");
+
+	// The status chips are single-select: `?status=` holds at most one value.
+	// Legacy `?deactivated=true` links map onto the Deactivated chip so old
+	// URLs keep working. No param means the default view (no status filter).
+	function getStatusFilterFromUrl(
+		searchParams: URLSearchParams,
+	): ModelMappingStatus | null {
+		const status = searchParams.get("status");
+		if (status && isModelMappingStatus(status)) {
+			return status;
+		}
+		return searchParams.get("deactivated") === "true" ? "deactivated" : null;
+	}
+
 	const [filters, setFilters] = useState({
 		// With the selector hidden there is no way to see or change the
 		// category, so ignore any URL override and pin the default. When the
@@ -876,6 +892,7 @@ export function AllModels({
 			discounted: searchParams.get("discounted") === "true",
 		},
 		selectedProvider: searchParams.get("provider") ?? "all",
+		status: getStatusFilterFromUrl(searchParams),
 		showDeactivated: searchParams.get("deactivated") === "true",
 		source: searchParams.get("source") ?? "all",
 		eligibleOnly: searchParams.get("eligibility") === "eligible",
@@ -1541,6 +1558,7 @@ export function AllModels({
 		(filters.tier && filters.tier !== "all") ||
 		Object.values(filters.capabilities).some(Boolean) ||
 		(filters.selectedProvider && filters.selectedProvider !== "all") ||
+		filters.status !== null ||
 		filters.showDeactivated ||
 		(filters.source && filters.source !== "all") ||
 		filters.eligibleOnly ||
@@ -1721,6 +1739,7 @@ export function AllModels({
 				discounted: false,
 			},
 			selectedProvider: "all",
+			status: null,
 			showDeactivated: false,
 			source: "all",
 			eligibleOnly: false,
@@ -1750,6 +1769,7 @@ export function AllModels({
 			free: undefined,
 			discounted: undefined,
 			provider: undefined,
+			status: undefined,
 			deactivated: undefined,
 			source: undefined,
 			eligibility: undefined,

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -2148,18 +2148,20 @@ export function AllModels({
 						<div className="flex flex-col items-start gap-1.5">
 							<Tooltip>
 								<TooltipTrigger asChild>
-									<Toggle
-										variant="outline"
-										size="sm"
-										pressed={filters.status === "deactivated"}
-										onPressedChange={(pressed) => {
-											setStatusFilter(pressed ? "deactivated" : null);
-										}}
-										className="gap-1.5 w-fit"
-									>
-										<AlertCircle className="h-3.5 w-3.5 text-red-500" />
-										<span className="text-xs">Deactivated</span>
-									</Toggle>
+									<span>
+										<Toggle
+											variant="outline"
+											size="sm"
+											pressed={filters.status === "deactivated"}
+											onPressedChange={(pressed) => {
+												setStatusFilter(pressed ? "deactivated" : null);
+											}}
+											className="gap-1.5 w-fit"
+										>
+											<AlertCircle className="h-3.5 w-3.5 text-red-500" />
+											<span className="text-xs">Deactivated</span>
+										</Toggle>
+									</span>
 								</TooltipTrigger>
 								<TooltipContent>
 									<p className="text-xs">
@@ -2169,18 +2171,20 @@ export function AllModels({
 							</Tooltip>
 							<Tooltip>
 								<TooltipTrigger asChild>
-									<Toggle
-										variant="outline"
-										size="sm"
-										pressed={filters.status === "scheduled"}
-										onPressedChange={(pressed) => {
-											setStatusFilter(pressed ? "scheduled" : null);
-										}}
-										className="gap-1.5 w-fit"
-									>
-										<Clock className="h-3.5 w-3.5 text-amber-500" />
-										<span className="text-xs">Scheduled</span>
-									</Toggle>
+									<span>
+										<Toggle
+											variant="outline"
+											size="sm"
+											pressed={filters.status === "scheduled"}
+											onPressedChange={(pressed) => {
+												setStatusFilter(pressed ? "scheduled" : null);
+											}}
+											className="gap-1.5 w-fit"
+										>
+											<Clock className="h-3.5 w-3.5 text-amber-500" />
+											<span className="text-xs">Scheduled</span>
+										</Toggle>
+									</span>
 								</TooltipTrigger>
 								<TooltipContent>
 									<p className="text-xs">
@@ -2191,18 +2195,20 @@ export function AllModels({
 							</Tooltip>
 							<Tooltip>
 								<TooltipTrigger asChild>
-									<Toggle
-										variant="outline"
-										size="sm"
-										pressed={filters.status === "deprecated"}
-										onPressedChange={(pressed) => {
-											setStatusFilter(pressed ? "deprecated" : null);
-										}}
-										className="gap-1.5 w-fit"
-									>
-										<AlertTriangle className="h-3.5 w-3.5 text-amber-500" />
-										<span className="text-xs">Deprecated</span>
-									</Toggle>
+									<span>
+										<Toggle
+											variant="outline"
+											size="sm"
+											pressed={filters.status === "deprecated"}
+											onPressedChange={(pressed) => {
+												setStatusFilter(pressed ? "deprecated" : null);
+											}}
+											className="gap-1.5 w-fit"
+										>
+											<AlertTriangle className="h-3.5 w-3.5 text-amber-500" />
+											<span className="text-xs">Deprecated</span>
+										</Toggle>
+									</span>
 								</TooltipTrigger>
 								<TooltipContent>
 									<p className="text-xs">
@@ -2212,18 +2218,20 @@ export function AllModels({
 							</Tooltip>
 							<Tooltip>
 								<TooltipTrigger asChild>
-									<Toggle
-										variant="outline"
-										size="sm"
-										pressed={filters.status === "active"}
-										onPressedChange={(pressed) => {
-											setStatusFilter(pressed ? "active" : null);
-										}}
-										className="gap-1.5 w-fit"
-									>
-										<Check className="h-3.5 w-3.5 text-green-500" />
-										<span className="text-xs">Active</span>
-									</Toggle>
+									<span>
+										<Toggle
+											variant="outline"
+											size="sm"
+											pressed={filters.status === "active"}
+											onPressedChange={(pressed) => {
+												setStatusFilter(pressed ? "active" : null);
+											}}
+											className="gap-1.5 w-fit"
+										>
+											<Check className="h-3.5 w-3.5 text-green-500" />
+											<span className="text-xs">Active</span>
+										</Toggle>
+									</span>
 								</TooltipTrigger>
 								<TooltipContent>
 									<p className="text-xs">Healthy / no retirement notices</p>

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -2145,7 +2145,7 @@ export function AllModels({
 						)}
 
 						<div className="font-medium text-sm">Status</div>
-						<div className="flex flex-wrap gap-2">
+						<div className="flex flex-col gap-1.5">
 							<Toggle
 								variant="outline"
 								size="sm"
@@ -2153,7 +2153,7 @@ export function AllModels({
 								onPressedChange={(pressed) => {
 									setStatusFilter(pressed ? "deactivated" : null);
 								}}
-								className="gap-1.5"
+								className="w-full justify-start gap-1.5"
 							>
 								<AlertCircle className="h-3.5 w-3.5 text-red-500" />
 								<span className="text-xs">Deactivated</span>
@@ -2165,7 +2165,7 @@ export function AllModels({
 								onPressedChange={(pressed) => {
 									setStatusFilter(pressed ? "scheduled" : null);
 								}}
-								className="gap-1.5"
+								className="w-full justify-start gap-1.5"
 							>
 								<Clock className="h-3.5 w-3.5 text-amber-500" />
 								<span className="text-xs">Scheduled</span>
@@ -2177,7 +2177,7 @@ export function AllModels({
 								onPressedChange={(pressed) => {
 									setStatusFilter(pressed ? "deprecated" : null);
 								}}
-								className="gap-1.5"
+								className="w-full justify-start gap-1.5"
 							>
 								<AlertTriangle className="h-3.5 w-3.5 text-amber-500" />
 								<span className="text-xs">Deprecated</span>
@@ -2189,7 +2189,7 @@ export function AllModels({
 								onPressedChange={(pressed) => {
 									setStatusFilter(pressed ? "active" : null);
 								}}
-								className="gap-1.5"
+								className="w-full justify-start gap-1.5"
 							>
 								<Check className="h-3.5 w-3.5 text-green-500" />
 								<span className="text-xs">Active</span>

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -864,7 +864,7 @@ export function AllModels({
 		searchParams: URLSearchParams,
 	): ModelMappingStatus | null {
 		const status = searchParams.get("status");
-		if (status && isModelMappingStatus(status)) {
+		if (status && isModelMappingStatus(status) && status !== "active") {
 			return status;
 		}
 		return searchParams.get("deactivated") === "true" ? "deactivated" : null;
@@ -2214,27 +2214,6 @@ export function AllModels({
 									<p className="text-xs">
 										Still works / provider announced sunset, migrate soon
 									</p>
-								</TooltipContent>
-							</Tooltip>
-							<Tooltip>
-								<TooltipTrigger asChild>
-									<span>
-										<Toggle
-											variant="outline"
-											size="sm"
-											pressed={filters.status === "active"}
-											onPressedChange={(pressed) => {
-												setStatusFilter(pressed ? "active" : null);
-											}}
-											className="gap-1.5 w-fit"
-										>
-											<Check className="h-3.5 w-3.5 text-green-500" />
-											<span className="text-xs">Active</span>
-										</Toggle>
-									</span>
-								</TooltipTrigger>
-								<TooltipContent>
-									<p className="text-xs">Healthy / no retirement notices</p>
 								</TooltipContent>
 							</Tooltip>
 							{hasBlockedMappings && (

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -41,6 +41,7 @@ import {
 	Volume2,
 	Mic,
 	ListOrdered,
+	Clock,
 } from "lucide-react";
 import Link from "next/link.js";
 import { usePathname, useRouter, useSearchParams } from "next/navigation.js";
@@ -893,7 +894,6 @@ export function AllModels({
 		},
 		selectedProvider: searchParams.get("provider") ?? "all",
 		status: getStatusFilterFromUrl(searchParams),
-		showDeactivated: searchParams.get("deactivated") === "true",
 		source: searchParams.get("source") ?? "all",
 		eligibleOnly: searchParams.get("eligibility") === "eligible",
 		inputPrice: {
@@ -939,6 +939,18 @@ export function AllModels({
 		[router, searchParams],
 	);
 
+	const setStatusFilter = useCallback(
+		(status: ModelMappingStatus | null) => {
+			setFilters((prev) => ({ ...prev, status }));
+			updateUrlWithFilters({
+				status: status ?? undefined,
+				deactivated: undefined,
+				page: undefined,
+			});
+		},
+		[updateUrlWithFilters],
+	);
+
 	// Calculate total counts (excluding deprecated and deactivated models)
 	const { totalModelCount, totalProviderCount } = useMemo(() => {
 		const now = new Date();
@@ -950,7 +962,7 @@ export function AllModels({
 					mapping,
 					{
 						status: filters.status,
-						showDeactivated: filters.showDeactivated,
+						showDeactivated: false,
 						eligibleOnly: filters.eligibleOnly,
 					},
 					now,
@@ -962,13 +974,7 @@ export function AllModels({
 			totalModelCount: visibleModelCount,
 			totalProviderCount: providers.length,
 		};
-	}, [
-		models,
-		providers,
-		filters.status,
-		filters.showDeactivated,
-		filters.eligibleOnly,
-	]);
+	}, [models, providers, filters.status, filters.eligibleOnly]);
 
 	const modelsWithProviders: ModelWithProviders[] = useMemo(() => {
 		const now = new Date();
@@ -992,7 +998,7 @@ export function AllModels({
 						mapping,
 						{
 							status: filters.status,
-							showDeactivated: filters.showDeactivated,
+							showDeactivated: false,
 							eligibleOnly: filters.eligibleOnly,
 						},
 						now,
@@ -1570,7 +1576,6 @@ export function AllModels({
 		Object.values(filters.capabilities).some(Boolean) ||
 		(filters.selectedProvider && filters.selectedProvider !== "all") ||
 		filters.status !== null ||
-		filters.showDeactivated ||
 		(filters.source && filters.source !== "all") ||
 		filters.eligibleOnly ||
 		filters.inputPrice.min ||
@@ -1751,7 +1756,6 @@ export function AllModels({
 			},
 			selectedProvider: "all",
 			status: null,
-			showDeactivated: false,
 			source: "all",
 			eligibleOnly: false,
 			inputPrice: { min: "", max: "" },
@@ -2138,18 +2142,50 @@ export function AllModels({
 							<Toggle
 								variant="outline"
 								size="sm"
-								pressed={filters.showDeactivated}
+								pressed={filters.status === "deactivated"}
 								onPressedChange={(pressed) => {
-									setFilters((prev) => ({ ...prev, showDeactivated: pressed }));
-									updateUrlWithFilters({
-										deactivated: pressed ? "true" : undefined,
-										page: undefined,
-									});
+									setStatusFilter(pressed ? "deactivated" : null);
 								}}
 								className="gap-1.5"
 							>
 								<AlertCircle className="h-3.5 w-3.5 text-red-500" />
-								<span className="text-xs">Show deactivated</span>
+								<span className="text-xs">Deactivated</span>
+							</Toggle>
+							<Toggle
+								variant="outline"
+								size="sm"
+								pressed={filters.status === "scheduled"}
+								onPressedChange={(pressed) => {
+									setStatusFilter(pressed ? "scheduled" : null);
+								}}
+								className="gap-1.5"
+							>
+								<Clock className="h-3.5 w-3.5 text-amber-500" />
+								<span className="text-xs">Scheduled</span>
+							</Toggle>
+							<Toggle
+								variant="outline"
+								size="sm"
+								pressed={filters.status === "deprecated"}
+								onPressedChange={(pressed) => {
+									setStatusFilter(pressed ? "deprecated" : null);
+								}}
+								className="gap-1.5"
+							>
+								<AlertTriangle className="h-3.5 w-3.5 text-amber-500" />
+								<span className="text-xs">Deprecated</span>
+							</Toggle>
+							<Toggle
+								variant="outline"
+								size="sm"
+								pressed={filters.status === "active"}
+								onPressedChange={(pressed) => {
+									setStatusFilter(pressed ? "active" : null);
+								}}
+								className="gap-1.5"
+							>
+								<Check className="h-3.5 w-3.5 text-green-500" />
+								<span className="text-xs">Active</span>
 							</Toggle>
 							{hasBlockedMappings && (
 								<Toggle
@@ -2518,7 +2554,7 @@ export function AllModels({
 														: 0,
 													Object.values(filters.capabilities).filter(Boolean)
 														.length,
-													filters.showDeactivated ? 1 : 0,
+													filters.status ? 1 : 0,
 													filters.source && filters.source !== "all" ? 1 : 0,
 													filters.eligibleOnly ? 1 : 0,
 													[

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -504,7 +504,7 @@ const ModelTableRow = React.memo(
 									</TooltipTrigger>
 									<TooltipContent>
 										<p className="text-xs">
-											Premium tier — $5+/M input or $15+/M output. Subject to
+											Premium tier / $5+/M input or $15+/M output. Subject to
 											the weekly fair-use allowance on DevPass plans.
 										</p>
 									</TooltipContent>
@@ -1879,7 +1879,7 @@ export function AllModels({
 
 						{showPricingTierFilter ? (
 							<>
-								{/* Pricing tier — stacked under Use Case (or standing in
+								{/* Pricing tier / stacked under Use Case (or standing in
 								    for it when that select is hidden) to keep the filter
 								    grid on a single row */}
 								<div className="font-medium text-sm">
@@ -2163,7 +2163,7 @@ export function AllModels({
 								</TooltipTrigger>
 								<TooltipContent>
 									<p className="text-xs">
-										Dead — requests return errors and no longer route
+										Dead / requests return errors and no longer route
 									</p>
 								</TooltipContent>
 							</Tooltip>
@@ -2184,7 +2184,7 @@ export function AllModels({
 								</TooltipTrigger>
 								<TooltipContent>
 									<p className="text-xs">
-										Still works — deactivation scheduled within 90 days, plan to
+										Still works / deactivation scheduled within 90 days, plan to
 										migrate
 									</p>
 								</TooltipContent>
@@ -2206,7 +2206,7 @@ export function AllModels({
 								</TooltipTrigger>
 								<TooltipContent>
 									<p className="text-xs">
-										Still works — provider announced sunset, migrate soon
+										Still works / provider announced sunset, migrate soon
 									</p>
 								</TooltipContent>
 							</Tooltip>
@@ -2226,7 +2226,7 @@ export function AllModels({
 									</Toggle>
 								</TooltipTrigger>
 								<TooltipContent>
-									<p className="text-xs">Healthy — no retirement notices</p>
+									<p className="text-xs">Healthy / no retirement notices</p>
 								</TooltipContent>
 							</Tooltip>
 							{hasBlockedMappings && (

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -2145,7 +2145,7 @@ export function AllModels({
 						)}
 
 						<div className="font-medium text-sm">Status</div>
-						<div className="flex flex-col gap-1.5">
+						<div className="flex flex-col items-start gap-1.5">
 							<Toggle
 								variant="outline"
 								size="sm"
@@ -2153,7 +2153,7 @@ export function AllModels({
 								onPressedChange={(pressed) => {
 									setStatusFilter(pressed ? "deactivated" : null);
 								}}
-								className="w-full justify-start gap-1.5"
+								className="gap-1.5 w-fit"
 							>
 								<AlertCircle className="h-3.5 w-3.5 text-red-500" />
 								<span className="text-xs">Deactivated</span>
@@ -2165,7 +2165,7 @@ export function AllModels({
 								onPressedChange={(pressed) => {
 									setStatusFilter(pressed ? "scheduled" : null);
 								}}
-								className="w-full justify-start gap-1.5"
+								className="gap-1.5 w-fit"
 							>
 								<Clock className="h-3.5 w-3.5 text-amber-500" />
 								<span className="text-xs">Scheduled</span>
@@ -2177,7 +2177,7 @@ export function AllModels({
 								onPressedChange={(pressed) => {
 									setStatusFilter(pressed ? "deprecated" : null);
 								}}
-								className="w-full justify-start gap-1.5"
+								className="gap-1.5 w-fit"
 							>
 								<AlertTriangle className="h-3.5 w-3.5 text-amber-500" />
 								<span className="text-xs">Deprecated</span>
@@ -2189,7 +2189,7 @@ export function AllModels({
 								onPressedChange={(pressed) => {
 									setStatusFilter(pressed ? "active" : null);
 								}}
-								className="w-full justify-start gap-1.5"
+								className="gap-1.5 w-fit"
 							>
 								<Check className="h-3.5 w-3.5 text-green-500" />
 								<span className="text-xs">Active</span>

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -2146,54 +2146,89 @@ export function AllModels({
 
 						<div className="font-medium text-sm">Status</div>
 						<div className="flex flex-col items-start gap-1.5">
-							<Toggle
-								variant="outline"
-								size="sm"
-								pressed={filters.status === "deactivated"}
-								onPressedChange={(pressed) => {
-									setStatusFilter(pressed ? "deactivated" : null);
-								}}
-								className="gap-1.5 w-fit"
-							>
-								<AlertCircle className="h-3.5 w-3.5 text-red-500" />
-								<span className="text-xs">Deactivated</span>
-							</Toggle>
-							<Toggle
-								variant="outline"
-								size="sm"
-								pressed={filters.status === "scheduled"}
-								onPressedChange={(pressed) => {
-									setStatusFilter(pressed ? "scheduled" : null);
-								}}
-								className="gap-1.5 w-fit"
-							>
-								<Clock className="h-3.5 w-3.5 text-amber-500" />
-								<span className="text-xs">Scheduled</span>
-							</Toggle>
-							<Toggle
-								variant="outline"
-								size="sm"
-								pressed={filters.status === "deprecated"}
-								onPressedChange={(pressed) => {
-									setStatusFilter(pressed ? "deprecated" : null);
-								}}
-								className="gap-1.5 w-fit"
-							>
-								<AlertTriangle className="h-3.5 w-3.5 text-amber-500" />
-								<span className="text-xs">Deprecated</span>
-							</Toggle>
-							<Toggle
-								variant="outline"
-								size="sm"
-								pressed={filters.status === "active"}
-								onPressedChange={(pressed) => {
-									setStatusFilter(pressed ? "active" : null);
-								}}
-								className="gap-1.5 w-fit"
-							>
-								<Check className="h-3.5 w-3.5 text-green-500" />
-								<span className="text-xs">Active</span>
-							</Toggle>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<Toggle
+										variant="outline"
+										size="sm"
+										pressed={filters.status === "deactivated"}
+										onPressedChange={(pressed) => {
+											setStatusFilter(pressed ? "deactivated" : null);
+										}}
+										className="gap-1.5 w-fit"
+									>
+										<AlertCircle className="h-3.5 w-3.5 text-red-500" />
+										<span className="text-xs">Deactivated</span>
+									</Toggle>
+								</TooltipTrigger>
+								<TooltipContent>
+									<p className="text-xs">
+										Dead — requests return errors and no longer route
+									</p>
+								</TooltipContent>
+							</Tooltip>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<Toggle
+										variant="outline"
+										size="sm"
+										pressed={filters.status === "scheduled"}
+										onPressedChange={(pressed) => {
+											setStatusFilter(pressed ? "scheduled" : null);
+										}}
+										className="gap-1.5 w-fit"
+									>
+										<Clock className="h-3.5 w-3.5 text-amber-500" />
+										<span className="text-xs">Scheduled</span>
+									</Toggle>
+								</TooltipTrigger>
+								<TooltipContent>
+									<p className="text-xs">
+										Still works — deactivation scheduled within 90 days, plan to
+										migrate
+									</p>
+								</TooltipContent>
+							</Tooltip>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<Toggle
+										variant="outline"
+										size="sm"
+										pressed={filters.status === "deprecated"}
+										onPressedChange={(pressed) => {
+											setStatusFilter(pressed ? "deprecated" : null);
+										}}
+										className="gap-1.5 w-fit"
+									>
+										<AlertTriangle className="h-3.5 w-3.5 text-amber-500" />
+										<span className="text-xs">Deprecated</span>
+									</Toggle>
+								</TooltipTrigger>
+								<TooltipContent>
+									<p className="text-xs">
+										Still works — provider announced sunset, migrate soon
+									</p>
+								</TooltipContent>
+							</Tooltip>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<Toggle
+										variant="outline"
+										size="sm"
+										pressed={filters.status === "active"}
+										onPressedChange={(pressed) => {
+											setStatusFilter(pressed ? "active" : null);
+										}}
+										className="gap-1.5 w-fit"
+									>
+										<Check className="h-3.5 w-3.5 text-green-500" />
+										<span className="text-xs">Active</span>
+									</Toggle>
+								</TooltipTrigger>
+								<TooltipContent>
+									<p className="text-xs">Healthy — no retirement notices</p>
+								</TooltipContent>
+							</Tooltip>
 							{hasBlockedMappings && (
 								<Toggle
 									variant="outline"

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -74,7 +74,6 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import {
-	isMappingDeactivated,
 	isModelMappingStatus,
 	shouldShowDeactivationNotice,
 	type ModelMappingStatus,
@@ -86,6 +85,7 @@ import { matchesCapability } from "./capability-filters";
 import { formatDeprecationDate, formatPerImagePriceRange } from "./format";
 import { ModelCard } from "./model-card";
 import { applyCategoryFilter } from "./model-category-filters";
+import { isVisibleMapping } from "./status-filters";
 import {
 	applyUseCaseFilter,
 	isUseCaseCategory,
@@ -945,19 +945,30 @@ export function AllModels({
 
 		// Count models that have at least one visible mapping
 		const visibleModelCount = models.filter((model) =>
-			model.mappings.some((mapping) => {
-				if (mapping.deprecatedAt && new Date(mapping.deprecatedAt) <= now) {
-					return false;
-				}
-				return filters.showDeactivated || !isMappingDeactivated(mapping, now);
-			}),
+			model.mappings.some((mapping) =>
+				isVisibleMapping(
+					mapping,
+					{
+						status: filters.status,
+						showDeactivated: filters.showDeactivated,
+						eligibleOnly: filters.eligibleOnly,
+					},
+					now,
+				),
+			),
 		).length;
 
 		return {
 			totalModelCount: visibleModelCount,
 			totalProviderCount: providers.length,
 		};
-	}, [models, providers, filters.showDeactivated]);
+	}, [
+		models,
+		providers,
+		filters.status,
+		filters.showDeactivated,
+		filters.eligibleOnly,
+	]);
 
 	const modelsWithProviders: ModelWithProviders[] = useMemo(() => {
 		const now = new Date();
@@ -974,19 +985,19 @@ export function AllModels({
 			})
 			.map((model) => {
 				// Filter out deprecated provider mappings, plus deactivated ones
-				// unless the visitor opted into seeing them
-				const visibleMappings = model.mappings.filter((mapping) => {
-					if (mapping.deprecatedAt && new Date(mapping.deprecatedAt) <= now) {
-						return false;
-					}
-					if (!filters.showDeactivated && isMappingDeactivated(mapping, now)) {
-						return false;
-					}
-					if (filters.eligibleOnly && mapping.blockedReasons?.length) {
-						return false;
-					}
-					return true;
-				});
+				// unless the visitor opted into seeing them; with a status chip
+				// active only mappings of exactly that status remain
+				const visibleMappings = model.mappings.filter((mapping) =>
+					isVisibleMapping(
+						mapping,
+						{
+							status: filters.status,
+							showDeactivated: filters.showDeactivated,
+							eligibleOnly: filters.eligibleOnly,
+						},
+						now,
+					),
+				);
 
 				return {
 					...model,

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -87,7 +87,6 @@ import { matchesCapability } from "./capability-filters";
 import { formatDeprecationDate, formatPerImagePriceRange } from "./format";
 import { ModelCard } from "./model-card";
 import { applyCategoryFilter } from "./model-category-filters";
-import { ModelStatusBadge } from "./model-status-badge";
 import { isVisibleMapping } from "./status-filters";
 import {
 	applyUseCaseFilter,
@@ -176,9 +175,6 @@ interface FlattenedModelRow {
 	rowKey: string;
 	capabilities: CapabilityIcon[];
 	ProviderIcon: React.ComponentType<{ className?: string }> | null;
-	isAllDeactivated: boolean;
-	isAllScheduled: boolean;
-	isAllDeprecated: boolean;
 }
 
 // Helper to compute capabilities (moved outside component for performance).
@@ -513,13 +509,6 @@ const ModelTableRow = React.memo(
 										</p>
 									</TooltipContent>
 								</Tooltip>
-							)}
-							{row.isAllDeactivated && (
-								<ModelStatusBadge status="deactivated" isPast />
-							)}
-							{row.isAllScheduled && <ModelStatusBadge status="scheduled" />}
-							{row.isAllDeprecated && (
-								<ModelStatusBadge status="deprecated" isPast />
 							)}
 							<button
 								onClick={(e) => {
@@ -1451,27 +1440,6 @@ export function AllModels({
 				: null;
 
 		for (const model of modelsWithProviders) {
-			// Model-level retirement state — all visible mappings share a
-			// status. The filter (any-mapping) decides *whether* a model
-			// appears; this decides *how* its name badge renders.
-			const isAllDeactivated =
-				model.providerDetails.length > 0 &&
-				model.providerDetails.every(
-					({ provider }) => getMappingStatus(provider) === "deactivated",
-				);
-			const isAllScheduled =
-				!isAllDeactivated &&
-				model.providerDetails.length > 0 &&
-				model.providerDetails.every(
-					({ provider }) => getMappingStatus(provider) === "scheduled",
-				);
-			const isAllDeprecated =
-				!isAllDeactivated &&
-				!isAllScheduled &&
-				model.providerDetails.length > 0 &&
-				model.providerDetails.every(
-					({ provider }) => getMappingStatus(provider) === "deprecated",
-				);
 			for (const { provider, providerInfo } of model.providerDetails) {
 				// Single source of truth for which rows belong in the filtered
 				// table: provider, capability, category, and use-case filters
@@ -1513,9 +1481,6 @@ export function AllModels({
 					rowKey: `${provider.providerId}-${model.id}-${provider.region ?? ""}`,
 					capabilities: computeCapabilities(provider, model),
 					ProviderIcon: getProviderIcon(provider.providerId),
-					isAllDeactivated,
-					isAllScheduled,
-					isAllDeprecated,
 				});
 			}
 		}

--- a/packages/shared/src/components/models-directory/model-card.tsx
+++ b/packages/shared/src/components/models-directory/model-card.tsx
@@ -5,6 +5,7 @@ import {
 	AlertCircle,
 	Ban,
 	CalendarClock,
+	Clock,
 	Copy,
 	Check,
 	ChevronDown,
@@ -33,7 +34,12 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { shouldShowDeactivationNotice } from "@/deactivation";
+import {
+	isDeactivationScheduledSoon,
+	isMappingDeactivated,
+	MODEL_DEACTIVATION_NOTICE_DAYS,
+	shouldShowDeactivationNotice,
+} from "@/deactivation";
 import { cn } from "@/lib/utils";
 
 import { formatContextSize, formatDeprecationDate } from "./format";
@@ -191,6 +197,12 @@ export function ModelCard({
 		allHaveDeactivatedAt &&
 		model.providerDetails.every(
 			({ provider }) => new Date(provider.deactivatedAt!) <= now,
+		);
+	const isAllScheduled =
+		allHaveDeactivatedAt &&
+		!deactivationAllPast &&
+		model.providerDetails.every(({ provider }) =>
+			shouldShowDeactivationNotice(provider, now),
 		);
 	const deprecationAllPast =
 		allHaveDeprecatedAt &&
@@ -376,12 +388,10 @@ export function ModelCard({
 									</TooltipContent>
 								</Tooltip>
 							)}
-							{showModelDeactivationStatus && (
-								<ModelStatusBadge
-									status="deactivated"
-									isPast={deactivationAllPast}
-								/>
+							{deactivationAllPast && (
+								<ModelStatusBadge status="deactivated" isPast />
 							)}
+							{isAllScheduled && <ModelStatusBadge status="scheduled" />}
 							{allHaveDeprecatedAt && (
 								<ModelStatusBadge
 									status="deprecated"
@@ -620,7 +630,15 @@ export function ProviderSection({
 	const [selectedServiceTierId, setSelectedServiceTierId] =
 		useState("standard");
 	const activeMapping = mappings[activeRegionIdx] ?? mappings[0];
-	const showDeactivationNotice = shouldShowDeactivationNotice(activeMapping);
+	const isDeactivated = isMappingDeactivated(activeMapping);
+	const isScheduled =
+		!isDeactivated &&
+		isDeactivationScheduledSoon(
+			activeMapping,
+			undefined,
+			MODEL_DEACTIVATION_NOTICE_DAYS,
+		);
+	const showDeactivationNotice = isDeactivated || isScheduled;
 	const hasMappingDetails =
 		(activeMapping.reasoningEfforts?.length ?? 0) > 0 ||
 		(activeMapping.supportedParameters?.length ?? 0) > 0;
@@ -838,12 +856,24 @@ export function ProviderSection({
 								)}
 							</Badge>
 						)}
-						{showDeactivationNotice && (
+						{isDeactivated && (
 							<Badge
 								variant="outline"
 								className="text-[10px] px-2 py-0.5 gap-1 bg-red-500/5 text-red-600 dark:text-red-400 border-red-500/20"
 							>
 								<AlertCircle className="h-2.5 w-2.5" />
+								{formatDeprecationDate(
+									activeMapping.deactivatedAt!,
+									"deactivated",
+								)}
+							</Badge>
+						)}
+						{isScheduled && (
+							<Badge
+								variant="outline"
+								className="text-[10px] px-2 py-0.5 gap-1 bg-amber-500/5 text-amber-600 dark:text-amber-400 border-amber-500/20"
+							>
+								<Clock className="h-2.5 w-2.5" />
 								{formatDeprecationDate(
 									activeMapping.deactivatedAt!,
 									"deactivated",

--- a/packages/shared/src/components/models-directory/model-status-badge.tsx
+++ b/packages/shared/src/components/models-directory/model-status-badge.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AlertCircle, AlertTriangle } from "lucide-react";
+import { AlertCircle, AlertTriangle, Clock } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import {
@@ -11,28 +11,33 @@ import {
 } from "@/components/ui/tooltip";
 
 interface ModelStatusBadgeProps {
-	status: "deactivated" | "deprecated";
-	isPast: boolean;
+	status: "deactivated" | "deprecated" | "scheduled";
+	isPast?: boolean;
 }
 
 export function ModelStatusBadge({ status, isPast }: ModelStatusBadgeProps) {
+	const isScheduled = status === "scheduled";
 	const isDeactivated = status === "deactivated";
 
-	const title = isPast
-		? isDeactivated
-			? "Model Deactivated"
-			: "Model Deprecated"
-		: isDeactivated
-			? "Scheduled for Deactivation"
-			: "Scheduled for Deprecation";
+	const title = isScheduled
+		? "Scheduled for Deactivation"
+		: isPast
+			? isDeactivated
+				? "Model Deactivated"
+				: "Model Deprecated"
+			: isDeactivated
+				? "Scheduled for Deactivation"
+				: "Scheduled for Deprecation";
 
-	const description = isPast
-		? isDeactivated
-			? "All providers for this model have been deactivated. Requests will return errors."
-			: "All providers for this model have been deprecated. The model still works but may be removed in the future."
-		: isDeactivated
-			? "All providers for this model are scheduled to be deactivated. Plan to migrate to an alternative model."
-			: "All providers for this model are scheduled for deprecation. Consider migrating to an alternative model.";
+	const description = isScheduled
+		? "All providers for this model are scheduled to be deactivated. Plan to migrate to an alternative model."
+		: isPast
+			? isDeactivated
+				? "All providers for this model have been deactivated. Requests will return errors."
+				: "All providers for this model have been deprecated. The model still works but may be removed in the future."
+			: isDeactivated
+				? "All providers for this model are scheduled to be deactivated. Plan to migrate to an alternative model."
+				: "All providers for this model are scheduled for deprecation. Consider migrating to an alternative model.";
 
 	return (
 		<TooltipProvider delayDuration={300}>
@@ -43,11 +48,15 @@ export function ModelStatusBadge({ status, isPast }: ModelStatusBadgeProps) {
 						className={`text-xs md:text-sm px-2 md:px-3 py-1 gap-1.5 cursor-help ${
 							isDeactivated
 								? "bg-red-50 dark:bg-red-500/5 text-red-700 dark:text-red-400 border-red-200 dark:border-red-500/20"
-								: "bg-amber-50 dark:bg-amber-500/5 text-amber-700 dark:text-amber-400 border-amber-200 dark:border-amber-500/20"
+								: isScheduled
+									? "bg-amber-50 dark:bg-amber-500/5 text-amber-700 dark:text-amber-400 border-amber-200 dark:border-amber-500/20"
+									: "bg-amber-50 dark:bg-amber-500/5 text-amber-700 dark:text-amber-400 border-amber-200 dark:border-amber-500/20"
 						}`}
 					>
 						{isDeactivated ? (
 							<AlertCircle className="h-3 w-3" />
+						) : isScheduled ? (
+							<Clock className="h-3 w-3" />
 						) : (
 							<AlertTriangle className="h-3 w-3" />
 						)}

--- a/packages/shared/src/components/models-directory/status-filters.spec.ts
+++ b/packages/shared/src/components/models-directory/status-filters.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { isMappingDeactivated } from "@/deactivation.js";
+import { getMappingStatus, isMappingDeactivated } from "@/deactivation.js";
 
 import type { ApiModel, ApiModelProviderMapping } from "./api-types";
 
@@ -234,6 +234,20 @@ describe("today's mapping visibility rules (phase 0 baseline)", () => {
 			eligibleOnly: true,
 		});
 		expect(visible.map((m) => m.providerId)).toEqual(["healthy"]);
+	});
+});
+
+describe("getMappingStatus classification of the baseline fixtures", () => {
+	test("classifies each phase-0 fixture exactly once", () => {
+		expect(getMappingStatus(healthy, NOW)).toBe("active");
+		expect(getMappingStatus(scheduledSoon, NOW)).toBe("scheduled");
+		// 91 days out is beyond the directory's 90-day notice window.
+		expect(getMappingStatus(scheduledFar, NOW)).toBe("active");
+		expect(getMappingStatus(deactivated, NOW)).toBe("deactivated");
+		expect(getMappingStatus(deactivatedBoundary, NOW)).toBe("deactivated");
+		expect(getMappingStatus(deprecatedPast, NOW)).toBe("deprecated");
+		expect(getMappingStatus(deprecatedFuture, NOW)).toBe("deprecated");
+		expect(getMappingStatus(deprecatedThenScheduled, NOW)).toBe("scheduled");
 	});
 });
 

--- a/packages/shared/src/components/models-directory/status-filters.spec.ts
+++ b/packages/shared/src/components/models-directory/status-filters.spec.ts
@@ -1,0 +1,292 @@
+import { describe, expect, test } from "vitest";
+
+import { isMappingDeactivated } from "@/deactivation.js";
+
+import type { ApiModel, ApiModelProviderMapping } from "./api-types";
+
+const NOW = new Date("2026-08-25T00:00:00.000Z");
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const daysFromNow = (days: number): string =>
+	new Date(NOW.getTime() + days * DAY_MS).toISOString();
+function makeMapping(
+	overrides: Partial<ApiModelProviderMapping> & { providerId: string },
+): ApiModelProviderMapping {
+	return {
+		id: `mapping-${overrides.providerId}`,
+		createdAt: "2026-01-01T00:00:00.000Z",
+		modelId: "mock-model",
+		externalId: "mock-model",
+		region: null,
+		inputPrice: "1e-6",
+		outputPrice: "3e-6",
+		cachedInputPrice: null,
+		cacheWriteInputPrice: null,
+		cacheWriteInputPrice1h: null,
+		imageInputPrice: null,
+		imageOutputPrice: null,
+		imageInputTokensByResolution: null,
+		imageOutputTokensByResolution: null,
+		inputCharacterPrice: null,
+		outputAudioPrice: null,
+		requestPrice: null,
+		contextSize: 128000,
+		maxOutput: 8192,
+		streaming: true,
+		vision: false,
+		reasoning: false,
+		reasoningOutput: null,
+		reasoningMaxTokens: false,
+		rerank: false,
+		tools: false,
+		jsonOutput: false,
+		jsonOutputSchema: false,
+		webSearch: false,
+		webSearchPrice: null,
+		quantization: null,
+		audio: null,
+		document: null,
+		realtime: null,
+		supportedVoices: null,
+		supportedVideoSizes: null,
+		supportedVideoDurationsSeconds: null,
+		supportedVideoDurationsSecondsImageToVideo: null,
+		supportsVideoAudio: null,
+		supportsVideoWithoutAudio: null,
+		perSecondPrice: null,
+		perImagePrice: null,
+		pricingTiers: null,
+		discount: null,
+		stability: "stable",
+		supportedParameters: null,
+		deprecatedAt: null,
+		deactivatedAt: null,
+		status: "active",
+		...overrides,
+	};
+}
+
+function makeModel(id: string, mappings: ApiModelProviderMapping[]): ApiModel {
+	return {
+		id,
+		createdAt: "2026-01-01T00:00:00.000Z",
+		releasedAt: null,
+		name: id,
+		aliases: null,
+		description: null,
+		family: "mock",
+		free: false,
+		output: ["text"],
+		imageInputRequired: false,
+		stability: "stable",
+		status: "active",
+		mappings,
+	};
+}
+
+interface VisibilityOptions {
+	showDeactivated: boolean;
+	eligibleOnly?: boolean;
+}
+
+/**
+ * Golden reference of the directory's current mapping-visibility rules
+ * (all-models.tsx visibleMappings + zero-mapping model drop). Phase 0 pins
+ * this behavior so the status-chip pipeline must reproduce it when no status
+ * is selected.
+ */
+function todayVisibleMappings(
+	mappings: ApiModelProviderMapping[],
+	{ showDeactivated, eligibleOnly }: VisibilityOptions,
+	now: Date = NOW,
+): ApiModelProviderMapping[] {
+	return mappings.filter((mapping) => {
+		if (mapping.deprecatedAt && new Date(mapping.deprecatedAt) <= now) {
+			return false;
+		}
+		if (!showDeactivated && isMappingDeactivated(mapping, now)) {
+			return false;
+		}
+		if (eligibleOnly && mapping.blockedReasons?.length) {
+			return false;
+		}
+		return true;
+	});
+}
+
+function todayVisibleModels(
+	models: ApiModel[],
+	options: VisibilityOptions,
+	now: Date = NOW,
+): ApiModel[] {
+	return models
+		.map((model) => ({
+			...model,
+			mappings: todayVisibleMappings(model.mappings, options, now),
+		}))
+		.filter((model) => model.mappings.length > 0);
+}
+
+const healthy = makeMapping({ providerId: "healthy" });
+const scheduledSoon = makeMapping({
+	providerId: "scheduled-soon",
+	deactivatedAt: daysFromNow(89),
+});
+const scheduledFar = makeMapping({
+	providerId: "scheduled-far",
+	deactivatedAt: daysFromNow(91),
+});
+const deactivated = makeMapping({
+	providerId: "deactivated",
+	deactivatedAt: daysFromNow(-1),
+});
+const deactivatedBoundary = makeMapping({
+	providerId: "deactivated-boundary",
+	deactivatedAt: NOW.toISOString(),
+});
+const deprecatedPast = makeMapping({
+	providerId: "deprecated-past",
+	deprecatedAt: daysFromNow(-1),
+});
+const deprecatedFuture = makeMapping({
+	providerId: "deprecated-future",
+	deprecatedAt: daysFromNow(30),
+});
+const deprecatedThenScheduled = makeMapping({
+	providerId: "deprecated-then-scheduled",
+	deprecatedAt: daysFromNow(-2),
+	deactivatedAt: daysFromNow(10),
+});
+
+describe("today's mapping visibility rules (phase 0 baseline)", () => {
+	test("default hides past-deactivated and past-deprecated mappings", () => {
+		const visible = todayVisibleMappings(
+			[healthy, deactivated, deprecatedPast],
+			{ showDeactivated: false },
+		);
+		expect(visible.map((m) => m.providerId)).toEqual(["healthy"]);
+	});
+
+	test("scheduled mappings stay visible regardless of the notice window", () => {
+		const visible = todayVisibleMappings(
+			[healthy, scheduledSoon, scheduledFar],
+			{ showDeactivated: false },
+		);
+		expect(visible.map((m) => m.providerId)).toEqual([
+			"healthy",
+			"scheduled-soon",
+			"scheduled-far",
+		]);
+	});
+
+	test("show deactivated reveals past-deactivated mappings", () => {
+		const visible = todayVisibleMappings([healthy, deactivated], {
+			showDeactivated: true,
+		});
+		expect(visible.map((m) => m.providerId)).toEqual([
+			"healthy",
+			"deactivated",
+		]);
+	});
+
+	test("past-deprecated mappings stay hidden even with show deactivated", () => {
+		const visible = todayVisibleMappings([healthy, deprecatedPast], {
+			showDeactivated: true,
+		});
+		expect(visible.map((m) => m.providerId)).toEqual(["healthy"]);
+	});
+
+	test("future-deprecated mappings stay visible", () => {
+		const visible = todayVisibleMappings([healthy, deprecatedFuture], {
+			showDeactivated: false,
+		});
+		expect(visible.map((m) => m.providerId)).toEqual([
+			"healthy",
+			"deprecated-future",
+		]);
+	});
+
+	test("a mapping deprecated in the past is dropped even if deactivation is only scheduled", () => {
+		const visible = todayVisibleMappings([deprecatedThenScheduled], {
+			showDeactivated: true,
+		});
+		expect(visible).toEqual([]);
+	});
+
+	test("deactivation boundary is inclusive: deactivatedAt === now is hidden", () => {
+		const visible = todayVisibleMappings([deactivatedBoundary], {
+			showDeactivated: false,
+		});
+		expect(visible).toEqual([]);
+		expect(
+			todayVisibleMappings([deactivatedBoundary], { showDeactivated: true }),
+		).toHaveLength(1);
+	});
+
+	test("eligibleOnly drops blocked mappings", () => {
+		const blocked = makeMapping({
+			providerId: "blocked",
+			blockedReasons: ["compliance"],
+		});
+		const visible = todayVisibleMappings([healthy, blocked], {
+			showDeactivated: false,
+			eligibleOnly: true,
+		});
+		expect(visible.map((m) => m.providerId)).toEqual(["healthy"]);
+	});
+});
+
+describe("today's model visibility rules (phase 0 baseline)", () => {
+	test("a fully deactivated model is dropped by default and restored by the toggle", () => {
+		const dead = makeModel("dead-model", [
+			makeMapping({ providerId: "a", deactivatedAt: daysFromNow(-5) }),
+			makeMapping({ providerId: "b", deactivatedAt: daysFromNow(-2) }),
+		]);
+		expect(todayVisibleModels([dead], { showDeactivated: false })).toEqual([]);
+		const shown = todayVisibleModels([dead], { showDeactivated: true });
+		expect(shown).toHaveLength(1);
+		expect(shown[0].mappings).toHaveLength(2);
+	});
+
+	test("a mixed model keeps only its live mappings by default", () => {
+		const mixed = makeModel("mixed-model", [
+			healthy,
+			makeMapping({ providerId: "dead", deactivatedAt: daysFromNow(-3) }),
+		]);
+		const byDefault = todayVisibleModels([mixed], {
+			showDeactivated: false,
+		});
+		expect(byDefault).toHaveLength(1);
+		expect(byDefault[0].mappings.map((m) => m.providerId)).toEqual(["healthy"]);
+
+		const revealed = todayVisibleModels([mixed], { showDeactivated: true });
+		expect(revealed[0].mappings).toHaveLength(2);
+	});
+
+	test("counting predicate agrees with the visible set", () => {
+		const models = [
+			makeModel("healthy-model", [healthy]),
+			makeModel("mixed-model", [
+				healthy,
+				makeMapping({ providerId: "dead", deactivatedAt: daysFromNow(-3) }),
+			]),
+			makeModel("dead-model", [
+				makeMapping({ providerId: "a", deactivatedAt: daysFromNow(-5) }),
+			]),
+		];
+		// Mirrors the totalModelCount predicate (all-models.tsx :930-937).
+		const counted = models.filter((model) =>
+			model.mappings.some((mapping) => {
+				if (mapping.deprecatedAt && new Date(mapping.deprecatedAt) <= NOW) {
+					return false;
+				}
+				return !isMappingDeactivated(mapping, NOW);
+			}),
+		).length;
+		expect(counted).toBe(
+			todayVisibleModels(models, { showDeactivated: false }).length,
+		);
+		expect(counted).toBe(2);
+	});
+});

--- a/packages/shared/src/components/models-directory/status-filters.spec.ts
+++ b/packages/shared/src/components/models-directory/status-filters.spec.ts
@@ -2,14 +2,19 @@ import { describe, expect, test } from "vitest";
 
 import { getMappingStatus, isMappingDeactivated } from "@/deactivation.js";
 
+import { isVisibleMapping } from "./status-filters";
+
 import type { ApiModel, ApiModelProviderMapping } from "./api-types";
 
 const NOW = new Date("2026-08-25T00:00:00.000Z");
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-const daysFromNow = (days: number): string =>
-	new Date(NOW.getTime() + days * DAY_MS).toISOString();
+const daysFromNow = (days: number): string => {
+	const offset = days * DAY_MS;
+	return new Date(NOW.getTime() + offset).toISOString();
+};
+
 function makeMapping(
 	overrides: Partial<ApiModelProviderMapping> & { providerId: string },
 ): ApiModelProviderMapping {
@@ -45,13 +50,8 @@ function makeMapping(
 		webSearch: false,
 		webSearchPrice: null,
 		quantization: null,
-		audio: null,
-		document: null,
-		realtime: null,
-		supportedVoices: null,
 		supportedVideoSizes: null,
 		supportedVideoDurationsSeconds: null,
-		supportedVideoDurationsSecondsImageToVideo: null,
 		supportsVideoAudio: null,
 		supportsVideoWithoutAudio: null,
 		perSecondPrice: null,
@@ -78,7 +78,7 @@ function makeModel(id: string, mappings: ApiModelProviderMapping[]): ApiModel {
 		family: "mock",
 		free: false,
 		output: ["text"],
-		imageInputRequired: false,
+		premium: false,
 		stability: "stable",
 		status: "active",
 		mappings,
@@ -248,6 +248,128 @@ describe("getMappingStatus classification of the baseline fixtures", () => {
 		expect(getMappingStatus(deprecatedPast, NOW)).toBe("deprecated");
 		expect(getMappingStatus(deprecatedFuture, NOW)).toBe("deprecated");
 		expect(getMappingStatus(deprecatedThenScheduled, NOW)).toBe("scheduled");
+	});
+});
+
+describe("isVisibleMapping (phase 3 pipeline)", () => {
+	const options = (
+		overrides: Partial<{
+			status: "active" | "scheduled" | "deprecated" | "deactivated" | null;
+			showDeactivated: boolean;
+			eligibleOnly: boolean;
+		}> = {},
+	) => ({
+		status: null,
+		showDeactivated: false,
+		...overrides,
+	});
+
+	test("null status reproduces the phase-0 default rules exactly", () => {
+		const all = [
+			healthy,
+			scheduledSoon,
+			scheduledFar,
+			deactivated,
+			deactivatedBoundary,
+			deprecatedPast,
+			deprecatedFuture,
+			deprecatedThenScheduled,
+		];
+		expect(all.filter((m) => isVisibleMapping(m, options(), NOW))).toEqual(
+			todayVisibleMappings(all, { showDeactivated: false }),
+		);
+	});
+
+	test("null status with legacy show deactivated reproduces the unhide rules", () => {
+		const all = [healthy, deactivated, deprecatedPast, deprecatedThenScheduled];
+		expect(
+			all.filter((m) =>
+				isVisibleMapping(m, options({ showDeactivated: true }), NOW),
+			),
+		).toEqual(todayVisibleMappings(all, { showDeactivated: true }));
+	});
+
+	test("legacy show deactivated overrides a selected status", () => {
+		expect(
+			isVisibleMapping(
+				healthy,
+				options({ status: "deactivated", showDeactivated: true }),
+				NOW,
+			),
+		).toBe(true);
+		expect(
+			isVisibleMapping(
+				deprecatedPast,
+				options({ status: "deactivated", showDeactivated: true }),
+				NOW,
+			),
+		).toBe(false);
+	});
+
+	test("deactivated chip keeps only past-deactivated mappings", () => {
+		const all = [healthy, scheduledSoon, deactivated, deprecatedPast];
+		expect(
+			all
+				.filter((m) =>
+					isVisibleMapping(m, options({ status: "deactivated" }), NOW),
+				)
+				.map((m) => m.providerId),
+		).toEqual(["deactivated"]);
+	});
+
+	test("scheduled chip keeps only in-window scheduled mappings", () => {
+		const all = [healthy, scheduledSoon, scheduledFar, deactivated];
+		expect(
+			all
+				.filter((m) =>
+					isVisibleMapping(m, options({ status: "scheduled" }), NOW),
+				)
+				.map((m) => m.providerId),
+		).toEqual(["scheduled-soon"]);
+	});
+
+	test("deprecated chip reveals past-deprecated mappings", () => {
+		const all = [healthy, deprecatedPast, deprecatedFuture, deactivated];
+		expect(
+			all
+				.filter((m) =>
+					isVisibleMapping(m, options({ status: "deprecated" }), NOW),
+				)
+				.map((m) => m.providerId),
+		).toEqual(["deprecated-past", "deprecated-future"]);
+	});
+
+	test("active chip keeps strictly healthy mappings only", () => {
+		const all = [
+			healthy,
+			scheduledSoon,
+			scheduledFar,
+			deactivated,
+			deprecatedFuture,
+		];
+		expect(
+			all
+				.filter((m) => isVisibleMapping(m, options({ status: "active" }), NOW))
+				.map((m) => m.providerId),
+		).toEqual(["healthy", "scheduled-far"]);
+	});
+
+	test("eligibleOnly composes inside a selected status", () => {
+		const blockedDead = makeMapping({
+			providerId: "blocked-dead",
+			deactivatedAt: daysFromNow(-1),
+			blockedReasons: ["compliance"],
+		});
+		expect(
+			isVisibleMapping(
+				blockedDead,
+				options({ status: "deactivated", eligibleOnly: true }),
+				NOW,
+			),
+		).toBe(false);
+		expect(
+			isVisibleMapping(blockedDead, options({ status: "deactivated" }), NOW),
+		).toBe(true);
 	});
 });
 

--- a/packages/shared/src/components/models-directory/status-filters.ts
+++ b/packages/shared/src/components/models-directory/status-filters.ts
@@ -1,0 +1,52 @@
+import {
+	getMappingStatus,
+	isMappingDeactivated,
+	type ModelMappingStatus,
+} from "@/deactivation";
+
+export type StatusFilter = ModelMappingStatus | null;
+
+interface StatusVisibilityMapping {
+	deprecatedAt?: Date | string | null;
+	deactivatedAt?: Date | string | null;
+	blockedReasons?: string[] | null;
+}
+
+interface StatusVisibilityOptions {
+	status: StatusFilter;
+	showDeactivated: boolean;
+	eligibleOnly?: boolean;
+}
+
+/**
+ * Whether a provider mapping may render in the directory.
+ *
+ * With a status selected, the mapping must be exactly of that status. With
+ * none selected the legacy default applies: past-deprecated and
+ * past-deactivated mappings are hidden (the legacy `?deactivated=true` toggle
+ * un-hides the latter and, for backwards compatibility, overrides any status
+ * — old links keep their original unhide-everything meaning).
+ */
+export function isVisibleMapping(
+	mapping: StatusVisibilityMapping,
+	{ status, showDeactivated, eligibleOnly }: StatusVisibilityOptions,
+	now: Date = new Date(),
+): boolean {
+	const effectiveStatus: StatusFilter = showDeactivated ? null : status;
+	if (effectiveStatus) {
+		if (getMappingStatus(mapping, now) !== effectiveStatus) {
+			return false;
+		}
+	} else {
+		if (mapping.deprecatedAt && new Date(mapping.deprecatedAt) <= now) {
+			return false;
+		}
+		if (!showDeactivated && isMappingDeactivated(mapping, now)) {
+			return false;
+		}
+	}
+	if (eligibleOnly && mapping.blockedReasons?.length) {
+		return false;
+	}
+	return true;
+}

--- a/packages/shared/src/deactivation.spec.ts
+++ b/packages/shared/src/deactivation.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import {
+	getMappingStatus,
 	isDeactivationScheduledSoon,
 	isMappingDeactivated,
 	shouldShowDeactivationNotice,
@@ -95,5 +96,81 @@ describe("shouldShowDeactivationNotice", () => {
 		expect(
 			shouldShowDeactivationNotice({ deactivatedAt: "2027-07-27" }, now),
 		).toBe(false);
+	});
+});
+
+describe("getMappingStatus", () => {
+	test("is active without any dates", () => {
+		expect(getMappingStatus({}, now)).toBe("active");
+		expect(
+			getMappingStatus({ deactivatedAt: null, deprecatedAt: null }, now),
+		).toBe("active");
+	});
+
+	test("is deactivated once the date has passed", () => {
+		expect(getMappingStatus({ deactivatedAt: "2026-07-26" }, now)).toBe(
+			"deactivated",
+		);
+		expect(
+			getMappingStatus({ deactivatedAt: new Date(now.getTime() - 1) }, now),
+		).toBe("deactivated");
+	});
+
+	test("is deactivated at the exact boundary (deactivatedAt === now)", () => {
+		expect(getMappingStatus({ deactivatedAt: now }, now)).toBe("deactivated");
+	});
+
+	test("is scheduled one second into the future", () => {
+		expect(
+			getMappingStatus({ deactivatedAt: new Date(now.getTime() + 1000) }, now),
+		).toBe("scheduled");
+	});
+
+	test("is scheduled at exactly 90 days and active one millisecond past it", () => {
+		const at90Days = new Date(now.getTime() + 90 * 24 * 60 * 60 * 1000);
+		expect(getMappingStatus({ deactivatedAt: at90Days }, now)).toBe(
+			"scheduled",
+		);
+		const past90Days = new Date(at90Days.getTime() + 1);
+		expect(getMappingStatus({ deactivatedAt: past90Days }, now)).toBe("active");
+	});
+
+	test("is deprecated whenever a deprecation date exists without deactivation", () => {
+		expect(getMappingStatus({ deprecatedAt: "2026-07-26" }, now)).toBe(
+			"deprecated",
+		);
+		expect(getMappingStatus({ deprecatedAt: "2028-01-01" }, now)).toBe(
+			"deprecated",
+		);
+	});
+
+	test("scheduled wins over deprecated (urgency precedence)", () => {
+		expect(
+			getMappingStatus(
+				{ deprecatedAt: "2026-07-26", deactivatedAt: "2026-09-01" },
+				now,
+			),
+		).toBe("scheduled");
+	});
+
+	test("deactivated wins over both deprecated and scheduled", () => {
+		expect(
+			getMappingStatus(
+				{
+					deprecatedAt: "2026-07-26",
+					deactivatedAt: "2026-07-26",
+				},
+				now,
+			),
+		).toBe("deactivated");
+	});
+
+	test("accepts string and Date inputs identically", () => {
+		expect(getMappingStatus({ deactivatedAt: "2026-09-01" }, now)).toBe(
+			"scheduled",
+		);
+		expect(
+			getMappingStatus({ deactivatedAt: new Date("2026-09-01") }, now),
+		).toBe("scheduled");
 	});
 });

--- a/packages/shared/src/deactivation.spec.ts
+++ b/packages/shared/src/deactivation.spec.ts
@@ -4,6 +4,8 @@ import {
 	getMappingStatus,
 	isDeactivationScheduledSoon,
 	isMappingDeactivated,
+	isModelMappingStatus,
+	MODEL_MAPPING_STATUSES,
 	shouldShowDeactivationNotice,
 } from "./deactivation";
 
@@ -99,6 +101,20 @@ describe("shouldShowDeactivationNotice", () => {
 	});
 });
 
+describe("isModelMappingStatus", () => {
+	test("accepts the four statuses", () => {
+		for (const status of MODEL_MAPPING_STATUSES) {
+			expect(isModelMappingStatus(status)).toBe(true);
+		}
+	});
+
+	test("rejects unknown values", () => {
+		expect(isModelMappingStatus("")).toBe(false);
+		expect(isModelMappingStatus("dead")).toBe(false);
+		expect(isModelMappingStatus("ACTIVE")).toBe(false);
+	});
+});
+
 describe("getMappingStatus", () => {
 	test("is active without any dates", () => {
 		expect(getMappingStatus({}, now)).toBe("active");
@@ -127,7 +143,8 @@ describe("getMappingStatus", () => {
 	});
 
 	test("is scheduled at exactly 90 days and active one millisecond past it", () => {
-		const at90Days = new Date(now.getTime() + 90 * 24 * 60 * 60 * 1000);
+		const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+		const at90Days = new Date(now.getTime() + NINETY_DAYS_MS);
 		expect(getMappingStatus({ deactivatedAt: at90Days }, now)).toBe(
 			"scheduled",
 		);

--- a/packages/shared/src/deactivation.ts
+++ b/packages/shared/src/deactivation.ts
@@ -56,3 +56,34 @@ export function shouldShowDeactivationNotice(
 		isDeactivationScheduledSoon(mapping, now, withinDays)
 	);
 }
+
+/**
+ * The single retirement status a mapping can be in. Exactly one applies,
+ * resolved by urgency: deactivated beats scheduled beats deprecated — a
+ * mapping that is both deprecated and scheduled-to-die counts as scheduled.
+ * Far-future deactivations (beyond the directory's notice window) stay
+ * "active" so the directory never nags about models dying next year.
+ */
+export type ModelMappingStatus =
+	"active" | "scheduled" | "deprecated" | "deactivated";
+
+export function getMappingStatus(
+	mapping: {
+		deactivatedAt?: Date | string | null;
+		deprecatedAt?: Date | string | null;
+	},
+	now: Date = new Date(),
+): ModelMappingStatus {
+	if (isMappingDeactivated(mapping, now)) {
+		return "deactivated";
+	}
+	if (
+		isDeactivationScheduledSoon(mapping, now, MODEL_DEACTIVATION_NOTICE_DAYS)
+	) {
+		return "scheduled";
+	}
+	if (mapping.deprecatedAt) {
+		return "deprecated";
+	}
+	return "active";
+}

--- a/packages/shared/src/deactivation.ts
+++ b/packages/shared/src/deactivation.ts
@@ -67,6 +67,19 @@ export function shouldShowDeactivationNotice(
 export type ModelMappingStatus =
 	"active" | "scheduled" | "deprecated" | "deactivated";
 
+export const MODEL_MAPPING_STATUSES = [
+	"active",
+	"scheduled",
+	"deprecated",
+	"deactivated",
+] as const;
+
+export function isModelMappingStatus(
+	value: string,
+): value is ModelMappingStatus {
+	return (MODEL_MAPPING_STATUSES as readonly string[]).includes(value);
+}
+
 export function getMappingStatus(
 	mapping: {
 		deactivatedAt?: Date | string | null;


### PR DESCRIPTION
This PR replaces the single “Show deactivated” toggle with three mutually-exclusive status chips so the directory can distinguish the retirement states that already existed as timestamps.

## Why

- The single toggle only *unhid* deactivated models by mixing them into the full list — there was no way to see “only deactivated” (the all-red view).
- Table view had no model-level badge — deactivated rows looked identical to live ones apart from a tiny per-provider dot; grid already had it.
- Scheduled (deactivating within 90 days) shared the **same red** as dead, so active models with a countdown looked dead.

## How

All statuses derive from the existing `deactivatedAt`/`deprecatedAt` timestamps — no new fields, no API/DB changes:

- `getMappingStatus()` in `deactivation.ts` (`deactivated > scheduled > deprecated > active`; scheduled = `deactivatedAt` ≤90d).
- `isVisibleMapping()` in `status-filters.ts` — single source of truth; legacy `?deactivated=true` still lands on Deactivated.
- Three `Toggle` chips replace the toggle, single-select: `Deactivated | Scheduled | Deprecated` (none = today’s default). `Active` was removed as duplicative — default already covers it.
- Chips are `w-fit` vertical (`flex-col items-start`), each with a `/` tooltip.
- `model-status-badge.tsx` gains an amber `scheduled` variant (Clock); `model-card.tsx` splits the per-provider badges (red past, amber scheduled).

## Result

- `none` = today’s default — zero visual change until a chip is pressed.
- Each chip shows **only** that status — the all-red / all-amber views you asked for.
- Verification: `pnpm format` clean, `turbo build` 13/13, scoped suites 99/99, isolated `live2` stack with 32 demo models verified light + dark.

## Screenshots
- Status Before / After 

<img width="247" height="92" alt="Status-Before" src="https://github.com/user-attachments/assets/05f1fb4e-acb9-4208-a83d-7f3d3d4da7af" />
<img width="232" height="197" alt="Status-After" src="https://github.com/user-attachments/assets/30372fc0-7917-46dc-a085-a46f03ea80b0" />


- Status Table Before

<img width="1590" height="890" alt="Table-Before" src="https://github.com/user-attachments/assets/99073c16-bfe5-4b22-a12a-592a9473bf96" />

- Status Table After 

<img width="766" height="912" alt="Table-After-Deactivated" src="https://github.com/user-attachments/assets/dee083e0-bd4a-4144-ae47-1eda552310cd" />

<img width="772" height="898" alt="Table-After-Scheduled" src="https://github.com/user-attachments/assets/dd84fbe2-6409-4cb5-9cba-1c68a23e5287" />

<img width="763" height="863" alt="Table-After-Deprecated" src="https://github.com/user-attachments/assets/c12e4cc5-2b70-409c-a42b-892601cedf03" />

- Video showcase 

https://github.com/user-attachments/assets/1e3a13d9-66ac-4218-b0f7-f5a0d000fa61



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model directories now distinguish active, deprecated, deactivated, and scheduled statuses.
  * Added status filters with URL support, legacy deactivation compatibility, counts, and explanatory tooltips.
  * Scheduled retirements display clear notices and clock icons across badges, cards, and tables.

* **Bug Fixes**
  * Future deactivations are no longer incorrectly shown as already deactivated.

* **Tests**
  * Expanded coverage for status classification, filtering, scheduling, deprecation, and visibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->