### PR TITLE
fix(gateway): reject undersized AWS EventStream frames

### DIFF
--- a/apps/gateway/src/chat/tools/parse-aws-eventstream.spec.ts
+++ b/apps/gateway/src/chat/tools/parse-aws-eventstream.spec.ts
@@ -1,6 +1,11 @@
+import { spawnSync } from "node:child_process";
+
 import { describe, expect, it } from "vitest";
 
-import { convertAwsEventStreamToSSE } from "./parse-aws-eventstream.js";
+import {
+	convertAwsEventStreamToSSE,
+	parseAwsEventStream,
+} from "./parse-aws-eventstream.js";
 
 function frame(payload: string): Uint8Array {
 	const bytes = new TextEncoder().encode(payload);
@@ -9,6 +14,39 @@ function frame(payload: string): Uint8Array {
 	new DataView(result.buffer).setUint32(0, totalLength, false);
 	result.set(bytes, 12);
 	return result;
+}
+
+/**
+ * Runs parseAwsEventStream on a payload in a separate process capped by a hard
+ * timeout and a small heap. A malformed prelude whose total length is below the
+ * 16-byte minimum (e.g. all zeros) would otherwise never advance the read
+ * offset, spinning forever while pushing empty messages until the process runs
+ * out of memory. A synchronous infinite loop cannot be interrupted by the test
+ * runner, so it must be contained here instead of called in-process.
+ */
+function parseInChild(bytes: number[]): {
+	terminated: boolean;
+	status: number | null;
+	timedOut: boolean;
+} {
+	const moduleUrl = new URL("./parse-aws-eventstream.ts", import.meta.url).href;
+	const script = `
+		const { parseAwsEventStream } = await import(${JSON.stringify(moduleUrl)});
+		parseAwsEventStream(new Uint8Array(${JSON.stringify(bytes)}));
+		process.stdout.write("TERMINATED");
+	`;
+	const result = spawnSync(
+		process.execPath,
+		["--max-old-space-size=128", "--input-type=module", "-e", script],
+		{ timeout: 5000, encoding: "utf8" },
+	);
+	return {
+		terminated: result.stdout === "TERMINATED",
+		status: result.status,
+		timedOut:
+			(result.error as NodeJS.ErrnoException | undefined)?.code ===
+				"ETIMEDOUT" || result.signal === "SIGTERM",
+	};
 }
 
 describe("convertAwsEventStreamToSSE", () => {
@@ -36,5 +74,31 @@ describe("convertAwsEventStreamToSSE", () => {
 			sse: 'data: {"completion":"ok"}\n\n',
 			bytesConsumed: complete.length,
 		});
+	});
+});
+
+describe("parseAwsEventStream malformed input", () => {
+	it("terminates on a zero-length prelude instead of looping forever", () => {
+		// 16 zero bytes: >= the 12-byte prelude, so the length guards run, but
+		// the encoded total length is 0. Without a minimum-length check the read
+		// offset never advances and the loop is infinite.
+		const result = parseInChild(new Array(16).fill(0));
+
+		expect(result.timedOut).toBe(false);
+		expect(result.terminated).toBe(true);
+		expect(result.status).toBe(0);
+	});
+
+	it("rejects a headers length larger than the frame", () => {
+		// Valid total length (16) but a headers length of 0xffffffff, which
+		// cannot fit inside the message. The guard must stop rather than read
+		// past the buffer.
+		const buffer = new Uint8Array(16);
+		const view = new DataView(buffer.buffer);
+		view.setUint32(0, 16, false); // total length
+		view.setUint32(4, 0xffffffff, false); // headers length
+
+		expect(() => parseAwsEventStream(buffer)).not.toThrow();
+		expect(parseAwsEventStream(buffer)).toEqual([]);
 	});
 });

--- a/apps/gateway/src/chat/tools/parse-aws-eventstream.ts
+++ b/apps/gateway/src/chat/tools/parse-aws-eventstream.ts
@@ -16,6 +16,13 @@ interface EventStreamMessage {
 	payload: Uint8Array;
 }
 
