### PR TITLE
feat(enterprise): warn before license expiry

### DIFF
--- a/apps/api/src/routes/user.spec.ts
+++ b/apps/api/src/routes/user.spec.ts
@@ -201,6 +201,8 @@ describe("user accounts and email editability", () => {
 			status: "development",
 			enterpriseEnabled: true,
 			whiteLabelEnabled: true,
+			kind: "white_label",
+			organizationId: null,
 			expiresAt: null,
 			graceEndsAt: null,
 		});

--- a/apps/api/src/routes/user.ts
+++ b/apps/api/src/routes/user.ts
@@ -58,6 +58,8 @@ const enterpriseLicenseSchema = z.object({
 	]),
 	enterpriseEnabled: z.boolean(),
 	whiteLabelEnabled: z.boolean(),
+	kind: z.enum(["enterprise", "white_label"]).nullable(),
+	organizationId: z.string().nullable(),
 	expiresAt: z.string().nullable(),
 	graceEndsAt: z.string().nullable(),
 });
@@ -193,6 +195,8 @@ user.openapi(get, async (c) => {
 			enterpriseEnabled: license.enterpriseEnabled,
 			whiteLabelEnabled:
 				license.enterpriseEnabled && license.kind === "white_label",
+			kind: license.kind,
+			organizationId: license.organizationId,
 			expiresAt: license.expiresAt,
 			graceEndsAt: license.graceEndsAt,
 		},

--- a/apps/ui/src/components/dashboard/enterprise-license-banner.tsx
+++ b/apps/ui/src/components/dashboard/enterprise-license-banner.tsx
@@ -13,6 +13,7 @@ import {
 
 function formatDate(date: Date): string {
 	return date.toLocaleDateString("en-US", {
+		timeZone: "UTC",
 		month: "long",
 		day: "numeric",
 		year: "numeric",
@@ -24,16 +25,16 @@ export function EnterpriseLicenseBanner() {
 	const { selectedOrganization } = useDashboardContext();
 	const license = data?.enterpriseLicense;
 
-	if (
-		selectedOrganization?.plan !== "enterprise" ||
-		!license ||
-		license.kind !== "enterprise" ||
-		license.organizationId !== selectedOrganization.id
-	) {
+	if (selectedOrganization?.plan !== "enterprise" || !license) {
 		return null;
 	}
 
-	const term = getEnterpriseLicenseTerm(license.expiresAt);
+	const isLicensedOrganization =
+		license.kind === "enterprise" &&
+		license.organizationId === selectedOrganization.id;
+	const term = isLicensedOrganization
+		? getEnterpriseLicenseTerm(license.expiresAt)
+		: null;
 
 	if (
 		license.status === "active" &&
@@ -61,6 +62,7 @@ export function EnterpriseLicenseBanner() {
 	}
 
 	if (
+		isLicensedOrganization &&
 		selectedOrganization.enterpriseAccess === true &&
 		license.status === "grace"
 	) {

--- a/apps/ui/src/components/dashboard/enterprise-license-banner.tsx
+++ b/apps/ui/src/components/dashboard/enterprise-license-banner.tsx
@@ -6,13 +6,58 @@ import { useUser } from "@/hooks/useUser";
 import { Alert, AlertDescription, AlertTitle } from "@/lib/components/alert";
 import { useDashboardContext } from "@/lib/dashboard-context";
 
+import {
+	formatPlanTermLabel,
+	getEnterpriseLicenseTerm,
+} from "@llmgateway/shared";
+
+function formatDate(date: Date): string {
+	return date.toLocaleDateString("en-US", {
+		month: "long",
+		day: "numeric",
+		year: "numeric",
+	});
+}
+
 export function EnterpriseLicenseBanner() {
 	const { data } = useUser();
 	const { selectedOrganization } = useDashboardContext();
 	const license = data?.enterpriseLicense;
 
-	if (selectedOrganization?.plan !== "enterprise" || !license) {
+	if (
+		selectedOrganization?.plan !== "enterprise" ||
+		!license ||
+		license.kind !== "enterprise" ||
+		license.organizationId !== selectedOrganization.id
+	) {
 		return null;
+	}
+
+	const term = getEnterpriseLicenseTerm(license.expiresAt);
+
+	if (
+		license.status === "active" &&
+		term &&
+		(term.status === "expiring" || term.status === "critical")
+	) {
+		const critical = term.status === "critical";
+
+		return (
+			<Alert
+				className={
+					critical
+						? "rounded-none border-x-0 border-t-0 border-red-500/40 bg-red-500/10 px-6 text-red-950 dark:text-red-100"
+						: "rounded-none border-x-0 border-t-0 border-orange-500/40 bg-orange-500/10 px-6 text-orange-950 dark:text-orange-100"
+				}
+			>
+				<AlertTriangle />
+				<AlertTitle>Enterprise license expires soon</AlertTitle>
+				<AlertDescription className="text-current/90">
+					Install a renewed license before {formatDate(term.expiresAt)} (
+					{formatPlanTermLabel(term).toLowerCase()}) to keep Enterprise access.
+				</AlertDescription>
+			</Alert>
+		);
 	}
 
 	if (
@@ -20,12 +65,15 @@ export function EnterpriseLicenseBanner() {
 		license.status === "grace"
 	) {
 		return (
-			<Alert className="rounded-none border-x-0 border-t-0 border-amber-500/40 bg-amber-500/10 px-6 text-amber-950 dark:text-amber-100">
+			<Alert className="rounded-none border-x-0 border-t-0 border-red-500/40 bg-red-500/10 px-6 text-red-950 dark:text-red-100">
 				<AlertTriangle />
 				<AlertTitle>Enterprise license expired</AlertTitle>
-				<AlertDescription>
+				<AlertDescription className="text-current/90">
 					Enterprise access remains available during the seven-day grace period.
-					Install a renewed license before {license.graceEndsAt ?? "grace ends"}
+					Install a renewed license
+					{license.graceEndsAt
+						? ` before ${formatDate(new Date(license.graceEndsAt))}`
+						: " before grace ends"}
 					.
 				</AlertDescription>
 			</Alert>

--- a/ee/admin/src/components/admin-shell.tsx
+++ b/ee/admin/src/components/admin-shell.tsx
@@ -49,6 +49,11 @@ import {
 import { useUser } from "@/hooks/useUser";
 import { useAuth } from "@/lib/auth-client";
 
+import {
+	formatPlanTermLabel,
+	getEnterpriseLicenseTerm,
+} from "@llmgateway/shared";
+
 import { Logo } from "./ui/logo";
 
 import type { LucideIcon } from "lucide-react";
@@ -179,6 +184,14 @@ function isActive(item: NavItem, pathname: string): boolean {
 		: pathname.startsWith(item.href);
 }
 
+function formatDate(date: Date): string {
+	return date.toLocaleDateString("en-US", {
+		month: "long",
+		day: "numeric",
+		year: "numeric",
+	});
+}
+
 interface AdminShellProps {
 	children: ReactNode;
 	/**
@@ -232,6 +245,15 @@ export function AdminShell({ children, signedIn }: AdminShellProps) {
 	// list would suggest there is something reachable behind it, and a sign out
 	// button makes no sense when nobody is signed in.
 	const showNav = user ? user.isAdmin : isLoading && !error && signedIn;
+	const license = data?.enterpriseLicense;
+	const licenseTerm = getEnterpriseLicenseTerm(license?.expiresAt);
+	const whiteLabelExpiryTerm =
+		license?.kind === "white_label" &&
+		license.status === "active" &&
+		licenseTerm !== null &&
+		(licenseTerm.status === "expiring" || licenseTerm.status === "critical")
+			? licenseTerm
+			: null;
 
 	if (!showNav) {
 		return (
@@ -316,13 +338,35 @@ export function AdminShell({ children, signedIn }: AdminShellProps) {
 			</Sidebar>
 			<SidebarInset>
 				<MobileHeader />
-				{data?.enterpriseLicense?.status === "grace" && (
-					<Alert className="rounded-none border-x-0 border-t-0 border-amber-500/40 bg-amber-500/10 px-6 text-amber-950 dark:text-amber-100">
+				{whiteLabelExpiryTerm && (
+					<Alert
+						className={
+							whiteLabelExpiryTerm.status === "critical"
+								? "rounded-none border-x-0 border-t-0 border-red-500/40 bg-red-500/10 px-6 text-red-950 dark:text-red-100"
+								: "rounded-none border-x-0 border-t-0 border-orange-500/40 bg-orange-500/10 px-6 text-orange-950 dark:text-orange-100"
+						}
+					>
 						<AlertTriangle />
-						<AlertTitle>Enterprise license expired</AlertTitle>
-						<AlertDescription>
+						<AlertTitle>White-label license expires soon</AlertTitle>
+						<AlertDescription className="text-current/90">
+							Install a renewed license before{" "}
+							{formatDate(whiteLabelExpiryTerm.expiresAt)} (
+							{formatPlanTermLabel(whiteLabelExpiryTerm).toLowerCase()}) to keep
+							admin access.
+						</AlertDescription>
+					</Alert>
+				)}
+				{license?.kind === "white_label" && license.status === "grace" && (
+					<Alert className="rounded-none border-x-0 border-t-0 border-red-500/40 bg-red-500/10 px-6 text-red-950 dark:text-red-100">
+						<AlertTriangle />
+						<AlertTitle>White-label license expired</AlertTitle>
+						<AlertDescription className="text-current/90">
 							Admin access remains available during the seven-day grace period.
-							Install a renewed license before it ends.
+							Install a renewed license
+							{license.graceEndsAt
+								? ` before ${formatDate(new Date(license.graceEndsAt))}`
+								: " before grace ends"}
+							.
 						</AlertDescription>
 					</Alert>
 				)}

--- a/ee/admin/src/components/admin-shell.tsx
+++ b/ee/admin/src/components/admin-shell.tsx
@@ -186,6 +186,7 @@ function isActive(item: NavItem, pathname: string): boolean {
 
 function formatDate(date: Date): string {
 	return date.toLocaleDateString("en-US", {
+		timeZone: "UTC",
 		month: "long",
 		day: "numeric",
 		year: "numeric",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -183,11 +183,14 @@ export {
 
 export {
 	addCalendarDays,
+	ENTERPRISE_LICENSE_CRITICAL_DAYS,
+	ENTERPRISE_LICENSE_EXPIRING_DAYS,
 	ENTERPRISE_TRIAL_DAY_PRESETS,
 	ENTERPRISE_TRIAL_DAYS,
 	extendTrialEnd,
 	formatPlanTermBadge,
 	formatPlanTermLabel,
+	getEnterpriseLicenseTerm,
 	getOrganizationTerm,
 	getPlanTerm,
 	PLAN_TERM_CRITICAL_DAYS,

--- a/packages/shared/src/plan-term.spec.ts
+++ b/packages/shared/src/plan-term.spec.ts
@@ -5,6 +5,7 @@ import {
 	extendTrialEnd,
 	formatPlanTermBadge,
 	formatPlanTermLabel,
+	getEnterpriseLicenseTerm,
 	getOrganizationTerm,
 	getPlanTerm,
 } from "./plan-term.js";
@@ -71,6 +72,23 @@ describe("getPlanTerm", () => {
 				now,
 			})?.elapsedFraction,
 		).toBeNull();
+	});
+});
+
+describe("getEnterpriseLicenseTerm", () => {
+	test("uses 90-day warning and 30-day critical thresholds", () => {
+		expect(getEnterpriseLicenseTerm("2026-11-06T00:00:00Z", now)?.status).toBe(
+			"active",
+		); // 91 days
+		expect(getEnterpriseLicenseTerm("2026-11-05T00:00:00Z", now)?.status).toBe(
+			"expiring",
+		); // 90 days
+		expect(getEnterpriseLicenseTerm("2026-09-07T00:00:00Z", now)?.status).toBe(
+			"expiring",
+		); // 31 days
+		expect(getEnterpriseLicenseTerm("2026-09-06T00:00:00Z", now)?.status).toBe(
+			"critical",
+		); // 30 days
 	});
 });
 

--- a/packages/shared/src/plan-term.ts
+++ b/packages/shared/src/plan-term.ts
@@ -13,6 +13,12 @@ export const PLAN_TERM_EXPIRING_DAYS = 30;
 /** A contract term with this many days left or fewer needs attention now. */
 export const PLAN_TERM_CRITICAL_DAYS = 7;
 
+/** A deployment license with this many days left or fewer is close to expiry. */
+export const ENTERPRISE_LICENSE_EXPIRING_DAYS = 90;
+
+/** A deployment license with this many days left or fewer needs attention now. */
+export const ENTERPRISE_LICENSE_CRITICAL_DAYS = 30;
+
 /**
  * Trials run 30 days, so the contract thresholds would paint one amber from
  * the very first day. These are scaled to the shorter window instead.
@@ -141,6 +147,20 @@ export function getPlanTerm(input: {
 	}
 
 	return { expiresAt, startedAt, daysLeft, status, totalDays, elapsedFraction };
+}
+
+export function getEnterpriseLicenseTerm(
+	expiresAt: Date | string | null | undefined,
+	now?: Date,
+): PlanTerm | null {
+	return getPlanTerm({
+		expiresAt,
+		now,
+		thresholds: {
+			expiring: ENTERPRISE_LICENSE_EXPIRING_DAYS,
+			critical: ENTERPRISE_LICENSE_CRITICAL_DAYS,
+		},
+	});
 }
 
 /** Sentence-style countdown, e.g. "12 days left" or "Expired 3 days ago". */


### PR DESCRIPTION
## Summary

- warn 90 days before an Enterprise license expires, escalating from orange to red at 30 days
- show regular license warnings only in the licensed organization
- show white-label license warnings only in the admin dashboard
- scope grace-period warnings to the same surfaces and format their dates consistently
- preserve locked-license guidance for missing, invalid, or differently scoped licenses

## Testing

- `pnpm format`
- `pnpm build`
- `TEST_DATABASE_URL=postgres://postgres:pw@localhost:7132/test pnpm exec vitest run packages/shared/src/plan-term.spec.ts apps/api/src/routes/user.spec.ts --no-file-parallelism`

## Screenshots

Each image shows, from top to bottom: outside the warning window, orange with 60 days left, and red with 20 days left.

### Organization dashboard

Light:

![Organization dashboard in light mode](https://raw.githubusercontent.com/theopenco/llmgateway/6a20f4b8eff706ff2be8ae2a1abde1949ab24f1f/dashboard-light.png)

Dark:

![Organization dashboard in dark mode](https://raw.githubusercontent.com/theopenco/llmgateway/6a20f4b8eff706ff2be8ae2a1abde1949ab24f1f/dashboard-dark.png)

### White-label admin dashboard

Light:

![White-label admin dashboard in light mode](https://raw.githubusercontent.com/theopenco/llmgateway/6a20f4b8eff706ff2be8ae2a1abde1949ab24f1f/admin-light.png)

Dark:

![White-label admin dashboard in dark mode](https://raw.githubusercontent.com/theopenco/llmgateway/6a20f4b8eff706ff2be8ae2a1abde1949ab24f1f/admin-dark.png)
