### PR TITLE
fix(api): skip reserved email domains

### DIFF
--- a/apps/api/src/utils/email.spec.ts
+++ b/apps/api/src/utils/email.spec.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { sendTransactionalEmail } from "./email.js";
+
+const { resendSendMock } = vi.hoisted(() => ({
+	resendSendMock: vi.fn(),
+}));
+
+vi.mock("@llmgateway/db", () => ({
+	isOrgOwnerEmailVerified: vi.fn(async () => true),
+}));
+
+vi.mock("@llmgateway/logger", () => ({
+	logger: {
+		error: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+	},
+}));
+
+vi.mock("@llmgateway/shared/email", () => ({
+	fromEmail: "LLMGateway <contact@mail.llmgateway.io>",
+	getResendClient: () => ({
+		emails: { send: resendSendMock },
+	}),
+	replyToEmail: "contact@llmgateway.io",
+}));
+
+describe("sendTransactionalEmail", () => {
+	beforeEach(() => {
+		vi.stubEnv("NODE_ENV", "production");
+		resendSendMock.mockReset();
+		resendSendMock.mockResolvedValue({ data: { id: "email-id" }, error: null });
+	});
+
+	test.each([
+		"admin@example.com",
+		"admin@sub.example.net",
+		"admin@example.org",
+		"admin@example",
+		"admin@invalid",
+		"admin@service.test",
+		"admin@localhost",
+	])("skips reserved production address %s", async (to) => {
+		await expect(
+			sendTransactionalEmail({
+				to,
+				subject: "Reset your password",
+				text: "Reset link",
+				strict: true,
+			}),
+		).resolves.toBeUndefined();
+
+		expect(resendSendMock).not.toHaveBeenCalled();
+	});
+
+	test("sends production email to a deliverable domain", async () => {
+		await sendTransactionalEmail({
+			to: "user@llmgateway.io",
+			subject: "Reset your password",
+			text: "Reset link",
+			strict: true,
+		});
+
+		expect(resendSendMock).toHaveBeenCalledOnce();
+	});
+});

--- a/apps/api/src/utils/email.ts
+++ b/apps/api/src/utils/email.ts
@@ -32,9 +32,10 @@ export interface TransactionalEmailOptions {
 		contentType?: string;
 	}>;
 	/**
-	 * When true, the function rejects on misconfiguration and delivery
-	 * failures instead of silently logging. Use for flows where the caller
-	 * must know whether the email was actually queued (e.g. password reset).
+	 * When true, the function rejects on unexpected misconfiguration and
+	 * delivery failures instead of silently logging. Intentional policy skips
+	 * still resolve. Use for flows where the caller must know whether the email
+	 * was actually queued (e.g. password reset).
 	 */
 	strict?: boolean;
 	/**
@@ -54,6 +55,28 @@ export interface TransactionalEmailOptions {
 	organizationId?: string;
 }
 
+function isReservedEmailAddress(email: string): boolean {
+	const separatorIndex = email.lastIndexOf("@");
+	if (separatorIndex === -1) {
+		return false;
+	}
+
+	const domain = email.slice(separatorIndex + 1).toLowerCase();
+	const reservedDomains = [
+		"example",
+		"invalid",
+		"localhost",
+		"test",
+		"example.com",
+		"example.net",
+		"example.org",
+	];
+
+	return reservedDomains.some(
+		(reserved) => domain === reserved || domain.endsWith(`.${reserved}`),
+	);
+}
+
 export async function sendTransactionalEmail({
 	to,
 	subject,
@@ -64,6 +87,14 @@ export async function sendTransactionalEmail({
 	logSafe = false,
 	organizationId,
 }: TransactionalEmailOptions): Promise<void> {
+	if (process.env.NODE_ENV === "production" && isReservedEmailAddress(to)) {
+		logger.info("Skipping transactional email to reserved domain", {
+			to,
+			subject,
+		});
+		return;
+	}
+
 	// Policy gate: never send org-scoped transactional emails to an
 	// organization whose owner has not verified their email.
 	if (organizationId && !(await isOrgOwnerEmailVerified(organizationId))) {


### PR DESCRIPTION
## Problem

Production transactional sends to RFC-reserved email domains are rejected by Resend. Strict delivery flows then surface that expected rejection as an application error.

## Approach

- skip reserved-domain recipients before calling Resend in production
- preserve non-production email logging for local reset flows
- treat the skip as intentional even for strict delivery
- cover reserved recipients and normal production delivery

## Verification

- `pnpm exec vitest run apps/api/src/utils/email.spec.ts --no-file-parallelism`
- `pnpm format`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented transactional emails from being sent in production to reserved or non-deliverable addresses, including example, test, and localhost domains.
  * Policy-based email skips now complete successfully without being treated as errors.
* **Tests**
  * Added coverage confirming reserved addresses are skipped and valid deliverable addresses are sent normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->