### PR TITLE
feat(models): add Qwen3.8 Flash

### DIFF
--- a/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.spec.ts
@@ -789,6 +789,62 @@ describe("parseProviderResponse", () => {
 		});
 	});
 
+	describe("alibaba finish reason mapping", () => {
+		it("normalizes 'stop' to 'tool_calls' when the message has tool calls", () => {
+			const json = {
+				choices: [
+					{
+						message: {
+							role: "assistant",
+							content: "",
+							tool_calls: [
+								{
+									id: "call_1",
+									type: "function",
+									function: {
+										name: "get_weather",
+										arguments: '{"city":"San Francisco"}',
+									},
+								},
+							],
+						},
+						finish_reason: "stop",
+					},
+				],
+				usage: {
+					prompt_tokens: 10,
+					completion_tokens: 5,
+					total_tokens: 15,
+				},
+			};
+
+			const result = parseProviderResponse("alibaba", "qwen3.8-flash", json);
+
+			expect(result.finishReason).toBe("tool_calls");
+			expect(result.toolResults).toHaveLength(1);
+		});
+
+		it("leaves 'stop' unchanged when there are no tool calls", () => {
+			const json = {
+				choices: [
+					{
+						message: { role: "assistant", content: "Hello" },
+						finish_reason: "stop",
+					},
+				],
+				usage: {
+					prompt_tokens: 10,
+					completion_tokens: 5,
+					total_tokens: 15,
+				},
+			};
+
+			const result = parseProviderResponse("alibaba", "qwen3.8-flash", json);
+
+			expect(result.finishReason).toBe("stop");
+		});
+	});
+
 	describe("scx-ai finish reason mapping", () => {
 		it("normalizes 'stop' to 'tool_calls' when the message has tool calls", () => {
 			const json = {

--- a/apps/gateway/src/chat/tools/parse-provider-response.ts
+++ b/apps/gateway/src/chat/tools/parse-provider-response.ts
@@ -682,6 +682,17 @@ export function parseProviderResponse(
 					) ??
 					null;
 				finishReason = json.choices?.[0]?.finish_reason ?? null;
+				// DashScope returns finish_reason "stop" when the caller forced a
+				// named function via tool_choice, even though the message carries the
+				// tool call; normalize to "tool_calls" so downstream consumers see the
+				// OpenAI-standard value.
+				if (
+					finishReason === "stop" &&
+					Array.isArray(toolResults) &&
+					toolResults.length > 0
+				) {
+					finishReason = "tool_calls";
+				}
 				promptTokens = json.usage?.prompt_tokens ?? null;
 				completionTokens = json.usage?.completion_tokens ?? null;
 				reasoningTokens =

--- a/apps/gateway/src/lib/alibaba-pricing.spec.ts
+++ b/apps/gateway/src/lib/alibaba-pricing.spec.ts
@@ -14,16 +14,27 @@ const RATIO_TOLERANCE = 1e-9;
 // price without forcing the catalogue to overbill.
 const PUBLISHED_OFF_RATIO_CACHE_PRICES: Record<
 	string,
-	{ cachedInputPrice?: number; cacheReadInputPrice?: number }
+	{
+		cachedInputPrice?: number;
+		cacheReadInputPrice?: number;
+		cacheWriteInputPrice?: number;
+	}
 > = {
 	// $2/M input, but $0.25/M implicit hits (0.125x) and $0.17/M explicit hits
 	// (0.085x). Explicit cache creation still follows the usual 1.25x.
 	"qwen3.8-max": { cachedInputPrice: 0.25e-6, cacheReadInputPrice: 0.17e-6 },
+	// $0.15/M input, but $0.016/M for both implicit and explicit hits (0.107x)
+	// and $0.2/M creation (1.33x) — every cache rate is off-ratio here.
+	"qwen3.8-flash": {
+		cachedInputPrice: 0.016e-6,
+		cacheReadInputPrice: 0.016e-6,
+		cacheWriteInputPrice: 0.2e-6,
+	},
 };
 
 function expectedCacheRate(
 	externalId: string,
-	field: "cachedInputPrice" | "cacheReadInputPrice",
+	field: "cachedInputPrice" | "cacheReadInputPrice" | "cacheWriteInputPrice",
 	inputPrice: string,
 	multiplier: number,
 ) {
@@ -96,7 +107,7 @@ describe("Alibaba Qwen explicit-cache pricing", () => {
 	);
 
 	it.each(alibabaProviderEntries)(
-		"$modelId cacheWriteInputPrice follows the 1.25x explicit-cache multiplier",
+		"$modelId cacheWriteInputPrice follows the 1.25x explicit-cache multiplier (or its published off-ratio rate)",
 		({ provider }) => {
 			if (
 				provider.cacheWriteInputPrice !== undefined &&
@@ -106,7 +117,12 @@ describe("Alibaba Qwen explicit-cache pricing", () => {
 					provider.externalId,
 					"cacheWriteInputPrice (5m)",
 					provider.cacheWriteInputPrice,
-					Number(provider.inputPrice) * FIVE_MIN_WRITE_MULTIPLIER,
+					expectedCacheRate(
+						provider.externalId,
+						"cacheWriteInputPrice",
+						provider.inputPrice,
+						FIVE_MIN_WRITE_MULTIPLIER,
+					),
 				);
 			}
 			for (const tier of provider.pricingTiers ?? []) {

--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -2121,6 +2121,71 @@ export const alibabaModels = [
 		],
 	},
 	{
+		id: "qwen3.8-flash",
+		name: "Qwen3.8 Flash",
+		description:
+			"Fast, cost-effective Qwen3.8 model with hybrid reasoning, visual understanding and a 1M context for high-volume tasks.",
+		family: "alibaba",
+		releasedAt: new Date("2026-08-26"),
+		providers: [
+			{
+				providerId: "alibaba",
+				externalId: "qwen3.8-flash",
+				inputPrice: "0.15e-6",
+				outputPrice: "0.47e-6",
+				// Alibaba publishes off-ratio cache rates for this model: both implicit
+				// and explicit hits are 0.107x of input and creation is 1.33x, not the
+				// usual 0.20x/0.10x/1.25x. Do not "correct" these to the ratio.
+				cachedInputPrice: "0.016e-6",
+				cacheReadInputPrice: "0.016e-6",
+				cacheWriteInputPrice: "0.2e-6",
+				regions: [{ id: "singapore" }],
+				requestPrice: "0",
+				contextSize: 1000000,
+				maxOutput: 131072,
+				reasoning: true,
+				reasoningEfforts: [
+					"none",
+					"minimal",
+					"low",
+					"medium",
+					"high",
+					"xhigh",
+					"max",
+				],
+				reasoningMaxTokens: true,
+				reasoningOutput: "omit",
+				streaming: true,
+				vision: true,
+				tools: true,
+				// The deployment 400s on "required" and named-function tool_choice with
+				// "The tool_choice parameter does not support being set to required or
+				// object in thinking mode", but honours both once thinking is off.
+				supportedToolChoices: ["auto", "none"],
+				supportedToolChoicesWithThinkingDisabled: ["required", "function"],
+				webSearch: true,
+				webSearchForcedOnly: true,
+				webSearchPrice: "0.01",
+				jsonOutput: true,
+				jsonOutputSchema: true,
+				supportsDeveloperRole: false,
+				supportedParameters: [
+					"temperature",
+					"max_tokens",
+					"top_p",
+					"frequency_penalty",
+					"presence_penalty",
+					"stop",
+					"stream",
+					"tools",
+					"tool_choice",
+					"response_format",
+					"reasoning_effort",
+				],
+			},
+		],
+	},
+	{
 		id: "qwen3-coder-next",
 		name: "Qwen3 Coder Next",
 		description:


### PR DESCRIPTION
Adds `qwen3.8-flash` on Alibaba Cloud Model Studio, plus the `finish_reason`
normalization the mapping's forced named-function tool choice needs.

## Mapping

`alibaba` / `qwen3.8-flash`, region `singapore`.

| Field | Value |
| --- | --- |
| external id | `qwen3.8-flash` |
| input / output | `$0.15` / `$0.47` per 1M |
| implicit + explicit cache read | `$0.016` per 1M |
| explicit cache creation | `$0.2` per 1M |
| context | 1,000,000 |
| max output | 131,072 |
| capabilities | reasoning, vision, tools, JSON object + strict schema, forced web search |

Pricing is flat — no context-length bands. `qwen3.7-flash` has three
(32K / 256K / 1M) and this model has none; both the first-party model page and
OpenRouter's catalogue, which encodes 3.7-flash's bands explicitly as pricing
overrides, list a single rate row for 3.8-flash.

Cache rates are deliberately off-ratio (0.107x of input for reads, 1.33x for
creation) rather than the usual 0.20x / 0.10x / 1.25x, same as `qwen3.8-max`.

## Pricing verification

Two live requests through the gateway, hand-computed against the rate card and
checked against the persisted `log` row:

| | prompt | completion | reasoning | hand-computed | `log.cost` |
| --- | --- | --- | --- | --- | --- |
| small | 59 | 197 | 113 | `0.00010144` | `0.00010144` |
| large | 42,047 | 1 | — | `0.00630752` | `0.00630752` |

Reasoning tokens are already inside `completion_tokens` upstream
(`total = prompt + completion`, and `text_tokens == completion_tokens`), in both
streaming and non-streaming, so `resolveCompletionTokens` leaves them alone and
output is billed once. Image input arrives as `prompt_tokens_details.image_tokens`
folded into `prompt_tokens`, so it bills at the input rate.

## Capabilities probed live

- **Reasoning efforts** — all seven accepted (`none` … `max`). `none` genuinely
  turns thinking off (no `reasoning_content`, no `reasoning_tokens`), so
  `reasoningOutput: "omit"`. `thinking_budget` is honoured, hence
  `reasoningMaxTokens`.
- **Tool choice** — `auto`, `none`, `required` and named function all work with
  thinking off. `required` and named function 400 with "The tool_choice
  parameter does not support being set to required or object in thinking mode"
  while thinking is on, which is what
  `supportedToolChoicesWithThinkingDisabled` exists for.
- **JSON** — `json_object` and strict `json_schema` both enforced upstream
  (enum + `additionalProperties: false` honoured), so `jsonOutputSchema: true`.
- **Vision** — confirmed on a base64 image; the deployment reports
  `image_tokens` separately.
- **Web search** — `enable_search` alone never retrieves (answers from
  parametric knowledge at unchanged prompt size), `search_options.forced_search`
  does (prompt jumps to ~2.4K tokens of injected snippets and the answer carries
  dated live data). That is exactly the `webSearchForcedOnly` case.
- **`developer` role** — rejected by DashScope
  (`developer is not one of ['system', 'assistant', 'user', 'tool', 'function']`),
  so `supportsDeveloperRole: false`.
- **Limits** — `max_tokens` 131,073 → "Range of max_tokens should be [1, 131072]";
  an oversized prompt → "Range of input length should be [1, 991808]".
- **Sampling** — `temperature`, `top_p`, `frequency_penalty`,
  `presence_penalty`, `stop` all accepted, and `stop` genuinely truncates.

## finish_reason fix

DashScope returns `finish_reason: "stop"` when the caller forces a **named
function** via `tool_choice`, even though the message carries the tool call.
`auto` and `required` correctly return `tool_calls`. Without this the new
mapping's named-function e2e case fails on `expected 'stop' to be 'tool_calls'`.

`parseProviderResponse` now normalizes it for `alibaba`, mirroring the existing
`scx-ai` normalization directly below it, guarded on tool calls actually being
present. Covered by two new cases in `parse-provider-response.spec.ts`.

The streaming path has the same upstream quirk and is **not** fixed here: the
terminal chunk carries no tool-call delta, so normalizing it needs cross-chunk
state that `transformOpenaiStreaming` does not have today. It is pre-existing
and equally affects `scx-ai`, which only has the non-streaming normalization.
Streaming with `tool_choice: "auto"` or `"required"` is unaffected.

## Not verified

Only the Singapore region is declared. The available credential is
Singapore-bound (`dashscope-us` and `dashscope` both reject it with
`invalid_api_key`), and the model is not yet listed on the Model Studio model
page that documents regional availability, so the other three regions are
unverified rather than assumed — same shape as `qwen3.6-max-preview`. They can
be added once a live call confirms them.

## Cache-ratio guard

`alibaba-pricing.spec.ts` pins Alibaba's standard cache multipliers and already
carries an off-ratio carve-out for `qwen3.8-max`. This model is off-ratio on all
three rates, including cache creation, so the carve-out record gained a
`cacheWriteInputPrice` field and the 1.25x assertion now consults it — the other
two assertions already did.

## Tests

```
TEST_MODELS="alibaba/qwen3.8-flash" FULL_MODE=true pnpm test:e2e
```

28 files passed, 125 tests passed, 0 failed (covering both
`alibaba/qwen3.8-flash` and `alibaba/qwen3.8-flash:singapore`).

`pnpm test:unit` is green (5,706 passed). The one failure in the run,
`logs.spec.ts` "should sign video content URLs…", asserts a hardcoded
`localhost:4001` and fails purely because the isolated worktree stack serves the
gateway on an offset port; it passes with `GATEWAY_URL` unset and is unrelated to
this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Alibaba’s Qwen 3.8 Flash model, including Singapore deployment, large context windows, reasoning, vision, tools, web search, and structured JSON output.
  - Added tier-specific pricing and configurable reasoning options.

- **Bug Fixes**
  - Tool-calling responses from Alibaba are now correctly identified as tool calls when applicable, improving downstream handling.

- **Pricing**
  - Updated cache pricing to reflect Alibaba’s published rates for Qwen 3.8 Flash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->