### PR TITLE
feat(models): add orcarouter provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -434,6 +434,9 @@ LLM_TOGETHER_AI_API_KEY=your_together_ai_key_here
 # SCX.ai
 LLM_SCX_AI_API_KEY=your_scx_ai_key_here
 
+# OrcaRouter
+LLM_ORCAROUTER_API_KEY=your_orcarouter_key_here
+
 # Mistral
 LLM_MISTRAL_API_KEY=your_mistral_key_here
 

--- a/apps/gateway/src/chat/tools/transform-response-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-response-to-openai.ts
@@ -651,6 +651,7 @@ export function transformResponseToOpenai(
 		case "together-ai":
 		case "scx-ai":
 		case "scx-ai-gp":
+		case "orcarouter":
 		case "groq": {
 			if (!transformedResponse.id) {
 				transformedResponse = {

--- a/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-streaming-to-openai.ts
@@ -1529,6 +1529,7 @@ export function transformStreamingToOpenai(
 		case "together-ai":
 		case "scx-ai":
 		case "scx-ai-gp":
+		case "orcarouter":
 		case "deepinfra":
 		case "custom":
 		case "nanogpt":

--- a/packages/actions/src/get-provider-endpoint.ts
+++ b/packages/actions/src/get-provider-endpoint.ts
@@ -231,6 +231,7 @@ const PROVIDER_DEFAULT_BASE_URLS: Partial<Record<ProviderId, string>> = {
 	ranoai: "https://api.ranoai.com",
 	baidu: "https://api.baiduqianfan.ai",
 	consensusprotocol: "https://api.consensusprotocol.org",
+	orcarouter: "https://api.orcarouter.ai",
 };
 
 export function getProviderDefaultBaseUrl(
@@ -1022,6 +1023,7 @@ export function getProviderEndpoint(
 		case "embercloud":
 		case "scx-ai":
 		case "scx-ai-gp":
+		case "orcarouter":
 		case "ranoai":
 		case "consensusprotocol":
 		case "custom":

--- a/packages/models/src/models/alibaba.ts
+++ b/packages/models/src/models/alibaba.ts
@@ -2118,6 +2118,29 @@ export const alibabaModels = [
 					"reasoning_effort",
 				],
 			},
+
+			{
+				// OrcaRouter is an OpenAI-compatible gateway that resells Alibaba
+				// models at the provider's published rate with zero markup, so
+				// pricing mirrors the first-party alibaba mapping.
+				providerId: "orcarouter",
+				externalId: "qwen/qwen3.8-max",
+				inputPrice: "2e-6",
+				outputPrice: "6e-6",
+				cachedInputPrice: "0.25e-6",
+				requestPrice: "0",
+				contextSize: 1000000,
+				maxOutput: 131072,
+				reasoning: true,
+				reasoningOutput: "omit",
+				streaming: true,
+				vision: true,
+				tools: true,
+				webSearch: true,
+				webSearchForcedOnly: true,
+				webSearchPrice: "0.01",
+				jsonOutput: true,
+			},
 		],
 	},
 	{

--- a/packages/models/src/models/anthropic.ts
+++ b/packages/models/src/models/anthropic.ts
@@ -1543,6 +1543,29 @@ export const anthropicModels = [
 				jsonOutputSchema: true,
 				supportedParameters: ["max_tokens", "effort"],
 			},
+
+			{
+				// OrcaRouter is an OpenAI-compatible gateway that resells Anthropic
+				// models at the provider's published rate with zero markup, so
+				// pricing mirrors the first-party anthropic mapping.
+				providerId: "orcarouter",
+				externalId: "anthropic/claude-opus-4.8",
+				inputPrice: "5.0e-6",
+				outputPrice: "25.0e-6",
+				cachedInputPrice: "0.5e-6",
+				requestPrice: "0",
+				contextSize: 1000000,
+				maxOutput: 128000,
+				reasoning: true,
+				reasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
+				reasoningOutput: "omit",
+				streaming: true,
+				vision: true,
+				tools: true,
+				jsonOutputSchema: true,
+				webSearch: true,
+				webSearchPrice: "0.01",
+			},
 		],
 	},
 	{

--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -588,6 +588,27 @@ export const deepseekModels = [
 				tools: true,
 				jsonOutput: true,
 			},
+
+			{
+				// OrcaRouter is an OpenAI-compatible gateway that resells DeepSeek
+				// models at the provider's published rate with zero markup, so
+				// pricing mirrors the first-party deepseek mapping.
+				providerId: "orcarouter",
+				externalId: "deepseek/deepseek-v4-pro",
+				inputPrice: "0.435e-6",
+				outputPrice: "0.87e-6",
+				cachedInputPrice: "0.003625e-6",
+				requestPrice: "0",
+				contextSize: 1050000,
+				maxOutput: 393216,
+				jsonOutput: true,
+				streaming: true,
+				reasoning: true,
+				reasoningEfforts: ["none", "high", "max"],
+				vision: false,
+				tools: true,
+				supportsDeveloperRole: false,
+			},
 		],
 	},
 	{

--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -898,6 +898,25 @@ export const googleModels = [
 				jsonOutput: true,
 				jsonOutputSchema: true,
 			},
+
+			{
+				// OrcaRouter is an OpenAI-compatible gateway that resells Google
+				// models at the provider's published rate with zero markup, so
+				// pricing mirrors the first-party google-ai-studio mapping.
+				providerId: "orcarouter",
+				externalId: "google/gemini-3.1-pro-preview",
+				inputPrice: "2e-6",
+				outputPrice: "12e-6",
+				cachedInputPrice: "0.2e-6",
+				requestPrice: "0",
+				contextSize: 1048576,
+				maxOutput: 65536,
+				reasoning: true,
+				streaming: true,
+				vision: true,
+				tools: true,
+				jsonOutput: true,
+			},
 		],
 	},
 	{

--- a/packages/models/src/models/minimax.ts
+++ b/packages/models/src/models/minimax.ts
@@ -169,6 +169,26 @@ export const minimaxModels = [
 				tools: true,
 				jsonOutput: true,
 			},
+
+			{
+				// OrcaRouter is an OpenAI-compatible gateway that resells MiniMax
+				// models at the provider's published rate with zero markup, so
+				// pricing mirrors the first-party minimax mapping.
+				providerId: "orcarouter",
+				externalId: "minimax/minimax-m2.7",
+				inputPrice: "0.3e-6",
+				cachedInputPrice: "0.06e-6",
+				outputPrice: "1.2e-6",
+				requestPrice: "0",
+				contextSize: 204800,
+				maxOutput: 131100,
+				streaming: true,
+				reasoning: true,
+				reasoningEfforts: ["low", "medium", "high", "xhigh", "max"],
+				vision: false,
+				tools: true,
+				jsonOutput: false,
+			},
 		],
 	},
 	{

--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -908,6 +908,26 @@ export const moonshotModels = [
 					"reasoning_effort",
 				],
 			},
