### PR TITLE
test(gateway): always check prompt caching

### DIFF
--- a/apps/gateway/src/chat-prompt-caching.e2e.ts
+++ b/apps/gateway/src/chat-prompt-caching.e2e.ts
@@ -82,15 +82,6 @@ const promptCachingModels = filteredModels
 		return testCases;
 	});
 
-// Only run prompt caching tests when TEST_CACHE_MODE=true
-const testCacheMode = process.env.TEST_CACHE_MODE === "true";
-
-if (testCacheMode) {
-	console.log(
-		`Testing ${promptCachingModels.length} models with prompt caching support`,
-	);
-}
-
 describe("e2e prompt caching", getConcurrentTestOptions(), () => {
 	beforeAll(beforeAllHook);
 
@@ -100,7 +91,7 @@ describe("e2e prompt caching", getConcurrentTestOptions(), () => {
 		expect(true).toBe(true);
 	});
 
-	if (testCacheMode) {
+	describe("cacheable models", () => {
 		test.each(promptCachingModels)(
 			"prompt caching works for $model",
 			getTestOptions(),
@@ -344,5 +335,5 @@ describe("e2e prompt caching", getConcurrentTestOptions(), () => {
 				}
 			},
 		);
-	}
+	});
 });


### PR DESCRIPTION
## Summary

- run prompt-cache assertions in every E2E run
- remove the obsolete opt-in log
- preserve existing model filtering

## Why

Prompt-cache regressions were invisible unless `TEST_CACHE_MODE` was set explicitly.

## Verification

- `pnpm format`
- `pnpm build`
- targeted cache E2E without `TEST_CACHE_MODE` (expected failure confirms the current provider cache miss is now caught)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated prompt-caching test coverage to run consistently across environments.
  * Standardized cacheable model test organization and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->