### PR TITLE
feat(models): add LLM Tech provider and Qwen3.8-27B

### DIFF
--- a/packages/actions/src/get-provider-endpoint.ts
+++ b/packages/actions/src/get-provider-endpoint.ts
@@ -218,6 +218,7 @@ const PROVIDER_DEFAULT_BASE_URLS: Partial<Record<ProviderId, string>> = {
 	nebius: "https://api.tokenfactory.nebius.com",
 	zai: "https://api.z.ai",
 	nanogpt: "https://nano-gpt.com/api",
+	llmtech: "https://api.llmtech.eu",
 	bytedance: "https://ark.ap-southeast.bytepluses.com/api/v3",
 	minimax: "https://api.minimax.io",
 	sakana: "https://api.sakana.ai",

--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -3662,6 +3662,46 @@ export const alibabaModels = [
 		],
 	},
 	{
+		id: "qwen3.8-27b",
+		name: "Qwen3.8 27B",
+		description:
+			"Open-weight dense vision-language model from Alibaba for coding, agentic workflows and long-context tasks, with thinking that can be toggled per request.",
+		family: "alibaba",
+		releasedAt: new Date("2026-08-14"),
+		providers: [
+			{
+				providerId: "llmtech",
+				externalId: "unsloth/Qwen3.8-27B-NVFP4",
+				inputPrice: "0.25e-6",
+				cachedInputPrice: "0.04e-6",
+				outputPrice: "2.09e-6",
+				requestPrice: "0",
+				contextSize: 262144,
+				maxOutput: 32768,
+				quantization: "fp4",
+				streaming: true,
+				reasoning: true,
+				reasoningEfforts: ["low", "medium", "xhigh"],
+				vision: true,
+				tools: true,
+				jsonOutput: true,
+				// Qwen thinking models reject tool_choice "required" or object
+				supportedParameters: [
+					"temperature",
+					"max_tokens",
+					"top_p",
+					"frequency_penalty",
+					"presence_penalty",
+					"stop",
+					"stream",
+					"response_format",
+					"tools",
+					"reasoning_effort",
+				],
+			},
+		],
+	},
+	{
 		id: "qwen3.6-35b-a3b",
 		name: "Qwen3.6 35B A3B",
 		description:

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -1991,6 +1991,35 @@ export const providers: ProviderDefinition[] = [
 			retentionPeriod: "0 days",
 		},
 	},
+	{
+		id: "llmtech",
+		name: "LLM Tech",
+		forwardsSafetyIdentifier: false,
+		description:
+			"EU inference provider serving open-weight models on Blackwell hardware with an OpenAI-compatible API, prompt caching and zero data retention.",
+		env: {
+			required: {
+				apiKey: "LLM_LLMTECH_API_KEY",
+			},
+		},
+		streaming: true,
+		cancellation: true,
+		color: "#0F766E",
+		website: "https://llmtech.eu",
+		statusPageUrl: "https://llmtech.eu/status",
+		announcement: null,
+		termsUrl: "https://llmtech.eu/terms.html",
+		privacyPolicyUrl: "https://llmtech.eu/privacy.html",
+		headquarters: "PL",
+		dataPolicy: {
+			apiTraining: false,
+			promptLogging: false,
+			retentionPeriod: "0 days",
+			soc2: null,
+			iso27001: false,
+			gdpr: true,
+		},
+	},
 ] as const satisfies ProviderDefinition[];
 
 export type ProviderId = (typeof providers)[number]["id"];
@@ -2387,6 +2416,7 @@ export const PROVIDER_COUNTRY_NAMES: Record<string, string> = {
 	JP: "Japan",
 	AU: "Australia",
 	GB: "United Kingdom",
+	PL: "Poland",
 };
 
 /** Convert an ISO 3166-1 alpha-2 country code to its Unicode flag emoji. */


### PR DESCRIPTION
Adds LLM Tech as a provider and Qwen3.8-27B as a model. The model isn't in the catalogue yet (only `qwen3.8-max` is), so this fills a gap rather than adding a second source for an existing entry.

About the provider: we're a small EU inference operator running open-weight models on Blackwell hardware. Disclosure: I run LLM Tech, so this is a self-submission. The endpoint is OpenAI-compatible, so it lands in the default `/v1/chat/completions` branch with no special handling.

Production numbers for the endpoint, all measured on live traffic and published at https://llmtech.eu/status (refreshed every 5 min): 252M tokens and 4,900 requests served since Aug 22, two 5xx responses in that span, generation at 80 tok/s median (92 at p90), median TTFT 1.1s on prompts of 10K tokens or more.

Two details worth flagging:

- The data policy fields are filled in deliberately. Prompts and completions are never persisted, never used for training, and processing is EU-only, so `gdpr: true` / `promptLogging: false` / `retentionPeriod: "0 days"` are accurate and the compliance filter can rely on them. `soc2` stays `null` and `iso27001` stays `false` because we don't hold those.
- `vision: true` is not a guess. The NVFP4 quant of this model keeps the vision tower, and we verified image input against our production endpoint (`multimodal_tokens` comes back in usage). Most catalogues list this model as text-only.

`reasoningEfforts` was verified end to end against production rather than taken from the model card: a top-level `reasoning_effort` now reaches the engine and returns real reasoning tokens on all three levels.

Checks run locally: `tsc --noEmit` on `packages/models`, the full `packages/models` vitest suite (159 passing, including the compliance test that required adding `PL` to `PROVIDER_COUNTRY_NAMES`), and prettier on the touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the LLMTech provider, including streaming, request cancellation, and EU-based service details.
  * Added the Alibaba Qwen3.8-27B model, with vision, tools, streaming, JSON output, and configurable reasoning effort.
  * Added Poland to the provider location listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->