+
+			{
+				// OrcaRouter is an OpenAI-compatible gateway that resells Moonshot
+				// models at the provider's published rate with zero markup, so
+				// pricing mirrors the first-party moonshot mapping.
+				providerId: "orcarouter",
+				externalId: "kimi/kimi-k3",
+				inputPrice: "3.0e-6",
+				cachedInputPrice: "0.3e-6",
+				outputPrice: "15.0e-6",
+				requestPrice: "0",
+				contextSize: 1048576,
+				maxOutput: 1048576,
+				reasoning: true,
+				reasoningEfforts: ["low", "high", "max"],
+				streaming: true,
+				vision: true,
+				tools: true,
+				jsonOutput: true,
+			},
 		],
 	},
 	{

--- a/packages/models/src/models/openai.ts
+++ b/packages/models/src/models/openai.ts
@@ -1853,6 +1853,30 @@ export const openaiModels = [
 				],
 				jsonOutput: true,
 			},
+
+			{
+				// OrcaRouter is an OpenAI-compatible gateway: it resells the
+				// provider's own model at the provider's published rate with zero
+				// markup, so pricing mirrors the first-party openai mapping.
+				providerId: "orcarouter",
+				externalId: "openai/gpt-5.5",
+				inputPrice: "5.0e-6",
+				outputPrice: "30.0e-6",
+				cachedInputPrice: "0.5e-6",
+				requestPrice: "0",
+				contextSize: 1050000,
+				maxOutput: 128000,
+				streaming: true,
+				vision: true,
+				tools: true,
+				webSearch: true,
+				webSearchPrice: "0.01",
+				reasoning: true,
+				reasoningEfforts: ["none", "low", "medium", "high", "xhigh"],
+				reasoningOutput: "omit",
+				jsonOutputSchema: true,
+				jsonOutput: true,
+			},
 		],
 	},
 	{

--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -400,6 +400,28 @@ export const zaiModels = [
 				tools: true,
 				jsonOutput: true,
 			},
+
+			{
+				// OrcaRouter is an OpenAI-compatible gateway that resells Z.ai
+				// models at the provider's published rate with zero markup, so
+				// pricing mirrors the first-party zai mapping.
+				providerId: "orcarouter",
+				externalId: "z-ai/glm-5.2",
+				inputPrice: "1.4e-6",
+				cachedInputPrice: "0.26e-6",
+				outputPrice: "4.4e-6",
+				requestPrice: "0",
+				contextSize: 1000000,
+				maxOutput: 128000,
+				streaming: true,
+				reasoning: true,
+				reasoningEfforts: ["none", "high", "max"],
+				vision: false,
+				tools: true,
+				webSearch: true,
+				webSearchPrice: "0.01",
+				jsonOutput: true,
+			},
 		],
 	},
 	{

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -1489,6 +1489,28 @@ export const providers: ProviderDefinition[] = [
 		},
 	},
 	{
+		id: "orcarouter",
+		name: "OrcaRouter",
+		forwardsSafetyIdentifier: false,
+		description:
+			"OrcaRouter is an OpenAI-compatible AI gateway that routes every request to the best model across 200+ frontier and open models, with automatic failover, zero markup on provider pricing, and gateway-level security for AI agents.",
+		env: {
+			required: {
+				apiKey: "LLM_ORCAROUTER_API_KEY",
+			},
+		},
+		streaming: true,
+		cancellation: true,
+		color: "#7c3aed",
+		website: "https://www.orcarouter.ai",
+		statusPageUrl: "https://statuspage.incident.io/orca-router",
+		announcement: null,
+		termsUrl: null,
+		privacyPolicyUrl: null,
+		headquarters: null,
+		dataPolicy: null,
+	},
+	{
 		id: "custom",
 		name: "Custom",
 		forwardsSafetyIdentifier: false,


### PR DESCRIPTION
## What

Adds **OrcaRouter** as a first-class provider in the LLM Gateway catalogue. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents — like OpenRouter it exposes a provider/model namespace across many models, but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a named provider means LLM Gateway users can route to that whole stack directly (`orcarouter/<model>`), instead of treating it as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## What changed

Following the same wiring the catalogue uses for other OpenAI-compatible gateway providers (e.g. `scx-ai` / `consensusprotocol`):

- **`packages/models/src/providers.ts`** — new `orcarouter` provider definition (`LLM_ORCAROUTER_API_KEY`).
- **`packages/actions/src/get-provider-endpoint.ts`** — `orcarouter` default base URL (`https://api.orcarouter.ai`) and the shared OpenAI-compatible `/v1/chat/completions` path.
- **`packages/models/src/models/*.ts`** — provider mappings for 8 models OrcaRouter serves across its supported families:
  `openai/gpt-5.5`, `anthropic/claude-opus-4.8`, `deepseek/deepseek-v4-pro`, `google/gemini-3.1-pro-preview`, `qwen/qwen3.8-max`, `z-ai/glm-5.2`, `kimi/kimi-k3`, `minimax/minimax-m2.7`.
- **`apps/gateway/src/chat/tools/transform-{response,streaming}-to-openai.ts`** — `orcarouter` joins the shared OpenAI streaming/response transform group.
- **`.env.example`** — `LLM_ORCAROUTER_API_KEY`.

OrcaRouter resells each model at the upstream provider's published rate with zero markup, so each mapping's prices mirror the corresponding first-party mapping and the gateway's cost engine stays accurate.

## Verification

- **Live (L3):** exercised the exact gateway code path — `getProviderDefaultBaseUrl("orcarouter")` → `getProviderEndpoint(...)` → `POST https://api.orcarouter.ai/v1/chat/completions` with the `openai/gpt-5.5` external id — returned **HTTP 200** with real usage/latency payload. All 8 mapped external ids were verified live against the OrcaRouter API.
- **Build:** `turbo run build` clean for `@llmgateway/models`, `@llmgateway/actions`, and `gateway`.
- **Tests:** catalogue specs (`providers`, `model-metadata`, `free-models`, `compliance`, `helpers`, `provider`) plus actions `get-provider-endpoint` / `models` specs — **276 passed**. (A separate `env-inventory` spec fails locally only because it needs a live Redis, which isn't running in this environment; it's unrelated to this change.)

## Notes

- The public provider page at `/providers/orcarouter` is generated automatically from the catalogue entry.
- A provider logo isn't included in this PR; the UI already falls back to the LLM Gateway logo for catalogue providers without a dedicated icon.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OrcaRouter as an AI provider with API key configuration.
  * Added access to supported Alibaba, Anthropic, DeepSeek, Google, MiniMax, Moonshot, OpenAI, and ZAI models through OrcaRouter.
  * Enabled streaming, tool use, reasoning, vision, web search, and JSON features where supported.

* **Bug Fixes**
  * Improved OrcaRouter response and streaming handling for OpenAI-compatible requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->