### PR TITLE
fix(gateway): classify Fireworks spend limit

### DIFF
--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
@@ -51,6 +51,15 @@ describe("getFinishReasonFromError", () => {
 		);
 	});
 
+	it("returns gateway_error for Fireworks monthly spending limit", () => {
+		expect(
+			getFinishReasonFromError(
+				400,
+				'{"error":{"message":"Request rejected because the account is reaching the monthly spending limit."}}',
+			),
+		).toBe("gateway_error");
+	});
+
 	it("returns gateway_error for 405 method not allowed", () => {
 		expect(getFinishReasonFromError(405)).toBe("gateway_error");
 		expect(getFinishReasonFromError(405, "Method Not Allowed")).toBe(

--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
@@ -82,7 +82,9 @@ export function getFinishReasonFromError(
 	// provider.
 	if (
 		errorText &&
-		/credit balance is too low|insufficient balance/i.test(errorText)
+		/credit balance is too low|insufficient balance|reaching the monthly spending limit/i.test(
+			errorText,
+		)
 	) {
 		return "gateway_error";
 	}


### PR DESCRIPTION
## Problem

Fireworks can return a client-status response when its provider account is reaching the monthly spending limit. The gateway treated this as a caller error, preventing provider fallback.

## Change

Classify that spending-limit message as `gateway_error`, alongside other exhausted provider-account errors, and add regression coverage.

## Verification

- `pnpm exec vitest run --no-file-parallelism apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts`
- `pnpm format`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of gateway account-limit errors.
  - Requests affected by a monthly spending limit are now correctly reported as gateway errors.
  - Added coverage to verify the updated error classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->