### PR TITLE
feat(admin): show organization access

### DIFF
--- a/apps/api/src/routes/admin-org-details.spec.ts
+++ b/apps/api/src/routes/admin-org-details.spec.ts
@@ -54,24 +54,151 @@ describe("admin organization details endpoints", () => {
 	});
 
 	it("rejects unauthenticated and non-admin requests", async () => {
-		for (const path of ["/audit-logs", "/settings", "/guardrails", "/sso"]) {
+		for (const path of [
+			"/members",
+			"/audit-logs",
+			"/settings",
+			"/guardrails",
+			"/sso",
+		]) {
 			expect((await get(path)).status).toBe(401);
 		}
 
 		process.env.ADMIN_EMAILS = "someone-else@example.com";
-		for (const path of ["/audit-logs", "/settings", "/guardrails", "/sso"]) {
+		for (const path of [
+			"/members",
+			"/audit-logs",
+			"/settings",
+			"/guardrails",
+			"/sso",
+		]) {
 			expect((await get(path, cookie)).status).toBe(403);
 		}
 	});
 
 	it("returns 404 for an unknown organization", async () => {
-		for (const path of ["/audit-logs", "/settings", "/guardrails", "/sso"]) {
+		for (const path of [
+			"/members",
+			"/audit-logs",
+			"/settings",
+			"/guardrails",
+			"/sso",
+		]) {
 			const res = await app.request(
 				`/admin/organizations/does-not-exist${path}`,
 				{ headers: { Cookie: cookie } },
 			);
 			expect(res.status).toBe(404);
 		}
+	});
+
+	it("returns members, teams, and their IAM policies", async () => {
+		await db.insert(tables.organizationTeam).values({
+			id: "admin-team",
+			organizationId: ORG_ID,
+			name: "Platform",
+			isDefault: true,
+			maxApiKeys: 5,
+			usageLimit: "100",
+			periodUsageLimit: "25",
+			periodUsageDurationValue: 1,
+			periodUsageDurationUnit: "month",
+		});
+		await db.insert(tables.project).values({
+			id: "admin-team-project",
+			organizationId: ORG_ID,
+			name: "Production",
+		});
+		await db.insert(tables.organizationTeamProject).values({
+			teamId: "admin-team",
+			projectId: "admin-team-project",
+		});
+		await db.insert(tables.user).values({
+			id: "admin-team-member-user",
+			name: "Team Member",
+			email: "team-member@test.example",
+			emailVerified: true,
+		});
+		await db.insert(tables.userOrganization).values([
+			{
+				id: "admin-owner-membership",
+				userId: "test-user-id",
+				organizationId: ORG_ID,
+				role: "owner",
+			},
+			{
+				id: "admin-team-membership",
+				userId: "admin-team-member-user",
+				organizationId: ORG_ID,
+				teamId: "admin-team",
+				teamAssignmentSource: "sso",
+				role: "developer",
+			},
+		]);
+		await db.insert(tables.userIamRule).values({
+			id: "admin-member-rule",
+			userOrganizationId: "admin-team-membership",
+			ruleType: "allow_providers",
+			ruleValue: { providers: ["openai"] },
+		});
+		await db.insert(tables.organizationTeamIamRule).values({
+			id: "admin-team-rule",
+			teamId: "admin-team",
+			ruleType: "deny_models",
+			ruleValue: { models: ["restricted-model"] },
+		});
+
+		const res = await get("/members", cookie);
+		expect(res.status).toBe(200);
+		const json = await res.json();
+
+		expect(json.total).toBe(2);
+		expect(json.teamTotal).toBe(1);
+		expect(json.members).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					id: "admin-team-membership",
+					role: "developer",
+					teamAssignmentSource: "sso",
+					team: expect.objectContaining({
+						id: "admin-team",
+						name: "Platform",
+						isDefault: true,
+					}),
+					iamRules: [
+						expect.objectContaining({
+							id: "admin-member-rule",
+							ruleType: "allow_providers",
+						}),
+					],
+				}),
+			]),
+		);
+		expect(json.teams[0]).toMatchObject({
+			id: "admin-team",
+			name: "Platform",
+			isDefault: true,
+			budget: {
+				maxApiKeys: 5,
+				usageLimit: "100",
+				periodUsageLimit: "25",
+				periodUsageDurationValue: 1,
+				periodUsageDurationUnit: "month",
+			},
+			members: [
+				expect.objectContaining({
+					id: "admin-team-membership",
+					email: "team-member@test.example",
+				}),
+			],
+			projects: [{ id: "admin-team-project", name: "Production" }],
+			iamRules: [
+				expect.objectContaining({
+					id: "admin-team-rule",
+					ruleType: "deny_models",
+				}),
+			],
+		});
 	});
 
 	it("returns paginated audit logs with filters", async () => {

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -586,30 +586,37 @@ const projectsListSchema = z.object({
 	total: z.number(),
 });
 
-const iamRuleAdminSchema = z.object({
+const iamRuleTypeAdminSchema = z.enum([
+	"allow_models",
+	"deny_models",
+	"allow_pricing",
+	"deny_pricing",
+	"allow_providers",
+	"deny_providers",
+	"allow_ip_cidrs",
+	"deny_ip_cidrs",
+]);
+
+const iamRuleValueAdminSchema = z.object({
+	models: z.array(z.string()).optional(),
+	providers: z.array(z.string()).optional(),
+	pricingType: z.enum(["free", "paid"]).optional(),
+	maxInputPrice: z.number().optional(),
+	maxOutputPrice: z.number().optional(),
+	ipCidrs: z.array(z.string()).optional(),
+});
+
+const scopedIamRuleAdminSchema = z.object({
 	id: z.string(),
 	createdAt: z.string(),
 	updatedAt: z.string(),
-	apiKeyId: z.string(),
-	ruleType: z.enum([
-		"allow_models",
-		"deny_models",
-		"allow_pricing",
-		"deny_pricing",
-		"allow_providers",
-		"deny_providers",
-		"allow_ip_cidrs",
-		"deny_ip_cidrs",
-	]),
-	ruleValue: z.object({
-		models: z.array(z.string()).optional(),
-		providers: z.array(z.string()).optional(),
-		pricingType: z.enum(["free", "paid"]).optional(),
-		maxInputPrice: z.number().optional(),
-		maxOutputPrice: z.number().optional(),
-		ipCidrs: z.array(z.string()).optional(),
-	}),
+	ruleType: iamRuleTypeAdminSchema,
+	ruleValue: iamRuleValueAdminSchema,
 	status: z.enum(["active", "inactive"]),
+});
+
+const iamRuleAdminSchema = scopedIamRuleAdminSchema.extend({
+	apiKeyId: z.string(),
 });
 
 const apiKeySchema = z.object({
@@ -716,8 +723,17 @@ const providerKeysListSchema = z.object({
 const memberSchema = z.object({
 	id: z.string(),
 	userId: z.string(),
-	role: z.string(),
+	role: z.enum(["owner", "admin", "developer"]),
 	createdAt: z.string(),
+	teamAssignmentSource: z.enum(["manual", "sso", "default"]),
+	team: z
+		.object({
+			id: z.string(),
+			name: z.string(),
+			isDefault: z.boolean(),
+		})
+		.nullable(),
+	iamRules: z.array(scopedIamRuleAdminSchema),
 	user: z.object({
 		id: z.string(),
 		email: z.string(),
@@ -726,9 +742,43 @@ const memberSchema = z.object({
 	}),
 });
 
+const organizationTeamAdminSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	isDefault: z.boolean(),
+	createdAt: z.string(),
+	updatedAt: z.string(),
+	budget: z.object({
+		maxApiKeys: z.number().nullable(),
+		usageLimit: z.string().nullable(),
+		periodUsageLimit: z.string().nullable(),
+		periodUsageDurationValue: z.number().nullable(),
+		periodUsageDurationUnit: z
+			.enum(["hour", "day", "week", "month"])
+			.nullable(),
+	}),
+	members: z.array(
+		z.object({
+			id: z.string(),
+			userId: z.string(),
+			name: z.string().nullable(),
+			email: z.string(),
+		}),
+	),
+	projects: z.array(
+		z.object({
+			id: z.string(),
+			name: z.string(),
+		}),
+	),
+	iamRules: z.array(scopedIamRuleAdminSchema),
+});
+
 const membersListSchema = z.object({
 	members: z.array(memberSchema),
 	total: z.number(),
+	teams: z.array(organizationTeamAdminSchema),
+	teamTotal: z.number(),
 });
 
 const getMetrics = createRoute({
@@ -3557,20 +3607,39 @@ admin.openapi(getOrganizationMembers, async (c) => {
 		});
 	}
 
-	const members = await db
-		.select({
-			id: tables.userOrganization.id,
-			userId: tables.userOrganization.userId,
-			role: tables.userOrganization.role,
-			createdAt: tables.userOrganization.createdAt,
-			userName: tables.user.name,
-			userEmail: tables.user.email,
-			userEmailVerified: tables.user.emailVerified,
-		})
-		.from(tables.userOrganization)
-		.innerJoin(tables.user, eq(tables.userOrganization.userId, tables.user.id))
-		.where(eq(tables.userOrganization.organizationId, orgId))
-		.orderBy(desc(tables.userOrganization.createdAt));
+	const [members, teams] = await Promise.all([
+		db.query.userOrganization.findMany({
+			where: { organizationId: { eq: orgId } },
+			with: {
+				user: {
+					columns: { id: true, email: true, name: true, emailVerified: true },
+				},
+				team: { columns: { id: true, name: true, isDefault: true } },
+				iamRules: true,
+			},
+			orderBy: { createdAt: "desc" },
+		}),
+		db.query.organizationTeam.findMany({
+			where: { organizationId: { eq: orgId } },
+			with: {
+				members: {
+					columns: { id: true, userId: true },
+					with: {
+						user: { columns: { name: true, email: true } },
+					},
+				},
+				projects: {
+					with: {
+						project: {
+							columns: { id: true, name: true, status: true },
+						},
+					},
+				},
+				iamRules: true,
+			},
+			orderBy: { name: "asc" },
+		}),
+	]);
 
 	return c.json({
 		members: members.map((m) => ({
@@ -3578,14 +3647,59 @@ admin.openapi(getOrganizationMembers, async (c) => {
 			userId: m.userId,
 			role: m.role,
 			createdAt: m.createdAt.toISOString(),
+			teamAssignmentSource: m.teamAssignmentSource,
+			team: m.team,
+			iamRules: m.iamRules.map((rule) => ({
+				id: rule.id,
+				createdAt: rule.createdAt.toISOString(),
+				updatedAt: rule.updatedAt.toISOString(),
+				ruleType: rule.ruleType,
+				ruleValue: rule.ruleValue,
+				status: rule.status,
+			})),
 			user: {
-				id: m.userId,
-				email: m.userEmail,
-				name: m.userName,
-				emailVerified: m.userEmailVerified,
+				id: m.user!.id,
+				email: m.user!.email,
+				name: m.user!.name,
+				emailVerified: m.user!.emailVerified,
 			},
 		})),
 		total: members.length,
+		teams: teams.map((team) => ({
+			id: team.id,
+			name: team.name,
+			isDefault: team.isDefault,
+			createdAt: team.createdAt.toISOString(),
+			updatedAt: team.updatedAt.toISOString(),
+			budget: {
+				maxApiKeys: team.maxApiKeys,
+				usageLimit: team.usageLimit,
+				periodUsageLimit: team.periodUsageLimit,
+				periodUsageDurationValue: team.periodUsageDurationValue,
+				periodUsageDurationUnit: team.periodUsageDurationUnit,
+			},
+			members: team.members.map((member) => ({
+				id: member.id,
+				userId: member.userId,
+				name: member.user?.name ?? null,
+				email: member.user!.email,
+			})),
+			projects: team.projects
+				.filter((entry) => entry.project && entry.project.status !== "deleted")
+				.map((entry) => ({
+					id: entry.project!.id,
+					name: entry.project!.name,
+				})),
+			iamRules: team.iamRules.map((rule) => ({
+				id: rule.id,
+				createdAt: rule.createdAt.toISOString(),
+				updatedAt: rule.updatedAt.toISOString(),
+				ruleType: rule.ruleType,
+				ruleValue: rule.ruleValue,
+				status: rule.status,
+			})),
+		})),
+		teamTotal: teams.length,
 	});
 });
 

--- a/ee/admin/src/app/organizations/[orgId]/member-access-tab.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/member-access-tab.tsx
@@ -1,0 +1,392 @@
+import { FolderOpen, Layers3, Shield, Users } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+
+import { SendEmailDialog } from "./send-email-dialog";
+
+import type { paths } from "@/lib/api/v1";
+
+type MemberAccessData =
+	paths["/admin/organizations/{orgId}/members"]["get"]["responses"]["200"]["content"]["application/json"];
+type IamRule = MemberAccessData["members"][number]["iamRules"][number];
+type Team = MemberAccessData["teams"][number];
+
+const creditsFormatter = new Intl.NumberFormat("en-US", {
+	style: "currency",
+	currency: "USD",
+	maximumFractionDigits: 2,
+});
+
+function formatDate(dateString: string) {
+	return new Date(dateString).toLocaleDateString("en-US", {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+	});
+}
+
+function formatRuleType(type: IamRule["ruleType"]) {
+	return type
+		.replaceAll("_", " ")
+		.replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function formatRuleValue(rule: IamRule) {
+	const value = rule.ruleValue;
+	if (value.models?.length) {
+		return value.models.join(", ");
+	}
+	if (value.providers?.length) {
+		return value.providers.join(", ");
+	}
+	if (value.ipCidrs?.length) {
+		return value.ipCidrs.join(", ");
+	}
+	if (
+		value.pricingType ||
+		typeof value.maxInputPrice === "number" ||
+		typeof value.maxOutputPrice === "number"
+	) {
+		const constraints: string[] = [];
+		if (value.pricingType) {
+			constraints.push(value.pricingType);
+		}
+		if (typeof value.maxInputPrice === "number") {
+			constraints.push(`input ≤ $${value.maxInputPrice}/M`);
+		}
+		if (typeof value.maxOutputPrice === "number") {
+			constraints.push(`output ≤ $${value.maxOutputPrice}/M`);
+		}
+		return constraints.join(" · ");
+	}
+	return "No constraints";
+}
+
+function IamRules({
+	rules,
+	emptyLabel,
+}: {
+	rules: IamRule[];
+	emptyLabel: string;
+}) {
+	if (rules.length === 0) {
+		return <span className="text-sm text-muted-foreground">{emptyLabel}</span>;
+	}
+
+	return (
+		<ul className="space-y-2">
+			{rules.map((rule) => (
+				<li key={rule.id} className="min-w-0 text-sm">
+					<div className="flex flex-wrap items-center gap-1.5">
+						<Badge
+							variant={
+								rule.ruleType.startsWith("deny_") ? "destructive" : "secondary"
+							}
+						>
+							{formatRuleType(rule.ruleType)}
+						</Badge>
+						{rule.status === "inactive" ? (
+							<Badge variant="outline">Inactive</Badge>
+						) : null}
+					</div>
+					<p className="mt-1 break-words text-xs leading-5 text-muted-foreground">
+						{formatRuleValue(rule)}
+					</p>
+				</li>
+			))}
+		</ul>
+	);
+}
+
+function roleBadgeVariant(role: string) {
+	if (role === "owner") {
+		return "default" as const;
+	}
+	if (role === "admin") {
+		return "secondary" as const;
+	}
+	return "outline" as const;
+}
+
+function teamLimits(team: Team) {
+	const limits: string[] = [];
+	if (team.budget.maxApiKeys !== null) {
+		limits.push(`${team.budget.maxApiKeys} API keys`);
+	}
+	if (team.budget.usageLimit !== null) {
+		limits.push(
+			`${creditsFormatter.format(Number(team.budget.usageLimit))} lifetime spend`,
+		);
+	}
+	if (
+		team.budget.periodUsageLimit !== null &&
+		team.budget.periodUsageDurationValue !== null &&
+		team.budget.periodUsageDurationUnit !== null
+	) {
+		const duration = team.budget.periodUsageDurationValue;
+		const unit = team.budget.periodUsageDurationUnit;
+		limits.push(
+			`${creditsFormatter.format(Number(team.budget.periodUsageLimit))} every ${duration} ${unit}${duration === 1 ? "" : "s"}`,
+		);
+	}
+	return limits;
+}
+
+export function MemberAccessTab({
+	data,
+	organizationName,
+	plan,
+}: {
+	data: MemberAccessData;
+	organizationName: string;
+	plan: string;
+}) {
+	return (
+		<div className="space-y-8">
+			<section className="space-y-3" aria-labelledby="organization-members">
+				<div>
+					<div className="flex items-center gap-2">
+						<Users className="h-5 w-5 text-muted-foreground" />
+						<h2 id="organization-members" className="text-lg font-semibold">
+							Members
+						</h2>
+						<span className="text-sm text-muted-foreground">
+							({data.total})
+						</span>
+					</div>
+					<p className="mt-1 text-sm text-muted-foreground">
+						Organization roles, team assignments, and member-specific IAM
+						restrictions.
+					</p>
+				</div>
+
+				<div className="overflow-x-auto rounded-lg border border-border/60 bg-card">
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Name</TableHead>
+								<TableHead>Email</TableHead>
+								<TableHead>Verified</TableHead>
+								<TableHead>Organization role</TableHead>
+								<TableHead>Team</TableHead>
+								<TableHead className="min-w-64">Direct IAM rules</TableHead>
+								<TableHead>Joined</TableHead>
+								<TableHead className="w-10">
+									<span className="sr-only">Actions</span>
+								</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{data.members.length === 0 ? (
+								<TableRow>
+									<TableCell
+										colSpan={8}
+										className="h-24 text-center text-muted-foreground"
+									>
+										No members found
+									</TableCell>
+								</TableRow>
+							) : (
+								data.members.map((member) => (
+									<TableRow key={member.id}>
+										<TableCell className="font-medium">
+											{member.user.name ?? "—"}
+										</TableCell>
+										<TableCell>{member.user.email}</TableCell>
+										<TableCell>
+											<Badge
+												variant={
+													member.user.emailVerified ? "secondary" : "outline"
+												}
+											>
+												{member.user.emailVerified ? "Verified" : "Unverified"}
+											</Badge>
+										</TableCell>
+										<TableCell>
+											<Badge variant={roleBadgeVariant(member.role)}>
+												{member.role}
+											</Badge>
+										</TableCell>
+										<TableCell>
+											{member.team ? (
+												<div className="space-y-1">
+													<div className="flex flex-wrap items-center gap-1.5">
+														<Badge variant="outline">{member.team.name}</Badge>
+														{member.team.isDefault ? (
+															<Badge variant="secondary">Default</Badge>
+														) : null}
+													</div>
+													<p className="text-xs text-muted-foreground">
+														Assigned via {member.teamAssignmentSource}
+													</p>
+												</div>
+											) : (
+												<span className="text-sm text-muted-foreground">
+													Unassigned
+												</span>
+											)}
+										</TableCell>
+										<TableCell>
+											<IamRules
+												rules={member.iamRules}
+												emptyLabel="No direct rules"
+											/>
+										</TableCell>
+										<TableCell className="text-muted-foreground">
+											{formatDate(member.createdAt)}
+										</TableCell>
+										<TableCell>
+											<SendEmailDialog
+												userName={member.user.name ?? ""}
+												userEmail={member.user.email}
+												orgName={organizationName}
+												plan={plan}
+											/>
+										</TableCell>
+									</TableRow>
+								))
+							)}
+						</TableBody>
+					</Table>
+				</div>
+			</section>
+
+			<section className="space-y-3" aria-labelledby="organization-teams">
+				<div>
+					<div className="flex items-center gap-2">
+						<Layers3 className="h-5 w-5 text-muted-foreground" />
+						<h2 id="organization-teams" className="text-lg font-semibold">
+							Teams
+						</h2>
+						<span className="text-sm text-muted-foreground">
+							({data.teamTotal})
+						</span>
+					</div>
+					<p className="mt-1 text-sm text-muted-foreground">
+						Assigned members, project access, budget ceilings, and shared IAM
+						rules.
+					</p>
+				</div>
+
+				{data.teams.length === 0 ? (
+					<div className="flex min-h-36 flex-col items-center justify-center rounded-lg border border-dashed border-border/60 bg-muted/20 px-4 text-center">
+						<Layers3 className="mb-3 h-6 w-6 text-muted-foreground" />
+						<p className="font-medium">No organization teams configured</p>
+						<p className="mt-1 text-sm text-muted-foreground">
+							Members only use their direct IAM and API-key rules.
+						</p>
+					</div>
+				) : (
+					<div className="divide-y divide-border/60 overflow-hidden rounded-lg border border-border/60 bg-card">
+						{data.teams.map((team) => {
+							const limits = teamLimits(team);
+							return (
+								<article key={team.id} className="p-4 md:p-5">
+									<div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+										<div>
+											<div className="flex flex-wrap items-center gap-2">
+												<h3 className="font-semibold">{team.name}</h3>
+												{team.isDefault ? (
+													<Badge variant="secondary">Default</Badge>
+												) : null}
+											</div>
+											<p className="mt-1 text-xs text-muted-foreground">
+												Updated {formatDate(team.updatedAt)}
+											</p>
+										</div>
+										<div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+											<span>{team.members.length} members</span>
+											<span aria-hidden="true">·</span>
+											<span>{team.projects.length} projects</span>
+											<span aria-hidden="true">·</span>
+											<span>{team.iamRules.length} IAM rules</span>
+										</div>
+									</div>
+
+									<div className="mt-5 grid gap-5 md:grid-cols-2 xl:grid-cols-4">
+										<div>
+											<h4 className="mb-2 flex items-center gap-1.5 text-sm font-medium">
+												<Users className="h-4 w-4 text-muted-foreground" />
+												Members
+											</h4>
+											{team.members.length === 0 ? (
+												<p className="text-sm text-muted-foreground">
+													No assigned members
+												</p>
+											) : (
+												<ul className="space-y-1.5 text-sm">
+													{team.members.map((member) => (
+														<li key={member.id} className="min-w-0">
+															<p className="truncate font-medium">
+																{member.name ?? "—"}
+															</p>
+															<p className="truncate text-xs text-muted-foreground">
+																{member.email}
+															</p>
+														</li>
+													))}
+												</ul>
+											)}
+										</div>
+
+										<div>
+											<h4 className="mb-2 flex items-center gap-1.5 text-sm font-medium">
+												<FolderOpen className="h-4 w-4 text-muted-foreground" />
+												Project access
+											</h4>
+											{team.projects.length === 0 ? (
+												<Badge variant="destructive">No access</Badge>
+											) : (
+												<div className="flex flex-wrap gap-1.5">
+													{team.projects.map((project) => (
+														<Badge key={project.id} variant="outline">
+															{project.name}
+														</Badge>
+													))}
+												</div>
+											)}
+										</div>
+
+										<div>
+											<h4 className="mb-2 text-sm font-medium">Limits</h4>
+											{limits.length === 0 ? (
+												<p className="text-sm text-muted-foreground">
+													No team limits
+												</p>
+											) : (
+												<ul className="space-y-1.5 text-sm">
+													{limits.map((limit) => (
+														<li key={limit}>{limit}</li>
+													))}
+												</ul>
+											)}
+										</div>
+
+										<div>
+											<h4 className="mb-2 flex items-center gap-1.5 text-sm font-medium">
+												<Shield className="h-4 w-4 text-muted-foreground" />
+												Team IAM rules
+											</h4>
+											<IamRules
+												rules={team.iamRules}
+												emptyLabel="No shared rules"
+											/>
+										</div>
+									</div>
+								</article>
+							);
+						})}
+					</div>
+				)}
+			</section>
+		</div>
+	);
+}

--- a/ee/admin/src/app/organizations/[orgId]/page.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/page.tsx
@@ -54,6 +54,7 @@ import { ApiKeysTable } from "./api-keys-table";
 import { AuditLogsTab } from "./audit-logs-tab";
 import { GuardrailsTab } from "./guardrails-tab";
 import { ManageOrgDialog } from "./manage-org-dialog";
+import { MemberAccessTab } from "./member-access-tab";
 import { OrgCostByModel } from "./org-cost-by-model";
 import { OrgCostByModelTimeseries } from "./org-cost-by-model-timeseries";
 import { OrgMetricsSection } from "./org-metrics";
@@ -61,7 +62,6 @@ import { OrgSettingsTab } from "./org-settings-tab";
 import { OrganizationTabs } from "./organization-tabs";
 import { ProviderKeysTable } from "./provider-keys-table";
 import { ReferralBonusDialog } from "./referral-bonus-dialog";
-import { SendEmailDialog } from "./send-email-dialog";
 import { SsoTab } from "./sso-tab";
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {
@@ -315,7 +315,6 @@ export default async function OrganizationPage({
 	const akTotalPages = Math.ceil(akTotal / akLimit);
 	const providerKeys = providerKeysData?.providerKeys ?? [];
 	const pkCounts = providerKeysData?.counts ?? emptyKeyCounts;
-	const members = membersData?.members ?? [];
 	const membersTotal = membersData?.total ?? 0;
 
 	return (
@@ -792,82 +791,17 @@ export default async function OrganizationPage({
 				</TabsContent>
 
 				<TabsContent value="members">
-					<div className="space-y-4">
-						<div className="overflow-x-auto rounded-lg border border-border/60 bg-card">
-							<Table>
-								<TableHeader>
-									<TableRow>
-										<TableHead>Name</TableHead>
-										<TableHead>Email</TableHead>
-										<TableHead>Verified</TableHead>
-										<TableHead>Role</TableHead>
-										<TableHead>Joined</TableHead>
-										<TableHead className="w-10">
-											<span className="sr-only">Actions</span>
-										</TableHead>
-									</TableRow>
-								</TableHeader>
-								<TableBody>
-									{members.length === 0 ? (
-										<TableRow>
-											<TableCell
-												colSpan={6}
-												className="h-24 text-center text-muted-foreground"
-											>
-												No members found
-											</TableCell>
-										</TableRow>
-									) : (
-										members.map((member) => (
-											<TableRow key={member.id}>
-												<TableCell className="font-medium">
-													{member.user.name ?? "—"}
-												</TableCell>
-												<TableCell>{member.user.email}</TableCell>
-												<TableCell>
-													<Badge
-														variant={
-															member.user.emailVerified
-																? "secondary"
-																: "outline"
-														}
-													>
-														{member.user.emailVerified
-															? "verified"
-															: "unverified"}
-													</Badge>
-												</TableCell>
-												<TableCell>
-													<Badge
-														variant={
-															member.role === "owner"
-																? "default"
-																: member.role === "admin"
-																	? "secondary"
-																	: "outline"
-														}
-													>
-														{member.role}
-													</Badge>
-												</TableCell>
-												<TableCell className="text-muted-foreground">
-													{formatDate(member.createdAt)}
-												</TableCell>
-												<TableCell>
-													<SendEmailDialog
-														userName={member.user.name ?? ""}
-														userEmail={member.user.email}
-														orgName={org.name}
-														plan={org.plan}
-													/>
-												</TableCell>
-											</TableRow>
-										))
-									)}
-								</TableBody>
-							</Table>
-						</div>
-					</div>
+					{membersData ? (
+						<MemberAccessTab
+							data={membersData}
+							organizationName={org.name}
+							plan={org.plan}
+						/>
+					) : (
+						<p className="py-8 text-center text-sm text-muted-foreground">
+							Failed to load members and teams
+						</p>
+					)}
 				</TabsContent>
 
 				<TabsContent value="audit-logs">


### PR DESCRIPTION
## Summary

- expand the admin organization members endpoint with organization roles, team assignments, direct IAM rules, and complete team access data
- show every member and team in the organization detail Members tab, including projects, limits, and team IAM rules
- cover authentication, missing organizations, and member/team IAM serialization

## Screenshots

### Before — light

![Members tab before in light mode](https://raw.githubusercontent.com/theopenco/llmgateway/948d1f5c82f1626ff35e54aad52c1ed60520b373/before-light.png)

### After — light

![Members tab after in light mode](https://raw.githubusercontent.com/theopenco/llmgateway/948d1f5c82f1626ff35e54aad52c1ed60520b373/after-light.png)

### Before — dark

![Members tab before in dark mode](https://raw.githubusercontent.com/theopenco/llmgateway/948d1f5c82f1626ff35e54aad52c1ed60520b373/before-dark.png)

### After — dark

![Members tab after in dark mode](https://raw.githubusercontent.com/theopenco/llmgateway/948d1f5c82f1626ff35e54aad52c1ed60520b373/after-dark.png)

## Verification

- `pnpm format`
- `pnpm build`
- `pnpm test:unit apps/api/src/routes/admin-org-details.spec.ts`
- interface quality detector


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a member access view to organization administration.
  * Display member roles, email verification, team assignments, join dates, and direct access rules.
  * Added team details including member counts, project access, budgets, usage limits, and shared access rules.
  * Added empty states and a message when member data cannot be loaded.

* **Bug Fixes**
  * Improved organization member data loading to include teams, memberships, projects, and access policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->