### PR TITLE
fix(models): update Gonka24 pricing

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -916,9 +916,9 @@ export const deepseekModels = [
 			{
 				providerId: "gonka24",
 				externalId: "deepseek-v4-flash-0731",
-				inputPrice: "0.075e-6",
-				cachedInputPrice: "0.0155e-6",
-				outputPrice: "0.175e-6",
+				inputPrice: "0.051e-6",
+				cachedInputPrice: "0.0097e-6",
+				outputPrice: "0.104e-6",
 				requestPrice: "0",
 				// The deployment shares one 390000-token window between prompt and
 				// completion, and stops generating at 16384 tokens with


### PR DESCRIPTION
## Summary

Update the user-facing Gonka24 price for DeepSeek V4 Flash:

- input: $0.051 per 1M tokens
- cached input: $0.0097 per 1M tokens
- output: $0.104 per 1M tokens

## Mapping

- provider/model: `gonka24/deepseek-v4-flash`
- external ID: `deepseek-v4-flash-0731`
- context: 390,000 tokens
- max output: 16,384 tokens
- capabilities unchanged: streaming, reasoning, tools, JSON output
- reasoning efforts unchanged: `none`, `low`, `medium`, `high`

The live provider model endpoint confirmed the deployment ID and max output. It does not expose billing fields. The public broker page advertises a separate promotional rate without a cache-read rate, so the platform prices supplied for this update are used directly. Token semantics and capabilities are unchanged.

## Verification

- `pnpm format`
- focused metadata and cost specs: 148 passed
- `TEST_MODELS=gonka24/deepseek-v4-flash FULL_MODE=true pnpm test:e2e`: 96 passed, 96 skipped
- `pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Lowered pricing for the DeepSeek V4 Flash model, including input, cached input, and output usage rates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->