### PR TITLE
feat(models): add Muse Image

### DIFF
--- a/apps/docs/content/features/image-generation.mdx
+++ b/apps/docs/content/features/image-generation.mdx
@@ -638,6 +638,36 @@ curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
 	is not available on other Google image models.
 </Callout>
 
+### Meta Models
+
+Muse Image uses Meta's Responses API for generation and editing. It reasons
+before rendering and can use reference images across refinement turns.
+
+```bash
+curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
+  -H "Authorization: Bearer $LLM_GATEWAY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "meta/muse-image-1.0",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Create a product photo on a warm studio background"
+      }
+    ],
+    "image_config": {
+      "image_size": "1024x1536"
+    }
+  }'
+```
+
+| Parameter    | Type   | Description                                                                |
+| ------------ | ------ | -------------------------------------------------------------------------- |
+| `image_size` | string | One of `"1024x1024"`, `"1024x1536"`, or `"1536x1024"`. Defaults to square. |
+
+Muse Image does not expose a quality setting. Use `image_size` to choose square,
+portrait, or landscape output.
+
 ### Alibaba Models
 
 ```bash

--- a/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
@@ -51,6 +51,45 @@ describe("parseProviderResponse", () => {
 	});
 
 	describe("openai responses format reasoning", () => {
+		it("extracts Muse images and usage from Responses output", () => {
+			const result = parseProviderResponse("meta", "muse-image-1.0", {
+				id: "resp_muse",
+				status: "completed",
+				output: [
+					{
+						type: "reasoning",
+						summary: [{ type: "summary_text", text: "Planning the image" }],
+					},
+					{
+						type: "image_generation_call",
+						result: "UklGRmFrZQ==",
+					},
+				],
+				usage: {
+					input_tokens: 9520,
+					output_tokens: 443,
+					total_tokens: 9963,
+					input_tokens_details: { cached_tokens: 7936 },
+					output_tokens_details: { reasoning_tokens: 160 },
+				},
+			});
+
+			expect(result.content).toBe("Image generated");
+			expect(result.images).toEqual([
+				{
+					type: "image_url",
+					image_url: {
+						url: "data:image/webp;base64,UklGRmFrZQ==",
+					},
+				},
+			]);
+			expect(result.reasoningContent).toBe("Planning the image");
+			expect(result.promptTokens).toBe(9520);
+			expect(result.completionTokens).toBe(443);
+			expect(result.cachedTokens).toBe(7936);
+			expect(result.reasoningTokens).toBe(160);
+		});
+
 		it("extracts encrypted reasoning payloads into reasoningDetails", () => {
 			const json = {
 				id: "resp_123",

--- a/apps/gateway/src/chat/tools/parse-provider-response.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.ts
@@ -834,6 +834,27 @@ export function parseProviderResponse(
 				const messageOutput = json.output.find(
 					(item: any) => item.type === "message",
 				);
+				const imageOutputs = json.output.filter(
+					(
+						item: Record<string, unknown>,
+					): item is Record<string, unknown> & { result: string } =>
+						item.type === "image_generation_call" &&
+						typeof item.result === "string" &&
+						item.result.length > 0,
+				);
+				if (imageOutputs.length > 0) {
+					images = imageOutputs.map(
+						(
+							item: Record<string, unknown> & { result: string },
+						): ImageObject => ({
+							type: "image_url",
+							image_url: {
+								url: `data:image/webp;base64,${item.result}`,
+							},
+						}),
+					);
+					content = imageLabel;
+				}
 				// A response can carry several reasoning items (e.g. one before
 				// each tool call), so collect them all once — both the summary text
 				// and the encrypted payloads below are derived from every item.
@@ -880,10 +901,11 @@ export function parseProviderResponse(
 				// Extract message content. With multiple phased messages, join
 				// them so nothing is dropped from the chat-completions surface.
 				if (allMessageOutputs.length > 1) {
-					content = allMessageOutputs
-						.map((m: { text: string }) => m.text)
-						.filter(Boolean)
-						.join("\n\n");
+					content =
+						allMessageOutputs
+							.map((m: { text: string }) => m.text)
+							.filter(Boolean)
+							.join("\n\n") || content;
 				} else if (messageOutput?.content?.[0]?.text) {
 					content = messageOutput.content[0].text;
 				}

--- a/apps/gateway/src/chat/tools/transform-response-to-openai.spec.ts
+++ b/apps/gateway/src/chat/tools/transform-response-to-openai.spec.ts
@@ -27,6 +27,43 @@ vi.mock("@llmgateway/logger", () => ({
 }));
 
 describe("transformResponseToOpenai", () => {
+	test("includes Responses API images in Meta chat output", () => {
+		const images = [
+			{
+				type: "image_url" as const,
+				image_url: { url: "data:image/webp;base64,UklGRmFrZQ==" },
+			},
+		];
+		const response = transformResponseToOpenai(
+			"meta",
+			"muse-image-1.0",
+			{
+				id: "resp_muse",
+				created_at: 1,
+				output: [{ type: "image_generation_call" }],
+			},
+			"Image generated",
+			"Planning the image",
+			"stop",
+			10,
+			5,
+			15,
+			2,
+			3,
+			null,
+			images,
+			"meta/muse-image-1.0",
+			"meta",
+			"muse-image-1.0",
+		);
+
+		expect(response.choices[0].message).toMatchObject({
+			content: "Image generated",
+			reasoning: "Planning the image",
+			images,
+		});
+	});
+
 	test("includes request_id in response metadata", () => {
 		const response = transformResponseToOpenai(
 			"openai",

--- a/apps/gateway/src/chat/tools/transform-response-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-response-to-openai.ts
@@ -1001,6 +1001,7 @@ export function transformResponseToOpenai(
 							message: {
 								role: "assistant",
 								content: content,
+								...(images && images.length > 0 && { images }),
 								...(reasoningContent !== null && {
 									reasoning: reasoningContent,
 								}),

--- a/apps/gateway/src/lib/costs.spec.ts
+++ b/apps/gateway/src/lib/costs.spec.ts
@@ -1565,6 +1565,27 @@ describe("calculateCosts", () => {
 		);
 	});
 
+	it("bills Muse at its flat per-image price", async () => {
+		const result = await calculateCosts(
+			"muse-image-1.0",
+			"meta",
+			null,
+			9520,
+			443,
+			7936,
+			undefined,
+			160,
+			1,
+			"1024x1024",
+			0,
+		);
+
+		expect(result.inputCost).toBe(0);
+		expect(result.imageOutputCost).toBeCloseTo(0.01);
+		expect(result.outputCost).toBeCloseTo(0.01);
+		expect(result.totalCost).toBeCloseTo(0.01);
+	});
+
 	it("bills perImagePrice even when prompt usage is absent or zero", async () => {
 		// An upstream response that omits prompt usage must still charge for the
 		// generated images instead of bailing out of cost calculation entirely.

--- a/apps/gateway/src/responses/responses.spec.ts
+++ b/apps/gateway/src/responses/responses.spec.ts
@@ -254,6 +254,24 @@ describe("responsesRequestSchema", () => {
 
 		expect(result.success).toBe(true);
 	});
+
+	it("accepts Muse image tools and completed image output", () => {
+		const result = responsesRequestSchema.safeParse({
+			model: "meta/muse-image-1.0",
+			input: [
+				{
+					type: "image_generation_call",
+					id: "ig_123",
+					status: "completed",
+					result: "UklGRmFrZQ==",
+				},
+				{ role: "user", content: "Make the background blue" },
+			],
+			tools: [{ type: "image_generation", size: "1024x1536" }],
+		});
+
+		expect(result.success).toBe(true);
+	});
 });
 
 describe("convertResponsesInputToMessages", () => {
@@ -285,6 +303,33 @@ describe("convertResponsesInputToMessages", () => {
 		expect(result[0]!.content).toBe("Hello");
 		expect(result[1]!.role).toBe("assistant");
 		expect(result[1]!.content).toBe("Hi there");
+	});
+
+	it("replays a generated image as a reference on the next user turn", () => {
+		const input = [
+			{
+				type: "image_generation_call",
+				id: "ig_123",
+				status: "completed",
+				result: "UklGRmFrZQ==",
+			},
+			{ role: "user", content: "Make the background blue" },
+		] as Parameters<typeof convertResponsesInputToMessages>[0];
+
+		expect(convertResponsesInputToMessages(input)).toEqual([
+			{
+				role: "user",
+				content: [
+					{
+						type: "image_url",
+						image_url: {
+							url: "data:image/webp;base64,UklGRmFrZQ==",
+						},
+					},
+					{ type: "text", text: "Make the background blue" },
+				],
+			},
+		]);
 	});
 
 	it("keeps an explicit prompt cache breakpoint on a replayed output_text part", () => {
@@ -637,6 +682,42 @@ describe("convertChatResponseToResponses", () => {
 		expect(messageOutput).toBeDefined();
 		expect((messageOutput as any).content[0].type).toBe("output_text");
 		expect((messageOutput as any).content[0].text).toBe("Hello!");
+	});
+
+	it("converts generated images to Responses output items", () => {
+		const result = convertChatResponseToResponses(
+			{
+				choices: [
+					{
+						message: {
+							role: "assistant",
+							content: "Image generated",
+							images: [
+								{
+									type: "image_url",
+									image_url: {
+										url: "data:image/webp;base64,UklGRmFrZQ==",
+									},
+								},
+							],
+						},
+						finish_reason: "stop",
+					},
+				],
+				usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+			},
+			"meta/muse-image-1.0",
+		);
+
+		expect(result.output).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					type: "image_generation_call",
+					status: "completed",
+					result: "UklGRmFrZQ==",
+				}),
+			]),
+		);
 	});
 
 	it("echoes the served service tier from the chat response", () => {

--- a/apps/gateway/src/responses/responses.ts
+++ b/apps/gateway/src/responses/responses.ts
@@ -315,6 +315,9 @@ responses.post("/", async (c) => {
 			return null;
 		})
 		.filter((t): t is NonNullable<typeof t> => t !== null);
+	const imageGenerationTool = req.tools?.find(
+		(tool: Record<string, unknown>) => tool.type === "image_generation",
+	) as Record<string, unknown> | undefined;
 
 	// Convert text.format to response_format
 	let response_format: Record<string, unknown> | undefined;
@@ -352,6 +355,11 @@ responses.post("/", async (c) => {
 	}
 	if (tools && tools.length > 0) {
 		chatRequest.tools = tools;
+	}
+	if (typeof imageGenerationTool?.size === "string") {
+		chatRequest.image_config = {
+			image_size: imageGenerationTool.size,
+		};
 	}
 	if (req.tool_choice) {
 		// The chat handler speaks Chat Completions, so a Responses-shaped named

--- a/apps/gateway/src/responses/schemas.ts
+++ b/apps/gateway/src/responses/schemas.ts
@@ -230,7 +230,6 @@ export const UNREPLAYABLE_ITEM_TYPES = [
 	"local_shell_call",
 	"local_shell_call_output",
 	"web_search_call",
-	"image_generation_call",
 	"tool_search_call",
 	"tool_search_output",
 	"compaction",
@@ -240,6 +239,15 @@ export const UNREPLAYABLE_ITEM_TYPES = [
 
 const unreplayableItemSchema = z
 	.object({ type: z.enum(UNREPLAYABLE_ITEM_TYPES) })
+	.passthrough();
+
+const imageGenerationCallItemSchema = z
+	.object({
+		type: z.literal("image_generation_call"),
+		id: nullishToUndefined(z.string()),
+		result: nullishToUndefined(z.string()),
+		status: itemStatusSchema,
+	})
 	.passthrough();
 
 const reasoningItemSchema = z.object({
@@ -280,6 +288,7 @@ const inputItemSchema = z.preprocess(
 		functionCallOutputItemSchema,
 		customToolCallItemSchema,
 		customToolCallOutputItemSchema,
+		imageGenerationCallItemSchema,
 		additionalToolsItemSchema,
 		itemReferenceItemSchema,
 		unreplayableItemSchema,
@@ -352,6 +361,10 @@ export const responsesRequestSchema = z.object({
 					max_uses: z.number().optional(),
 					allowed_domains: z.array(z.string()).optional(),
 					blocked_domains: z.array(z.string()).optional(),
+				}),
+				z.object({
+					type: z.literal("image_generation"),
+					size: z.enum(["1024x1024", "1024x1536", "1536x1024"]).optional(),
 				}),
 				// catch-all for unknown tool types (e.g. computer_use, code_interpreter)
 				z.record(z.any()),

--- a/apps/gateway/src/responses/tools/convert-chat-to-responses.ts
+++ b/apps/gateway/src/responses/tools/convert-chat-to-responses.ts
@@ -14,6 +14,11 @@ interface ChatCompletionsResponse {
 		message?: {
 			role?: string;
 			content?: string | null;
+			images?: Array<{
+				type?: string;
+				image_url?: { url?: string };
+				url?: string;
+			}>;
 			tool_calls?: Array<{
 				id: string;
 				type: string;
@@ -436,6 +441,23 @@ export function convertChatResponseToResponses(
 		);
 	});
 	emitMessagesUpTo(Number.MAX_SAFE_INTEGER);
+
+	for (const image of message?.images ?? []) {
+		const url = image.image_url?.url ?? image.url;
+		if (typeof url !== "string") {
+			continue;
+		}
+		const match = url.match(/^data:image\/[\w+.-]+;base64,(.+)$/s);
+		if (!match) {
+			continue;
+		}
+		output.push({
+			type: "image_generation_call",
+			id: `ig_${shortid(24)}`,
+			status: "completed",
+			result: match[1],
+		});
+	}
 
 	// Map finish_reason to status. Providers served via the OpenAI Responses
 	// API surface truncation as finish_reason "incomplete" (from the upstream

--- a/apps/gateway/src/responses/tools/convert-responses-to-chat.ts
+++ b/apps/gateway/src/responses/tools/convert-responses-to-chat.ts
@@ -127,6 +127,7 @@ export function convertResponsesInputToMessages(
 	// and attach to the next assistant message so the provider layer can replay
 	// the reasoning (encrypted payloads and/or text) on this turn.
 	const pendingReasoning: PendingReasoning = { texts: [], details: [] };
+	const pendingGeneratedImages: Array<Record<string, unknown>> = [];
 
 	let i = 0;
 	while (i < input.length) {
@@ -227,6 +228,22 @@ export function convertResponsesInputToMessages(
 			continue;
 		}
 
+		if (
+			"type" in item &&
+			item.type === "image_generation_call" &&
+			typeof item.result === "string" &&
+			item.result.length > 0
+		) {
+			pendingGeneratedImages.push({
+				type: "image_url",
+				image_url: {
+					url: `data:image/webp;base64,${item.result}`,
+				},
+			});
+			i++;
+			continue;
+		}
+
 		if ("type" in item && SKIPPED_ITEM_TYPES.has(item.type as string)) {
 			i++;
 			continue;
@@ -269,9 +286,19 @@ export function convertResponsesInputToMessages(
 			}
 		}
 
+		const convertedContent = convertContent(msg.content);
+		const content =
+			role === "user" && pendingGeneratedImages.length > 0
+				? [
+						...pendingGeneratedImages.splice(0),
+						...(typeof convertedContent === "string"
+							? [{ type: "text", text: convertedContent }]
+							: (convertedContent ?? [])),
+					]
+				: convertedContent;
 		const chatMsg: ChatMessage = {
 			role,
-			content: convertContent(msg.content),
+			content,
 			...(role === "assistant" ? takePendingReasoning(pendingReasoning) : {}),
 			...(role === "assistant" && msg.phase ? { phase: msg.phase } : {}),
 		};
@@ -290,6 +317,10 @@ export function convertResponsesInputToMessages(
 
 		messages.push(chatMsg);
 		i++;
+	}
+
+	if (pendingGeneratedImages.length > 0) {
+		messages.push({ role: "user", content: pendingGeneratedImages });
 	}
 
 	return messages;

--- a/apps/playground/AGENTS.md
+++ b/apps/playground/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/apps/playground/CLAUDE.md
+++ b/apps/playground/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/apps/playground/src/components/playground/chat-ui.tsx
+++ b/apps/playground/src/components/playground/chat-ui.tsx
@@ -1066,6 +1066,7 @@ export const ChatUI = ({
 	// shared with the image playground so both surfaces offer the same options.
 	const {
 		isGptImage,
+		isMuseImage,
 		usesPixelDimensions,
 		availableSizes,
 		supportsQuality,
@@ -1997,13 +1998,22 @@ export const ChatUI = ({
 										<SelectValue placeholder="Image Size" />
 									</SelectTrigger>
 									<SelectContent>
-										<SelectItem value="1024x1024">1024x1024</SelectItem>
-										<SelectItem value="720x1280">720x1280</SelectItem>
-										<SelectItem value="1280x720">1280x720</SelectItem>
-										<SelectItem value="1024x1536">1024x1536</SelectItem>
-										<SelectItem value="1536x1024">1536x1024</SelectItem>
-										<SelectItem value="2048x1024">2048x1024</SelectItem>
-										<SelectItem value="1024x2048">1024x2048</SelectItem>
+										{(isMuseImage
+											? availableSizes
+											: [
+													"1024x1024",
+													"720x1280",
+													"1280x720",
+													"1024x1536",
+													"1536x1024",
+													"2048x1024",
+													"1024x2048",
+												]
+										).map((size) => (
+											<SelectItem key={size} value={size}>
+												{size}
+											</SelectItem>
+										))}
 									</SelectContent>
 								</Select>
 							)}

--- a/apps/playground/src/components/playground/image-controls.tsx
+++ b/apps/playground/src/components/playground/image-controls.tsx
@@ -390,13 +390,22 @@ export function ImageControls({
 								<SelectValue placeholder="Image Size" />
 							</SelectTrigger>
 							<SelectContent>
-								<SelectItem value="1024x1024">1024x1024</SelectItem>
-								<SelectItem value="720x1280">720x1280</SelectItem>
-								<SelectItem value="1280x720">1280x720</SelectItem>
-								<SelectItem value="1024x1536">1024x1536</SelectItem>
-								<SelectItem value="1536x1024">1536x1024</SelectItem>
-								<SelectItem value="2048x1024">2048x1024</SelectItem>
-								<SelectItem value="1024x2048">1024x2048</SelectItem>
+								{(config.isMuseImage
+									? config.availableSizes
+									: [
+											"1024x1024",
+											"720x1280",
+											"1280x720",
+											"1024x1536",
+											"1536x1024",
+											"2048x1024",
+											"1024x2048",
+										]
+								).map((size) => (
+									<SelectItem key={size} value={size}>
+										{size}
+									</SelectItem>
+								))}
 							</SelectContent>
 						</Select>
 					)}

--- a/apps/playground/src/lib/image-gen.spec.ts
+++ b/apps/playground/src/lib/image-gen.spec.ts
@@ -45,4 +45,18 @@ describe("getModelImageConfig", () => {
 		]);
 		expect(config.defaultQuality).toBe("low");
 	});
+
+	it("offers Muse sizes without an unsupported quality control", () => {
+		const config = getModelImageConfig("meta/muse-image-1.0");
+
+		expect(config.usesPixelDimensions).toBe(true);
+		expect(config.availableSizes).toEqual([
+			"1024x1024",
+			"1024x1536",
+			"1536x1024",
+		]);
+		expect(config.defaultSize).toBe("1024x1024");
+		expect(config.supportsQuality).toBe(false);
+		expect(config.availableQualities).toEqual([]);
+	});
 });

--- a/apps/playground/src/lib/image-gen.ts
+++ b/apps/playground/src/lib/image-gen.ts
@@ -75,9 +75,11 @@ export function getModelImageConfig(model: string) {
 
 	const isGptImage = lower.includes("gpt-image");
 	const isReve = lower.includes("reve");
+	const isMuseImage = lower.includes("muse-image");
 
 	const usesPixelDimensions =
 		isGptImage ||
+		isMuseImage ||
 		lower.includes("alibaba") ||
 		lower.includes("qwen-image") ||
 		lower.includes("zai") ||
@@ -101,25 +103,29 @@ export function getModelImageConfig(model: string) {
 
 	const availableSizes = isGptImage
 		? GPT_IMAGE_SIZES
-		: isReve
-			? (["2K"] as const)
-			: isSeedreamPro || isGrokImagine20
-				? (["1K", "2K"] as const)
-				: isSeedream
-					? (["2K", "4K"] as const)
-					: isGemini31FlashLiteImage
-						? (["1K"] as const)
-						: isGemini31FlashImage
-							? (["0.5K", "1K", "2K", "4K"] as const)
-							: (["1K", "2K", "4K"] as const);
+		: isMuseImage
+			? (["1024x1024", "1024x1536", "1536x1024"] as const)
+			: isReve
+				? (["2K"] as const)
+				: isSeedreamPro || isGrokImagine20
+					? (["1K", "2K"] as const)
+					: isSeedream
+						? (["2K", "4K"] as const)
+						: isGemini31FlashLiteImage
+							? (["1K"] as const)
+							: isGemini31FlashImage
+								? (["0.5K", "1K", "2K", "4K"] as const)
+								: (["1K", "2K", "4K"] as const);
 
 	const defaultSize = isGptImage
 		? "1024x1024"
-		: isReve
-			? "2K"
-			: isSeedream
+		: isMuseImage
+			? "1024x1024"
+			: isReve
 				? "2K"
-				: "1K";
+				: isSeedream
+					? "2K"
+					: "1K";
 
 	const supportsQuality = isGptImage || isGrokImagine20;
 	const availableQualities = isGptImage
@@ -146,6 +152,7 @@ export function getModelImageConfig(model: string) {
 		isSeedream,
 		isGemini31FlashImage,
 		isGptImage,
+		isMuseImage,
 		isReve,
 		availableSizes,
 		defaultSize,

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -12,6 +12,7 @@ import {
 import type {
 	AnthropicRequestBody,
 	OpenAIRequestBody,
+	OpenAIResponsesRequestBody,
 	ProviderCacheControlMode,
 	ProviderModelMapping,
 } from "@llmgateway/models";
@@ -64,6 +65,40 @@ async function prepareOpenAIImageRequest(imageConfig: {
 		undefined,
 		true,
 	);
+}
+
+async function prepareMetaImageRequest(imageConfig: {
+	image_size?: string;
+	image_quality?: string;
+}) {
+	return (await prepareRequestBody(
+		"meta",
+		"muse-image-1.0",
+		null,
+		"muse-image-1.0",
+		[{ role: "user", content: "Generate a cinematic landscape" }],
+		false,
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		true,
+		false,
+		20,
+		null,
+		undefined,
+		imageConfig,
+		undefined,
+		true,
+		undefined,
+		undefined,
+		true,
+	)) as OpenAIResponsesRequestBody;
 }
 
 async function prepareOpenAITextRequest(options: {
@@ -1492,6 +1527,29 @@ describe("prepareRequestBody - OpenAI image generation", () => {
 
 		expect(requestBody.size).toBe("1024x1024");
 		expect(requestBody.quality).toBeUndefined();
+	});
+});
+
+describe("prepareRequestBody - Meta image generation", () => {
+	test.each(["1024x1024", "1024x1536", "1536x1024"])(
+		"adds the Muse image tool with size %s",
+		async (size) => {
+			const requestBody = await prepareMetaImageRequest({
+				image_size: size,
+				image_quality: "high",
+			});
+
+			expect(requestBody).toMatchObject({
+				model: "muse-image-1.0",
+				tools: [{ type: "image_generation", size }],
+			});
+		},
+	);
+
+	test("rejects a size Muse does not support", async () => {
+		await expect(
+			prepareMetaImageRequest({ image_size: "2048x2048" }),
+		).rejects.toBeInstanceOf(RequestError);
 	});
 });
 

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -2346,7 +2346,11 @@ export async function prepareRequestBody(
 				// Add web search tool for Responses API
 				if (webSearchTool) {
 					responsesBody.tools ??= [];
-					const webSearch: any = { type: "web_search" };
+					const webSearch: {
+						type: "web_search";
+						user_location?: unknown;
+						search_context_size?: string;
+					} = { type: "web_search" };
 					if (webSearchTool.user_location) {
 						webSearch.user_location = webSearchTool.user_location;
 					}
@@ -2361,6 +2365,34 @@ export async function prepareRequestBody(
 					if (webSearchTool.forced) {
 						responsesBody.tool_choice = { type: "web_search" };
 					}
+				}
+
+				if (usedProvider === "meta" && usedInternalModel === "muse-image-1.0") {
+					const supportedSizes = [
+						"1024x1024",
+						"1024x1536",
+						"1536x1024",
+					] as const;
+					const requestedSize = image_config?.image_size;
+					if (
+						requestedSize !== undefined &&
+						!supportedSizes.includes(
+							requestedSize as (typeof supportedSizes)[number],
+						)
+					) {
+						throw new RequestError(
+							`Invalid image_size for Muse Image: "${requestedSize}". Allowed values: ${supportedSizes.join(
+								", ",
+							)}`,
+						);
+					}
+					responsesBody.tools ??= [];
+					responsesBody.tools.push({
+						type: "image_generation",
+						...(requestedSize && {
+							size: requestedSize as (typeof supportedSizes)[number],
+						}),
+					});
 				}
 				if (resolvedToolChoice) {
 					responsesBody.tool_choice = toResponsesToolChoice(resolvedToolChoice);

--- a/packages/models/src/models/meta.ts
+++ b/packages/models/src/models/meta.ts
@@ -2,6 +2,35 @@ import type { ModelDefinition } from "@/models.js";
 
 export const metaModels = [
 	{
+		id: "muse-image-1.0",
+		name: "Muse Image 1.0",
+		description:
+			"Meta's agentic image model for generation, editing, multi-reference composition, and iterative refinement.",
+		family: "meta",
+		output: ["image"],
+		releasedAt: new Date("2026-07-07"),
+		providers: [
+			{
+				test: "skip",
+				providerId: "meta",
+				externalId: "muse-image-1.0",
+				inputPrice: "0",
+				outputPrice: "0",
+				perImagePrice: {
+					default: "0.01",
+				},
+				requestPrice: "0",
+				streaming: false,
+				reasoning: true,
+				supportsResponsesApi: true,
+				vision: true,
+				tools: false,
+				jsonOutput: false,
+				imageGenerations: true,
+			},
+		],
+	},
+	{
 		id: "muse-spark-1.2",
 		name: "Muse Spark 1.2",
 		description:

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -1671,7 +1671,7 @@ export const providers: ProviderDefinition[] = [
 		name: "Meta",
 		forwardsSafetyIdentifier: false,
 		description:
-			"Meta's Model API serving the Muse Spark multimodal reasoning models via an OpenAI-compatible API",
+			"Meta's Model API serving Muse reasoning and image models via an OpenAI-compatible API",
 		env: {
 			required: {
 				apiKey: "LLM_META_API_KEY",

--- a/packages/models/src/types.ts
+++ b/packages/models/src/types.ts
@@ -462,12 +462,23 @@ export interface OpenAIResponsesRequestBody {
 	 * preserve reasoning without stored responses.
 	 */
 	include?: string[];
-	tools?: Array<{
-		type: "function";
-		name: string;
-		description?: string;
-		parameters: FunctionParameter;
-	}>;
+	tools?: Array<
+		| {
+				type: "function";
+				name: string;
+				description?: string;
+				parameters: FunctionParameter;
+		  }
+		| {
+				type: "web_search";
+				user_location?: unknown;
+				search_context_size?: string;
+		  }
+		| {
+				type: "image_generation";
+				size?: "1024x1024" | "1024x1536" | "1536x1024";
+		  }
+	>;
 	tool_choice?: ResponsesToolChoice;
 	stream?: boolean;
 	temperature?: number;


### PR DESCRIPTION
## Problem

[Muse Image](https://developer.meta.com/ai/models/muse-image/) is available through Meta Model API, but the catalogue, gateway Responses bridge, and image playground did not support it. Meta exposes image generation through an `image_generation` tool and does not accept a quality option.

## Approach

- add `meta/muse-image-1.0` at the published flat image price
- translate image size into Meta's Responses image-generation tool
- preserve generated WebP output, reasoning, references, and multi-turn refinement across the Chat Completions and Responses APIs
- restrict the playground to Meta's supported sizes and hide quality selection
- document the model-specific request shape and add focused regression coverage

## Mapping evidence

The [official API cookbook](https://github.com/meta-models/meta-model-cookbook/tree/main/05_muse_image/01_image_api_fundamentals) uses `muse-image-1.0` with `POST /v1/responses`. The [anchored-generation guide](https://github.com/meta-models/meta-model-cookbook/tree/main/05_muse_image/03_anchored_generation) documents `1024x1024`, `1024x1536`, and `1536x1024` as the supported sizes.

| Field | Value |
| --- | --- |
| Canonical model | `muse-image-1.0` |
| Provider / region | `meta` / `global` |
| External model | `muse-image-1.0` |
| Pricing | `$0.01` per image; zero token and request prices |
| Capabilities | image output, reasoning, vision/reference input, Responses API |
| Unsupported | streaming, function tools, JSON output, quality selection |

Context and output-token limits are omitted because Meta does not publish them for this image model. The mapping remains skipped in the default paid-provider e2e sweep; explicit `TEST_MODELS` coverage overrides that metadata.

## Verification

- `pnpm format`
- `pnpm build` — 17/17 tasks passed
- focused unit and metadata suite — 8 files, 631 tests passed
- `TEST_MODELS='meta/muse-image-1.0' FULL_MODE=true TEST_IMAGE_MODE=true TEST_IMAGE_SIZE='1024x1024' CONCURRENT_TESTS=false pnpm test:e2e` — 84 passed, including Chat Completions, Responses, image generations, image edits, and reasoning
- live chained Responses requests generated and refined an image through `previous_response_id`
- persisted billing reconciled to the flat `$0.01` image charge with zero token cost
- browser verification showed only the three supported sizes and no quality control


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Meta’s Muse Image model, including image generation through the Responses API.
  * Added supported image sizes: 1024×1024, 1024×1536, and 1536×1024.
  * Playground image controls now display Muse-specific size options.
  * Generated images, reasoning, and usage details are preserved across compatible responses.
  * Added Muse Image documentation and model pricing information.

* **Bug Fixes**
  * Preserved existing response content when image-generation output contains no text.
  * Added validation and clear errors for unsupported image sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->