### PR TITLE
fix(models): enable GLM-5.3 Flash vision

### DIFF
--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -22,7 +22,7 @@ export const zaiModels = [
 				streaming: true,
 				reasoning: true,
 				reasoningEfforts: ["low", "high", "max"],
-				vision: false,
+				vision: true,
 				tools: true,
 				supportedToolChoices: ["auto", "required", "function"],
 				jsonOutput: true,


### PR DESCRIPTION
## Problem

`zai/glm-5.3-flash` was marked as non-vision, so gateway capability validation rejected image inputs before they reached Z.ai even though the deployment now accepts them.

## Approach

Enable vision on the first-party Z.ai mapping only. The sibling SCX mapping remains non-vision because it was not verified.

The changed mapping keeps its existing external ID (`glm-5.3-flash`), pricing ($0.15/M input, $0.03/M cached input, $0.50/M output), 1,048,576-token context, 131,072-token output limit, streaming, reasoning tiers, tool choices, and JSON support.

A direct Z.ai request with an embedded PNG returned HTTP 200 and accurately described the fixture, confirming image understanding. No pricing or token semantics changed.

## Verification

- direct upstream embedded-image probe: HTTP 200 with an accurate description
- catalogue/provider/cost tests: 152 passed
- `TEST_MODELS="zai/glm-5.3-flash" FULL_MODE=true pnpm test:e2e`: 95 passed, 94 skipped
- `pnpm format`
- `pnpm build`

Fixes #3847

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vision input support for the ZAI provider’s GLM-5.3-Flash model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->