### PR TITLE
fix(models-directory): disable implied toggles

### DIFF
--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -2017,54 +2017,75 @@ export function AllModels({
 									icon: Percent,
 									color: "text-red-500",
 								},
-							].map(({ key, label, icon: Icon, color }) => (
-								<Toggle
-									key={`${key}-${label}`}
-									variant="outline"
-									size="sm"
-									pressed={
-										filters.capabilities[
-											key as keyof typeof filters.capabilities
-										]
-									}
-									onPressedChange={(pressed) => {
-										setFilters((prev) => ({
-											...prev,
-											capabilities: {
-												...prev.capabilities,
-												[key]: pressed,
-											},
-										}));
-										if (key === "discounted") {
-											if (pressed) {
-												setSortField("discount");
-												setSortDirection("desc");
-												updateUrlWithFilters({
-													[key]: "true",
-													sortField: "discount",
-													sortDir: "desc",
-												});
+							].map(({ key, label, icon: Icon, color }) => {
+								const isImplied =
+									!hideUseCaseFilter &&
+									((filters.category === "reasoning" && key === "reasoning") ||
+										(filters.category === "multimodal" && key === "vision") ||
+										(filters.category === "image" &&
+											key === "imageGeneration"));
+								const toggle = (
+									<Toggle
+										key={`${key}-${label}`}
+										variant="outline"
+										size="sm"
+										disabled={isImplied}
+										pressed={
+											filters.capabilities[
+												key as keyof typeof filters.capabilities
+											]
+										}
+										onPressedChange={(pressed) => {
+											setFilters((prev) => ({
+												...prev,
+												capabilities: {
+													...prev.capabilities,
+													[key]: pressed,
+												},
+											}));
+											if (key === "discounted") {
+												if (pressed) {
+													setSortField("discount");
+													setSortDirection("desc");
+													updateUrlWithFilters({
+														[key]: "true",
+														sortField: "discount",
+														sortDir: "desc",
+													});
+												} else {
+													setSortField(null);
+													setSortDirection("desc");
+													updateUrlWithFilters({
+														[key]: undefined,
+														sortField: undefined,
+														sortDir: undefined,
+													});
+												}
 											} else {
-												setSortField(null);
-												setSortDirection("desc");
 												updateUrlWithFilters({
-													[key]: undefined,
-													sortField: undefined,
-													sortDir: undefined,
+													[key]: pressed ? "true" : undefined,
 												});
 											}
-										} else {
-											updateUrlWithFilters({
-												[key]: pressed ? "true" : undefined,
-											});
-										}
-									}}
-									className="gap-1.5"
-								>
-									<Icon className={`h-3.5 w-3.5 ${color}`} />
-									<span className="text-xs">{label}</span>
-								</Toggle>
-							))}
+										}}
+										className="gap-1.5"
+									>
+										<Icon className={`h-3.5 w-3.5 ${color}`} />
+										<span className="text-xs">{label}</span>
+									</Toggle>
+								);
+								return isImplied ? (
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<span>{toggle}</span>
+										</TooltipTrigger>
+										<TooltipContent>
+											<p className="text-xs">Already included in Use Case</p>
+										</TooltipContent>
+									</Tooltip>
+								) : (
+									toggle
+								);
+							})}
 						</div>
 					</div>
 

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -2370,18 +2370,34 @@ export function AllModels({
 
 	// Capability filter keys that are active, used to pin the matching icon to
 	// the front of the features column in the table view.
-	const pinnedCapabilityKeys = useMemo(
-		() =>
-			(
-				Object.entries(filters.capabilities) as Array<
-					[keyof typeof filters.capabilities, boolean]
-				>
-			)
-				.filter(([, pressed]) => pressed)
-				.map(([key]) => key)
-				.filter((key) => CAPABILITY_LABEL_BY_FILTER_KEY[key]),
-		[filters.capabilities],
-	);
+	const pinnedCapabilityKeys = useMemo(() => {
+		const keys = (
+			Object.entries(filters.capabilities) as Array<
+				[keyof typeof filters.capabilities, boolean]
+			>
+		)
+			.filter(([, pressed]) => pressed)
+			.map(([key]) => key)
+			.filter((key) => CAPABILITY_LABEL_BY_FILTER_KEY[key]);
+
+		if (!hideUseCaseFilter) {
+			if (filters.category === "reasoning") {
+				keys.push("reasoning");
+			} else if (filters.category === "multimodal") {
+				keys.push("vision");
+			} else if (filters.category === "image") {
+				keys.push("imageGeneration");
+			} else if (filters.category === "code") {
+				keys.push("tools", "streaming");
+			} else if (filters.category === "chat") {
+				keys.push("streaming");
+			} else if (filters.category === "creative") {
+				keys.push("streaming");
+			}
+		}
+
+		return Array.from(new Set(keys));
+	}, [filters.capabilities, filters.category, hideUseCaseFilter]);
 
 	const renderTableView = () => {
 		return (

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -2020,7 +2020,11 @@ export function AllModels({
 							].map(({ key, label, icon: Icon, color }) => {
 								const isImplied =
 									!hideUseCaseFilter &&
-									((filters.category === "reasoning" && key === "reasoning") ||
+									((filters.category === "code" &&
+										(key === "streaming" || key === "tools")) ||
+										(filters.category === "chat" && key === "streaming") ||
+										(filters.category === "reasoning" && key === "reasoning") ||
+										(filters.category === "creative" && key === "streaming") ||
 										(filters.category === "multimodal" && key === "vision") ||
 										(filters.category === "image" &&
 											key === "imageGeneration"));
@@ -2074,7 +2078,7 @@ export function AllModels({
 									</Toggle>
 								);
 								return isImplied ? (
-									<Tooltip>
+									<Tooltip key={`${key}-${label}`}>
 										<TooltipTrigger asChild>
 											<span>{toggle}</span>
 										</TooltipTrigger>

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -90,6 +90,7 @@ import { applyCategoryFilter } from "./model-category-filters";
 import { isVisibleMapping } from "./status-filters";
 import {
 	applyUseCaseFilter,
+	getImpliedCapabilityKeys,
 	isUseCaseCategory,
 	providerRowPassesFilters,
 } from "./use-case-filters";
@@ -668,9 +669,15 @@ const ModelTableRow = React.memo(
 								.map((key) => CAPABILITY_LABEL_BY_FILTER_KEY[key])
 								.filter((label): label is string => Boolean(label));
 							const ordered = [
-								...row.capabilities.filter((c) =>
-									pinnedLabels.includes(c.label),
-								),
+								...pinnedCapabilityKeys
+									.map((key) => CAPABILITY_LABEL_BY_FILTER_KEY[key])
+									.filter((label): label is string => Boolean(label))
+									.map((label) =>
+										row.capabilities.find((c) => c.label === label),
+									)
+									.filter((c): c is (typeof row.capabilities)[number] =>
+										Boolean(c),
+									),
 								...row.capabilities.filter(
 									(c) => !pinnedLabels.includes(c.label),
 								),
@@ -2018,16 +2025,10 @@ export function AllModels({
 									color: "text-red-500",
 								},
 							].map(({ key, label, icon: Icon, color }) => {
-								const isImplied =
-									!hideUseCaseFilter &&
-									((filters.category === "code" &&
-										(key === "streaming" || key === "tools")) ||
-										(filters.category === "chat" && key === "streaming") ||
-										(filters.category === "reasoning" && key === "reasoning") ||
-										(filters.category === "creative" && key === "streaming") ||
-										(filters.category === "multimodal" && key === "vision") ||
-										(filters.category === "image" &&
-											key === "imageGeneration"));
+								const isImplied = getImpliedCapabilityKeys(
+									filters.category,
+									hideUseCaseFilter,
+								).includes(key);
 								const toggle = (
 									<Toggle
 										key={`${key}-${label}`}
@@ -2371,7 +2372,7 @@ export function AllModels({
 	// Capability filter keys that are active, used to pin the matching icon to
 	// the front of the features column in the table view.
 	const pinnedCapabilityKeys = useMemo(() => {
-		const keys = (
+		const explicitKeys = (
 			Object.entries(filters.capabilities) as Array<
 				[keyof typeof filters.capabilities, boolean]
 			>
@@ -2380,23 +2381,12 @@ export function AllModels({
 			.map(([key]) => key)
 			.filter((key) => CAPABILITY_LABEL_BY_FILTER_KEY[key]);
 
-		if (!hideUseCaseFilter) {
-			if (filters.category === "reasoning") {
-				keys.push("reasoning");
-			} else if (filters.category === "multimodal") {
-				keys.push("vision");
-			} else if (filters.category === "image") {
-				keys.push("imageGeneration");
-			} else if (filters.category === "code") {
-				keys.push("tools", "streaming");
-			} else if (filters.category === "chat") {
-				keys.push("streaming");
-			} else if (filters.category === "creative") {
-				keys.push("streaming");
-			}
-		}
+		const impliedKeys = getImpliedCapabilityKeys(
+			filters.category,
+			hideUseCaseFilter,
+		);
 
-		return Array.from(new Set(keys));
+		return Array.from(new Set([...impliedKeys, ...explicitKeys]));
 	}, [filters.capabilities, filters.category, hideUseCaseFilter]);
 
 	const renderTableView = () => {

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -90,6 +90,7 @@ import { applyCategoryFilter } from "./model-category-filters";
 import { isVisibleMapping } from "./status-filters";
 import {
 	applyUseCaseFilter,
+	getExcludedCapabilityKeys,
 	getImpliedCapabilityKeys,
 	isUseCaseCategory,
 	providerRowPassesFilters,
@@ -669,9 +670,7 @@ const ModelTableRow = React.memo(
 								.map((key) => CAPABILITY_LABEL_BY_FILTER_KEY[key])
 								.filter((label): label is string => Boolean(label));
 							const ordered = [
-								...pinnedCapabilityKeys
-									.map((key) => CAPABILITY_LABEL_BY_FILTER_KEY[key])
-									.filter((label): label is string => Boolean(label))
+								...pinnedLabels
 									.map((label) =>
 										row.capabilities.find((c) => c.label === label),
 									)
@@ -877,19 +876,18 @@ export function AllModels({
 		return searchParams.get("deactivated") === "true" ? "deactivated" : null;
 	}
 
-	const [filters, setFilters] = useState({
+	const [filters, setFilters] = useState(() => {
 		// With the selector hidden there is no way to see or change the
 		// category, so ignore any URL override and pin the default. When the
 		// selector is shown, only accept a known category from the URL so an
 		// unsupported value falls back to the default instead of silently
 		// matching every row.
-		category: hideUseCaseFilter
+		const category = hideUseCaseFilter
 			? defaultCategory
 			: isUseCaseCategory(urlCategory)
 				? urlCategory
-				: defaultCategory,
-		tier: searchParams.get("tier") ?? "all",
-		capabilities: {
+				: defaultCategory;
+		const capabilities = {
 			streaming: searchParams.get("streaming") === "true",
 			vision: searchParams.get("vision") === "true",
 			tools: searchParams.get("tools") === "true",
@@ -905,23 +903,36 @@ export function AllModels({
 			webSearch: searchParams.get("webSearch") === "true",
 			free: searchParams.get("free") === "true",
 			discounted: searchParams.get("discounted") === "true",
-		},
-		selectedProvider: searchParams.get("provider") ?? "all",
-		status: getStatusFilterFromUrl(searchParams),
-		source: searchParams.get("source") ?? "all",
-		eligibleOnly: searchParams.get("eligibility") === "eligible",
-		inputPrice: {
-			min: searchParams.get("inputPriceMin") ?? "",
-			max: searchParams.get("inputPriceMax") ?? "",
-		},
-		outputPrice: {
-			min: searchParams.get("outputPriceMin") ?? "",
-			max: searchParams.get("outputPriceMax") ?? "",
-		},
-		contextSize: {
-			min: searchParams.get("contextSizeMin") ?? "",
-			max: searchParams.get("contextSizeMax") ?? "",
-		},
+		};
+		// A deep link can pair the category with a capability it excludes; the
+		// toggle renders disabled, so drop the filter rather than emptying the
+		// directory through a control that cannot be cleared.
+		for (const key of getExcludedCapabilityKeys(category)) {
+			if (key in capabilities) {
+				capabilities[key as keyof typeof capabilities] = false;
+			}
+		}
+		return {
+			category,
+			tier: searchParams.get("tier") ?? "all",
+			capabilities,
+			selectedProvider: searchParams.get("provider") ?? "all",
+			status: getStatusFilterFromUrl(searchParams),
+			source: searchParams.get("source") ?? "all",
+			eligibleOnly: searchParams.get("eligibility") === "eligible",
+			inputPrice: {
+				min: searchParams.get("inputPriceMin") ?? "",
+				max: searchParams.get("inputPriceMax") ?? "",
+			},
+			outputPrice: {
+				min: searchParams.get("outputPriceMin") ?? "",
+				max: searchParams.get("outputPriceMax") ?? "",
+			},
+			contextSize: {
+				min: searchParams.get("contextSizeMin") ?? "",
+				max: searchParams.get("contextSizeMax") ?? "",
+			},
+		};
 	});
 
 	// Org-directory extensions: the Source and Eligibility filters only appear
@@ -1794,9 +1805,11 @@ export function AllModels({
 			videoGeneration: undefined,
 			audioGeneration: undefined,
 			embedding: undefined,
+			rerank: undefined,
 			webSearch: undefined,
 			free: undefined,
 			discounted: undefined,
+			page: undefined,
 			provider: undefined,
 			status: undefined,
 			deactivated: undefined,
@@ -1827,10 +1840,36 @@ export function AllModels({
 								<Select
 									value={filters.category}
 									onValueChange={(value) => {
-										setFilters((prev) => ({ ...prev, category: value }));
-										updateUrlWithFilters({
-											category: value !== defaultCategory ? value : undefined,
+										// Clear capability filters the outgoing or incoming
+										// category implies or excludes: implied ones are
+										// absorbed by the category, and leaving any of them
+										// pressed would silently re-apply after the next
+										// category switch, with no enabled toggle to clear it.
+										const staleKeys = Array.from(
+											new Set([
+												...getImpliedCapabilityKeys(filters.category),
+												...getExcludedCapabilityKeys(filters.category),
+												...getImpliedCapabilityKeys(value),
+												...getExcludedCapabilityKeys(value),
+											]),
+										);
+										setFilters((prev) => {
+											const capabilities = { ...prev.capabilities };
+											for (const key of staleKeys) {
+												if (key in capabilities) {
+													capabilities[key as keyof typeof capabilities] =
+														false;
+												}
+											}
+											return { ...prev, category: value, capabilities };
 										});
+										const urlUpdates: Record<string, string | undefined> = {
+											category: value !== defaultCategory ? value : undefined,
+										};
+										for (const key of staleKeys) {
+											urlUpdates[key] = undefined;
+										}
+										updateUrlWithFilters(urlUpdates);
 									}}
 								>
 									<SelectTrigger className="w-full">
@@ -2025,20 +2064,20 @@ export function AllModels({
 									color: "text-red-500",
 								},
 							].map(({ key, label, icon: Icon, color }) => {
-								const isImplied = getImpliedCapabilityKeys(
-									filters.category,
-									hideUseCaseFilter,
-								).includes(key);
+								const isImplied = impliedCapabilityKeys.includes(key);
+								const isExcluded = excludedCapabilityKeys.includes(key);
 								const toggle = (
 									<Toggle
 										key={`${key}-${label}`}
 										variant="outline"
 										size="sm"
-										disabled={isImplied}
+										disabled={isImplied || isExcluded}
 										pressed={
-											filters.capabilities[
-												key as keyof typeof filters.capabilities
-											]
+											!isExcluded &&
+											(isImplied ||
+												filters.capabilities[
+													key as keyof typeof filters.capabilities
+												])
 										}
 										onPressedChange={(pressed) => {
 											setFilters((prev) => ({
@@ -2078,13 +2117,20 @@ export function AllModels({
 										<span className="text-xs">{label}</span>
 									</Toggle>
 								);
-								return isImplied ? (
+								return isImplied || isExcluded ? (
 									<Tooltip key={`${key}-${label}`}>
 										<TooltipTrigger asChild>
-											<span>{toggle}</span>
+											{/* The disabled toggle is unfocusable, so the wrapper
+											    takes the tab stop to keep the tooltip reachable
+											    by keyboard and assistive tech. */}
+											<span tabIndex={0}>{toggle}</span>
 										</TooltipTrigger>
 										<TooltipContent>
-											<p className="text-xs">Already included in Use Case</p>
+											<p className="text-xs">
+												{isImplied
+													? "Already included in the selected category"
+													: "No models in the selected category can match this"}
+											</p>
 										</TooltipContent>
 									</Tooltip>
 								) : (
@@ -2369,8 +2415,20 @@ export function AllModels({
 		</Card>
 	);
 
-	// Capability filter keys that are active, used to pin the matching icon to
-	// the front of the features column in the table view.
+	// Capability toggles the active category disables: implied ones are
+	// satisfied by every matching model, excluded ones can never match.
+	const impliedCapabilityKeys = useMemo(
+		() => getImpliedCapabilityKeys(filters.category, categoryFilter),
+		[filters.category, categoryFilter],
+	);
+	const excludedCapabilityKeys = useMemo(
+		() => getExcludedCapabilityKeys(filters.category),
+		[filters.category],
+	);
+
+	// Capability keys pinned to the front of the features column in the table
+	// view: explicitly pressed filters first, then keys the active category
+	// implies (which every row necessarily has).
 	const pinnedCapabilityKeys = useMemo(() => {
 		const explicitKeys = (
 			Object.entries(filters.capabilities) as Array<
@@ -2381,13 +2439,8 @@ export function AllModels({
 			.map(([key]) => key)
 			.filter((key) => CAPABILITY_LABEL_BY_FILTER_KEY[key]);
 
-		const impliedKeys = getImpliedCapabilityKeys(
-			filters.category,
-			hideUseCaseFilter,
-		);
-
-		return Array.from(new Set([...impliedKeys, ...explicitKeys]));
-	}, [filters.capabilities, filters.category, hideUseCaseFilter]);
+		return Array.from(new Set([...explicitKeys, ...impliedCapabilityKeys]));
+	}, [filters.capabilities, impliedCapabilityKeys]);
 
 	const renderTableView = () => {
 		return (

--- a/packages/shared/src/components/models-directory/use-case-filters.spec.ts
+++ b/packages/shared/src/components/models-directory/use-case-filters.spec.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "vitest";
 
+import { applyCategoryFilter } from "./model-category-filters";
 import {
 	applyUseCaseFilter,
+	getExcludedCapabilityKeys,
+	getImpliedCapabilityKeys,
 	providerRowPassesFilters,
+	useCaseCategories,
 } from "./use-case-filters";
 
 import type {
@@ -10,6 +14,7 @@ import type {
 	ApiModelProviderMapping,
 	ApiProvider,
 } from "./api-types";
+import type { ModelCategoryFilter } from "./model-category-filters";
 import type { ProviderRowFilterOptions } from "./use-case-filters";
 // Realistic mock mapping: every field the directory renders, with capability
 // flags off by default so a test can flip exactly the one it cares about.
@@ -363,5 +368,172 @@ describe("providerRowPassesFilters: full production row-filter path", () => {
 			)
 			.map(({ provider }) => provider);
 		expect(rows.map((r) => r.id)).toEqual(["alpha", "beta"]);
+	});
+});
+
+// Pin the implication tables to the real predicates: each test breaks (or
+// grants) exactly one capability on an otherwise fully-capable model and
+// expects the category to reject it. Loosening a predicate without updating
+// the table fails here, so a toggle is never wrongly left disabled.
+describe("category → capability implication tables", () => {
+	const capableMapping: Partial<ApiModelProviderMapping> = {
+		streaming: true,
+		tools: true,
+		reasoning: true,
+		vision: true,
+		webSearch: true,
+		cachedInputPrice: "0.2e-6",
+		discount: "0.2",
+	};
+	const mappingBreakers: Record<string, Partial<ApiModelProviderMapping>> = {
+		streaming: { streaming: false },
+		tools: { tools: false },
+		reasoning: { reasoning: false },
+		vision: { vision: false },
+		webSearch: { webSearch: false },
+		discounted: { discount: null },
+	};
+	// Capability keys whose predicate is a model output modality rather than a
+	// mapping flag; breaking them means removing that modality from `output`.
+	const outputModalityByCapability: Record<string, string> = {
+		imageGeneration: "image",
+		videoGeneration: "video",
+		embedding: "embedding",
+	};
+
+	function capableModel(output: string[]) {
+		const model = makeModel([makeMapping(capableMapping)]);
+		model.output = output;
+		return model;
+	}
+
+	function brokenModel(output: string[], key: string) {
+		const modality = outputModalityByCapability[key];
+		if (modality) {
+			return capableModel(output.filter((o) => o !== modality));
+		}
+		const breaker = mappingBreakers[key];
+		if (!breaker) {
+			throw new Error(`no capability breaker defined for key "${key}"`);
+		}
+		const model = makeModel([makeMapping({ ...capableMapping, ...breaker })]);
+		model.output = output;
+		return model;
+	}
+
+	describe("Use Case implied keys are enforced by applyUseCaseFilter", () => {
+		function outputFor(category: string): string[] {
+			return category === "image" ? ["image"] : ["text"];
+		}
+
+		for (const category of useCaseCategories) {
+			for (const key of getImpliedCapabilityKeys(category)) {
+				test(`${category} implies ${key}`, () => {
+					const good = capableModel(outputFor(category));
+					expect(applyUseCaseFilter(category, good, good.mappings)).toBe(true);
+					const bad = brokenModel(outputFor(category), key);
+					expect(applyUseCaseFilter(category, bad, bad.mappings)).toBe(false);
+				});
+			}
+		}
+
+		test("'all' and unknown categories imply nothing", () => {
+			expect(getImpliedCapabilityKeys("all")).toEqual([]);
+			expect(getImpliedCapabilityKeys(null)).toEqual([]);
+			expect(getImpliedCapabilityKeys("not-a-real-category")).toEqual([]);
+		});
+	});
+
+	describe("Use Case excluded keys can never match", () => {
+		// Granting the excluded capability must make the category reject the
+		// model, proving the combination is empty by construction.
+		const granters: Record<
+			string,
+			(model: ReturnType<typeof capableModel>) => void
+		> = {
+			free: (model) => {
+				model.free = true;
+			},
+			imageGeneration: (model) => {
+				model.output = [...(model.output ?? []), "image"];
+			},
+		};
+
+		for (const category of useCaseCategories) {
+			for (const key of getExcludedCapabilityKeys(category)) {
+				test(`${category} excludes ${key}`, () => {
+					const granter = granters[key];
+					if (!granter) {
+						throw new Error(`no capability granter defined for key "${key}"`);
+					}
+					const model = capableModel(["text"]);
+					expect(applyUseCaseFilter(category, model, model.mappings)).toBe(
+						true,
+					);
+					granter(model);
+					expect(applyUseCaseFilter(category, model, model.mappings)).toBe(
+						false,
+					);
+				});
+			}
+		}
+
+		test("categories without exclusions return an empty list", () => {
+			expect(getExcludedCapabilityKeys("chat")).toEqual([]);
+			expect(getExcludedCapabilityKeys("all")).toEqual([]);
+			expect(getExcludedCapabilityKeys(null)).toEqual([]);
+		});
+	});
+
+	describe("category-page implied keys are enforced by applyCategoryFilter", () => {
+		const filtersWithImplications: ModelCategoryFilter[] = [
+			"text-to-image",
+			"image-to-image",
+			"video",
+			"embedding",
+			"web-search",
+			"vision",
+			"reasoning",
+			"tools",
+			"discounted",
+		];
+
+		function outputFor(categoryFilter: ModelCategoryFilter): string[] {
+			switch (categoryFilter) {
+				case "text-to-image":
+				case "image-to-image":
+					return ["image"];
+				case "video":
+					return ["video"];
+				case "embedding":
+					return ["embedding"];
+				default:
+					return ["text"];
+			}
+		}
+
+		for (const categoryFilter of filtersWithImplications) {
+			const implied = getImpliedCapabilityKeys(null, categoryFilter);
+			test(`${categoryFilter} implies ${implied.join(", ")}`, () => {
+				expect(implied.length).toBeGreaterThan(0);
+				for (const key of implied) {
+					const good = capableModel(outputFor(categoryFilter));
+					expect(applyCategoryFilter(categoryFilter, good, good.mappings)).toBe(
+						true,
+					);
+					const bad = brokenModel(outputFor(categoryFilter), key);
+					expect(applyCategoryFilter(categoryFilter, bad, bad.mappings)).toBe(
+						false,
+					);
+				}
+			});
+		}
+
+		test("curated and price-based category pages imply nothing", () => {
+			expect(getImpliedCapabilityKeys(null, "coding")).toEqual([]);
+			expect(getImpliedCapabilityKeys(null, "cheapest")).toEqual([]);
+			expect(getImpliedCapabilityKeys(null, "long-context")).toEqual([]);
+			expect(getImpliedCapabilityKeys(null, "text")).toEqual([]);
+		});
 	});
 });

--- a/packages/shared/src/components/models-directory/use-case-filters.ts
+++ b/packages/shared/src/components/models-directory/use-case-filters.ts
@@ -27,6 +27,34 @@ export function isUseCaseCategory(
 	);
 }
 
+export function getImpliedCapabilityKeys(
+	category: string | null,
+	hideUseCaseFilter?: boolean,
+): string[] {
+	if (hideUseCaseFilter) {
+		return [];
+	}
+	if (category === "reasoning") {
+		return ["reasoning"];
+	}
+	if (category === "multimodal") {
+		return ["vision"];
+	}
+	if (category === "image") {
+		return ["imageGeneration"];
+	}
+	if (category === "code") {
+		return ["tools", "streaming"];
+	}
+	if (category === "chat") {
+		return ["streaming"];
+	}
+	if (category === "creative") {
+		return ["streaming"];
+	}
+	return [];
+}
+
 export function applyUseCaseFilter(
 	category: string,
 	model: ApiModel,

--- a/packages/shared/src/components/models-directory/use-case-filters.ts
+++ b/packages/shared/src/components/models-directory/use-case-filters.ts
@@ -27,32 +27,68 @@ export function isUseCaseCategory(
 	);
 }
 
+// Capability toggle keys every model matching the Use Case already satisfies,
+// making the toggle a guaranteed no-op while that category is active. Each
+// entry mirrors a clause of applyUseCaseFilter / mappingSupportsCoding below;
+// the spec pins them together so a predicate change breaks a test here.
+const IMPLIED_CAPABILITY_KEYS_BY_USE_CASE: Partial<
+	Record<UseCaseCategory, readonly string[]>
+> = {
+	code: ["tools", "streaming"],
+	chat: ["streaming"],
+	reasoning: ["reasoning"],
+	creative: ["streaming"],
+	image: ["imageGeneration"],
+	multimodal: ["vision"],
+};
+
+// Same idea for the category pages (`categoryFilter` prop): entries only for
+// filters whose applyCategoryFilter predicate is identical to the matching
+// capability toggle. Curated-list and price-based filters imply nothing.
+const IMPLIED_CAPABILITY_KEYS_BY_CATEGORY_FILTER: Partial<
+	Record<ModelCategoryFilter, readonly string[]>
+> = {
+	"text-to-image": ["imageGeneration"],
+	"image-to-image": ["imageGeneration", "vision"],
+	video: ["videoGeneration"],
+	embedding: ["embedding"],
+	"web-search": ["webSearch"],
+	vision: ["vision"],
+	reasoning: ["reasoning"],
+	tools: ["tools"],
+	discounted: ["discounted"],
+};
+
+// Toggles the Use Case makes unsatisfiable: pressing them can only produce an
+// empty directory, so they are disabled like the implied ones.
+const EXCLUDED_CAPABILITY_KEYS_BY_USE_CASE: Partial<
+	Record<UseCaseCategory, readonly string[]>
+> = {
+	// isCodingModel rejects free models outright.
+	code: ["free"],
+	// creative rejects image-output models, which is exactly what the
+	// imageGeneration toggle requires.
+	creative: ["imageGeneration"],
+};
+
 export function getImpliedCapabilityKeys(
 	category: string | null,
-	hideUseCaseFilter?: boolean,
+	categoryFilter?: ModelCategoryFilter,
 ): string[] {
-	if (hideUseCaseFilter) {
-		return [];
-	}
-	if (category === "reasoning") {
-		return ["reasoning"];
-	}
-	if (category === "multimodal") {
-		return ["vision"];
-	}
-	if (category === "image") {
-		return ["imageGeneration"];
-	}
-	if (category === "code") {
-		return ["tools", "streaming"];
-	}
-	if (category === "chat") {
-		return ["streaming"];
-	}
-	if (category === "creative") {
-		return ["streaming"];
-	}
-	return [];
+	return [
+		...(isUseCaseCategory(category)
+			? (IMPLIED_CAPABILITY_KEYS_BY_USE_CASE[category] ?? [])
+			: []),
+		...(categoryFilter
+			? (IMPLIED_CAPABILITY_KEYS_BY_CATEGORY_FILTER[categoryFilter] ?? [])
+			: []),
+	];
+}
+
+export function getExcludedCapabilityKeys(category: string | null): string[] {
+	return isUseCaseCategory(category)
+		? [...(EXCLUDED_CAPABILITY_KEYS_BY_USE_CASE[category] ?? [])]
+		: [];
 }
 
 export function applyUseCaseFilter(


### PR DESCRIPTION
Fixes the `Use Case` filter duplicating capability toggles with no visible effect.

## Why

- `Use Case = Reasoning & Analysis` tests `p.reasoning` (`use-case-filters.ts`) — identical to the `Reasoning` capability toggle (`capability-filters.ts`).
- Same for `Multimodal (Vision)` ↔ `Vision`, `Image Generation` ↔ `Image Gen`, and the streaming/tools clauses of `chat`/`creative`/`code`. Picking the Use Case then toggling the capability ANDs the same flag — 0 rows change, but the UI gives no hint why.

## How

- `use-case-filters.ts` now owns the implication tables: `getImpliedCapabilityKeys` (keys every model in the category already satisfies) and `getExcludedCapabilityKeys` (keys the category makes unsatisfiable — `code`+`Free`, `creative`+`Image Gen`). Implied and excluded toggles render disabled with distinct tooltips; the filter pipeline is unchanged.
- The treatment covers all three category mechanisms: the Use Case select, the `categoryFilter` SEO pages (`/models/vision`, `/models/tools`, …, whose predicates are identical to the matching toggles), and the DevPass directory (pinned to `code` with the selector hidden).
- Switching Use Case clears capability state the old or new category implies/excludes, so a pressed+disabled toggle can never strand a filter that silently re-applies after the next switch; deep links pairing a category with an excluded capability are normalized instead of emptying the directory behind a disabled control.
- **Features** column pins explicitly pressed filters first, then the category-implied icons (same `ordered = [pinned, rest]` path, capped at 4 + `+N` tooltip).
- Disabled-toggle tooltips are keyboard/AT reachable via a focusable wrapper; `Clear` now also removes `rerank` and `page` from the URL.

## Verification

- `pnpm format` clean; `turbo build` green (shared, ui, code)
- `use-case-filters.spec.ts` 41/41, `capability-filters.spec.ts` 38/38 — includes 21 new tests pinning each implication/exclusion to the real predicates (`applyUseCaseFilter`, `isCodingModel`, `applyCategoryFilter`), so loosening a predicate without updating the table fails the suite
- Manual: `localhost:3002/models` → `Reasoning & Analysis` → `Reasoning` greyed out with tooltip

## Screenshots
## - Before 
<img width="1577" height="762" alt="Before" src="https://github.com/user-attachments/assets/e26c96a2-2e16-4555-b822-d4d51341130b" />

## - After
<img width="1507" height="790" alt="After" src="https://github.com/user-attachments/assets/95456868-1b13-4381-af9c-4c6f2e4704bc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Capability filters now account for capabilities implied or excluded by selected use cases and categories.
  - Disabled capability options include explanatory tooltips.
  - Implied and explicitly selected capabilities remain pinned in model feature tables without duplicates.

- **Bug Fixes**
  - Clears incompatible filters when categories change or filters are initialized from a URL.
  - Clearing filters now also resets reranking and pagination.
  - Preserved existing discounted sorting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
