### PR TITLE
fix(images): support Seedream references

### DIFF
--- a/apps/docs/content/features/image-generation.mdx
+++ b/apps/docs/content/features/image-generation.mdx
@@ -815,10 +815,11 @@ curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
 
 Available ByteDance models (see the [models page](https://llmgateway.io/models?filters=1&imageGeneration=true) for current pricing):
 
-| Model                    | Description                                                     |
-| ------------------------ | --------------------------------------------------------------- |
-| `bytedance/seedream-4-0` | High-quality text-to-image generation with 2K default output    |
-| `bytedance/seedream-4-5` | Enhanced quality and consistency with improved prompt adherence |
+| Model                        | Description                                                     |
+| ---------------------------- | --------------------------------------------------------------- |
+| `bytedance/seedream-4-0`     | High-quality text-to-image generation with 2K default output    |
+| `bytedance/seedream-4-5`     | Enhanced quality and consistency with improved prompt adherence |
+| `bytedance/seedream-5-0-pro` | Precise generation and reference-image editing at 1K or 2K      |
 
 <Callout type="info">
 	Seedream models support up to 2-10 reference images for multi-image fusion and

--- a/apps/playground/src/lib/image-gen.spec.ts
+++ b/apps/playground/src/lib/image-gen.spec.ts
@@ -59,4 +59,12 @@ describe("getModelImageConfig", () => {
 		expect(config.supportsQuality).toBe(false);
 		expect(config.availableQualities).toEqual([]);
 	});
+
+	it("allows Seedream 5.0 Pro reference images", () => {
+		const config = getModelImageConfig("bytedance/seedream-5-0-pro");
+
+		expect(config.availableSizes).toEqual(["1K", "2K"]);
+		expect(config.defaultSize).toBe("2K");
+		expect(config.maxInputImages).toBe(10);
+	});
 });

--- a/packages/actions/src/prepare-request-body.images.spec.ts
+++ b/packages/actions/src/prepare-request-body.images.spec.ts
@@ -20,6 +20,13 @@ type ErnieRequestBody = OpenAIRequestBody & {
 	chat_template_kwargs?: Record<string, boolean>;
 };
 
+interface ByteDanceImageRequest {
+	model: string;
+	prompt: string;
+	size?: string;
+	image?: string | string[];
+}
+
 const MODEL_ID = "ernie-4.5-vl-424b-a47b";
 const EXTERNAL_ID = "baidu/ernie-4.5-vl-424b-a47b";
 
