### PR TITLE
feat(airside): rotate flagship departures

### DIFF
--- a/apps/airside/e2e/airside.pw.ts
+++ b/apps/airside/e2e/airside.pw.ts
@@ -19,6 +19,8 @@ async function login(page: Page, email = "ops@mistral.ai") {
 test("landing page shows the departure board and CTA", async ({ page }) => {
 	await page.goto("/");
 	await expect(page.getByText("Departures — model traffic")).toBeVisible();
+	await expect(page.getByLabel("GPT-5.6-SOL")).toBeVisible();
+	await expect(page.getByLabel("KIMI-K3")).toBeVisible({ timeout: 10_000 });
 	await expect(
 		page.getByRole("heading", {
 			name: "Put your models on the departure board.",

--- a/apps/airside/src/app/globals.css
+++ b/apps/airside/src/app/globals.css
@@ -145,6 +145,13 @@
 	animation: beacon 3.2s ease-in-out infinite;
 }
 
+@media (prefers-reduced-motion: reduce) {
+	.animate-flap,
+	.animate-beacon {
+		animation: none;
+	}
+}
+
 /* Dashed runway centerline separator */
 @utility runway-line {
 	background-image: linear-gradient(

--- a/apps/airside/src/components/DepartureBoard.tsx
+++ b/apps/airside/src/components/DepartureBoard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -9,46 +9,105 @@ interface BoardRow {
 	carrier: string;
 	gate: string;
 	status: string;
-	tone: "ok" | "new" | "hold";
+	tone: "ok" | "new";
 }
 
 const ROWS: BoardRow[] = [
 	{
-		flight: "GLM-5.2",
-		carrier: "EMBERCLOUD",
-		gate: "A12",
+		flight: "GPT-5.6-SOL",
+		carrier: "OPENAI",
+		gate: "A01",
 		status: "BOARDING",
 		tone: "ok",
 	},
 	{
-		flight: "LARGE-4",
-		carrier: "MISTRAL",
-		gate: "B03",
-		status: "FARE FILED",
-		tone: "new",
-	},
-	{
-		flight: "K3-TURBO",
-		carrier: "MOONSHOT",
-		gate: "C07",
+		flight: "GPT-5.6-TERRA",
+		carrier: "OPENAI",
+		gate: "A02",
 		status: "ON TIME",
 		tone: "ok",
 	},
 	{
-		flight: "CODESTRAL-3",
-		carrier: "MISTRAL",
-		gate: "B04",
+		flight: "GPT-5.6-LUNA",
+		carrier: "OPENAI",
+		gate: "A03",
+		status: "ON TIME",
+		tone: "ok",
+	},
+	{
+		flight: "OPUS-5",
+		carrier: "ANTHROPIC",
+		gate: "B01",
+		status: "BOARDING",
+		tone: "ok",
+	},
+	{
+		flight: "FABLE-5",
+		carrier: "ANTHROPIC",
+		gate: "B02",
+		status: "NEW ROUTE",
+		tone: "new",
+	},
+	{
+		flight: "KIMI-K3",
+		carrier: "MOONSHOT",
+		gate: "C01",
+		status: "ON TIME",
+		tone: "ok",
+	},
+	{
+		flight: "DEEPSEEK-V4-PRO",
+		carrier: "DEEPSEEK",
+		gate: "D01",
+		status: "BOARDING",
+		tone: "ok",
+	},
+	{
+		flight: "DEEPSEEK-V4-FLASH",
+		carrier: "DEEPSEEK",
+		gate: "D02",
+		status: "ON TIME",
+		tone: "ok",
+	},
+	{
+		flight: "MIMO-V2.5",
+		carrier: "XIAOMI",
+		gate: "E01",
 		status: "CLEARED",
 		tone: "ok",
 	},
 	{
-		flight: "V3.4-EXP",
-		carrier: "DEEPSEEK",
-		gate: "D01",
-		status: "REVIEW",
-		tone: "hold",
+		flight: "GLM-5.3",
+		carrier: "Z.AI",
+		gate: "F01",
+		status: "ON TIME",
+		tone: "ok",
+	},
+	{
+		flight: "MINIMAX-M3",
+		carrier: "MINIMAX",
+		gate: "G01",
+		status: "BOARDING",
+		tone: "ok",
+	},
+	{
+		flight: "QWEN3.8-MAX",
+		carrier: "ALIBABA",
+		gate: "H01",
+		status: "ON TIME",
+		tone: "ok",
+	},
+	{
+		flight: "MUSE-SPARK-1.2",
+		carrier: "META",
+		gate: "J01",
+		status: "NEW ROUTE",
+		tone: "new",
 	},
 ];
+
+const VISIBLE_ROW_COUNT = 5;
+const CYCLE_INTERVAL_MS = 8_000;
 
 function FlapText({ text, delay }: { text: string; delay: number }) {
 	return (
@@ -58,6 +117,7 @@ function FlapText({ text, delay }: { text: string; delay: number }) {
 				return (
 					<span
 						key={`${text}-${i}`}
+						aria-hidden="true"
 						className={cn(
 							"animate-flap bg-foreground/5 inline-block min-w-[1ch] rounded-[2px] px-px text-center",
 							char === " " && "bg-transparent",
@@ -75,23 +135,64 @@ function FlapText({ text, delay }: { text: string; delay: number }) {
 const toneClass = {
 	ok: "text-signal",
 	new: "text-primary",
-	hold: "text-muted-foreground",
 } as const;
 
 /** Split-flap departure board listing model "flights". */
 export function DepartureBoard() {
-	// Re-key rows periodically so the flaps re-run — quiet, ambient motion.
 	const [cycle, setCycle] = useState(0);
+	const [isActive, setIsActive] = useState(false);
+	const boardRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
-		const timer = setInterval(() => {
-			setCycle((c) => c + 1);
-		}, 9000);
-		return () => clearInterval(timer);
+		const board = boardRef.current;
+		if (!board) {
+			return;
+		}
+
+		const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+		let isIntersecting = false;
+
+		const updateActivity = () => {
+			setIsActive(isIntersecting && !document.hidden && !reducedMotion.matches);
+		};
+		const observer = new IntersectionObserver(([entry]) => {
+			isIntersecting = entry.isIntersecting;
+			updateActivity();
+		});
+
+		observer.observe(board);
+		document.addEventListener("visibilitychange", updateActivity);
+		reducedMotion.addEventListener("change", updateActivity);
+
+		return () => {
+			observer.disconnect();
+			document.removeEventListener("visibilitychange", updateActivity);
+			reducedMotion.removeEventListener("change", updateActivity);
+		};
 	}, []);
 
+	useEffect(() => {
+		if (!isActive) {
+			return;
+		}
+
+		const timer = setInterval(() => {
+			setCycle((c) => c + 1);
+		}, CYCLE_INTERVAL_MS);
+		return () => clearInterval(timer);
+	}, [isActive]);
+
+	const visibleRows = Array.from({ length: VISIBLE_ROW_COUNT }, (_, index) => {
+		const batchStart = cycle * VISIBLE_ROW_COUNT;
+		const rowIndex = (batchStart + index) % ROWS.length;
+		return ROWS[rowIndex];
+	});
+
 	return (
-		<div className="border-border bg-card overflow-hidden rounded-xl border shadow-2xl">
+		<div
+			ref={boardRef}
+			className="border-border bg-card overflow-hidden rounded-xl border shadow-2xl"
+		>
 			<div className="border-border text-muted-foreground flex items-center justify-between border-b px-4 py-2.5 font-mono text-[0.65rem] tracking-[0.25em] uppercase">
 				<span>Departures — model traffic</span>
 				<span className="text-primary animate-beacon">● LIVE</span>
@@ -109,7 +210,7 @@ export function DepartureBoard() {
 						</tr>
 					</thead>
 					<tbody key={cycle}>
-						{ROWS.map((row, i) => {
+						{visibleRows.map((row, i) => {
 							const rowDelay = i * 120;
 							return (
 								<tr

--- a/apps/airside/src/components/DepartureBoard.tsx
+++ b/apps/airside/src/components/DepartureBoard.tsx
@@ -56,20 +56,6 @@ const ROWS: BoardRow[] = [
 		tone: "ok",
 	},
 	{
-		flight: "DEEPSEEK-V4-PRO",
-		carrier: "DEEPSEEK",
-		gate: "D01",
-		status: "BOARDING",
-		tone: "ok",
-	},
-	{
-		flight: "DEEPSEEK-V4-FLASH",
-		carrier: "DEEPSEEK",
-		gate: "D02",
-		status: "ON TIME",
-		tone: "ok",
-	},
-	{
 		flight: "MIMO-V2.5",
 		carrier: "XIAOMI",
 		gate: "E01",
@@ -198,11 +184,13 @@ export function DepartureBoard() {
 				<span className="text-primary animate-beacon">● LIVE</span>
 			</div>
 			<div className="overflow-x-auto">
-				<table className="w-full font-mono text-xs sm:text-sm">
+				<table className="w-full font-mono text-xs">
 					<thead>
 						<tr className="text-muted-foreground text-left text-[0.65rem] tracking-[0.2em] uppercase">
 							<th className="px-4 py-2 font-normal">Model</th>
-							<th className="px-4 py-2 font-normal">Carrier</th>
+							<th className="hidden px-4 py-2 font-normal sm:table-cell">
+								Carrier
+							</th>
 							<th className="hidden px-4 py-2 font-normal sm:table-cell">
 								Gate
 							</th>
@@ -220,7 +208,7 @@ export function DepartureBoard() {
 									<td className="px-4 py-2.5">
 										<FlapText text={row.flight} delay={rowDelay} />
 									</td>
-									<td className="text-muted-foreground px-4 py-2.5">
+									<td className="text-muted-foreground hidden px-4 py-2.5 sm:table-cell">
 										<FlapText text={row.carrier} delay={rowDelay + 60} />
 									</td>
 									<td className="text-muted-foreground hidden px-4 py-2.5 sm:table-cell">


### PR DESCRIPTION
## Problem

The Airside departure board replayed its split-flap animation over the same outdated rows, so the display never reflected a changing model lineup.

## Changes

- replace the initial board with current flagship catalog models
- rotate through all 11 departures in five-row batches every eight seconds
- keep long model names readable and hide secondary columns on narrow screens
- pause ambient updates offscreen, in hidden tabs, and for reduced-motion users
- cover the initial lineup and first real content swap in Playwright

## Recording

<img width="960" alt="Airside departure board cycling through flagship models" src="https://raw.githubusercontent.com/theopenco/llmgateway/30fa0a10601bad196339a5833e6e7e673d58b3bd/departure-board.gif" />

## Verification

- `pnpm format`
- `pnpm build`
- `PW_BASE_URL=http://localhost:3307 pnpm --filter airside exec playwright test e2e/airside.pw.ts --grep 'landing page shows'`
- Impeccable UI detector

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the departure board with refreshed model listings and a five-row rotating display.
  - The board now pauses when off-screen or when the browser tab is inactive.
  - Improved mobile presentation by simplifying the board layout on smaller screens.

- **Accessibility**
  - Animations now respect reduced-motion preferences.
  - Decorative board animation elements are hidden from screen readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->