### PR TITLE
fix(admin): split credits revenue lines

### DIFF
--- a/ee/admin/src/app/page.tsx
+++ b/ee/admin/src/app/page.tsx
@@ -313,8 +313,14 @@ export default async function Page({
 							style={revealAt(2)}
 							rows={[
 								{
-									label: "Credits",
+									label: "Credits Stripe",
 									value: currencyFormatter.format(metrics.grossCreditsRevenue),
+								},
+								{
+									label: "Credits external",
+									value: currencyFormatter.format(
+										metrics.grossManualPaymentsRevenue,
+									),
 								},
 								{
 									label: "DevPass",
@@ -344,16 +350,6 @@ export default async function Page({
 												label: "Pro subs",
 												value: currencyFormatter.format(
 													metrics.grossProSubscriptionsRevenue,
-												),
-											},
-										]
-									: []),
-								...(metrics.grossManualPaymentsRevenue > 0
-									? [
-											{
-												label: "Manual payments",
-												value: currencyFormatter.format(
-													metrics.grossManualPaymentsRevenue,
 												),
 											},
 										]

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -2372,6 +2372,62 @@ async function seed() {
 		description: "Test credit top-up for referral eligibility",
 	});
 
+	await upsert(tables.transaction, {
+		id: "seed-manual-payment-wire-id",
+		organizationId: "test-org-id",
+		createdAt: daysAgo(21),
+		type: "credit_manual_payment",
+		amount: "500",
+		creditAmount: "500",
+		currency: "USD",
+		status: "completed",
+		paymentMethod: "wire",
+		externalReference: "seed-wire-payment",
+		description: "Seeded external credit payment by wire",
+	});
+
+	await upsert(tables.transaction, {
+		id: "seed-manual-payment-crypto-id",
+		organizationId: "test-org-id",
+		createdAt: daysAgo(14),
+		type: "credit_manual_payment",
+		amount: "300",
+		creditAmount: "300",
+		currency: "USD",
+		status: "completed",
+		paymentMethod: "crypto",
+		externalReference: "seed-crypto-payment",
+		description: "Seeded external credit payment by crypto",
+	});
+
+	await upsert(tables.transaction, {
+		id: "seed-manual-payment-paypal-id",
+		organizationId: "test-org-id",
+		createdAt: daysAgo(7),
+		type: "credit_manual_payment",
+		amount: "200",
+		creditAmount: "200",
+		currency: "USD",
+		status: "completed",
+		paymentMethod: "paypal",
+		externalReference: "seed-paypal-payment",
+		description: "Seeded external credit payment by PayPal",
+	});
+
+	await upsert(tables.transaction, {
+		id: "seed-enterprise-license-fee-id",
+		organizationId: "enterprise-org-id",
+		createdAt: daysAgo(10),
+		type: "enterprise_license_fee",
+		amount: "5000",
+		creditAmount: null,
+		currency: "USD",
+		status: "completed",
+		paymentMethod: "wire",
+		externalReference: "seed-enterprise-license",
+		description: "Seeded enterprise license fee",
+	});
+
 	const devpassStartCreatedAt = daysAgo(36);
 	await upsert(tables.transaction, {
 		id: "test-devpass-start-transaction-id",


### PR DESCRIPTION
## Problem

The total revenue breakdown combined Stripe credit sales under a generic Credits label and only showed external credit payments when non-zero.

## Approach

- rename the Stripe-backed row to Credits Stripe
- add an always-visible Credits external row using the existing external-payment metric
- remove the conditional Manual payments row
- seed representative external-credit payments and enterprise-license revenue for local verification

## Screenshots

### Light

| Before | After |
| --- | --- |
| <img width="760" alt="Revenue breakdown before the credit split in light mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/a7d8fe16a2e321f82a1853e63b0c8c1a94a8e542/before-light.png" /> | <img width="760" alt="Revenue breakdown with Stripe and external credit rows in light mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/a7d8fe16a2e321f82a1853e63b0c8c1a94a8e542/after-light.png" /> |

### Dark

| Before | After |
| --- | --- |
| <img width="760" alt="Revenue breakdown before the credit split in dark mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/a7d8fe16a2e321f82a1853e63b0c8c1a94a8e542/before-dark.png" /> | <img width="760" alt="Revenue breakdown with Stripe and external credit rows in dark mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/a7d8fe16a2e321f82a1853e63b0c8c1a94a8e542/after-dark.png" /> |

## Verification

- `pnpm format`
- `pnpm build`
- confirmed seeded revenue totals directly in the isolated database
- verified the seeded admin dashboard at 1440px in light and dark themes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * The admin dashboard’s **Total revenue** breakdown now separates credit revenue into:
    * **Credits Stripe**
    * **Credits external**
  * The **Credits external** row is now always displayed, including when its value is zero.
  * Added sample completed credit payments and an enterprise license payment for test data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->