### PR TITLE
feat(admin): release DevPass fingerprint

### DIFF
--- a/apps/api/src/routes/admin-org-details.ts
+++ b/apps/api/src/routes/admin-org-details.ts
@@ -367,6 +367,7 @@ const adminPaymentMethodSchema = z.object({
 	type: z.string(),
 	createdAt: z.string(),
 	isDefault: z.boolean(),
+	canReleaseDevPlanCardFingerprint: z.boolean(),
 	card: z
 		.object({
 			brand: z.string(),
@@ -383,6 +384,7 @@ type PaymentMethodOrganization = Pick<
 	| "stripeCustomerId"
 	| "stripeSubscriptionId"
 	| "devPlanStripeSubscriptionId"
+	| "devPlanCardFingerprint"
 	| "chatPlanStripeSubscriptionId"
 >;
 
@@ -576,6 +578,11 @@ adminOrgDetails.openapi(getOrganizationPaymentMethods, async (c) => {
 			type: paymentMethod.type,
 			createdAt: new Date(paymentMethod.created * 1000).toISOString(),
 			isDefault: state.defaultPaymentMethodIds.has(paymentMethod.id),
+			canReleaseDevPlanCardFingerprint: Boolean(
+				!org.devPlanStripeSubscriptionId &&
+				paymentMethod.card?.fingerprint &&
+				paymentMethod.card.fingerprint === org.devPlanCardFingerprint,
+			),
 			card: paymentMethod.card
 				? {
 						brand: paymentMethod.card.brand,
@@ -601,6 +608,7 @@ const deleteOrganizationPaymentMethod = createRoute({
 				"application/json": {
 					schema: z.object({
 						replacementPaymentMethodId: z.string().optional(),
+						releaseDevPlanCardFingerprint: z.boolean().optional(),
 					}),
 				},
 			},
@@ -629,7 +637,8 @@ const deleteOrganizationPaymentMethod = createRoute({
 
 adminOrgDetails.openapi(deleteOrganizationPaymentMethod, async (c) => {
 	const { orgId, paymentMethodId } = c.req.valid("param");
-	const { replacementPaymentMethodId } = c.req.valid("json");
+	const { replacementPaymentMethodId, releaseDevPlanCardFingerprint } =
+		c.req.valid("json");
 	const org = await requireOrganization(orgId);
 	const user = c.get("user");
 
@@ -666,6 +675,19 @@ adminOrgDetails.openapi(deleteOrganizationPaymentMethod, async (c) => {
 		stripeCustomerId === null && Boolean(localPaymentMethod);
 	if (!attachedToOrganization && !hasDetachedLocalMethod) {
 		throw new HTTPException(404, { message: "Payment method not found" });
+	}
+
+	const paymentMethodFingerprint = paymentMethod?.card?.fingerprint ?? null;
+	const canReleaseDevPlanCardFingerprint = Boolean(
+		!org.devPlanStripeSubscriptionId &&
+		paymentMethodFingerprint &&
+		paymentMethodFingerprint === org.devPlanCardFingerprint,
+	);
+	if (releaseDevPlanCardFingerprint && !canReleaseDevPlanCardFingerprint) {
+		throw new HTTPException(400, {
+			message:
+				"This payment method cannot release the retained DevPass card fingerprint.",
+		});
 	}
 
 	const state = await getOrganizationPaymentMethodState(org);
@@ -844,15 +866,18 @@ adminOrgDetails.openapi(deleteOrganizationPaymentMethod, async (c) => {
 		if (
 			disableAutoTopUp ||
 			updateDevPlanFingerprint ||
-			updateChatPlanFingerprint
+			updateChatPlanFingerprint ||
+			releaseDevPlanCardFingerprint
 		) {
 			await tx
 				.update(tables.organization)
 				.set({
 					...(disableAutoTopUp ? { autoTopUpEnabled: false } : {}),
-					...(updateDevPlanFingerprint
-						? { devPlanCardFingerprint: replacementFingerprint }
-						: {}),
+					...(releaseDevPlanCardFingerprint
+						? { devPlanCardFingerprint: null }
+						: updateDevPlanFingerprint
+							? { devPlanCardFingerprint: replacementFingerprint }
+							: {}),
 					...(updateChatPlanFingerprint
 						? { chatPlanCardFingerprint: replacementFingerprint }
 						: {}),
@@ -880,6 +905,7 @@ adminOrgDetails.openapi(deleteOrganizationPaymentMethod, async (c) => {
 			cardLast4: paymentMethod?.card?.last4,
 			replacementPaymentMethodId: replacementId,
 			autoTopUpDisabled: disableAutoTopUp && org.autoTopUpEnabled,
+			devPlanCardFingerprintReleased: releaseDevPlanCardFingerprint === true,
 		},
 	});
 

--- a/apps/api/src/routes/admin-payment-methods.spec.ts
+++ b/apps/api/src/routes/admin-payment-methods.spec.ts
@@ -50,11 +50,15 @@ async function deletePaymentMethod(
 	cookie: string,
 	paymentMethodId = STRIPE_PAYMENT_METHOD_ID,
 	replacementPaymentMethodId?: string,
+	releaseDevPlanCardFingerprint?: boolean,
 ) {
 	return await request(`/${paymentMethodId}`, {
 		method: "DELETE",
 		headers: { Cookie: cookie, "Content-Type": "application/json" },
-		body: JSON.stringify({ replacementPaymentMethodId }),
+		body: JSON.stringify({
+			replacementPaymentMethodId,
+			releaseDevPlanCardFingerprint,
+		}),
 	});
 }
 
@@ -162,6 +166,7 @@ describe("admin organization payment methods", () => {
 					type: "card",
 					createdAt: "2030-01-01T00:00:00.000Z",
 					isDefault: true,
+					canReleaseDevPlanCardFingerprint: false,
 					card: {
 						brand: "visa",
 						last4: "4242",
@@ -174,6 +179,37 @@ describe("admin organization payment methods", () => {
 		expect(stripeMock.paymentMethods.list).toHaveBeenCalledWith({
 			customer: STRIPE_CUSTOMER_ID,
 			limit: 100,
+		});
+	});
+
+	it("marks a card that can release a retained DevPass fingerprint", async () => {
+		await db
+			.update(tables.organization)
+			.set({ devPlanCardFingerprint: "retained_fingerprint" })
+			.where(eq(tables.organization.id, ORG_ID));
+		stripeMock.paymentMethods.list.mockResolvedValue({
+			data: [
+				{
+					id: STRIPE_PAYMENT_METHOD_ID,
+					type: "card",
+					created: 1_893_456_000,
+					card: {
+						brand: "visa",
+						last4: "4242",
+						exp_month: 12,
+						exp_year: 2030,
+						fingerprint: "retained_fingerprint",
+					},
+				},
+			],
+		});
+
+		const response = await request("", { headers: { Cookie: cookie } });
+
+		expect(response.status).toBe(200);
+		expect((await response.json()).paymentMethods[0]).toMatchObject({
+			id: STRIPE_PAYMENT_METHOD_ID,
+			canReleaseDevPlanCardFingerprint: true,
 		});
 	});
 
@@ -284,6 +320,99 @@ describe("admin organization payment methods", () => {
 			resourceId: STRIPE_PAYMENT_METHOD_ID,
 			metadata: { cardLast4: "4242" },
 		});
+	});
+
+	it("keeps a retained DevPass fingerprint by default", async () => {
+		await db
+			.update(tables.organization)
+			.set({ devPlanCardFingerprint: "retained_fingerprint" })
+			.where(eq(tables.organization.id, ORG_ID));
+		stripeMock.paymentMethods.retrieve.mockResolvedValue({
+			id: STRIPE_PAYMENT_METHOD_ID,
+			customer: STRIPE_CUSTOMER_ID,
+			type: "card",
+			card: { fingerprint: "retained_fingerprint" },
+		});
+
+		const response = await deletePaymentMethod(cookie);
+
+		expect(response.status).toBe(200);
+		expect(
+			await db.query.organization.findFirst({
+				where: { id: { eq: ORG_ID } },
+			}),
+		).toMatchObject({ devPlanCardFingerprint: "retained_fingerprint" });
+	});
+
+	it("releases a retained DevPass fingerprint when requested", async () => {
+		await db
+			.update(tables.organization)
+			.set({ devPlanCardFingerprint: "retained_fingerprint" })
+			.where(eq(tables.organization.id, ORG_ID));
+		stripeMock.paymentMethods.retrieve.mockResolvedValue({
+			id: STRIPE_PAYMENT_METHOD_ID,
+			customer: STRIPE_CUSTOMER_ID,
+			type: "card",
+			card: {
+				last4: "4242",
+				fingerprint: "retained_fingerprint",
+			},
+		});
+
+		const response = await deletePaymentMethod(
+			cookie,
+			STRIPE_PAYMENT_METHOD_ID,
+			undefined,
+			true,
+		);
+
+		expect(response.status).toBe(200);
+		expect(
+			await db.query.organization.findFirst({
+				where: { id: { eq: ORG_ID } },
+			}),
+		).toMatchObject({ devPlanCardFingerprint: null });
+
+		const auditLog = await db.query.auditLog.findFirst({
+			where: {
+				organizationId: { eq: ORG_ID },
+				action: { eq: "payment.method.delete" },
+			},
+		});
+		expect(auditLog?.metadata).toMatchObject({
+			devPlanCardFingerprintReleased: true,
+		});
+	});
+
+	it("rejects releasing a fingerprint for an active DevPass subscription", async () => {
+		await db
+			.update(tables.organization)
+			.set({
+				devPlanStripeSubscriptionId: SUBSCRIPTION_ID,
+				devPlanCardFingerprint: "retained_fingerprint",
+			})
+			.where(eq(tables.organization.id, ORG_ID));
+		stripeMock.paymentMethods.retrieve.mockResolvedValue({
+			id: STRIPE_PAYMENT_METHOD_ID,
+			customer: STRIPE_CUSTOMER_ID,
+			type: "card",
+			card: { fingerprint: "retained_fingerprint" },
+		});
+
+		const response = await deletePaymentMethod(
+			cookie,
+			STRIPE_PAYMENT_METHOD_ID,
+			undefined,
+			true,
+		);
+
+		expect(response.status).toBe(400);
+		expect(stripeMock.paymentMethods.detach).not.toHaveBeenCalled();
+		expect(
+			await db.query.organization.findFirst({
+				where: { id: { eq: ORG_ID } },
+			}),
+		).toMatchObject({ devPlanCardFingerprint: "retained_fingerprint" });
 	});
 
 	it("requires an attached replacement before deleting a default method", async () => {

--- a/ee/admin/src/app/organizations/[orgId]/org-settings-tab.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/org-settings-tab.tsx
@@ -273,6 +273,7 @@ export function OrgSettingsTab({
 	onDeletePaymentMethod: (
 		paymentMethodId: string,
 		replacementPaymentMethodId?: string,
+		releaseDevPlanCardFingerprint?: boolean,
 	) => Promise<{ success: boolean; error?: string }>;
 }) {
 	const { organization: org, customProviders } = settings;

--- a/ee/admin/src/app/organizations/[orgId]/page.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/page.tsx
@@ -895,12 +895,14 @@ export default async function OrganizationPage({
 							onDeletePaymentMethod={async (
 								paymentMethodId,
 								replacementPaymentMethodId,
+								releaseDevPlanCardFingerprint,
 							) => {
 								"use server";
 								return await deleteOrganizationPaymentMethod(
 									orgId,
 									paymentMethodId,
 									replacementPaymentMethodId,
+									releaseDevPlanCardFingerprint,
 								);
 							}}
 						/>

--- a/ee/admin/src/app/organizations/[orgId]/payment-methods-list.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/payment-methods-list.tsx
@@ -12,6 +12,7 @@ import { useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
 	Dialog,
 	DialogContent,
@@ -35,6 +36,7 @@ export interface AdminPaymentMethod {
 	type: string;
 	createdAt: string;
 	isDefault: boolean;
+	canReleaseDevPlanCardFingerprint: boolean;
 	card: {
 		brand: string;
 		last4: string;
@@ -50,6 +52,7 @@ interface DeletePaymentMethodDialogProps {
 	onDelete: (
 		paymentMethodId: string,
 		replacementPaymentMethodId?: string,
+		releaseDevPlanCardFingerprint?: boolean,
 	) => Promise<{ success: boolean; error?: string }>;
 }
 
@@ -83,6 +86,8 @@ function DeletePaymentMethodDialog({
 	const [replacementPaymentMethodId, setReplacementPaymentMethodId] = useState(
 		replacementOptions[0]?.id ?? "",
 	);
+	const [releaseDevPlanCardFingerprint, setReleaseDevPlanCardFingerprint] =
+		useState(false);
 	const label = paymentMethodLabel(paymentMethod);
 	const requiresReplacement =
 		paymentMethod.isDefault && replacementOptions.length > 0;
@@ -95,6 +100,7 @@ function DeletePaymentMethodDialog({
 			const result = await onDelete(
 				paymentMethod.id,
 				requiresReplacement ? replacementPaymentMethodId : undefined,
+				releaseDevPlanCardFingerprint,
 			);
 			if (!result.success) {
 				setError(result.error ?? "Failed to delete payment method");
@@ -125,6 +131,7 @@ function DeletePaymentMethodDialog({
 				if (nextOpen) {
 					setError(null);
 					setReplacementPaymentMethodId(replacementOptions[0]?.id ?? "");
+					setReleaseDevPlanCardFingerprint(false);
 				}
 				if (!nextOpen) {
 					setError(null);
@@ -205,6 +212,31 @@ function DeletePaymentMethodDialog({
 					</div>
 				) : null}
 
+				{paymentMethod.canReleaseDevPlanCardFingerprint ? (
+					<div className="flex items-start gap-3 rounded-md border px-3 py-3">
+						<Checkbox
+							id={`release-devpass-fingerprint-${paymentMethod.id}`}
+							checked={releaseDevPlanCardFingerprint}
+							onCheckedChange={(checked) =>
+								setReleaseDevPlanCardFingerprint(checked === true)
+							}
+							disabled={loading}
+						/>
+						<div className="space-y-1">
+							<Label
+								htmlFor={`release-devpass-fingerprint-${paymentMethod.id}`}
+							>
+								Release DevPass card fingerprint
+							</Label>
+							<p className="text-xs text-muted-foreground">
+								Allow this card to be used on another DevPass account. Use only
+								for a verified account transfer; this bypasses the
+								one-card-per-account safeguard.
+							</p>
+						</div>
+					</div>
+				) : null}
+
 				{error ? (
 					<p className="text-sm text-destructive" role="alert">
 						{error}
@@ -227,7 +259,9 @@ function DeletePaymentMethodDialog({
 						}
 					>
 						{loading ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
-						Delete payment method
+						{releaseDevPlanCardFingerprint
+							? "Delete and release card"
+							: "Delete payment method"}
 					</Button>
 				</DialogFooter>
 			</DialogContent>
@@ -247,6 +281,7 @@ export function PaymentMethodsList({
 	onDelete: (
 		paymentMethodId: string,
 		replacementPaymentMethodId?: string,
+		releaseDevPlanCardFingerprint?: boolean,
 	) => Promise<{ success: boolean; error?: string }>;
 }) {
 	const router = useRouter();

--- a/ee/admin/src/lib/admin-organizations.ts
+++ b/ee/admin/src/lib/admin-organizations.ts
@@ -231,13 +231,17 @@ export async function deleteOrganizationPaymentMethod(
 	orgId: string,
 	paymentMethodId: string,
 	replacementPaymentMethodId?: string,
+	releaseDevPlanCardFingerprint?: boolean,
 ): Promise<{ success: boolean; error?: string }> {
 	const $api = await createServerApiClient();
 	const { data, error } = await $api.DELETE(
 		"/admin/organizations/{orgId}/payment-methods/{paymentMethodId}",
 		{
 			params: { path: { orgId, paymentMethodId } },
-			body: { replacementPaymentMethodId },
+			body: {
+				replacementPaymentMethodId,
+				releaseDevPlanCardFingerprint,
+			},
 		},
 	);
 


### PR DESCRIPTION
## Problem

Deleting a payment method without an active DevPass subscription keeps its retained fingerprint. Support has no audited UI path to approve a legitimate account transfer, so the card remains blocked by the one-card-per-account safeguard.

## Approach

- Identify an attached card that matches the retained DevPass fingerprint.
- Offer an unchecked release option in the admin deletion dialog.
- Validate the override server-side and reject active-subscription or mismatched-card attempts.
- Record the override in payment-method deletion audit metadata.

## Screenshots

### Light

| Before | After |
| --- | --- |
| ![Payment-method deletion dialog before the change in light mode](https://raw.githubusercontent.com/theopenco/llmgateway/assets/pr-3830/before-light.png) | ![Payment-method deletion dialog with fingerprint release in light mode](https://raw.githubusercontent.com/theopenco/llmgateway/assets/pr-3830/after-light.png) |

### Dark

| Before | After |
| --- | --- |
| ![Payment-method deletion dialog before the change in dark mode](https://raw.githubusercontent.com/theopenco/llmgateway/assets/pr-3830/before-dark.png) | ![Payment-method deletion dialog with fingerprint release in dark mode](https://raw.githubusercontent.com/theopenco/llmgateway/assets/pr-3830/after-dark.png) |

## Verification

- pnpm exec vitest run apps/api/src/routes/admin-payment-methods.spec.ts --no-file-parallelism
- pnpm format
- pnpm build
- Browser-tested the seeded admin deletion flow in an isolated stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admins can now release a retained DevPass card fingerprint when deleting an organization payment method.
  * Payment-method details indicate when fingerprint release is available.
  * The deletion dialog includes an optional “Release DevPass card fingerprint” checkbox and updates the action label accordingly.
* **Bug Fixes**
  * Prevents fingerprint release when the organization has an active DevPass subscription.
  * Records fingerprint-release actions in the audit log.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->