### PR TITLE
feat(models): add SCX Kimi K3 and K2.7 Code

### DIFF
--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -678,6 +678,21 @@ export const moonshotModels = [
 				// content on this deployment (verified 2026-07-22).
 				jsonOutput: false,
 			},
+			{
+				providerId: "scx-ai-gp",
+				externalId: "Kimi-K2.7-Code",
+				inputPrice: "0.8e-6",
+				cachedInputPrice: "0.16e-6",
+				outputPrice: "3.34e-6",
+				requestPrice: "0",
+				contextSize: 262144,
+				maxOutput: 32768,
+				quantization: "fp8",
+				streaming: true,
+				reasoning: true,
+				vision: true,
+				jsonOutput: false,
+			},
 		],
 	},
 	{
@@ -887,6 +902,28 @@ export const moonshotModels = [
 					"max",
 				],
 				vision: true,
+				tools: true,
+				jsonOutput: true,
+			},
+			{
+				providerId: "scx-ai-gp",
+				externalId: "Kimi-K3",
+				inputPrice: "2.83e-6",
+				cachedInputPrice: "0.28e-6",
+				outputPrice: "14.13e-6",
+				requestPrice: "0",
+				// SCX's models endpoint reports 1M context / 1M output, but its
+				// model page advertises 256k context and 128k output; keep the
+				// smaller published limits until the deployment is probed live.
+				contextSize: 262144,
+				maxOutput: 131072,
+				quantization: "fp8",
+				streaming: true,
+				reasoning: true,
+				// SCX's model page lists text-only input while its models endpoint
+				// reports image input; keep vision off until an image request is
+				// verified live.
+				vision: false,
 				tools: true,
 				jsonOutput: true,
 			},


### PR DESCRIPTION
Adds `scx-ai-gp` provider mappings for two existing models, priced from SCX's published USD rate card.

## Mappings

### `kimi-k3` → `Kimi-K3`

- inputPrice `2.83e-6`, cachedInputPrice `0.28e-6`, outputPrice `14.13e-6` — exactly the USD/1M rates on https://scx.ai/models/kimi-k3
- contextSize 262144, maxOutput 131072 — the model page's published 256k / 128k limits
- reasoning, tools, jsonOutput; `vision: false`
- quantization fp8, streaming

### `kimi-k2.7-code` → `Kimi-K2.7-Code`

- inputPrice `0.8e-6`, cachedInputPrice `0.16e-6`, outputPrice `3.34e-6` — exactly the USD/1M rates on https://scx.ai/models/kimi-k2-7-code
- contextSize 262144, maxOutput 32768 — the model page's published 256k / 32k limits
- reasoning, tools, vision; `jsonOutput: false`
- quantization fp8, streaming

## Source discrepancies (resolved conservatively, commented in the mappings)

SCX's model pages and its live `/v1/models` metadata disagree on a few fields; the smaller/safer value was taken in each case:

- **Kimi-K3 context/output**: models endpoint reports 1M / 1M, model page says 256k / 128k → kept 256k / 128k.
- **Kimi-K3 vision**: models endpoint reports image input, model page lists text-only → kept `vision: false`.
- **Kimi-K2.7-Code max output**: models endpoint reports 256k, model page says 32k → kept 32k.
- **Kimi-K2.7-Code JSON mode**: model page advertises it, but the models endpoint does not list `json_mode`, and other K2.7-Code deployments have returned JSON-mode answers in `reasoning_content` → kept `jsonOutput: false`.

Both deployments run from SCX's SG datacenter per `/v1/models`, so neither mapping declares the `au` region (matching the existing `GLM-5.2-Fast` mapping).

## Verification

- Rates confirmed against both the SCX pricing page and each model's detail page; the `/v1/models` AUD rates are FX-consistent with the published USD rates.
- `model-metadata.spec.ts`, `providers.spec.ts`, and `costs.spec.ts` pass (137 tests); full `pnpm build` passes.
- **Not verified live**: no funded SCX account was available in this environment, so no request was served through either mapping and no `log.cost` reconciliation was done. Reasoning-effort behaviour, tool_choice modes, and the conservative flags above should be probed (or scoped e2e run with `TEST_MODELS="scx-ai-gp/kimi-k3,scx-ai-gp/kimi-k2.7-code"`) before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Kimi K2.7 Code model, including vision, streaming, reasoning, and tool capabilities.
  * Added support for the Kimi K3 model with extended context, JSON output, streaming, reasoning, and tool capabilities.
  * Added pricing and cached-input pricing details for both models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->