@@ -58,6 +65,71 @@ async function prepare(options: {
 function imagePart(url: string) {
 	return { type: "image_url", image_url: { url } };
 }
+
+async function prepareSeedream(content: unknown) {
+	return (await prepareRequestBody(
+		"bytedance",
+		"seedream-5-0-pro",
+		null,
+		"dola-seedream-5-0-pro-260628",
+		[{ role: "user", content }] as Parameters<typeof prepareRequestBody>[4],
+		false,
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		undefined,
+		false,
+		false,
+		20,
+		null,
+		undefined,
+		{ image_size: "1K" },
+		undefined,
+		true,
+	)) as unknown as ByteDanceImageRequest;
+}
+
+describe("prepareRequestBody - Seedream image editing", () => {
+	test("the Seedream 5.0 Pro mapping accepts image input", () => {
+		const mapping = models
+			.find((m) => m.id === "seedream-5-0-pro")
+			?.providers.find((p) => p.providerId === "bytedance");
+
+		expect(mapping?.vision).toBe(true);
+	});
+
+	test("forwards one reference image in ByteDance's scalar format", async () => {
+		const requestBody = await prepareSeedream([
+			imagePart("data:image/png;base64,aGVsbG8="),
+			{ type: "text", text: "Keep the subject and change the background" },
+		]);
+
+		expect(requestBody).toEqual({
+			model: "dola-seedream-5-0-pro-260628",
+			prompt: "Keep the subject and change the background",
+			size: "1K",
+			image: "data:image/png;base64,aGVsbG8=",
+		});
+	});
+
+	test("forwards multiple reference images as an array", async () => {
+		const requestBody = await prepareSeedream([
+			{ type: "text", text: "Combine the subjects from both images" },
+			imagePart("https://example.com/first.png"),
+			imagePart("data:image/jpeg;base64,d29ybGQ="),
+		]);
+
+		expect(requestBody.image).toEqual([
+			"https://example.com/first.png",
+			"data:image/jpeg;base64,d29ybGQ=",
+		]);
+	});
+});
 
 describe("prepareRequestBody - requiresBase64Images", () => {
 	beforeEach(() => {

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -1712,27 +1712,37 @@ export async function prepareRequestBody(
 
 	// Handle ByteDance Seedream image generation
 	if (imageGenerations && usedProvider === "bytedance") {
-		// Extract prompt from last user message
 		const lastUserMessage = [...messages]
 			.reverse()
 			.find((m) => m.role === "user");
 		let prompt = "";
+		const imageUrls: string[] = [];
 		if (lastUserMessage) {
 			if (typeof lastUserMessage.content === "string") {
 				prompt = lastUserMessage.content;
 			} else if (Array.isArray(lastUserMessage.content)) {
-				prompt = lastUserMessage.content
-					.filter((p): p is { type: "text"; text: string } => p.type === "text")
-					.map((p) => p.text)
-					.join("\n");
+				for (const part of lastUserMessage.content) {
+					if (part.type === "text" && part.text) {
+						prompt += (prompt ? "\n" : "") + part.text;
+					} else if (part.type === "image_url" && part.image_url) {
+						const url =
+							typeof part.image_url === "string"
+								? part.image_url
+								: part.image_url.url;
+						if (url) {
+							imageUrls.push(url);
+						}
+					}
+				}
 			}
 		}
 
-		// ByteDance Seedream format
 		const bytedanceImageRequest: any = {
 			model: usedExternalId,
 			prompt,
 			...(image_config?.image_size && { size: image_config.image_size }),
+			...(imageUrls.length === 1 && { image: imageUrls[0] }),
+			...(imageUrls.length > 1 && { image: imageUrls }),
 		};
 
 		return bytedanceImageRequest;

--- a/packages/models/src/models/bytedance.ts
+++ b/packages/models/src/models/bytedance.ts
@@ -431,7 +431,7 @@ export const bytedanceModels = [
 		id: "seedream-5-0-pro",
 		name: "Seedream 5.0 Pro",
 		description:
-			"ByteDance Seedream 5.0 Pro flagship text-to-image generation model with precise layout control, multilingual text rendering, and up to 2K output",
+			"ByteDance Seedream 5.0 Pro flagship image generation and editing model with precise layout control, multilingual text rendering, and up to 2K output",
 		family: "bytedance",
 		output: ["text", "image"],
 		releasedAt: new Date("2026-06-28"),
@@ -446,7 +446,7 @@ export const bytedanceModels = [
 				contextSize: 2000,
 				maxOutput: 4096,
 				streaming: false,
-				vision: false,
+				vision: true,
 				tools: false,
 				jsonOutput: false,
 				imageGenerations: true,


### PR DESCRIPTION
## Summary

- accept Seedream 5.0 Pro reference images in image-generation requests
- map one or multiple OpenAI-style image parts to ByteDance's `image` field
- expose the model as vision-capable and document reference-image editing
- cover request mapping and playground configuration with tests

## Verification

- `pnpm exec vitest run --no-file-parallelism packages/actions/src/prepare-request-body.images.spec.ts apps/playground/src/lib/image-gen.spec.ts packages/models/src/model-metadata.spec.ts` (21 passed)
- `TEST_MODELS="bytedance/seedream-5-0-pro" FULL_MODE=true TEST_IMAGE_MODE=true TEST_IMAGE_SIZE=1K pnpm test:e2e` (83 passed; live reference-image edit passed)
- `pnpm format`
- `pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ByteDance Seedream 5.0 Pro image generation and editing.
  * Supports 1K and 2K output resolutions, with 2K as the default.
  * Added support for using up to 10 reference images, including multiple-image inputs.
  * Updated documentation with model capabilities and configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->