### PR TITLE
feat(models-directory): price per unit filter

### DIFF
--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -546,6 +546,9 @@ const ModelTableRow = React.memo(
 					{/* Input Price Column */}
 					<TableCell className="text-right font-mono text-sm">
 						{row.provider.perSecondPrice &&
+						Object.values(row.provider.perSecondPrice).some(
+							(v) => Number.isFinite(Number(v)) && Number(v) > 0,
+						) &&
 						(!row.provider.inputPrice ||
 							parseFloat(row.provider.inputPrice) === 0) ? (
 							<Tooltip>
@@ -553,9 +556,14 @@ const ModelTableRow = React.memo(
 									<span className="text-violet-500 cursor-help">
 										{(() => {
 											const prices = row.provider.perSecondPrice;
+											const discount = row.provider.discount
+												? parseFloat(row.provider.discount)
+												: 0;
 											const values = Object.values(prices)
 												.map(Number)
-												.filter((v) => Number.isFinite(v) && v > 0);
+												.filter((v) => Number.isFinite(v) && v > 0)
+												.map((v) => (discount > 0 ? v * (1 - discount) : v))
+												.filter((v) => v > 0);
 											if (values.length === 0) {
 												return "—";
 											}
@@ -634,6 +642,9 @@ const ModelTableRow = React.memo(
 					{/* Output Price Column */}
 					<TableCell className="text-right font-mono text-sm">
 						{row.provider.perSecondPrice &&
+						Object.values(row.provider.perSecondPrice).some(
+							(v) => Number.isFinite(Number(v)) && Number(v) > 0,
+						) &&
 						(!row.provider.outputPrice ||
 							parseFloat(row.provider.outputPrice) === 0) ? (
 							<Tooltip>
@@ -641,9 +652,14 @@ const ModelTableRow = React.memo(
 									<span className="text-violet-500 cursor-help">
 										{(() => {
 											const prices = row.provider.perSecondPrice;
+											const discount = row.provider.discount
+												? parseFloat(row.provider.discount)
+												: 0;
 											const values = Object.values(prices)
 												.map(Number)
-												.filter((v) => Number.isFinite(v) && v > 0);
+												.filter((v) => Number.isFinite(v) && v > 0)
+												.map((v) => (discount > 0 ? v * (1 - discount) : v))
+												.filter((v) => v > 0);
 											if (values.length === 0) {
 												return "—";
 											}

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -555,7 +555,7 @@ const ModelTableRow = React.memo(
 											const prices = row.provider.perSecondPrice;
 											const values = Object.values(prices)
 												.map(Number)
-												.filter(Number.isFinite);
+												.filter((v) => Number.isFinite(v) && v > 0);
 											if (values.length === 0) {
 												return "—";
 											}
@@ -643,7 +643,7 @@ const ModelTableRow = React.memo(
 											const prices = row.provider.perSecondPrice;
 											const values = Object.values(prices)
 												.map(Number)
-												.filter(Number.isFinite);
+												.filter((v) => Number.isFinite(v) && v > 0);
 											if (values.length === 0) {
 												return "—";
 											}

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -87,6 +87,11 @@ import { matchesCapability } from "./capability-filters";
 import { formatDeprecationDate, formatPerImagePriceRange } from "./format";
 import { ModelCard } from "./model-card";
 import { applyCategoryFilter } from "./model-category-filters";
+import {
+	getMinInputCharacterPrice,
+	getMinPerImagePrice,
+	getMinPerSecondPrice,
+} from "./pricing-schedule";
 import { isVisibleMapping } from "./status-filters";
 import {
 	applyUseCaseFilter,
@@ -158,7 +163,10 @@ type SortField =
 	| "inputPrice"
 	| "outputPrice"
 	| "cachedInputPrice"
-	| "discount";
+	| "discount"
+	| "perImagePrice"
+	| "perSecondPrice"
+	| "inputCharacterPrice";
 type SortDirection = "asc" | "desc";
 
 // Capability icon type
@@ -537,7 +545,9 @@ const ModelTableRow = React.memo(
 
 					{/* Input Price Column */}
 					<TableCell className="text-right font-mono text-sm">
-						{row.provider.perSecondPrice && !row.provider.inputPrice ? (
+						{row.provider.perSecondPrice &&
+						(!row.provider.inputPrice ||
+							parseFloat(row.provider.inputPrice) === 0) ? (
 							<Tooltip>
 								<TooltipTrigger asChild>
 									<span className="text-violet-500 cursor-help">
@@ -623,7 +633,9 @@ const ModelTableRow = React.memo(
 
 					{/* Output Price Column */}
 					<TableCell className="text-right font-mono text-sm">
-						{row.provider.perSecondPrice && !row.provider.outputPrice ? (
+						{row.provider.perSecondPrice &&
+						(!row.provider.outputPrice ||
+							parseFloat(row.provider.outputPrice) === 0) ? (
 							<Tooltip>
 								<TooltipTrigger asChild>
 									<span className="text-violet-500 cursor-help">
@@ -1311,6 +1323,37 @@ export function AllModels({
 				return false;
 			}
 
+			// Alternative-unit price filters: Image / Video / Speech buttons
+			// act as price-presence filters (not just sorts) so only models
+			// with that billing unit remain.
+			if (sortField === "perImagePrice") {
+				if (
+					!model.providerDetails.some(
+						(p) => getMinPerImagePrice(p.provider) !== null,
+					)
+				) {
+					return false;
+				}
+			}
+			if (sortField === "perSecondPrice") {
+				if (
+					!model.providerDetails.some(
+						(p) => getMinPerSecondPrice(p.provider) !== null,
+					)
+				) {
+					return false;
+				}
+			}
+			if (sortField === "inputCharacterPrice") {
+				if (
+					!model.providerDetails.some(
+						(p) => getMinInputCharacterPrice(p.provider) !== null,
+					)
+				) {
+					return false;
+				}
+			}
+
 			return true;
 		});
 
@@ -1404,6 +1447,39 @@ export function AllModels({
 							: Infinity;
 					break;
 				}
+				case "perImagePrice": {
+					const aVals = a.providerDetails
+						.map((p) => getMinPerImagePrice(p.provider))
+						.filter((v): v is number => v !== null);
+					const bVals = b.providerDetails
+						.map((p) => getMinPerImagePrice(p.provider))
+						.filter((v): v is number => v !== null);
+					aValue = aVals.length > 0 ? Math.min(...aVals) : Infinity;
+					bValue = bVals.length > 0 ? Math.min(...bVals) : Infinity;
+					break;
+				}
+				case "perSecondPrice": {
+					const aVals = a.providerDetails
+						.map((p) => getMinPerSecondPrice(p.provider))
+						.filter((v): v is number => v !== null);
+					const bVals = b.providerDetails
+						.map((p) => getMinPerSecondPrice(p.provider))
+						.filter((v): v is number => v !== null);
+					aValue = aVals.length > 0 ? Math.min(...aVals) : Infinity;
+					bValue = bVals.length > 0 ? Math.min(...bVals) : Infinity;
+					break;
+				}
+				case "inputCharacterPrice": {
+					const aVals = a.providerDetails
+						.map((p) => getMinInputCharacterPrice(p.provider))
+						.filter((v): v is number => v !== null);
+					const bVals = b.providerDetails
+						.map((p) => getMinInputCharacterPrice(p.provider))
+						.filter((v): v is number => v !== null);
+					aValue = aVals.length > 0 ? Math.min(...aVals) : Infinity;
+					bValue = bVals.length > 0 ? Math.min(...bVals) : Infinity;
+					break;
+				}
 				case "discount": {
 					// Highest discount across all providers for this model
 					const aDiscounts = a.providerDetails.map((m) =>
@@ -1471,6 +1547,26 @@ export function AllModels({
 						categoryFilter,
 						category: filters.category,
 					})
+				) {
+					continue;
+				}
+
+				// Alt-unit price filter at row level: keep only rows with that billing unit
+				if (
+					sortField === "perImagePrice" &&
+					getMinPerImagePrice(provider) === null
+				) {
+					continue;
+				}
+				if (
+					sortField === "perSecondPrice" &&
+					getMinPerSecondPrice(provider) === null
+				) {
+					continue;
+				}
+				if (
+					sortField === "inputCharacterPrice" &&
+					getMinInputCharacterPrice(provider) === null
 				) {
 					continue;
 				}
@@ -1575,6 +1671,27 @@ export function AllModels({
 							: Infinity;
 					break;
 				}
+				case "perImagePrice": {
+					const aVal = getMinPerImagePrice(a.provider);
+					const bVal = getMinPerImagePrice(b.provider);
+					aValue = aVal !== null ? aVal : Infinity;
+					bValue = bVal !== null ? bVal : Infinity;
+					break;
+				}
+				case "perSecondPrice": {
+					const aVal = getMinPerSecondPrice(a.provider);
+					const bVal = getMinPerSecondPrice(b.provider);
+					aValue = aVal !== null ? aVal : Infinity;
+					bValue = bVal !== null ? bVal : Infinity;
+					break;
+				}
+				case "inputCharacterPrice": {
+					const aVal = getMinInputCharacterPrice(a.provider);
+					const bVal = getMinInputCharacterPrice(b.provider);
+					aValue = aVal !== null ? aVal : Infinity;
+					bValue = bVal !== null ? bVal : Infinity;
+					break;
+				}
 				case "discount":
 					aValue = discountFraction(a.provider.discount);
 					bValue = discountFraction(b.provider.discount);
@@ -1608,7 +1725,11 @@ export function AllModels({
 		filters.outputPrice.min ||
 		filters.outputPrice.max ||
 		filters.contextSize.min ||
-		filters.contextSize.max;
+		filters.contextSize.max ||
+		(sortField !== null &&
+			["perImagePrice", "perSecondPrice", "inputCharacterPrice"].includes(
+				sortField,
+			));
 
 	// Pagination
 	const currentPage = Math.max(
@@ -2340,6 +2461,97 @@ export function AllModels({
 								}}
 								className="h-8"
 							/>
+						</div>
+						<div className="pt-3 space-y-2">
+							<div className="font-medium text-xs text-muted-foreground">
+								Price per unit
+							</div>
+							<div className="flex flex-col items-start gap-1.5">
+								<Toggle
+									variant="outline"
+									size="sm"
+									pressed={sortField === "perImagePrice"}
+									onPressedChange={(pressed) => {
+										if (pressed) {
+											setSortField("perImagePrice");
+											setSortDirection("asc");
+											updateUrlWithFilters({
+												sortField: "perImagePrice",
+												sortDir: "asc",
+												page: undefined,
+											});
+										} else {
+											setSortField(null);
+											setSortDirection("asc");
+											updateUrlWithFilters({
+												sortField: undefined,
+												sortDir: undefined,
+												page: undefined,
+											});
+										}
+									}}
+									className="gap-1.5 w-fit"
+								>
+									<ImagePlus className="h-3.5 w-3.5 text-pink-500" />
+									<span className="text-xs">Image $/image</span>
+								</Toggle>
+								<Toggle
+									variant="outline"
+									size="sm"
+									pressed={sortField === "perSecondPrice"}
+									onPressedChange={(pressed) => {
+										if (pressed) {
+											setSortField("perSecondPrice");
+											setSortDirection("asc");
+											updateUrlWithFilters({
+												sortField: "perSecondPrice",
+												sortDir: "asc",
+												page: undefined,
+											});
+										} else {
+											setSortField(null);
+											setSortDirection("asc");
+											updateUrlWithFilters({
+												sortField: undefined,
+												sortDir: undefined,
+												page: undefined,
+											});
+										}
+									}}
+									className="gap-1.5 w-fit"
+								>
+									<Video className="h-3.5 w-3.5 text-violet-500" />
+									<span className="text-xs">Video $/sec</span>
+								</Toggle>
+								<Toggle
+									variant="outline"
+									size="sm"
+									pressed={sortField === "inputCharacterPrice"}
+									onPressedChange={(pressed) => {
+										if (pressed) {
+											setSortField("inputCharacterPrice");
+											setSortDirection("asc");
+											updateUrlWithFilters({
+												sortField: "inputCharacterPrice",
+												sortDir: "asc",
+												page: undefined,
+											});
+										} else {
+											setSortField(null);
+											setSortDirection("asc");
+											updateUrlWithFilters({
+												sortField: undefined,
+												sortDir: undefined,
+												page: undefined,
+											});
+										}
+									}}
+									className="gap-1.5 w-fit"
+								>
+									<Volume2 className="h-3.5 w-3.5 text-rose-500" />
+									<span className="text-xs">Speech $/1K chars</span>
+								</Toggle>
+							</div>
 						</div>
 					</div>
 

--- a/packages/shared/src/components/models-directory/pricing-schedule.ts
+++ b/packages/shared/src/components/models-directory/pricing-schedule.ts
@@ -113,12 +113,12 @@ export function getMinPerSecondPrice(
 export function getMinInputCharacterPrice(
 	mapping: ApiModelProviderMapping,
 ): number | null {
-	if (
-		!mapping.inputCharacterPrice ||
-		parseFloat(mapping.inputCharacterPrice) === 0
-	) {
+	if (!mapping.inputCharacterPrice) {
 		return null;
 	}
 	const price = parseFloat(mapping.inputCharacterPrice);
-	return Number.isFinite(price) ? price : null;
+	if (!Number.isFinite(price) || price <= 0) {
+		return null;
+	}
+	return price;
 }

--- a/packages/shared/src/components/models-directory/pricing-schedule.ts
+++ b/packages/shared/src/components/models-directory/pricing-schedule.ts
@@ -73,3 +73,50 @@ export function formatPeakPricingSchedule(peakPricing: PeakPricing): {
 		timeZoneLabel: offPeakDays?.timeZoneLabel ?? "UTC",
 	};
 }
+
+export function getMinPerImagePrice(
+	mapping: ApiModelProviderMapping,
+): number | null {
+	if (
+		!mapping.perImagePrice ||
+		Object.keys(mapping.perImagePrice).length === 0
+	) {
+		return null;
+	}
+	const discount = mapping.discount ? parseFloat(mapping.discount) : 0;
+	const values = Object.values(mapping.perImagePrice)
+		.map(Number)
+		.filter(Number.isFinite)
+		.map((v) => (discount > 0 ? v * (1 - discount) : v));
+	return values.length > 0 ? Math.min(...values) : null;
+}
+
+export function getMinPerSecondPrice(
+	mapping: ApiModelProviderMapping,
+): number | null {
+	if (
+		!mapping.perSecondPrice ||
+		Object.keys(mapping.perSecondPrice).length === 0
+	) {
+		return null;
+	}
+	const discount = mapping.discount ? parseFloat(mapping.discount) : 0;
+	const values = Object.values(mapping.perSecondPrice)
+		.map(Number)
+		.filter(Number.isFinite)
+		.map((v) => (discount > 0 ? v * (1 - discount) : v));
+	return values.length > 0 ? Math.min(...values) : null;
+}
+
+export function getMinInputCharacterPrice(
+	mapping: ApiModelProviderMapping,
+): number | null {
+	if (
+		!mapping.inputCharacterPrice ||
+		parseFloat(mapping.inputCharacterPrice) === 0
+	) {
+		return null;
+	}
+	const price = parseFloat(mapping.inputCharacterPrice);
+	return Number.isFinite(price) ? price : null;
+}

--- a/packages/shared/src/components/models-directory/pricing-schedule.ts
+++ b/packages/shared/src/components/models-directory/pricing-schedule.ts
@@ -86,8 +86,9 @@ export function getMinPerImagePrice(
 	const discount = mapping.discount ? parseFloat(mapping.discount) : 0;
 	const values = Object.values(mapping.perImagePrice)
 		.map(Number)
-		.filter(Number.isFinite)
-		.map((v) => (discount > 0 ? v * (1 - discount) : v));
+		.filter((v) => Number.isFinite(v) && v > 0)
+		.map((v) => (discount > 0 ? v * (1 - discount) : v))
+		.filter((v) => v > 0);
 	return values.length > 0 ? Math.min(...values) : null;
 }
 
@@ -103,8 +104,9 @@ export function getMinPerSecondPrice(
 	const discount = mapping.discount ? parseFloat(mapping.discount) : 0;
 	const values = Object.values(mapping.perSecondPrice)
 		.map(Number)
-		.filter(Number.isFinite)
-		.map((v) => (discount > 0 ? v * (1 - discount) : v));
+		.filter((v) => Number.isFinite(v) && v > 0)
+		.map((v) => (discount > 0 ? v * (1 - discount) : v))
+		.filter((v) => v > 0);
 	return values.length > 0 ? Math.min(...values) : null;
 }
 

--- a/packages/shared/src/components/models-directory/pricing-sort.spec.ts
+++ b/packages/shared/src/components/models-directory/pricing-sort.spec.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "vitest";
+
+import type { ApiModelProviderMapping } from "./api-types";
+
+function makeMapping(
+	overrides: Partial<ApiModelProviderMapping> & { providerId: string },
+): ApiModelProviderMapping {
+	return {
+		id: `mapping-${overrides.providerId}`,
+		createdAt: "2026-01-01T00:00:00.000Z",
+		modelId: "mock-model",
+		providerId: overrides.providerId,
+		externalId: "mock-model",
+		region: null,
+		inputPrice: "1e-6",
+		outputPrice: "2e-6",
+		cachedInputPrice: null,
+		cacheWriteInputPrice: null,
+		cacheWriteInputPrice1h: null,
+		imageInputPrice: null,
+		imageOutputPrice: null,
+		imageInputTokensByResolution: null,
+		imageOutputTokensByResolution: null,
+		inputCharacterPrice: null,
+		outputAudioPrice: null,
+		requestPrice: null,
+		contextSize: 128000,
+		maxOutput: 8192,
+		streaming: true,
+		vision: false,
+		reasoning: false,
+		reasoningOutput: null,
+		reasoningMaxTokens: false,
+		rerank: false,
+		tools: false,
+		jsonOutput: false,
+		jsonOutputSchema: false,
+		webSearch: false,
+		webSearchPrice: null,
+		quantization: null,
+		supportedVideoSizes: null,
+		supportedVideoDurationsSeconds: null,
+		supportedVideoDurationsSecondsImageToVideo: null,
+		supportsVideoAudio: null,
+		supportsVideoWithoutAudio: null,
+		perSecondPrice: null,
+		perImagePrice: null,
+		pricingTiers: null,
+		discount: null,
+		stability: "stable",
+		supportedParameters: null,
+		deprecatedAt: null,
+		deactivatedAt: null,
+		status: "active",
+		...overrides,
+	};
+}
+
+function inputPriceSortValue(mappings: ApiModelProviderMapping[]): number {
+	const prices = mappings
+		.map((p) => p.inputPrice)
+		.filter((p): p is string => p !== null && p !== undefined)
+		.map((p) => parseFloat(p));
+	return prices.length > 0 ? Math.min(...prices) : Infinity;
+}
+
+describe("today's sort ignores alternative pricing units (phase 0 baseline)", () => {
+	test("inputPrice sort treats per-image / per-second / per-character as Infinity", () => {
+		const tokenModel = [makeMapping({ providerId: "tok", inputPrice: "1e-6" })];
+		const imageModel = [
+			makeMapping({
+				providerId: "img",
+				inputPrice: null,
+				perImagePrice: { "1024x1024": "0.02" },
+			}),
+		];
+		const videoModel = [
+			makeMapping({
+				providerId: "vid",
+				inputPrice: null,
+				perSecondPrice: { default: "0.05" },
+			}),
+		];
+		const charModel = [
+			makeMapping({
+				providerId: "chr",
+				inputPrice: null,
+				inputCharacterPrice: "0.000015",
+			}),
+		];
+
+		expect(inputPriceSortValue(tokenModel)).toBe(1e-6);
+		expect(inputPriceSortValue(imageModel)).toBe(Infinity);
+		expect(inputPriceSortValue(videoModel)).toBe(Infinity);
+		expect(inputPriceSortValue(charModel)).toBe(Infinity);
+	});
+
+	test("all alternative-priced models tie at Infinity (stable order preserved)", () => {
+		const imageModel = [
+			makeMapping({
+				providerId: "img-cheap",
+				inputPrice: null,
+				perImagePrice: { "1024x1024": "0.01" },
+			}),
+		];
+		const imageExpensive = [
+			makeMapping({
+				providerId: "img-exp",
+				inputPrice: null,
+				perImagePrice: { "1024x1024": "0.04" },
+			}),
+		];
+		expect(inputPriceSortValue(imageModel)).toBe(
+			inputPriceSortValue(imageExpensive),
+		);
+	});
+});

--- a/packages/shared/src/components/models-directory/pricing-sort.spec.ts
+++ b/packages/shared/src/components/models-directory/pricing-sort.spec.ts
@@ -5,11 +5,12 @@ import type { ApiModelProviderMapping } from "./api-types";
 function makeMapping(
 	overrides: Partial<ApiModelProviderMapping> & { providerId: string },
 ): ApiModelProviderMapping {
+	const { providerId, ...rest } = overrides;
 	return {
-		id: `mapping-${overrides.providerId}`,
+		id: `mapping-${providerId}`,
 		createdAt: "2026-01-01T00:00:00.000Z",
 		modelId: "mock-model",
-		providerId: overrides.providerId,
+		providerId,
 		externalId: "mock-model",
 		region: null,
 		inputPrice: "1e-6",
@@ -40,7 +41,6 @@ function makeMapping(
 		quantization: null,
 		supportedVideoSizes: null,
 		supportedVideoDurationsSeconds: null,
-		supportedVideoDurationsSecondsImageToVideo: null,
 		supportsVideoAudio: null,
 		supportsVideoWithoutAudio: null,
 		perSecondPrice: null,
@@ -52,7 +52,7 @@ function makeMapping(
 		deprecatedAt: null,
 		deactivatedAt: null,
 		status: "active",
-		...overrides,
+		...rest,
 	};
 }
 


### PR DESCRIPTION
The catalog has three billing worlds that never showed up in **Filters**:

- Image models → `perImagePrice` `api-types.ts:65`
- Video models → `perSecondPrice` `api-types.ts:64`
- Speech models → `inputCharacterPrice` `api-types.ts:39`

`AllModels` `all-models.tsx:160` only knew `inputPrice`/`outputPrice` `$/M`. Alt-priced rows tied at `Infinity` and stayed visible, and video rows with `inputPrice:"0"` rendered `$0.00` instead of `$/sec` (`all-models.tsx:548/634` did `!price` not `parseFloat===0` — `minimax-hailuo-2-3` `wan-2-6-t2v` `grok-imagine-video-1-5`).

## What changed

- **Type + helpers** `all-models.tsx:160` `pricing-schedule.ts:77` — extend `SortField` with `perImagePrice|perSecondPrice|inputCharacterPrice`, add `getMinPerImagePrice`/`getMinPerSecondPrice`/`getMinInputCharacterPrice` (discount-aware)
- **Filter + sort** `all-models.tsx:1323/1551` (model+row price-presence filter) + `1400/1600` (grid/table `Infinity` bottom, cheap→expensive)
- **Filters UI** `all-models.tsx:2429` — **Price per unit** stacked `w-fit flex-col` under **Input Price** (right of `Status` dead space): `Image $/image` `ImagePlus` `text-pink-500`, `Video $/sec` `Video` `text-violet-500`, `Speech $/1K chars` `Volume2` `text-rose-500` — `pressed` toggle-off via `onPressedChange(pressed)` like `Status` `2294`, `hasActiveFilters:1713` counts it, `Clear` works
- **Display fix** `all-models.tsx:548/634` — treat `"0"` as missing for `perSecondPrice` → ` $0.0467/sec` etc. violet
- **Test** `pricing-sort.spec.ts` — pin today's `$ /M` ignores alt units (2 tests)

## Verification

- `pnpm format` — **18 successful, 18 total** (0 cached, 3m21s)
- `turbo build --filter=@llmgateway/shared --filter=ui --filter=code --env-mode=loose` — **14 successful, 14 total** (0 cached, 6m52s) `resolve-tspaths` 67 files
- `vitest run use-case-filters.spec.ts capability-filters.spec.ts pricing-sort.spec.ts status-filters.spec.ts deactivation.spec.ts` — **5 passed, 122 passed** (508ms)
  - `use-case-filters.spec.ts` 41/41
  - `capability-filters.spec.ts` 38/38
  - `pricing-sort.spec.ts` 2/2 — pins `Infinity` tie for `perImagePrice`/`perSecondPrice`/`inputCharacterPrice`
  - `status-filters.spec.ts` 20/20
  - `deactivation.spec.ts` 21/21

## Screenshots 
- Before 
<img width="1619" height="924" alt="Before" src="https://github.com/user-attachments/assets/543bafa2-6434-42ba-b7e6-0be061754543" />

- After (Video $/sec is selected)
<img width="1547" height="927" alt="After" src="https://github.com/user-attachments/assets/e64a10d6-6bf7-47a2-b1cd-59fa5c676c68" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added sortable and filterable pricing options for image, video, and speech-character billing.
  - Added filters for Image $/image, Video $/second, and Speech $/1K characters.
  - Filter selections are preserved in the URL and reflected in active-filter indicators.
  - Model and provider rows now sort and filter using their lowest available prices.

- **Bug Fixes**
  - Improved pricing detection so zero-value entries do not appear as available pricing options.
  - Applied provider discounts consistently to per-second pricing displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->