+/**
+ * Fixed per-message overhead: 8-byte prelude (total length + headers length) +
+ * 4-byte prelude CRC + 4-byte message CRC. A message with zero headers and an
+ * empty payload is exactly this many bytes, so no valid total length is smaller.
+ */
+const MIN_MESSAGE_LENGTH = 16;
+
 export function parseAwsEventStream(buffer: Uint8Array): EventStreamMessage[] {
 	const messages: EventStreamMessage[] = [];
 	let offset = 0;
@@ -37,6 +44,20 @@ export function parseAwsEventStream(buffer: Uint8Array): EventStreamMessage[] {
 			buffer.byteOffset + offset + 4,
 			4,
 		).getUint32(0, false);
+
+		// Reject a corrupt or truncated prelude before trusting its length.
+		// A total length below the fixed overhead cannot describe a real frame,
+		// and totalLength === 0 would advance offset by 0 below and loop
+		// forever, pushing empty messages until the process runs out of memory.
+		if (totalLength < MIN_MESSAGE_LENGTH) {
+			break;
+		}
+
+		// Headers must fit within the message alongside the fixed overhead;
+		// an oversized headers length is corrupt and would read past the frame.
+		if (headersLength > totalLength - MIN_MESSAGE_LENGTH) {
+			break;
+		}
 
 		// Check if we have the full message
 		if (offset + totalLength > buffer.length) {


### PR DESCRIPTION
## Summary

`parseAwsEventStream` trusted the 4-byte total-length field of each AWS
EventStream frame without a lower bound. A prelude declaring `totalLength === 0`
passed the only guard (`offset + totalLength > buffer.length`) and then advanced
the read offset by `0`, so the `while` loop never progressed: it spun at 100% CPU
pushing empty messages until the process ran out of memory.

This runs inside `parseAwsEventStream`, called by `convertAwsEventStreamToSSE`,
before the chat streaming loop's `MAX_BUFFER_SIZE` cap can act — so that cap does
not protect this path. It is reachable from a truncated/corrupt Bedrock frame or a
response mis-routed as EventStream: 12+ bytes whose first 8 are zero is enough.
Impact is a denial of service local to the gateway process (CPU spin then OOM).

## Cause

The prelude has a fixed structural minimum — 8-byte prelude + 4-byte prelude CRC +
4-byte message CRC = 16 bytes for a frame with zero headers and an empty payload
(see the format doc-comment at the top of the file). No `totalLength` below that is
valid, but the parser accepted any value, including 0.

## Change

- Reject any frame whose `totalLength` is below the 16-byte structural minimum
  (`MIN_MESSAGE_LENGTH`), which also removes the non-advancing-offset infinite loop.
- Reject a `headersLength` that cannot fit within the frame alongside the fixed
  overhead (`headersLength > totalLength - 16`), which previously let header parsing
  read past the frame.

Both stop parsing at the malformed frame, matching the existing truncated-frame
behaviour (`break`).

## Tests

`apps/gateway/src/chat/tools/parse-aws-eventstream.spec.ts`:

- A malformed zero-length prelude terminates instead of looping forever. Because a
  synchronous infinite loop cannot be interrupted by the runner, the real function
  is exercised in a child process capped by a 5s timeout and a 128 MB heap; a
  timed-out/killed child proves non-termination. Verified RED without the fix
  (child killed) and GREEN with it.
- An oversized `headersLength` is rejected without reading past the frame.

```
vitest run apps/gateway/src/chat/tools/parse-aws-eventstream.spec.ts --no-file-parallelism
# 4 passed, exit 0
```

`prettier --check` and `eslint` on the changed files both pass. The full gateway
suite needs Postgres/Redis; this parser spec does not and was run in isolation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of malformed or truncated AWS event stream data.
  - Prevented parsing from hanging on zero-length frames.
  - Added validation to reject frames with invalid header lengths safely.
  - Improved resilience against corrupt input and out-of-bounds reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->