### PR TITLE
chore(models): retire DeepInfra Kimi K2.5

### DIFF
--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -362,6 +362,7 @@ export const moonshotModels = [
 			{
 				providerId: "deepinfra",
 				externalId: "moonshotai/Kimi-K2.5",
+				deactivatedAt: new Date("2026-09-07"),
 				inputPrice: "0.45e-6",
 				cachedInputPrice: "0.07e-6",
 				outputPrice: "2.25e-6",


### PR DESCRIPTION
## Summary

DeepInfra will deprecate `moonshotai/Kimi-K2.5` on September 7, 2026 and redirect subsequent inference to Kimi K3. Continuing to expose the old mapping after that cutoff would apply K2.5 metadata and pricing to K3 responses.

Schedule the existing `deepinfra` mapping for deactivation on the announced date. No DeepInfra Kimi K3 mapping is added because one is not currently present in the catalogue.

## Verification

- `pnpm format`
- `pnpm build`
- `pnpm exec vitest run --no-file-parallelism packages/models/src/model-metadata.spec.ts packages/models/src/providers.spec.ts packages/models/src/realtime-models.spec.ts apps/gateway/src/lib/costs.spec.ts` (153 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Model Availability**
  * Marked the DeepInfra deployment of `kimi-k2.5` as scheduled for retirement on September 7, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->