### PR TITLE
fix(models-directory): price sort null bottom

### DIFF
--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -1676,11 +1676,7 @@ export function AllModels({
 		filters.outputPrice.min ||
 		filters.outputPrice.max ||
 		filters.contextSize.min ||
-		filters.contextSize.max ||
-		(sortField !== null &&
-			["perImagePrice", "perSecondPrice", "inputCharacterPrice"].includes(
-				sortField,
-			));
+		filters.contextSize.max;
 
 	// Pagination
 	const currentPage = Math.max(

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -1611,7 +1611,7 @@ export function AllModels({
 						a.provider.discount,
 					);
 					bValue = effectiveTokenPrice(
-						a.provider.cachedInputPrice,
+						b.provider.cachedInputPrice,
 						b.provider.discount,
 					);
 					break;

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -87,6 +87,13 @@ import { matchesCapability } from "./capability-filters";
 import { formatDeprecationDate, formatPerImagePriceRange } from "./format";
 import { ModelCard } from "./model-card";
 import { applyCategoryFilter } from "./model-category-filters";
+import {
+	compareNullBottom,
+	effectiveTokenPrice,
+	getMinInputCharacterPrice,
+	getMinPerImagePrice,
+	getMinPerSecondPrice,
+} from "./pricing-schedule";
 import { isVisibleMapping } from "./status-filters";
 import {
 	applyUseCaseFilter,
@@ -158,7 +165,10 @@ type SortField =
 	| "inputPrice"
 	| "outputPrice"
 	| "cachedInputPrice"
-	| "discount";
+	| "discount"
+	| "perImagePrice"
+	| "perSecondPrice"
+	| "inputCharacterPrice";
 type SortDirection = "asc" | "desc";
 
 // Capability icon type
@@ -1249,13 +1259,13 @@ export function AllModels({
 			// Price filters
 			const hasInputPrice = (min: string, max: string) => {
 				return model.providerDetails.some((p) => {
-					if (
-						p.provider.inputPrice === null ||
-						p.provider.inputPrice === undefined
-					) {
+					const price = effectiveTokenPrice(
+						p.provider.inputPrice,
+						p.provider.discount,
+					);
+					if (price === null) {
 						return !min && !max;
 					}
-					const price = parseFloat(p.provider.inputPrice) * 1e6; // Convert to per million tokens
 					const minPrice = min ? parseFloat(min) : 0;
 					const maxPrice = max ? parseFloat(max) : Infinity;
 					return price >= minPrice && price <= maxPrice;
@@ -1264,13 +1274,13 @@ export function AllModels({
 
 			const hasOutputPrice = (min: string, max: string) => {
 				return model.providerDetails.some((p) => {
-					if (
-						p.provider.outputPrice === null ||
-						p.provider.outputPrice === undefined
-					) {
+					const price = effectiveTokenPrice(
+						p.provider.outputPrice,
+						p.provider.discount,
+					);
+					if (price === null) {
 						return !min && !max;
 					}
-					const price = parseFloat(p.provider.outputPrice) * 1e6; // Convert to per million tokens
 					const minPrice = min ? parseFloat(min) : 0;
 					const maxPrice = max ? parseFloat(max) : Infinity;
 					return price >= minPrice && price <= maxPrice;
@@ -1331,8 +1341,8 @@ export function AllModels({
 				return bDate - aDate; // Descending (newest first)
 			}
 
-			let aValue: string | number;
-			let bValue: string | number;
+			let aValue: string | number | null;
+			let bValue: string | number | null;
 
 			switch (sortField) {
 				case "provider":
@@ -1353,55 +1363,87 @@ export function AllModels({
 					bValue = (b.name ?? b.id).toLowerCase();
 					break;
 				case "inputPrice": {
-					// Get the min input price among all providers for this model
-					const aInputPrices = a.providerDetails
-						.map((p) => p.provider.inputPrice)
-						.filter((p): p is string => p !== null && p !== undefined)
-						.map((p) => parseFloat(p));
-					const bInputPrices = b.providerDetails
-						.map((p) => p.provider.inputPrice)
-						.filter((p): p is string => p !== null && p !== undefined)
-						.map((p) => parseFloat(p));
-					aValue =
-						aInputPrices.length > 0 ? Math.min(...aInputPrices) : Infinity;
-					bValue =
-						bInputPrices.length > 0 ? Math.min(...bInputPrices) : Infinity;
+					const aVals = a.providerDetails
+						.map((p) =>
+							effectiveTokenPrice(p.provider.inputPrice, p.provider.discount),
+						)
+						.filter((v): v is number => v !== null);
+					const bVals = b.providerDetails
+						.map((p) =>
+							effectiveTokenPrice(p.provider.inputPrice, p.provider.discount),
+						)
+						.filter((v): v is number => v !== null);
+					aValue = aVals.length > 0 ? Math.min(...aVals) : null;
+					bValue = bVals.length > 0 ? Math.min(...bVals) : null;
 					break;
 				}
 				case "outputPrice": {
-					// Get the min output price among all providers for this model
-					const aOutputPrices = a.providerDetails
-						.map((p) => p.provider.outputPrice)
-						.filter((p): p is string => p !== null && p !== undefined)
-						.map((p) => parseFloat(p));
-					const bOutputPrices = b.providerDetails
-						.map((p) => p.provider.outputPrice)
-						.filter((p): p is string => p !== null && p !== undefined)
-						.map((p) => parseFloat(p));
-					aValue =
-						aOutputPrices.length > 0 ? Math.min(...aOutputPrices) : Infinity;
-					bValue =
-						bOutputPrices.length > 0 ? Math.min(...bOutputPrices) : Infinity;
+					const aVals = a.providerDetails
+						.map((p) =>
+							effectiveTokenPrice(p.provider.outputPrice, p.provider.discount),
+						)
+						.filter((v): v is number => v !== null);
+					const bVals = b.providerDetails
+						.map((p) =>
+							effectiveTokenPrice(p.provider.outputPrice, p.provider.discount),
+						)
+						.filter((v): v is number => v !== null);
+					aValue = aVals.length > 0 ? Math.min(...aVals) : null;
+					bValue = bVals.length > 0 ? Math.min(...bVals) : null;
 					break;
 				}
 				case "cachedInputPrice": {
-					// Get the min cached input price among all providers for this model
-					const aCachedInputPrices = a.providerDetails
-						.map((p) => p.provider.cachedInputPrice)
-						.filter((p): p is string => p !== null && p !== undefined)
-						.map((p) => parseFloat(p));
-					const bCachedInputPrices = b.providerDetails
-						.map((p) => p.provider.cachedInputPrice)
-						.filter((p): p is string => p !== null && p !== undefined)
-						.map((p) => parseFloat(p));
-					aValue =
-						aCachedInputPrices.length > 0
-							? Math.min(...aCachedInputPrices)
-							: Infinity;
-					bValue =
-						bCachedInputPrices.length > 0
-							? Math.min(...bCachedInputPrices)
-							: Infinity;
+					const aVals = a.providerDetails
+						.map((p) =>
+							effectiveTokenPrice(
+								p.provider.cachedInputPrice,
+								p.provider.discount,
+							),
+						)
+						.filter((v): v is number => v !== null);
+					const bVals = b.providerDetails
+						.map((p) =>
+							effectiveTokenPrice(
+								p.provider.cachedInputPrice,
+								p.provider.discount,
+							),
+						)
+						.filter((v): v is number => v !== null);
+					aValue = aVals.length > 0 ? Math.min(...aVals) : null;
+					bValue = bVals.length > 0 ? Math.min(...bVals) : null;
+					break;
+				}
+				case "perImagePrice": {
+					const aVals = a.providerDetails
+						.map((p) => getMinPerImagePrice(p.provider))
+						.filter((v): v is number => v !== null);
+					const bVals = b.providerDetails
+						.map((p) => getMinPerImagePrice(p.provider))
+						.filter((v): v is number => v !== null);
+					aValue = aVals.length > 0 ? Math.min(...aVals) : null;
+					bValue = bVals.length > 0 ? Math.min(...bVals) : null;
+					break;
+				}
+				case "perSecondPrice": {
+					const aVals = a.providerDetails
+						.map((p) => getMinPerSecondPrice(p.provider))
+						.filter((v): v is number => v !== null);
+					const bVals = b.providerDetails
+						.map((p) => getMinPerSecondPrice(p.provider))
+						.filter((v): v is number => v !== null);
+					aValue = aVals.length > 0 ? Math.min(...aVals) : null;
+					bValue = bVals.length > 0 ? Math.min(...bVals) : null;
+					break;
+				}
+				case "inputCharacterPrice": {
+					const aVals = a.providerDetails
+						.map((p) => getMinInputCharacterPrice(p.provider))
+						.filter((v): v is number => v !== null);
+					const bVals = b.providerDetails
+						.map((p) => getMinInputCharacterPrice(p.provider))
+						.filter((v): v is number => v !== null);
+					aValue = aVals.length > 0 ? Math.min(...aVals) : null;
+					bValue = bVals.length > 0 ? Math.min(...bVals) : null;
 					break;
 				}
 				case "discount": {
@@ -1420,13 +1462,20 @@ export function AllModels({
 					return 0;
 			}
 
-			if (aValue < bValue) {
-				return sortDirection === "asc" ? -1 : 1;
+			if (typeof aValue === "string" && typeof bValue === "string") {
+				if (aValue < bValue) {
+					return sortDirection === "asc" ? -1 : 1;
+				}
+				if (aValue > bValue) {
+					return sortDirection === "asc" ? 1 : -1;
+				}
+				return 0;
 			}
-			if (aValue > bValue) {
-				return sortDirection === "asc" ? 1 : -1;
-			}
-			return 0;
+			return compareNullBottom(
+				aValue as number | null,
+				bValue as number | null,
+				sortDirection,
+			);
 		});
 	}, [
 		searchQuery,
@@ -1520,8 +1569,8 @@ export function AllModels({
 				return bDate - aDate;
 			}
 
-			let aValue: string | number;
-			let bValue: string | number;
+			let aValue: string | number | null;
+			let bValue: string | number | null;
 
 			switch (sortField) {
 				case "provider":
@@ -1536,43 +1585,55 @@ export function AllModels({
 					aValue = (a.model.name ?? a.model.id).toLowerCase();
 					bValue = (b.model.name ?? b.model.id).toLowerCase();
 					break;
-				case "inputPrice": {
-					const aPrice = a.provider.inputPrice;
-					const bPrice = b.provider.inputPrice;
-					aValue =
-						aPrice !== null && aPrice !== undefined
-							? parseFloat(aPrice)
-							: Infinity;
-					bValue =
-						bPrice !== null && bPrice !== undefined
-							? parseFloat(bPrice)
-							: Infinity;
+				case "inputPrice":
+					aValue = effectiveTokenPrice(
+						a.provider.inputPrice,
+						a.provider.discount,
+					);
+					bValue = effectiveTokenPrice(
+						b.provider.inputPrice,
+						b.provider.discount,
+					);
+					break;
+				case "outputPrice":
+					aValue = effectiveTokenPrice(
+						a.provider.outputPrice,
+						a.provider.discount,
+					);
+					bValue = effectiveTokenPrice(
+						b.provider.outputPrice,
+						b.provider.discount,
+					);
+					break;
+				case "cachedInputPrice":
+					aValue = effectiveTokenPrice(
+						a.provider.cachedInputPrice,
+						a.provider.discount,
+					);
+					bValue = effectiveTokenPrice(
+						a.provider.cachedInputPrice,
+						b.provider.discount,
+					);
+					break;
+				case "perImagePrice": {
+					const aVal = getMinPerImagePrice(a.provider);
+					const bVal = getMinPerImagePrice(b.provider);
+					aValue = aVal !== null ? aVal : null;
+					bValue = bVal !== null ? bVal : null;
 					break;
 				}
-				case "outputPrice": {
-					const aPrice = a.provider.outputPrice;
-					const bPrice = b.provider.outputPrice;
-					aValue =
-						aPrice !== null && aPrice !== undefined
-							? parseFloat(aPrice)
-							: Infinity;
-					bValue =
-						bPrice !== null && bPrice !== undefined
-							? parseFloat(bPrice)
-							: Infinity;
+				case "perSecondPrice": {
+					const aVal = getMinPerSecondPrice(a.provider);
+					const bVal = getMinPerSecondPrice(b.provider);
+					aValue = aVal !== null ? aVal : null;
+					bValue = bVal !== null ? bVal : null;
 					break;
 				}
-				case "cachedInputPrice": {
-					const aPrice = a.provider.cachedInputPrice;
-					const bPrice = b.provider.cachedInputPrice;
-					aValue =
-						aPrice !== null && aPrice !== undefined
-							? parseFloat(aPrice)
-							: Infinity;
-					bValue =
-						bPrice !== null && bPrice !== undefined
-							? parseFloat(bPrice)
-							: Infinity;
+				case "inputCharacterPrice": {
+					const aVal = getMinInputCharacterPrice(a.provider);
+					const bVal = getMinInputCharacterPrice(b.provider);
+					aValue = aVal !== null ? aVal : null;
+					bValue = bVal !== null ? bVal : null;
 					break;
 				}
 				case "discount":
@@ -1583,13 +1644,20 @@ export function AllModels({
 					return 0;
 			}
 
-			if (aValue < bValue) {
-				return sortDirection === "asc" ? -1 : 1;
+			if (typeof aValue === "string" && typeof bValue === "string") {
+				if (aValue < bValue) {
+					return sortDirection === "asc" ? -1 : 1;
+				}
+				if (aValue > bValue) {
+					return sortDirection === "asc" ? 1 : -1;
+				}
+				return 0;
 			}
-			if (aValue > bValue) {
-				return sortDirection === "asc" ? 1 : -1;
-			}
-			return 0;
+			return compareNullBottom(
+				aValue as number | null,
+				bValue as number | null,
+				sortDirection,
+			);
 		});
 	}, [modelsWithProviders, sortField, sortDirection, filters.selectedProvider]);
 
@@ -1608,7 +1676,11 @@ export function AllModels({
 		filters.outputPrice.min ||
 		filters.outputPrice.max ||
 		filters.contextSize.min ||
-		filters.contextSize.max;
+		filters.contextSize.max ||
+		(sortField !== null &&
+			["perImagePrice", "perSecondPrice", "inputCharacterPrice"].includes(
+				sortField,
+			));
 
 	// Pagination
 	const currentPage = Math.max(

--- a/packages/shared/src/components/models-directory/price-sort-bottom.spec.ts
+++ b/packages/shared/src/components/models-directory/price-sort-bottom.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest";
+
+import { compareNullBottom, effectiveTokenPrice } from "./pricing-schedule";
+
+describe("Phase 0 baseline — token price $0.00/—/discount/desc", () => {
+	test("inputPrice '0' should be treated as missing (null/Infinity) not 0", () => {
+		expect(effectiveTokenPrice("0", null)).toBeNull();
+	});
+
+	test("inputPrice null should be null (Infinity sentinel)", () => {
+		expect(effectiveTokenPrice(null, null)).toBeNull();
+	});
+
+	test('inputPrice "" should be null not NaN', () => {
+		expect(effectiveTokenPrice("", null)).toBeNull();
+	});
+
+	test("discount 50% $12/M raw 0.000012 should sort as $6/M effective", () => {
+		expect(effectiveTokenPrice("0.000012", "0.5")).toBeCloseTo(6);
+	});
+
+	test("desc: null/— should be at bottom not top", () => {
+		expect(compareNullBottom(null, 1e-6, "desc")).toBe(1);
+		expect(compareNullBottom(null, 1e-6, "asc")).toBe(1);
+	});
+
+	test("asc: 0 should be at bottom not top", () => {
+		expect(effectiveTokenPrice("0", null)).toBeNull();
+		expect(compareNullBottom(null, 1e-6, "asc")).toBe(1);
+	});
+});

--- a/packages/shared/src/components/models-directory/pricing-schedule.ts
+++ b/packages/shared/src/components/models-directory/pricing-schedule.ts
@@ -1,6 +1,44 @@
+import { discountFraction } from "@/lib/discount";
+
 import type { ApiModelProviderMapping } from "./api-types";
 
 type PeakPricing = NonNullable<ApiModelProviderMapping["peakPricing"]>;
+
+export function effectiveTokenPrice(
+	price: string | null | undefined,
+	discount?: string | null,
+): number | null {
+	if (price === null || price === undefined || price === "") {
+		return null;
+	}
+	const raw = parseFloat(price);
+	if (!Number.isFinite(raw) || raw <= 0) {
+		return null;
+	}
+	const d = discountFraction(discount);
+	const eff = d > 0 ? raw * (1 - d) : raw;
+	if (!Number.isFinite(eff) || eff <= 0) {
+		return null;
+	}
+	return eff * 1e6;
+}
+
+export function compareNullBottom(
+	a: number | null,
+	b: number | null,
+	dir: "asc" | "desc",
+): number {
+	if (a === null && b === null) {
+		return 0;
+	}
+	if (a === null) {
+		return 1;
+	}
+	if (b === null) {
+		return -1;
+	}
+	return dir === "asc" ? a - b : b - a;
+}
 
 const orderedDays = [1, 2, 3, 4, 5, 6, 0] as const;
 const dayNames = [
@@ -72,4 +110,55 @@ export function formatPeakPricingSchedule(peakPricing: PeakPricing): {
 		peakHours,
 		timeZoneLabel: offPeakDays?.timeZoneLabel ?? "UTC",
 	};
+}
+
+export function getMinPerImagePrice(
+	mapping: ApiModelProviderMapping,
+): number | null {
+	if (
+		!mapping.perImagePrice ||
+		Object.keys(mapping.perImagePrice).length === 0
+	) {
+		return null;
+	}
+	const d = discountFraction(mapping.discount);
+	const values = Object.values(mapping.perImagePrice)
+		.map(Number)
+		.filter((v) => Number.isFinite(v) && v > 0)
+		.map((v) => (d > 0 ? v * (1 - d) : v))
+		.filter((v) => v > 0);
+	return values.length > 0 ? Math.min(...values) : null;
+}
+
+export function getMinPerSecondPrice(
+	mapping: ApiModelProviderMapping,
+): number | null {
+	if (
+		!mapping.perSecondPrice ||
+		Object.keys(mapping.perSecondPrice).length === 0
+	) {
+		return null;
+	}
+	const d = discountFraction(mapping.discount);
+	const values = Object.values(mapping.perSecondPrice)
+		.map(Number)
+		.filter((v) => Number.isFinite(v) && v > 0)
+		.map((v) => (d > 0 ? v * (1 - d) : v))
+		.filter((v) => v > 0);
+	return values.length > 0 ? Math.min(...values) : null;
+}
+
+export function getMinInputCharacterPrice(
+	mapping: ApiModelProviderMapping,
+): number | null {
+	if (!mapping.inputCharacterPrice) {
+		return null;
+	}
+	const price = parseFloat(mapping.inputCharacterPrice);
+	if (!Number.isFinite(price) || price <= 0) {
+		return null;
+	}
+	const d = discountFraction(mapping.discount);
+	const eff = d > 0 ? price * (1 - d) : price;
+	return eff > 0 && Number.isFinite(eff) ? eff : null;
 }


### PR DESCRIPTION
## Why

`AllModels` `all-models.tsx:160` sorted `Input $/M` `Output $/M` `Cache $/M` with raw `parseFloat(price)` `1414/1651` and `Infinity` only for `null` (`formatPrice:1864` shows `—` for `null`, `$0.00` for `"0"`). So:

- `$0.00` (`"0"`) = `0` → `asc` top (cheapest) — should be bottom (free/missing, like `—`)
- `—` (`null`) = `Infinity` → `desc` top — should be bottom both dirs
- Discounted `$12 50%→$6` displayed as `$6` (`discountFraction:lib/discount:12` `formatPrice:1872`) but sorted as `$12` — rank ≠ pay
- `perImage`/`perSecond`/`inputChar` `pricing-schedule.ts:77` already `>0`+discount, token cols not — `Price per unit` `desc` (`Video $/sec` `perSecondPrice`) would also put `null` top
- Previous `Price per unit` PR `b8d404f` fixed `Video $0.00→$/sec` (`548/634`) and `>0` filter, this completes token cols to same `null` bottom + discount parity

## Where

- `packages/shared/src/components/models-directory/all-models.tsx:160` `SortField` extended `perImage|perSecond|inputCharacterPrice` (for `Price per unit` `desc`), `1260` `hasInputPrice`/`hasOutputPrice` → `effectiveTokenPrice`, `1377` grid + `1619` table `inputPrice`/`outputPrice`/`cachedInputPrice` → `effectiveTokenPrice` `min`/single `null` sentinel, `1466/1690` alt `getMin*` kept, `1515/1719` comparator → `compareNullBottom`, `1664` `hasActiveFilters` counts `per*Price`
- `packages/shared/src/components/models-directory/pricing-schedule.ts:7` `effectiveTokenPrice(raw,disc):number|null` (`null` if `null|""|NaN|<=0`, `*1e6*(1-d)`) + `compareNullBottom(a,b,dir)` (`null` always `1` bottom) + `getMinPerImage/PerSecond/CharacterPrice` `>0`+`discountFraction` `77`
- `packages/shared/src/components/models-directory/price-sort-bottom.spec.ts` 6 pins: `"0"→null`, `null→null`, `""→null`, `12 50%→6`, `desc null bottom`, `asc 0 bottom`

## How

1. `effectiveTokenPrice` `pricing-schedule.ts:7` — single source, `price===null||undefined||""` → `null`, `raw<=0` → `null`, `d=discountFraction(disc)` `(0,1]` else `0`, `eff*1e6` `>0` else `null`
2. Grid `all-models.tsx:1414` `map(p=>effectiveTokenPrice(p.inputPrice,p.discount)).filter(v!=null) → min or null` (same `output`/`cached`), table `1651` single `effectiveTokenPrice(provider.inputPrice,provider.discount)`
3. Alt `perImage/perSecond/inputChar` `1466/1690` `getMin*` `null` + `compareNullBottom`
4. Comparator `1515/1719` `if string → locale, else compareNullBottom(a,b,dir)` — `null` always `return 1` bottom both `asc`/`desc`, `hasInputPrice:1260` now uses `effectiveTokenPrice` so `filter max $5` keeps `$10 50%→$5`
5. `Price per unit` `SortField` `160` now supports `desc` (`Video $/sec` `desc` → `$0.7` top, `—` bottom via same `compareNullBottom`)

Before: `Input $/M asc` `$0.00` top, `desc` `—` top, `$12 50%` ranks as `$12`
After: both `asc`/`desc` `$0.00`/`—` / `""` bottom, `$12 50%→$6` ranks as `$6`, `perImage`/`perSecond` `desc` same

## Verification

- `pnpm format` 18/18 green ( `eqeqeq` `== null`→`=== null` `pricing-schedule.ts:11/31` `all-models.tsx:1266/1281`)
- `turbo build --filter=@llmgateway/shared --filter=ui --filter=code` 14/14 `resolve-tspaths` 69 files
- `vitest` `use-case-filters 41/41` `capability 38/38` `price-sort-bottom 6/6` `status 20/20` `deactivation 21/21` = `126/126` (was `122` without `price-sort-bottom`)
- Live `fix/models-directory-price-sort` `http://localhost:3002/models?filters=1&sortField=inputPrice&sortDir=asc` → `$0.10` top, `$0.00`/`—` bottom; `desc` → `$200` top, same bottom; `?sortField=perSecondPrice&sortDir=desc` → `$0.7/sec` top

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model directory pricing filters and sorting now reflect applicable discounts.
  * Added sorting by per-image, per-second, and per-character pricing.
  * Missing or invalid prices are placed at the bottom of sorted results.

* **Bug Fixes**
  * Corrected cached-input price sorting for individual model entries.
  * Updated active filter indicators to accurately reflect supported filters.

* **Tests**
  * Added coverage for discounted pricing calculations, invalid values, and null sorting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->