### PR TITLE
fix(gateway): forward GPT-5.6 output limits

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -3237,7 +3237,11 @@ describe("api", () => {
 		expect(logs[0].usedServiceTier).toBe("priority");
 	});
 
-	test("/v1/responses forwards max_output_tokens to GPT-5.6 Sol", async () => {
+	test.each([
+		"openai/gpt-5.6-sol",
+		"openai/gpt-5.6-terra",
+		"openai/gpt-5.6-luna",
+	])("/v1/responses forwards max_output_tokens to %s", async (model) => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id-responses-max-output-tokens",
 			...hashApiKeyForStorage("real-token-responses-max-output-tokens"),
@@ -3267,7 +3271,7 @@ describe("api", () => {
 				"x-no-fallback": "true",
 			},
 			body: JSON.stringify({
-				model: "openai/gpt-5.6-sol",
+				model,
 				service_tier: "flex",
 				reasoning: { effort: "max" },
 				max_output_tokens: 64,

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -3237,6 +3237,56 @@ describe("api", () => {
 		expect(logs[0].usedServiceTier).toBe("priority");
 	});
 
+	test("/v1/responses forwards max_output_tokens to GPT-5.6 Sol", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id-responses-max-output-tokens",
+			...hashApiKeyForStorage("real-token-responses-max-output-tokens"),
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-responses-max-output-tokens",
+			...encryptProviderKeyForStorage(
+				"sk-test-key",
+				"provider-key-id-responses-max-output-tokens",
+				"org-id",
+			),
+			provider: "openai",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		const res = await app.request("/v1/responses", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-responses-max-output-tokens",
+				"x-debug": "true",
+				"x-no-fallback": "true",
+			},
+			body: JSON.stringify({
+				model: "openai/gpt-5.6-sol",
+				service_tier: "flex",
+				reasoning: { effort: "max" },
+				max_output_tokens: 64,
+				input: "Hello!",
+			}),
+		});
+
+		expect(res.status).toBe(200);
+
+		const logs = await waitForLogs(1);
+		expect(logs).toHaveLength(1);
+		expect(logs[0].routingMetadata?.strippedParameters ?? []).not.toContain(
+			"max_tokens",
+		);
+		expect(logs[0].upstreamRequest).toMatchObject({
+			max_output_tokens: 64,
+		});
+	});
+
 	test("/v1/responses rejects unsupported service tiers", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id-responses-bad-service-tier",

--- a/packages/models/src/models/openai.ts
+++ b/packages/models/src/models/openai.ts
@@ -2101,6 +2101,7 @@ export const openaiModels = [
 				jsonOutputSchema: true,
 				supportedParameters: [
 					"temperature",
+					"max_tokens",
 					"top_p",
 					"frequency_penalty",
 					"presence_penalty",
@@ -2263,6 +2264,7 @@ export const openaiModels = [
 				jsonOutputSchema: true,
 				supportedParameters: [
 					"temperature",
+					"max_tokens",
 					"top_p",
 					"frequency_penalty",
 					"presence_penalty",

--- a/packages/models/src/models/openai.ts
+++ b/packages/models/src/models/openai.ts
@@ -1939,6 +1939,7 @@ export const openaiModels = [
 				jsonOutputSchema: true,
 				supportedParameters: [
 					"temperature",
+					"max_tokens",
 					"top_p",
 					"frequency_penalty",
 					"presence_penalty",


### PR DESCRIPTION
## Problem

The Responses API converts `max_output_tokens` to the gateway's internal `max_tokens` field. The first-party OpenAI mappings for GPT-5.6 Sol, Terra, and Luna did not declare that parameter, so routing stripped it before request serialization and OpenAI received no output limit.

## Changes

- declare `max_tokens` support for all three first-party GPT-5.6 mappings
- add a full gateway-route regression covering Responses conversion, routing, and the serialized OpenAI request for Sol, Terra, and Luna

Azure and AWS mappings remain unchanged because provider-specific capabilities require separate verification.

## Verification

- `pnpm format`
- `pnpm build`
- 153 model metadata, provider, realtime, and cost tests
- 194 gateway API tests (192 passed, 2 skipped)
- live provider `max_tokens` cases passed for Terra and Luna
- direct OpenAI `/v1/responses` requests with Flex, maximum reasoning, and a 64-token limit completed for Terra and Luna; OpenAI echoed `max_output_tokens: 64`, `reasoning.effort: max`, and `service_tier: flex`
- the broader scoped e2e run passed 152 cases; two unrelated provider/harness assertions failed (reasoning-token total accounting and an asynchronous log timeout)