### PR TITLE
test(gateway): run chat coverage by default

### DIFF
--- a/apps/gateway/src/chat-basic.e2e.ts
+++ b/apps/gateway/src/chat-basic.e2e.ts
@@ -89,7 +89,7 @@ describe("e2e", getConcurrentTestOptions(), () => {
 		// expect(log.cost).not.toBeNull();
 	});
 
-	if (process.env.EXPERIMENTAL) {
+	describe("extended coverage", () => {
 		test.each(providerModels)(
 			"complex $model",
 			getTestOptions(),
@@ -219,5 +219,5 @@ describe("e2e", getConcurrentTestOptions(), () => {
 				expect(json.usage.total_tokens).toBeGreaterThan(0);
 			},
 		);
-	}
+	});
 });

--- a/apps/gateway/src/chat-params.e2e.ts
+++ b/apps/gateway/src/chat-params.e2e.ts
@@ -71,7 +71,7 @@ describe("e2e params", getConcurrentTestOptions(), () => {
 		expect(true).toBe(true);
 	});
 
-	if (process.env.RUN_PARAM_TESTS === "true") {
+	describe("supported parameters", () => {
 		// Test all parameter combinations with all models
 		test.each(paramModelTestCases)(
 			"$paramName $model",
@@ -114,5 +114,5 @@ describe("e2e params", getConcurrentTestOptions(), () => {
 				await validateLogByRequestId(requestId);
 			},
 		);
-	}
+	});
 });


### PR DESCRIPTION
## Problem

Extended chat and parameter coverage is silently omitted unless opt-in environment variables are set.

## Approach

- run complex and parameterized basic-chat cases by default
- run the dedicated parameter matrix by default
- retain named groups in the test output

## Verification

- `pnpm format`
- `pnpm build`
- targeted E2E run without `EXPERIMENTAL` or `RUN_PARAM_TESTS` (15 tests passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated chat test coverage so extended scenarios run consistently.
  * Parameter support tests now execute by default rather than requiring environment-variable opt-in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->