### PR TITLE
feat(devpass): show exact plan times

### DIFF
--- a/apps/code/src/app/dashboard/(main)/billing/BillingClient.tsx
+++ b/apps/code/src/app/dashboard/(main)/billing/BillingClient.tsx
@@ -225,8 +225,9 @@ export default function BillingClient({
 				posthog.capture("dev_plan_cancelled");
 			}
 			toast.success("Subscription cancelled", {
-				description:
-					"Your plan will remain active until the end of your billing period.",
+				description: renewWhen
+					? `Your plan will remain active until ${renewWhen}.`
+					: "Your plan will remain active until the end of your billing period.",
 			});
 		} catch {
 			toast.error("Failed to cancel subscription");
@@ -341,7 +342,7 @@ export default function BillingClient({
 				})()
 			: null;
 	const renewWhen = renewAt
-		? formatDateTime(renewAt, displayTimeZone, "monthDayYear")
+		? formatDateTime(renewAt, displayTimeZone, "monthDayYearHourMinuteZone")
 		: null;
 
 	const renewalHint = !renewAt
@@ -445,9 +446,9 @@ export default function BillingClient({
 								<AlertDialogHeader>
 									<AlertDialogTitle>Cancel your Dev Plan?</AlertDialogTitle>
 									<AlertDialogDescription>
-										Your plan stays active until the end of the current billing
-										period. You won&apos;t be charged again, and you can resume
-										any time before then.
+										{renewWhen
+											? `Your plan stays active until ${renewWhen}. You won't be charged again, and you can resume any time before then.`
+											: "Your plan stays active until the end of the current billing period. You won't be charged again, and you can resume any time before then."}
 									</AlertDialogDescription>
 								</AlertDialogHeader>
 								<AlertDialogFooter>

--- a/apps/code/src/app/dashboard/components/ActivePlanChangeTier.tsx
+++ b/apps/code/src/app/dashboard/components/ActivePlanChangeTier.tsx
@@ -336,7 +336,7 @@ function formatRenewalDate(iso: string, timeZone: string): string | null {
 	const date = new Date(iso);
 	return Number.isNaN(date.getTime())
 		? null
-		: formatDateTime(date, timeZone, "monthDayYear");
+		: formatDateTime(date, timeZone, "monthDayYearHourMinuteZone");
 }
 
 // Shared between the timing chooser and the fallback preview copy so the

--- a/apps/code/src/app/dashboard/components/CapHitResetOfferDialog.tsx
+++ b/apps/code/src/app/dashboard/components/CapHitResetOfferDialog.tsx
@@ -21,7 +21,9 @@ import { getCookie, setCookie } from "@/lib/cookies";
 import {
 	DEV_PLAN_RESET_PASS_PURCHASE_MAX_CYCLE_USAGE,
 	DEV_PLAN_RESET_PASS_REDEEM_MAX_CYCLE_USAGE,
+	formatDateTime,
 	getDevPlanCycleUsageFraction,
+	useDisplayTimeZone,
 } from "@llmgateway/shared";
 
 // A dismissal keeps the offer quiet for the rest of the current cap window;
@@ -56,6 +58,7 @@ export default function CapHitResetOfferDialog({
 }: CapHitResetOfferDialogProps) {
 	const posthog = usePostHog();
 	const { posthogKey } = useAppConfig();
+	const { timeZone: displayTimeZone } = useDisplayTimeZone();
 	const [open, setOpen] = useState(false);
 	const shownTracked = useRef(false);
 
@@ -115,6 +118,13 @@ export default function CapHitResetOfferDialog({
 
 	const resetsIn = premiumWeekResetsAt
 		? formatDistanceToNowStrict(new Date(premiumWeekResetsAt))
+		: null;
+	const resetsWhen = premiumWeekResetsAt
+		? formatDateTime(
+				premiumWeekResetsAt,
+				displayTimeZone,
+				"monthDayHourMinuteZone",
+			)
 		: null;
 
 	const dismiss = () => {
@@ -176,8 +186,8 @@ export default function CapHitResetOfferDialog({
 					</DialogTitle>
 					<DialogDescription className="pr-10">
 						{`You've used the full $${premiumWeeklyLimit.toFixed(2)} premium-model allowance on the ${tier} plan`}
-						{resetsIn
-							? `, and the window doesn't reopen for ${resetsIn}. `
+						{resetsWhen && resetsIn
+							? `, and the window doesn't reopen until ${resetsWhen} (${resetsIn}). `
 							: ". "}
 						{canRedeem
 							? `You're holding ${available} Reset Pass${available === 1 ? "" : "es"} — stamp one now and the full allowance is back instantly.`

--- a/apps/code/src/app/dashboard/components/UsageOverview.tsx
+++ b/apps/code/src/app/dashboard/components/UsageOverview.tsx
@@ -127,7 +127,7 @@ function WeeklyAllowanceMeter({
 					</div>
 					<div className="mt-0.5 text-xs text-muted-foreground">
 						{resetsAt
-							? `Resets ${formatDateTime(resetsAt, displayTimeZone, "monthDay")}`
+							? `Resets ${formatDateTime(resetsAt, displayTimeZone, "monthDayHourMinuteZone")}`
 							: "Window starts with your first premium request"}
 					</div>
 				</div>
@@ -329,12 +329,15 @@ export default function UsageOverview({
 				})()
 			: null;
 
+	const renewWhen = renewAt
+		? formatDateTime(renewAt, displayTimeZone, "monthDayYearHourMinuteZone")
+		: null;
 	const cycleEndsHint = cancelledAtPeriodEnd
-		? renewAt
-			? `Cancels ${formatDateTime(renewAt, displayTimeZone, "monthDayYear")}`
+		? renewWhen
+			? `Cancels ${renewWhen}`
 			: "Cancels at period end"
 		: renewAt
-			? `Renews in ${formatDistanceToNowStrict(renewAt)}`
+			? `Renews ${renewWhen} (in ${formatDistanceToNowStrict(renewAt)})`
 			: "—";
 
 	return (


### PR DESCRIPTION
## Problem

DevPass plan renewal, cancellation, and weekly allowance reset moments were shown as bare dates or relative durations. Members could not tell the exact local time a plan or allowance changes.

## Approach

- Port only the date-time presentation changes from #3832.
- Show renewal, cancellation, scheduled tier-change, and weekly reset moments to the minute with the viewer's selected timezone.
- Include the exact moment in cancellation feedback and the weekly cap dialog while retaining useful relative countdowns.
- Leave all billing-state, Stripe, database, API, and admin changes from #3832 out of scope.

## Verification

- `pnpm format`
- `pnpm build`
- Drove billing, cancellation, usage, and weekly-cap states on an isolated seeded stack in light and dark themes, with the browser timezone set to `America/New_York`.

## Screenshots

All screenshots use locally seeded data. Before → after.

<details open>
<summary>Billing renewal</summary>

Light

<p>
<img width="49%" alt="DevPass billing showing a date-only renewal in light mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/2798ee94f1e39f2c14ed4fa718af0ca7b9a04799/before-billing-light.png" />
<img width="49%" alt="DevPass billing showing the exact renewal time and zone in light mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/2798ee94f1e39f2c14ed4fa718af0ca7b9a04799/after-billing-light.png" />
</p>

Dark

<p>
<img width="49%" alt="DevPass billing showing a date-only renewal in dark mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/2798ee94f1e39f2c14ed4fa718af0ca7b9a04799/before-billing-dark.png" />
<img width="49%" alt="DevPass billing showing the exact renewal time and zone in dark mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/2798ee94f1e39f2c14ed4fa718af0ca7b9a04799/after-billing-dark.png" />
</p>
</details>

<details>
<summary>Cancellation dialog</summary>

Light

<p>
<img width="49%" alt="DevPass cancellation dialog showing a generic period-end message in light mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/2798ee94f1e39f2c14ed4fa718af0ca7b9a04799/before-cancel-light.png" />
<img width="49%" alt="DevPass cancellation dialog showing the exact end time and zone in light mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/2798ee94f1e39f2c14ed4fa718af0ca7b9a04799/after-cancel-light.png" />
</p>

Dark

<p>
<img width="49%" alt="DevPass cancellation dialog showing a generic period-end message in dark mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/2798ee94f1e39f2c14ed4fa718af0ca7b9a04799/before-cancel-dark.png" />
<img width="49%" alt="DevPass cancellation dialog showing the exact end time and zone in dark mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/2798ee94f1e39f2c14ed4fa718af0ca7b9a04799/after-cancel-dark.png" />
</p>
</details>

<details open>
<summary>Usage renewal and weekly reset</summary>

Light

<p>
<img width="49%" alt="DevPass usage showing a relative renewal and date-only reset in light mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/2798ee94f1e39f2c14ed4fa718af0ca7b9a04799/before-usage-light.png" />
<img width="49%" alt="DevPass usage showing exact renewal and reset times in light mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/2798ee94f1e39f2c14ed4fa718af0ca7b9a04799/after-usage-light.png" />
</p>

Dark

<p>
<img width="49%" alt="DevPass usage showing a relative renewal and date-only reset in dark mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/2798ee94f1e39f2c14ed4fa718af0ca7b9a04799/before-usage-dark.png" />
<img width="49%" alt="DevPass usage showing exact renewal and reset times in dark mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/2798ee94f1e39f2c14ed4fa718af0ca7b9a04799/after-usage-dark.png" />
</p>
</details>

<details>
<summary>Weekly cap dialog</summary>

Light

<p>
<img width="49%" alt="Weekly cap dialog showing only a relative reset duration in light mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/2798ee94f1e39f2c14ed4fa718af0ca7b9a04799/before-cap-light.png" />
<img width="49%" alt="Weekly cap dialog showing the exact reset time and zone in light mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/2798ee94f1e39f2c14ed4fa718af0ca7b9a04799/after-cap-light.png" />
</p>

Dark

<p>
<img width="49%" alt="Weekly cap dialog showing only a relative reset duration in dark mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/2798ee94f1e39f2c14ed4fa718af0ca7b9a04799/before-cap-dark.png" />
<img width="49%" alt="Weekly cap dialog showing the exact reset time and zone in dark mode" src="https://raw.githubusercontent.com/theopenco/llmgateway/2798ee94f1e39f2c14ed4fa718af0ca7b9a04799/after-cap-dark.png" />
</p>
</details>
