### PR TITLE
fix(seo): audit fixes and OG images across apps

### DIFF
--- a/apps/airside/src/app/layout.tsx
+++ b/apps/airside/src/app/layout.tsx
@@ -35,6 +35,18 @@ export const metadata: Metadata = {
 	description:
 		"The self-serve console for LLM providers. Claim your carrier, register your fleet, file your fares, and watch dispatch route traffic to your models.",
 	applicationName: "Airside",
+	alternates: { canonical: "./" },
+	robots: {
+		index: true,
+		follow: true,
+		googleBot: {
+			index: true,
+			follow: true,
+			"max-video-preview": -1,
+			"max-image-preview": "large",
+			"max-snippet": -1,
+		},
+	},
 	openGraph: {
 		title: "Airside by LLM Gateway",
 		description:

--- a/apps/airside/src/app/legal/privacy/opengraph-image.tsx
+++ b/apps/airside/src/app/legal/privacy/opengraph-image.tsx
@@ -1,0 +1,19 @@
+import { airsideOgImage, ogContentType, ogSize } from "@/lib/og";
+
+export const alt = "Airside Supplemental Privacy Notice";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function PrivacyOgImage() {
+	return airsideOgImage({
+		eyebrow: "Legal",
+		title: "Airside Supplemental Privacy Notice",
+		subtitle:
+			"What Airside collects from carriers, why, and how long it is kept.",
+		board: [
+			{ flight: "CLAIMS", carrier: "COMPANY EMAIL", status: "VERIFIED" },
+			{ flight: "TRAFFIC", carrier: "AGGREGATED", status: "NO TENANTS" },
+			{ flight: "PROMPTS", carrier: "NEVER SHOWN", status: "SEALED" },
+		],
+	});
+}

--- a/apps/airside/src/app/legal/privacy/page.tsx
+++ b/apps/airside/src/app/legal/privacy/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-	title: "Privacy Notice — Airside",
+	title: "Privacy Notice",
 	description:
-		"Supplemental Airside Privacy Notice for AI model providers. What the carrier console collects, how claims and filings are reviewed, what traffic data you see, and how long it is kept.",
+		"Supplemental Airside Privacy Notice for AI model providers: what the carrier console collects, how claims and filings are reviewed, and how long data is kept.",
 	alternates: { canonical: "/legal/privacy" },
 	openGraph: {
 		title: "Airside Supplemental Privacy Notice",

--- a/apps/airside/src/app/legal/terms/opengraph-image.tsx
+++ b/apps/airside/src/app/legal/terms/opengraph-image.tsx
@@ -1,0 +1,19 @@
+import { airsideOgImage, ogContentType, ogSize } from "@/lib/og";
+
+export const alt = "Airside Supplemental Terms of Use";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function TermsOgImage() {
+	return airsideOgImage({
+		eyebrow: "Legal",
+		title: "Airside Supplemental Terms of Use",
+		subtitle:
+			"The terms that govern listing your models as a carrier on LLM Gateway.",
+		board: [
+			{ flight: "CLAIMS", carrier: "DOMAIN VERIFIED", status: "REQUIRED" },
+			{ flight: "TARIFFS", carrier: "PRICE FILINGS", status: "REVIEWED" },
+			{ flight: "DISPATCH", carrier: "ROUTING", status: "SCORED" },
+		],
+	});
+}

--- a/apps/airside/src/app/legal/terms/page.tsx
+++ b/apps/airside/src/app/legal/terms/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-	title: "Terms of Use — Airside",
+	title: "Terms of Use",
 	description:
-		"Supplemental Airside Terms of Use for AI model providers. Covers carrier claims and domain verification, the listing fee, tariff filings, dispatch routing, usage reporting, and delisting.",
+		"Supplemental Airside Terms of Use for model providers: carrier claims and domain verification, the listing fee, tariff filings, dispatch routing, and delisting.",
 	alternates: { canonical: "/legal/terms" },
 	openGraph: {
 		title: "Airside Supplemental Terms of Use",

--- a/apps/airside/src/app/opengraph-image.tsx
+++ b/apps/airside/src/app/opengraph-image.tsx
@@ -1,130 +1,14 @@
-import { ImageResponse } from "next/og";
+import { airsideOgImage, ogContentType, ogSize } from "@/lib/og";
 
 export const alt = "Airside by LLM Gateway — the carrier console";
-export const size = { width: 1200, height: 630 };
-export const contentType = "image/png";
-
-// Night-ops palette, matching the app's dark theme tokens in globals.css.
-const BACKGROUND = "#191d27";
-const FOREGROUND = "#ebe9e3";
-const PRIMARY = "#efab3d";
-const MUTED = "#8b8f9c";
-const BORDER = "#2b303d";
-
-const BOARD = [
-	{ flight: "GLM-5.2", carrier: "EMBERCLOUD", status: "BOARDING" },
-	{ flight: "LARGE-4", carrier: "MISTRAL", status: "FARE FILED" },
-	{ flight: "K3-TURBO", carrier: "MOONSHOT", status: "ON TIME" },
-];
-
-function BeaconMark() {
-	return (
-		<svg width="52" height="52" viewBox="0 0 32 32" fill="none">
-			<rect width="32" height="32" rx="7" fill={FOREGROUND} />
-			<circle cx="16" cy="16" r="3" fill={BACKGROUND} />
-			<path d="M16 16 L28 10 L28 22 Z" fill={BACKGROUND} opacity="0.55" />
-			<circle
-				cx="16"
-				cy="16"
-				r="8.5"
-				stroke={BACKGROUND}
-				strokeWidth="1.5"
-				strokeDasharray="3 4"
-				fill="none"
-				opacity="0.7"
-			/>
-		</svg>
-	);
-}
+export const size = ogSize;
+export const contentType = ogContentType;
 
 export default function AirsideOgImage() {
-	return new ImageResponse(
-		<div
-			style={{
-				width: "100%",
-				height: "100%",
-				display: "flex",
-				flexDirection: "column",
-				justifyContent: "space-between",
-				background: BACKGROUND,
-				backgroundImage: `radial-gradient(900px 520px at 78% -12%, rgba(239,171,61,0.18), transparent 62%)`,
-				padding: 64,
-				fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
-			}}
-		>
-			<div style={{ display: "flex", alignItems: "center", gap: 16 }}>
-				<BeaconMark />
-				<span
-					style={{
-						color: FOREGROUND,
-						fontSize: 34,
-						fontWeight: 800,
-						letterSpacing: "0.02em",
-					}}
-				>
-					AIRSIDE
-				</span>
-				<span style={{ color: MUTED, fontSize: 22 }}>by LLM Gateway</span>
-			</div>
-
-			<div style={{ display: "flex", flexDirection: "column", gap: 22 }}>
-				<span
-					style={{
-						color: PRIMARY,
-						fontSize: 20,
-						letterSpacing: "0.3em",
-						textTransform: "uppercase",
-					}}
-				>
-					The carrier console
-				</span>
-				<span
-					style={{
-						display: "flex",
-						color: FOREGROUND,
-						fontSize: 66,
-						fontWeight: 800,
-						lineHeight: 1.08,
-						letterSpacing: "-0.02em",
-						maxWidth: 940,
-					}}
-				>
-					Put your models on the departure board.
-				</span>
-				<span style={{ display: "flex", color: MUTED, fontSize: 27 }}>
-					Claim your carrier, register your fleet, file your fares — and win
-					routes.
-				</span>
-			</div>
-
-			<div
-				style={{
-					display: "flex",
-					flexDirection: "column",
-					borderTop: `1px solid ${BORDER}`,
-					paddingTop: 22,
-				}}
-			>
-				{BOARD.map((row) => (
-					<div
-						key={row.flight}
-						style={{
-							display: "flex",
-							alignItems: "center",
-							justifyContent: "space-between",
-							paddingTop: 7,
-							paddingBottom: 7,
-							fontSize: 21,
-							letterSpacing: "0.12em",
-						}}
-					>
-						<span style={{ color: FOREGROUND, width: 250 }}>{row.flight}</span>
-						<span style={{ color: MUTED, width: 320 }}>{row.carrier}</span>
-						<span style={{ color: PRIMARY }}>{row.status}</span>
-					</div>
-				))}
-			</div>
-		</div>,
-		size,
-	);
+	return airsideOgImage({
+		eyebrow: "The carrier console",
+		title: "Put your models on the departure board.",
+		subtitle:
+			"Claim your carrier, register your fleet, file your fares — and win routes.",
+	});
 }

--- a/apps/airside/src/lib/og.tsx
+++ b/apps/airside/src/lib/og.tsx
@@ -1,0 +1,157 @@
+import { ImageResponse } from "next/og";
+
+export const ogSize = { width: 1200, height: 630 };
+export const ogContentType = "image/png";
+
+// Night-ops palette, matching the app's dark theme tokens in globals.css.
+const BACKGROUND = "#191d27";
+const FOREGROUND = "#ebe9e3";
+const PRIMARY = "#efab3d";
+const MUTED = "#8b8f9c";
+const BORDER = "#2b303d";
+
+export interface BoardRow {
+	flight: string;
+	carrier: string;
+	status: string;
+}
+
+const DEFAULT_BOARD: BoardRow[] = [
+	{ flight: "GLM-5.2", carrier: "EMBERCLOUD", status: "BOARDING" },
+	{ flight: "LARGE-4", carrier: "MISTRAL", status: "FARE FILED" },
+	{ flight: "K3-TURBO", carrier: "MOONSHOT", status: "ON TIME" },
+];
+
+interface AirsideOgOptions {
+	eyebrow: string;
+	title: string;
+	subtitle: string;
+	board?: BoardRow[];
+}
+
+function BeaconMark() {
+	return (
+		<svg width="52" height="52" viewBox="0 0 32 32" fill="none">
+			<rect width="32" height="32" rx="7" fill={FOREGROUND} />
+			<circle cx="16" cy="16" r="3" fill={BACKGROUND} />
+			<path d="M16 16 L28 10 L28 22 Z" fill={BACKGROUND} opacity="0.55" />
+			<circle
+				cx="16"
+				cy="16"
+				r="8.5"
+				stroke={BACKGROUND}
+				strokeWidth="1.5"
+				strokeDasharray="3 4"
+				fill="none"
+				opacity="0.7"
+			/>
+		</svg>
+	);
+}
+
+/**
+ * Shared Airside OpenGraph card: departure-board styling for every public
+ * page. Inline styles only — rendered by next/og (Satori).
+ */
+export function airsideOgImage({
+	eyebrow,
+	title,
+	subtitle,
+	board = DEFAULT_BOARD,
+}: AirsideOgOptions) {
+	return new ImageResponse(
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				display: "flex",
+				flexDirection: "column",
+				justifyContent: "space-between",
+				background: BACKGROUND,
+				backgroundImage: `radial-gradient(900px 520px at 78% -12%, rgba(239,171,61,0.18), transparent 62%)`,
+				padding: 64,
+				fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+			}}
+		>
+			<div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+				<BeaconMark />
+				<span
+					style={{
+						color: FOREGROUND,
+						fontSize: 34,
+						fontWeight: 800,
+						letterSpacing: "0.02em",
+					}}
+				>
+					AIRSIDE
+				</span>
+				<span style={{ color: MUTED, fontSize: 22 }}>by LLM Gateway</span>
+			</div>
+
+			<div style={{ display: "flex", flexDirection: "column", gap: 22 }}>
+				<span
+					style={{
+						color: PRIMARY,
+						fontSize: 20,
+						letterSpacing: "0.3em",
+						textTransform: "uppercase",
+					}}
+				>
+					{eyebrow}
+				</span>
+				<span
+					style={{
+						display: "flex",
+						color: FOREGROUND,
+						fontSize: 66,
+						fontWeight: 800,
+						lineHeight: 1.08,
+						letterSpacing: "-0.02em",
+						maxWidth: 940,
+					}}
+				>
+					{title}
+				</span>
+				<span
+					style={{
+						display: "flex",
+						color: MUTED,
+						fontSize: 27,
+						maxWidth: 940,
+					}}
+				>
+					{subtitle}
+				</span>
+			</div>
+
+			<div
+				style={{
+					display: "flex",
+					flexDirection: "column",
+					borderTop: `1px solid ${BORDER}`,
+					paddingTop: 22,
+				}}
+			>
+				{board.map((row) => (
+					<div
+						key={row.flight}
+						style={{
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "space-between",
+							paddingTop: 7,
+							paddingBottom: 7,
+							fontSize: 21,
+							letterSpacing: "0.12em",
+						}}
+					>
+						<span style={{ color: FOREGROUND, width: 250 }}>{row.flight}</span>
+						<span style={{ color: MUTED, width: 320 }}>{row.carrier}</span>
+						<span style={{ color: PRIMARY }}>{row.status}</span>
+					</div>
+				))}
+			</div>
+		</div>,
+		ogSize,
+	);
+}

--- a/apps/code/public/llms.txt
+++ b/apps/code/public/llms.txt
@@ -13,10 +13,17 @@
 ## Key pages
 
 - [DevPass](https://devpass.llmgateway.io): Plans, supported coding agents, and setup.
-- [Docs & agent guides](https://docs.llmgateway.io/guides): Step-by-step setup for each coding agent.
-- [Models](https://llmgateway.io/models): Full catalog of supported models with pricing and capabilities.
+- [Pricing](https://devpass.llmgateway.io/pricing): Lite, Pro, and Max plans with included usage, premium fair-use limits, and Reset Passes.
+- [Pricing (machine-readable)](https://devpass.llmgateway.io/pricing.md): Plain-markdown DevPass pricing for AI agents.
+- [Compare](https://devpass.llmgateway.io/compare): DevPass vs Cursor, OpenCode, FirePass, the z.ai GLM Coding Plan, and Alibaba's Qwen plan.
+- [Claude Code alternative](https://devpass.llmgateway.io/claude-code-alternative): Keep the Claude Code CLI, replace the Max subscription.
+- [Coding models](https://devpass.llmgateway.io/models): Every model on DevPass, filterable by tier, capability, provider, price, and context.
+- [Setup guides](https://devpass.llmgateway.io/guides): Step-by-step setup for each coding agent.
+- [Model Census](https://devpass.llmgateway.io/data): Yearly value, quality, and speed ratings from developers with verified usage.
+- [Leaderboard](https://devpass.llmgateway.io/leaderboard): Developers ranked by tokens routed through DevPass.
+- [Docs & agent guides](https://docs.llmgateway.io/guides): Detailed integration docs per coding agent.
 - [LLM Gateway](https://llmgateway.io): The open-source gateway platform DevPass runs on.
-- [Pricing (machine-readable)](https://llmgateway.io/pricing.md): Plain-markdown pricing for the whole platform.
+- [Platform pricing (machine-readable)](https://llmgateway.io/pricing.md): Plain-markdown pricing for the whole platform.
 
 ## Notes
 

--- a/apps/code/public/pricing.md
+++ b/apps/code/public/pricing.md
@@ -1,0 +1,52 @@
+# DevPass by LLM Gateway — Pricing
+
+Last updated: 2026-09-01
+
+> DevPass is a flat-price monthly subscription for AI coding tools. One API key unlocks 200+ models across 40+ providers in any OpenAI- or Anthropic-compatible coding agent (DevPass Code, Claude Code, OpenCode, Cursor, Cline, and more). Usage is metered at provider list rates with no token markup.
+
+## Lite
+
+- Price: $29/month
+- Included usage: $87 of model usage per month (3× what you pay), metered at provider rates
+- Premium-model fair use: 12% of credits per week on models priced $5+/M input or $15+/M output
+- Reset Passes: buy anytime for $9 each (instant premium-allowance reset)
+- Support: email
+
+## Pro
+
+- Price: $79/month
+- Included usage: $237 of model usage per month (3× what you pay)
+- Premium-model fair use: 15% of credits per week
+- Reset Passes: 1 included per month, extras $29 each
+- Priority routing on flagship models
+- Support: priority
+
+## Max
+
+- Price: $179/month
+- Included usage: $537 of model usage per month (3× what you pay)
+- Premium-model fair use: 18% of credits per week
+- Reset Passes: 2 included per month, extras $79 each
+- Priority routing on flagship models and headroom for all-day agent runs
+- Support: front of queue
+
+## Every plan includes
+
+- All 200+ models, with new flagships available on release day (Claude, GPT, Gemini, GLM, Qwen, Kimi, and more)
+- Works with DevPass Code, Claude Code, OpenCode, Empryo, SoulForge, and any OpenAI/Anthropic-compatible tool
+- Real-time dashboard with per-request cost and latency
+- Switch tiers or cancel anytime — no lock-in, no cancellation fee
+- Optional pay-as-you-go overflow: top up a credits balance to keep going at provider rates once the monthly allowance is used
+
+## Refunds
+
+- Self-serve from the dashboard within 14 days of your first month while less than 20% of the allowance has been used.
+- Reset Passes: within 7 days, while the pass is unused.
+
+## Notes
+
+- Billing is monthly only; there is no annual plan.
+- DevPass always smart-routes each request to the best provider; provider pinning is not available (use LLM Gateway pay-as-you-go for that).
+- Human-readable pricing page: https://devpass.llmgateway.io/pricing
+- Plan comparisons: https://devpass.llmgateway.io/compare
+- Platform-wide pricing (LLM Gateway, Lounge, DevPass): https://llmgateway.io/pricing.md

--- a/apps/code/src/app/claude-code-alternative/page.tsx
+++ b/apps/code/src/app/claude-code-alternative/page.tsx
@@ -22,10 +22,10 @@ const BASE_URL = "https://devpass.llmgateway.io";
 const PAGE_PATH = "/claude-code-alternative";
 
 const TITLE = "Claude Code Alternative (2026): Keep the CLI, Skip the Caps";
-const DESCRIPTION = `Looking for a Claude Code alternative? DevPass keeps the Claude Code CLI and replaces the Max subscription: one key, 200+ models (Claude included) metered at provider rates, from $${DEV_PLAN_PRICES.lite}/mo. No weekly caps.`;
+const DESCRIPTION = `DevPass keeps the Claude Code CLI and replaces the Max subscription: one key, 200+ models (Claude included) at provider rates, from $${DEV_PLAN_PRICES.lite}/mo. No weekly caps.`;
 
 export const metadata: Metadata = {
-	title: TITLE,
+	title: { absolute: `${TITLE} | DevPass` },
 	description: DESCRIPTION,
 	alternates: { canonical: PAGE_PATH },
 	openGraph: {

--- a/apps/code/src/app/coding-models/opengraph-image.tsx
+++ b/apps/code/src/app/coding-models/opengraph-image.tsx
@@ -1,0 +1,15 @@
+import { devpassOgImage, ogContentType, ogSize } from "@/lib/og";
+
+export const alt = "AI models for coding on DevPass";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function CodingModelsOgImage() {
+	return devpassOgImage({
+		eyebrow: "Coding models",
+		title: "AI models built for coding",
+		subtitle:
+			"Tool calling, JSON output, streaming, and prompt caching — the models that ship code, in one subscription.",
+		path: "/coding-models",
+	});
+}

--- a/apps/code/src/app/coding-models/page.tsx
+++ b/apps/code/src/app/coding-models/page.tsx
@@ -15,6 +15,13 @@ export const metadata: Metadata = {
 	description:
 		"High-performance AI models optimized for coding tasks with tool support, JSON output, streaming, and prompt caching.",
 	alternates: { canonical: "/coding-models" },
+	openGraph: {
+		title: "AI Models for Coding | DevPass",
+		description:
+			"High-performance AI models optimized for coding tasks with tool support, JSON output, streaming, and prompt caching.",
+		type: "website",
+		url: "https://devpass.llmgateway.io/coding-models",
+	},
 };
 
 export default function CodingModelsPage() {

--- a/apps/code/src/app/compare/page.tsx
+++ b/apps/code/src/app/compare/page.tsx
@@ -11,7 +11,7 @@ import type { Comparison } from "content-collections";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-	title: "DevPass vs the Alternatives — Coding Plan Comparisons",
+	title: { absolute: "DevPass vs the Alternatives — Coding Plan Comparisons" },
 	description:
 		"How DevPass compares to Cursor, OpenCode, FirePass, the z.ai GLM Coding Plan, and Alibaba's Qwen plan. Pricing, model catalogs, and limits side by side.",
 	alternates: { canonical: "/compare" },

--- a/apps/code/src/app/data/[year]/opengraph-image.tsx
+++ b/apps/code/src/app/data/[year]/opengraph-image.tsx
@@ -1,0 +1,20 @@
+import { devpassOgImage, ogContentType, ogSize } from "@/lib/og";
+
+export const alt = "DevPass Model Census — coding models rated by developers";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default async function ModelCensusOgImage({
+	params,
+}: {
+	params: Promise<{ year: string }>;
+}) {
+	const { year } = await params;
+	return devpassOgImage({
+		eyebrow: `${year} Model Census`,
+		title: "Which coding models are actually worth the money?",
+		subtitle:
+			"Value, quality, and speed scores from DevPass developers with verified real-world usage.",
+		path: `/data/${year}`,
+	});
+}

--- a/apps/code/src/app/data/[year]/page.tsx
+++ b/apps/code/src/app/data/[year]/page.tsx
@@ -47,10 +47,10 @@ export async function generateMetadata({
 	if (!year) {
 		return {};
 	}
-	const title = `The ${year} DevPass Model Census — coding models rated by the developers who pay for them`;
-	const description = `Value, quality, and speed scores for coding models, rated only by DevPass developers with verified real-world usage. No benchmarks, no vibes — shipped-code verdicts.`;
+	const title = `The ${year} DevPass Model Census — Coding Models Rated by Developers`;
+	const description = `Value, quality, and speed scores for coding models, rated only by DevPass developers with verified real-world usage. No benchmarks — shipped-code verdicts.`;
 	return {
-		title,
+		title: { absolute: title },
 		description,
 		alternates: { canonical: `/data/${year}` },
 		openGraph: {

--- a/apps/code/src/app/guides/opengraph-image.tsx
+++ b/apps/code/src/app/guides/opengraph-image.tsx
@@ -1,0 +1,15 @@
+import { devpassOgImage, ogContentType, ogSize } from "@/lib/og";
+
+export const alt = "DevPass setup guides for coding agents";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function GuidesOgImage() {
+	return devpassOgImage({
+		eyebrow: "Guides",
+		title: "Plug DevPass into your coding agent",
+		subtitle:
+			"Step-by-step setup for Claude Code, OpenCode, Cursor, Cline, and every OpenAI-compatible tool.",
+		path: "/guides",
+	});
+}

--- a/apps/code/src/app/guides/page.tsx
+++ b/apps/code/src/app/guides/page.tsx
@@ -7,10 +7,17 @@ import { GuidesGrid } from "./GuidesGrid";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-	title: "Guides — DevPass",
+	title: "Setup Guides for Coding Agents",
 	description:
 		"Setup guides for integrating DevPass with Claude Code, Cursor, Cline, n8n, OpenCode, and every other coding tool.",
 	alternates: { canonical: "/guides" },
+	openGraph: {
+		title: "DevPass Setup Guides for Coding Agents",
+		description:
+			"Setup guides for integrating DevPass with Claude Code, Cursor, Cline, n8n, OpenCode, and every other coding tool.",
+		type: "website",
+		url: "https://devpass.llmgateway.io/guides",
+	},
 };
 
 export default function GuidesPage() {

--- a/apps/code/src/app/layout.tsx
+++ b/apps/code/src/app/layout.tsx
@@ -67,7 +67,6 @@ export const metadata: Metadata = {
 		title: "DevPass by LLM Gateway - All-Access Dev Plans for AI Coding",
 		description:
 			"One subscription, every coding model. Fixed-price dev plans for Claude Code, Cursor, and 200+ models.",
-		images: ["/opengraph.png?v=2"],
 		creator: "@llmgateway",
 	},
 };

--- a/apps/code/src/app/leaderboard/opengraph-image.tsx
+++ b/apps/code/src/app/leaderboard/opengraph-image.tsx
@@ -1,0 +1,15 @@
+import { devpassOgImage, ogContentType, ogSize } from "@/lib/og";
+
+export const alt = "DevPass leaderboard — developers ranked by tokens routed";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function LeaderboardOgImage() {
+	return devpassOgImage({
+		eyebrow: "Leaderboard",
+		title: "The most prolific developers on DevPass",
+		subtitle:
+			"Ranked by tokens routed through one key — make your profile public to claim your spot.",
+		path: "/leaderboard",
+	});
+}

--- a/apps/code/src/app/leaderboard/page.tsx
+++ b/apps/code/src/app/leaderboard/page.tsx
@@ -15,7 +15,7 @@ const BASE_URL = "https://devpass.llmgateway.io";
 export const revalidate = 300;
 
 export const metadata: Metadata = {
-	title: "DevPass Leaderboard — Developers ranked by tokens routed",
+	title: { absolute: "DevPass Leaderboard — Top Developers by Tokens Routed" },
 	description:
 		"See which developers route the most tokens through DevPass — one key, every model. Make your profile public to claim your spot.",
 	alternates: { canonical: "/leaderboard" },

--- a/apps/code/src/app/legal/privacy/opengraph-image.tsx
+++ b/apps/code/src/app/legal/privacy/opengraph-image.tsx
@@ -1,0 +1,15 @@
+import { devpassOgImage, ogContentType, ogSize } from "@/lib/og";
+
+export const alt = "DevPass supplemental Privacy Policy";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function PrivacyOgImage() {
+	return devpassOgImage({
+		eyebrow: "Legal",
+		title: "DevPass Privacy Policy",
+		subtitle:
+			"How DevPass handles request retention, per-agent metadata, AI provider routing, and sub-processors.",
+		path: "/legal/privacy",
+	});
+}

--- a/apps/code/src/app/legal/privacy/page.tsx
+++ b/apps/code/src/app/legal/privacy/page.tsx
@@ -3,10 +3,17 @@ import { LegalSummary } from "@/components/LegalSummary";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-	title: "Privacy Policy — DevPass",
+	title: "Privacy Policy",
 	description:
-		"Supplemental DevPass Privacy Policy. It builds on the LLM Gateway Privacy Policy and covers DevPass-specific request retention, per-agent metadata, AI provider routing, and sub-processors.",
+		"Supplemental DevPass Privacy Policy covering request retention, per-agent metadata, AI provider routing, and sub-processors, on top of the LLM Gateway policy.",
 	alternates: { canonical: "/legal/privacy" },
+	openGraph: {
+		title: "DevPass Supplemental Privacy Policy",
+		description:
+			"How DevPass handles request retention, per-agent metadata, AI provider routing, and sub-processors.",
+		type: "article",
+		url: "https://devpass.llmgateway.io/legal/privacy",
+	},
 };
 
 export default function PrivacyPage() {

--- a/apps/code/src/app/legal/terms/opengraph-image.tsx
+++ b/apps/code/src/app/legal/terms/opengraph-image.tsx
@@ -1,0 +1,15 @@
+import { devpassOgImage, ogContentType, ogSize } from "@/lib/og";
+
+export const alt = "DevPass supplemental Terms of Use";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function TermsOgImage() {
+	return devpassOgImage({
+		eyebrow: "Legal",
+		title: "DevPass Terms of Use",
+		subtitle:
+			"Supplemental terms for the flat-rate subscription: fair use, one account per developer, and approved coding tools.",
+		path: "/legal/terms",
+	});
+}

--- a/apps/code/src/app/legal/terms/page.tsx
+++ b/apps/code/src/app/legal/terms/page.tsx
@@ -5,10 +5,17 @@ import { LegalSummary } from "@/components/LegalSummary";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-	title: "Terms of Use — DevPass",
+	title: "Terms of Use",
 	description:
-		"Supplemental DevPass Terms of Use. These build on the LLM Gateway Terms of Use and cover the DevPass flat-rate subscription: fair-use limits, one account per developer, personal (non-team) use, approved coding tools, and AI provider policies.",
+		"Supplemental DevPass Terms of Use for the flat-rate subscription: fair-use limits, one account per developer, approved coding tools, and AI provider policies.",
 	alternates: { canonical: "/legal/terms" },
+	openGraph: {
+		title: "DevPass Supplemental Terms of Use",
+		description:
+			"The terms that govern the DevPass flat-rate subscription, on top of the LLM Gateway Terms of Use.",
+		type: "article",
+		url: "https://devpass.llmgateway.io/legal/terms",
+	},
 };
 
 export default function TermsPage() {

--- a/apps/code/src/app/login/page.tsx
+++ b/apps/code/src/app/login/page.tsx
@@ -234,11 +234,11 @@ function LoginForm() {
 								DevPass
 							</span>
 						</div>
-						<h1 className="text-4xl font-bold leading-tight tracking-tight text-white xl:text-5xl">
+						<p className="text-4xl font-bold leading-tight tracking-tight text-white xl:text-5xl">
 							Welcome back,
 							<br />
 							developer.
-						</h1>
+						</p>
 						<p className="mt-4 max-w-md text-lg text-zinc-400">
 							Your dev environment is ready. Pick up where you left off.
 						</p>

--- a/apps/code/src/app/models/opengraph-image.tsx
+++ b/apps/code/src/app/models/opengraph-image.tsx
@@ -1,0 +1,16 @@
+import { devpassOgImage, ogContentType, ogSize } from "@/lib/og";
+
+import { MARKETING_STATS } from "@llmgateway/shared";
+
+export const alt = "Coding models on DevPass — full directory";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function ModelsOgImage() {
+	return devpassOgImage({
+		eyebrow: "Models",
+		title: "Every coding model, one key",
+		subtitle: `Browse ${MARKETING_STATS.models} models — filter by tier, capabilities, provider, price, and context size.`,
+		path: "/models",
+	});
+}

--- a/apps/code/src/app/models/page.tsx
+++ b/apps/code/src/app/models/page.tsx
@@ -21,9 +21,11 @@ const PREMIUM_INPUT_PER_M = HIGH_COST_INPUT_PRICE * 1e6;
 const PREMIUM_OUTPUT_PER_M = HIGH_COST_OUTPUT_PRICE * 1e6;
 
 export const metadata: Metadata = {
-	title: "Coding Models on DevPass — Full Directory",
+	title: {
+		absolute: "Coding Models on DevPass — Full Directory | LLM Gateway",
+	},
 	description:
-		"Browse the coding models available on DevPass — search, filter by pricing tier, capabilities, provider, price, and context size. Premium models are marked exactly as the gateway classifies them.",
+		"Browse every coding model on DevPass — search and filter by pricing tier, capabilities, provider, price, and context size. Premium models marked.",
 	alternates: { canonical: "/models" },
 	openGraph: {
 		title: "Coding Models on DevPass — Full Directory",

--- a/apps/code/src/app/pricing/opengraph-image.tsx
+++ b/apps/code/src/app/pricing/opengraph-image.tsx
@@ -1,0 +1,16 @@
+import { devpassOgImage, ogContentType, ogSize } from "@/lib/og";
+
+import { DEV_PLAN_PRICES } from "@llmgateway/shared";
+
+export const alt = "DevPass pricing — flat-rate AI coding plans";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function PricingOgImage() {
+	return devpassOgImage({
+		eyebrow: "Pricing",
+		title: "Flat rate. Every model. No token math.",
+		subtitle: `Lite, Pro, and Max from $${DEV_PLAN_PRICES.lite}/month — 200+ coding models metered at provider rates, in any coding agent.`,
+		path: "/pricing",
+	});
+}

--- a/apps/code/src/app/pricing/page.tsx
+++ b/apps/code/src/app/pricing/page.tsx
@@ -32,14 +32,16 @@ import {
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-	title: "Pricing — DevPass",
+	title: "Pricing — Flat-Rate AI Coding Plans",
 	description:
 		"Flat-rate AI coding plans. Lite, Pro, and Max — every plan includes 200+ models metered at provider rates.",
 	alternates: { canonical: "/pricing" },
 	openGraph: {
-		title: "Pricing — DevPass",
+		title: "DevPass Pricing — Flat-Rate AI Coding Plans",
 		description:
 			"Flat-rate AI coding plans. Every plan includes 200+ models — Claude Opus 4.8, GPT-5.5, Gemini 3.1 Pro, GLM-4.7, and more.",
+		type: "website",
+		url: "https://devpass.llmgateway.io/pricing",
 	},
 };
 

--- a/apps/code/src/app/signup/page.tsx
+++ b/apps/code/src/app/signup/page.tsx
@@ -167,11 +167,11 @@ function SignupForm() {
 								DevPass
 							</span>
 						</div>
-						<h1 className="text-4xl font-bold leading-tight tracking-tight text-white xl:text-5xl">
+						<p className="text-4xl font-bold leading-tight tracking-tight text-white xl:text-5xl">
 							Ship faster
 							<br />
 							with AI.
-						</h1>
+						</p>
 						<p className="mt-4 max-w-md text-lg text-zinc-400">
 							Dev plans, coding tools, and AI-powered workflows for individual
 							developers.

--- a/apps/code/src/components/Footer.tsx
+++ b/apps/code/src/components/Footer.tsx
@@ -203,6 +203,46 @@ export function Footer() {
 									</Link>
 								</li>
 								<li>
+									<Link
+										href="/claude-code-alternative"
+										className="text-sm hover:underline underline-offset-4 hover:text-foreground"
+									>
+										Claude Code Alternative
+									</Link>
+								</li>
+								<li>
+									<Link
+										href="/models"
+										className="text-sm hover:underline underline-offset-4 hover:text-foreground"
+									>
+										Model Directory
+									</Link>
+								</li>
+								<li>
+									<Link
+										href="/guides"
+										className="text-sm hover:underline underline-offset-4 hover:text-foreground"
+									>
+										Setup Guides
+									</Link>
+								</li>
+								<li>
+									<Link
+										href={`/data/${new Date().getUTCFullYear()}`}
+										className="text-sm hover:underline underline-offset-4 hover:text-foreground"
+									>
+										Model Census
+									</Link>
+								</li>
+								<li>
+									<Link
+										href="/leaderboard"
+										className="text-sm hover:underline underline-offset-4 hover:text-foreground"
+									>
+										Leaderboard
+									</Link>
+								</li>
+								<li>
 									<a
 										href={`${config.uiUrl}/models?from=devpass`}
 										rel="noopener"

--- a/apps/code/src/lib/og.tsx
+++ b/apps/code/src/lib/og.tsx
@@ -1,0 +1,133 @@
+import { ImageResponse } from "next/og";
+
+export const ogSize = { width: 1200, height: 630 };
+export const ogContentType = "image/png";
+
+interface DevPassOgOptions {
+	eyebrow: string;
+	title: string;
+	subtitle: string;
+	path: string;
+}
+
+/**
+ * Shared DevPass OpenGraph card so every marketing page ships a branded
+ * 1200x630 image. Inline styles only — rendered by next/og (Satori).
+ */
+export function devpassOgImage({
+	eyebrow,
+	title,
+	subtitle,
+	path,
+}: DevPassOgOptions) {
+	return new ImageResponse(
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				display: "flex",
+				flexDirection: "column",
+				justifyContent: "space-between",
+				background: "#0a0a0b",
+				backgroundImage:
+					"radial-gradient(900px 500px at 50% -10%, rgba(255,255,255,0.10), transparent 60%), radial-gradient(700px 420px at 100% 110%, rgba(16,185,129,0.14), transparent 60%)",
+				padding: 64,
+				fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+			}}
+		>
+			<div
+				style={{
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "space-between",
+				}}
+			>
+				<div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							width: 44,
+							height: 44,
+							borderRadius: 12,
+							background: "#fafafa",
+							color: "#0a0a0b",
+							fontSize: 22,
+							fontWeight: 700,
+						}}
+					>
+						{"</>"}
+					</div>
+					<div style={{ display: "flex", alignItems: "baseline", gap: 10 }}>
+						<span style={{ color: "#fafafa", fontSize: 30, fontWeight: 700 }}>
+							DevPass
+						</span>
+						<span style={{ color: "#71717a", fontSize: 20 }}>
+							by LLM Gateway
+						</span>
+					</div>
+				</div>
+				<div
+					style={{
+						display: "flex",
+						padding: "10px 20px",
+						borderRadius: 9999,
+						background: "rgba(255,255,255,0.06)",
+						border: "1px solid rgba(255,255,255,0.14)",
+						color: "#d4d4d8",
+						fontSize: 20,
+						fontWeight: 600,
+						letterSpacing: 2,
+						textTransform: "uppercase",
+					}}
+				>
+					{eyebrow}
+				</div>
+			</div>
+
+			<div style={{ display: "flex", flexDirection: "column", gap: 26 }}>
+				<div
+					style={{
+						display: "flex",
+						color: "#fafafa",
+						fontSize: 72,
+						fontWeight: 700,
+						lineHeight: 1.05,
+						letterSpacing: "-0.02em",
+						maxWidth: 1000,
+					}}
+				>
+					{title}
+				</div>
+				<div
+					style={{
+						display: "flex",
+						color: "#a1a1aa",
+						fontSize: 30,
+						lineHeight: 1.35,
+						maxWidth: 900,
+					}}
+				>
+					{subtitle}
+				</div>
+			</div>
+
+			<div
+				style={{
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "space-between",
+					color: "#71717a",
+					fontSize: 20,
+				}}
+			>
+				<span style={{ color: "#fafafa", fontWeight: 600 }}>
+					devpass.llmgateway.io{path}
+				</span>
+				<span>One key. Every model. Flat price.</span>
+			</div>
+		</div>,
+		ogSize,
+	);
+}

--- a/apps/playground/public/llms.txt
+++ b/apps/playground/public/llms.txt
@@ -13,9 +13,20 @@
 ## Key pages
 
 - [Lounge](https://lounge.llmgateway.io): The members' lounge for AI.
+- [Pricing](https://lounge.llmgateway.io/pricing): Starter, Plus, and Pro memberships with included usage.
+- [Pricing (machine-readable)](https://lounge.llmgateway.io/pricing.md): Plain-markdown Lounge pricing for AI agents.
+- [Compare](https://lounge.llmgateway.io/compare): Lounge vs ChatGPT, Claude, Gemini, Poe, T3 Chat, Perplexity, and OpenRouter.
+- [Image studio](https://lounge.llmgateway.io/image): DALL·E, Flux, Stable Diffusion, and Seedream side by side.
+- [Video studio](https://lounge.llmgateway.io/video): Veo, Wan, and other text-to-video models.
+- [Audio studio](https://lounge.llmgateway.io/audio): ElevenLabs, OpenAI, and Gemini text to speech.
+- [Voice calls](https://lounge.llmgateway.io/realtime): Realtime speech-to-speech conversations.
+- [Group chat](https://lounge.llmgateway.io/group): One prompt to many models, compared side by side.
+- [Canvas](https://lounge.llmgateway.io/canvas): Build UIs from JSON specs with live preview.
+- [Sandbox Escape](https://lounge.llmgateway.io/escape): Watch a model try to break out of a sandboxed container, with a public leaderboard.
+- [Leaderboard](https://lounge.llmgateway.io/leaderboard): The most active Lounge members.
 - [Models](https://llmgateway.io/models): Every supported model with pricing and capabilities.
 - [LLM Gateway](https://llmgateway.io): The open-source gateway platform behind Lounge.
-- [Pricing (machine-readable)](https://llmgateway.io/pricing.md): Plain-markdown pricing for the whole platform.
+- [Platform pricing (machine-readable)](https://llmgateway.io/pricing.md): Plain-markdown pricing for the whole platform.
 
 ## Notes
 

--- a/apps/playground/public/pricing.md
+++ b/apps/playground/public/pricing.md
@@ -1,0 +1,42 @@
+# Lounge by LLM Gateway — Pricing
+
+Last updated: 2026-09-01
+
+> Lounge is a monthly AI chat membership: one subscription for 200+ models from OpenAI, Anthropic, Google, xAI, DeepSeek, Meta, Mistral, and more, plus image, video, and audio studios and multi-model group chat. Each tier includes a monthly credit allowance metered at provider list rates.
+
+## Starter
+
+- Price: $9/month
+- Included usage: $18 of model usage per month (2× what you pay)
+- Models: Claude Sonnet plus fast models such as Claude Haiku and Gemini Flash
+- Chat, image, video, and audio studios; real-time usage and per-message cost
+
+## Plus
+
+- Price: $19/month
+- Included usage: $47.50 of model usage per month (2.5× what you pay)
+- Models: every frontier model — Claude Opus, GPT-5, Gemini Pro, Grok, and more
+- Replaces ChatGPT Plus, Claude Pro, and Gemini Advanced with one bill
+
+## Pro
+
+- Price: $49/month
+- Included usage: $147 of model usage per month (3× what you pay)
+- Everything in Plus with the most headroom for all-day, heavy use
+
+## Every membership includes
+
+- Switch models mid-conversation; run the same prompt against several models at once
+- Image, video, and audio generation from the same credit balance
+- Projects with knowledge files, shareable read-only chat links
+- Free to start with no credit card; upgrade or cancel anytime — access continues until the end of the cycle
+
+## Refunds
+
+- Self-serve from the billing page within 14 days of your first month while less than 20% of the allowance has been used.
+
+## Notes
+
+- Human-readable pricing page: https://lounge.llmgateway.io/pricing
+- Comparisons with ChatGPT, Claude, Gemini, Poe, Perplexity, and OpenRouter: https://lounge.llmgateway.io/compare
+- Platform-wide pricing (LLM Gateway, DevPass, Lounge): https://llmgateway.io/pricing.md

--- a/apps/playground/src/app/audio/opengraph-image.tsx
+++ b/apps/playground/src/app/audio/opengraph-image.tsx
@@ -1,0 +1,15 @@
+import { loungeOgImage, ogContentType, ogSize } from "@/lib/og";
+
+export const alt = "AI text to speech — ElevenLabs, OpenAI, and Gemini voices";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function AudioStudioOgImage() {
+	return loungeOgImage({
+		eyebrow: "Audio studio",
+		title: "Text to speech with every major voice model",
+		subtitle:
+			"ElevenLabs, OpenAI, and Gemini TTS — pick a voice, compare providers, and download the audio.",
+		path: "/audio",
+	});
+}

--- a/apps/playground/src/app/audio/page.tsx
+++ b/apps/playground/src/app/audio/page.tsx
@@ -15,10 +15,17 @@ import type { Project, Organization } from "@/lib/types";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-	title: "AI Audio Generator — Text to Speech with ElevenLabs, OpenAI & Gemini",
+	title: "AI Text to Speech — ElevenLabs, OpenAI & Gemini",
 	description:
 		"Generate speech from text with ElevenLabs, OpenAI, and Gemini TTS models. Pick voices, compare providers, and download the audio in one playground.",
 	alternates: { canonical: "/audio" },
+	openGraph: {
+		title: "AI Text to Speech — ElevenLabs, OpenAI & Gemini | Lounge",
+		description:
+			"Generate speech from text with ElevenLabs, OpenAI, and Gemini TTS models. Pick voices, compare providers, and download the audio.",
+		type: "website",
+		url: "https://lounge.llmgateway.io/audio",
+	},
 };
 
 export default async function AudioPage({

--- a/apps/playground/src/app/canvas/opengraph-image.tsx
+++ b/apps/playground/src/app/canvas/opengraph-image.tsx
@@ -1,0 +1,15 @@
+import { loungeOgImage, ogContentType, ogSize } from "@/lib/og";
+
+export const alt = "Canvas — build UIs from JSON specs with live preview";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function CanvasOgImage() {
+	return loungeOgImage({
+		eyebrow: "Canvas",
+		title: "Build UIs from JSON specs",
+		subtitle:
+			"Generate and edit interactive UI specs with any of 200+ models, preview live, and export to PDF or PNG.",
+		path: "/canvas",
+	});
+}

--- a/apps/playground/src/app/canvas/page.tsx
+++ b/apps/playground/src/app/canvas/page.tsx
@@ -15,10 +15,17 @@ import type { Project, Organization } from "@/lib/types";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-	title: "Canvas — Build UIs from JSON Specs with Live Preview",
+	title: "Canvas — Build UIs from JSON Specs",
 	description:
 		"Build UIs from JSON specs with live preview, PDF and image export. Part of Lounge by LLM Gateway.",
 	alternates: { canonical: "/canvas" },
+	openGraph: {
+		title: "Canvas — Build UIs from JSON Specs | Lounge",
+		description:
+			"Build UIs from JSON specs with live preview, PDF and image export. Part of Lounge by LLM Gateway.",
+		type: "website",
+		url: "https://lounge.llmgateway.io/canvas",
+	},
 };
 
 export default async function CanvasPage({

--- a/apps/playground/src/app/compare/page.tsx
+++ b/apps/playground/src/app/compare/page.tsx
@@ -8,7 +8,7 @@ import { comparisons, US } from "@/lib/comparisons";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-	title: "Compare Lounge — vs ChatGPT, Claude, Gemini & more",
+	title: "Compare Lounge vs ChatGPT, Claude & Gemini",
 	description:
 		"Compare Lounge to ChatGPT, Claude, Gemini, Poe, Perplexity and OpenRouter — every frontier model on one $19/mo subscription.",
 	alternates: { canonical: "/compare" },

--- a/apps/playground/src/app/escape/opengraph-image.tsx
+++ b/apps/playground/src/app/escape/opengraph-image.tsx
@@ -1,0 +1,15 @@
+import { loungeOgImage, ogContentType, ogSize } from "@/lib/og";
+
+export const alt = "Sandbox Escape — can your LLM break out?";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function EscapeOgImage() {
+	return loungeOgImage({
+		eyebrow: "Sandbox Escape",
+		title: "Can your LLM break out?",
+		subtitle:
+			"Every model gets the same five maps. One API call per step. See which one actually escapes.",
+		path: "/escape",
+	});
+}

--- a/apps/playground/src/app/escape/page.tsx
+++ b/apps/playground/src/app/escape/page.tsx
@@ -20,7 +20,7 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
 	title: "Sandbox Escape — Can Your LLM Break Out?",
 	description:
-		"Pick a model and watch it try to escape a sandboxed container, one billed API call per move. Five levels, a public leaderboard, and a shareable result. Part of Lounge by LLM Gateway.",
+		"Pick a model and watch it try to escape a sandboxed container, one billed API call per move. Five levels, a public leaderboard, and a shareable result.",
 	alternates: { canonical: "/escape" },
 	openGraph: {
 		title: "Sandbox Escape — Can Your LLM Break Out?",

--- a/apps/playground/src/app/group/opengraph-image.tsx
+++ b/apps/playground/src/app/group/opengraph-image.tsx
@@ -1,0 +1,15 @@
+import { loungeOgImage, ogContentType, ogSize } from "@/lib/og";
+
+export const alt = "Group chat — compare AI models side by side";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function GroupChatOgImage() {
+	return loungeOgImage({
+		eyebrow: "Group chat",
+		title: "One prompt. Every model. Side by side.",
+		subtitle:
+			"Send the same prompt to GPT, Claude, Gemini, Grok, and more at once and compare the streamed answers.",
+		path: "/group",
+	});
+}

--- a/apps/playground/src/app/group/page.tsx
+++ b/apps/playground/src/app/group/page.tsx
@@ -11,10 +11,17 @@ import type { Project, Organization } from "@/lib/types";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-	title: "Group Chat - Compare AI Models Side by Side",
+	title: "Group Chat — Compare AI Models Side by Side",
 	description:
-		"Send one prompt to multiple AI models simultaneously. Compare responses from GPT-4, Claude, Gemini, and more in real-time.",
+		"Send one prompt to multiple AI models simultaneously. Compare responses from GPT-5, Claude, Gemini, and more in real time.",
 	alternates: { canonical: "/group" },
+	openGraph: {
+		title: "Group Chat — Compare AI Models Side by Side | Lounge",
+		description:
+			"Send one prompt to multiple AI models simultaneously. Compare responses from GPT-5, Claude, Gemini, and more in real time.",
+		type: "website",
+		url: "https://lounge.llmgateway.io/group",
+	},
 };
 
 export interface GatewayModel {

--- a/apps/playground/src/app/image/opengraph-image.tsx
+++ b/apps/playground/src/app/image/opengraph-image.tsx
@@ -1,0 +1,16 @@
+import { loungeOgImage, ogContentType, ogSize } from "@/lib/og";
+
+export const alt =
+	"AI image generator — DALL·E, Flux, Stable Diffusion side by side";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function ImageStudioOgImage() {
+	return loungeOgImage({
+		eyebrow: "Image studio",
+		title: "AI image generation, side by side",
+		subtitle:
+			"DALL·E, Flux, Stable Diffusion, and Seedream — one prompt, up to four variants, one membership.",
+		path: "/image",
+	});
+}

--- a/apps/playground/src/app/image/page.tsx
+++ b/apps/playground/src/app/image/page.tsx
@@ -15,10 +15,17 @@ import type { Project, Organization } from "@/lib/types";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-	title: "AI Image Generator — DALL·E, Flux, Stable Diffusion Side-by-Side",
+	title: "AI Image Generator — DALL·E, Flux, Stable Diffusion",
 	description:
 		"Generate images with DALL-E, Stable Diffusion, Flux, and other AI models. Compare outputs across providers in one playground.",
 	alternates: { canonical: "/image" },
+	openGraph: {
+		title: "AI Image Generator — DALL·E, Flux, Stable Diffusion | Lounge",
+		description:
+			"Generate images with DALL-E, Stable Diffusion, Flux, and other AI models. Compare outputs across providers in one playground.",
+		type: "website",
+		url: "https://lounge.llmgateway.io/image",
+	},
 };
 
 export default async function ImagePage({

--- a/apps/playground/src/app/layout.tsx
+++ b/apps/playground/src/app/layout.tsx
@@ -69,7 +69,6 @@ export const metadata: Metadata = {
 		title: `${BRAND.name} — Chat with 200+ AI Models (GPT, Claude, Gemini)`,
 		description:
 			"The members' lounge for AI. Chat, generate images and videos, and run multi-model group chats — every frontier model, one membership.",
-		images: ["/opengraph.png?v=3"],
 		creator: "@llmgateway",
 	},
 };

--- a/apps/playground/src/app/leaderboard/opengraph-image.tsx
+++ b/apps/playground/src/app/leaderboard/opengraph-image.tsx
@@ -1,0 +1,15 @@
+import { loungeOgImage, ogContentType, ogSize } from "@/lib/og";
+
+export const alt = "Lounge leaderboard — the most active members";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function LeaderboardOgImage() {
+	return loungeOgImage({
+		eyebrow: "Leaderboard",
+		title: "The most active members of the Lounge",
+		subtitle:
+			"Ranked by points earned chatting and creating across every frontier model.",
+		path: "/leaderboard",
+	});
+}

--- a/apps/playground/src/app/leaderboard/page.tsx
+++ b/apps/playground/src/app/leaderboard/page.tsx
@@ -10,11 +10,18 @@ import type { Metadata } from "next";
 export const revalidate = 300;
 
 export const metadata: Metadata = {
-	title: "Leaderboard",
+	title: "Leaderboard — Most Active Members",
 	description:
 		"The most active members of the Lounge, ranked by points earned chatting and creating across every frontier model.",
 	alternates: {
 		canonical: "/leaderboard",
+	},
+	openGraph: {
+		title: "Lounge Leaderboard — Most Active Members",
+		description:
+			"The most active members of the Lounge, ranked by points earned chatting and creating across every frontier model.",
+		type: "website",
+		url: "https://lounge.llmgateway.io/leaderboard",
 	},
 };
 

--- a/apps/playground/src/app/org/layout.tsx
+++ b/apps/playground/src/app/org/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+// Org-scoped shared-chat views are member-only; keep them out of search.
+export const metadata: Metadata = {
+	robots: { index: false, follow: false },
+};
+
+export default function OrgLayout({ children }: { children: ReactNode }) {
+	return children;
+}

--- a/apps/playground/src/app/pricing/opengraph-image.tsx
+++ b/apps/playground/src/app/pricing/opengraph-image.tsx
@@ -1,0 +1,16 @@
+import { loungeOgImage, ogContentType, ogSize } from "@/lib/og";
+
+import { CHAT_PLAN_PRICES } from "@llmgateway/shared";
+
+export const alt = "Lounge membership pricing";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function PricingOgImage() {
+	return loungeOgImage({
+		eyebrow: "Pricing",
+		title: "Every frontier model. One membership.",
+		subtitle: `Claude Opus, GPT-5, Gemini, and Grok from $${CHAT_PLAN_PRICES.plus}/mo — start on fast models from $${CHAT_PLAN_PRICES.starter}/mo.`,
+		path: "/pricing",
+	});
+}

--- a/apps/playground/src/app/pricing/page.tsx
+++ b/apps/playground/src/app/pricing/page.tsx
@@ -16,9 +16,16 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
 	title: "Membership Pricing",
 	description:
-		"Every frontier model in one membership — Claude Opus, GPT-5, Gemini and Grok, from $19/mo. Start on fast models from $9/mo. Replaces ChatGPT Plus, Claude Pro and Gemini Advanced — with more usage than you pay for.",
+		"Every frontier model in one membership — Claude Opus, GPT-5, Gemini and Grok from $19/mo, fast models from $9/mo. Replaces ChatGPT Plus, Claude Pro and Gemini Advanced.",
 	alternates: {
 		canonical: "/pricing",
+	},
+	openGraph: {
+		title: "Lounge Membership Pricing — Every Frontier Model, One Plan",
+		description:
+			"Claude Opus, GPT-5, Gemini and Grok from $19/mo, fast models from $9/mo. Replaces ChatGPT Plus, Claude Pro and Gemini Advanced.",
+		type: "website",
+		url: "https://lounge.llmgateway.io/pricing",
 	},
 };
 

--- a/apps/playground/src/app/projects/page.tsx
+++ b/apps/playground/src/app/projects/page.tsx
@@ -2,6 +2,12 @@ import ProjectsPageClient from "@/components/playground/projects-page-client";
 import { fetchServerData } from "@/lib/server-api";
 
 import type { Organization } from "@/lib/types";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+	title: "Projects",
+	robots: { index: false, follow: false },
+};
 
 export default async function ProjectsPage({
 	searchParams,

--- a/apps/playground/src/app/realtime/opengraph-image.tsx
+++ b/apps/playground/src/app/realtime/opengraph-image.tsx
@@ -1,0 +1,15 @@
+import { loungeOgImage, ogContentType, ogSize } from "@/lib/og";
+
+export const alt = "AI voice calls — realtime speech-to-speech";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function RealtimeOgImage() {
+	return loungeOgImage({
+		eyebrow: "Voice",
+		title: "Talk to AI in real time",
+		subtitle:
+			"Live speech-to-speech calls — pick a model and voice, interrupt mid-sentence, and read both transcripts.",
+		path: "/realtime",
+	});
+}

--- a/apps/playground/src/app/realtime/page.tsx
+++ b/apps/playground/src/app/realtime/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { LastUsedProjectTracker } from "@/components/last-used-project-tracker";
 import RealtimePageClient from "@/components/playground/realtime-page-client";
+import { PlaygroundSeoSection } from "@/components/seo/playground-seo-section";
 import { fetchModels, fetchProviders } from "@/lib/fetch-models";
 import {
 	decodeModelPreference,
@@ -14,10 +15,17 @@ import type { Project, Organization } from "@/lib/types";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-	title: "AI Voice Calls — Realtime Speech-to-Speech Playground",
+	title: "AI Voice Calls — Realtime Speech to Speech",
 	description:
 		"Have live voice conversations with realtime speech-to-speech models. Pick a model and voice, talk naturally, interrupt mid-sentence, and read both transcripts.",
 	alternates: { canonical: "/realtime" },
+	openGraph: {
+		title: "AI Voice Calls — Realtime Speech to Speech | Lounge",
+		description:
+			"Live voice conversations with realtime speech-to-speech models. Pick a model and voice, interrupt mid-sentence, and read both transcripts.",
+		type: "website",
+		url: "https://lounge.llmgateway.io/realtime",
+	},
 };
 
 export default async function RealtimePage({
@@ -117,6 +125,7 @@ export default async function RealtimePage({
 					projectId={selectedProject.id}
 				/>
 			) : null}
+			<PlaygroundSeoSection variant="realtime" />
 			<RealtimePageClient
 				models={models}
 				providers={providers}

--- a/apps/playground/src/app/sitemap.ts
+++ b/apps/playground/src/app/sitemap.ts
@@ -77,6 +77,24 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 			priority: 0.7,
 		},
 		{
+			url: `${baseUrl}/realtime`,
+			lastModified: now,
+			changeFrequency: "weekly",
+			priority: 0.8,
+		},
+		{
+			url: `${baseUrl}/escape`,
+			lastModified: now,
+			changeFrequency: "weekly",
+			priority: 0.7,
+		},
+		{
+			url: `${baseUrl}/leaderboard`,
+			lastModified: now,
+			changeFrequency: "daily",
+			priority: 0.6,
+		},
+		{
 			url: `${baseUrl}/compare`,
 			lastModified: now,
 			changeFrequency: "weekly",

--- a/apps/playground/src/app/skills/page.tsx
+++ b/apps/playground/src/app/skills/page.tsx
@@ -2,6 +2,12 @@ import SkillsPageClient from "@/components/playground/skills-page-client";
 import { fetchServerData } from "@/lib/server-api";
 
 import type { Organization } from "@/lib/types";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+	title: "Skills",
+	robots: { index: false, follow: false },
+};
 
 export default async function SkillsPage({
 	searchParams,

--- a/apps/playground/src/app/video/opengraph-image.tsx
+++ b/apps/playground/src/app/video/opengraph-image.tsx
@@ -1,0 +1,15 @@
+import { loungeOgImage, ogContentType, ogSize } from "@/lib/og";
+
+export const alt = "AI video generator — Veo, Wan, and more in one place";
+export const size = ogSize;
+export const contentType = ogContentType;
+
+export default function VideoStudioOgImage() {
+	return loungeOgImage({
+		eyebrow: "Video studio",
+		title: "AI video generation in one place",
+		subtitle:
+			"Generate short videos with Google Veo, Alibaba Wan, and other text-to-video models — preview and compare inline.",
+		path: "/video",
+	});
+}

--- a/apps/playground/src/app/video/page.tsx
+++ b/apps/playground/src/app/video/page.tsx
@@ -15,10 +15,17 @@ import type { Project, Organization } from "@/lib/types";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-	title: "AI Video Generator — Compare Veo, Wan & More in One Place",
+	title: "AI Video Generator — Veo, Wan & More",
 	description:
 		"Generate videos with Veo, Wan, and other AI video models. Preview results and compare providers in Lounge.",
 	alternates: { canonical: "/video" },
+	openGraph: {
+		title: "AI Video Generator — Veo, Wan & More | Lounge",
+		description:
+			"Generate videos with Veo, Wan, and other AI video models. Preview results and compare providers in Lounge.",
+		type: "website",
+		url: "https://lounge.llmgateway.io/video",
+	},
 };
 
 export default async function VideoPage({

--- a/apps/playground/src/components/auth/chat-brand-panel.tsx
+++ b/apps/playground/src/components/auth/chat-brand-panel.tsx
@@ -50,9 +50,9 @@ export function ChatBrandPanel({
 					transition={{ duration: 0.6, ease: "easeOut" }}
 				>
 					<ChatBrandBadge />
-					<h1 className="mt-6 font-display text-4xl font-semibold leading-tight tracking-tight text-white xl:text-5xl">
+					<p className="mt-6 font-display text-4xl font-semibold leading-tight tracking-tight text-white xl:text-5xl">
 						{headline}
-					</h1>
+					</p>
 					<p className="mt-4 max-w-md text-lg text-zinc-400">{subline}</p>
 				</motion.div>
 

--- a/apps/playground/src/components/playground/group-chat-client.tsx
+++ b/apps/playground/src/components/playground/group-chat-client.tsx
@@ -416,9 +416,9 @@ export default function GroupChatClient({
 						<div className="flex items-center gap-3 min-w-0 flex-1">
 							<SidebarTrigger />
 							<div className="flex items-center gap-2 flex-1 min-w-0">
-								<h1 className="text-lg font-semibold whitespace-nowrap">
+								<h2 className="text-lg font-semibold whitespace-nowrap">
 									Group Chat
-								</h1>
+								</h2>
 							</div>
 						</div>
 					</header>

--- a/apps/playground/src/components/seo/playground-seo-section.tsx
+++ b/apps/playground/src/components/seo/playground-seo-section.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 
 export type SeoVariant =
-	"chat" | "image" | "video" | "audio" | "group" | "canvas";
+	"chat" | "image" | "video" | "audio" | "group" | "canvas" | "realtime";
 
 interface VariantContent {
 	h1: string;
@@ -110,6 +110,22 @@ const variants: Record<SeoVariant, VariantContent> = {
 			{ href: "/image", label: "AI image generation" },
 			{ href: "/video", label: "AI video generation" },
 			{ href: "/audio", label: "AI audio generation" },
+			{ href: "/group", label: "Compare models side by side" },
+		],
+	},
+	realtime: {
+		h1: "AI voice calls — realtime speech to speech with any model",
+		intro:
+			"Have a live voice conversation with realtime speech-to-speech models. Pick a model and a voice, talk naturally, interrupt mid-sentence, and read both sides of the transcript afterwards.",
+		bullets: [
+			"Models include OpenAI gpt-realtime and gpt-realtime-mini plus other speech-to-speech providers.",
+			"Barge in mid-sentence; the model stops and listens like a phone call.",
+			"Calls route through LLM Gateway for unified billing and usage tracking.",
+		],
+		related: [
+			{ href: "/", label: "Lounge AI chat" },
+			{ href: "/audio", label: "AI audio generation" },
+			{ href: "/image", label: "AI image generation" },
 			{ href: "/group", label: "Compare models side by side" },
 		],
 	},

--- a/apps/playground/src/lib/og.tsx
+++ b/apps/playground/src/lib/og.tsx
@@ -1,0 +1,119 @@
+import { ImageResponse } from "next/og";
+
+import {
+	LgMark,
+	OG_BACKGROUND,
+	OG_CONTENT_TYPE,
+	OG_GRADIENT,
+	OG_SIZE,
+	Pill,
+} from "@/components/compare/og-shared";
+import { BRAND } from "@/lib/brand";
+
+export const ogSize = OG_SIZE;
+export const ogContentType = OG_CONTENT_TYPE;
+
+interface LoungeOgOptions {
+	eyebrow: string;
+	title: string;
+	subtitle: string;
+	path: string;
+}
+
+/**
+ * Shared Lounge OpenGraph card so every studio and marketing page ships a
+ * branded 1200x630 image. Inline styles only — rendered by next/og (Satori).
+ */
+export function loungeOgImage({
+	eyebrow,
+	title,
+	subtitle,
+	path,
+}: LoungeOgOptions) {
+	return new ImageResponse(
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				display: "flex",
+				flexDirection: "column",
+				justifyContent: "space-between",
+				background: OG_BACKGROUND,
+				backgroundImage: OG_GRADIENT,
+				color: "white",
+				fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, sans-serif",
+				padding: 64,
+				boxSizing: "border-box",
+			}}
+		>
+			<div
+				style={{
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "space-between",
+					width: "100%",
+				}}
+			>
+				<div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+					<LgMark size={44} />
+					<div style={{ display: "flex", flexDirection: "column" }}>
+						<span style={{ fontSize: 26, fontWeight: 700 }}>{BRAND.name}</span>
+						<span
+							style={{
+								fontSize: 16,
+								color: "#A1A1AA",
+								letterSpacing: "0.02em",
+							}}
+						>
+							by {BRAND.publisher}
+						</span>
+					</div>
+				</div>
+				<Pill>{eyebrow}</Pill>
+			</div>
+
+			<div style={{ display: "flex", flexDirection: "column", gap: 22 }}>
+				<span
+					style={{
+						display: "flex",
+						fontSize: 70,
+						fontWeight: 800,
+						lineHeight: 1.05,
+						letterSpacing: "-0.02em",
+						color: "#FAFAFA",
+						maxWidth: 1010,
+					}}
+				>
+					{title}
+				</span>
+				<span
+					style={{
+						display: "flex",
+						fontSize: 28,
+						lineHeight: 1.3,
+						color: "#A1A1AA",
+						maxWidth: 960,
+					}}
+				>
+					{subtitle}
+				</span>
+			</div>
+
+			<div
+				style={{
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "space-between",
+					fontSize: 20,
+					color: "#A1A1AA",
+				}}
+			>
+				<span style={{ color: "#FAFAFA", fontWeight: 600 }}>
+					lounge.llmgateway.io{path}
+				</span>
+				<span>{BRAND.tagline}</span>
+			</div>
+		</div>,
+		ogSize,
+	);
+}

--- a/apps/ui/src/app/about/opengraph-image.tsx
+++ b/apps/ui/src/app/about/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const alt = "About LLM Gateway — who builds it and why";
+
+export default function Image() {
+	return ogImage({
+		eyebrow: "About",
+		title: "Who Builds LLM Gateway, and Why",
+		subtitle:
+			"An open-source LLM API gateway routing requests across 40+ providers through one OpenAI-compatible API.",
+	});
+}

--- a/apps/ui/src/app/about/page.tsx
+++ b/apps/ui/src/app/about/page.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
 		"LLM Gateway is an open-source LLM API gateway routing requests across 40+ providers through one OpenAI-compatible API. Learn who builds it and why.",
 	alternates: { canonical: "/about" },
 	openGraph: {
-		title: "About | LLM Gateway",
+		title: "About LLM Gateway",
 		description:
 			"LLM Gateway is an open-source LLM API gateway routing requests across 40+ providers through one OpenAI-compatible API. Learn who builds it and why.",
 		url: "https://llmgateway.io/about",

--- a/apps/ui/src/app/add-provider/page.tsx
+++ b/apps/ui/src/app/add-provider/page.tsx
@@ -6,14 +6,16 @@ import { getConfig } from "@/lib/config-server";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-	title: "Add a Provider – LLM Gateway",
+	title: "Add a Provider",
 	description:
 		"List your AI provider on LLM Gateway: self-serve via the Airside carrier console, or share your details and our team will get in touch.",
+	alternates: { canonical: "/add-provider" },
 	openGraph: {
-		title: "Add a Provider – LLM Gateway",
+		title: "Add a Provider to LLM Gateway",
 		description:
 			"List your AI provider on LLM Gateway: self-serve via the Airside carrier console, or share your details and our team will get in touch.",
 		type: "website",
+		url: "https://llmgateway.io/add-provider",
 	},
 };
 

--- a/apps/ui/src/app/contact/opengraph-image.tsx
+++ b/apps/ui/src/app/contact/opengraph-image.tsx
@@ -1,0 +1,14 @@
+import { ogContentType, ogImage, ogSize } from "@/lib/og";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const alt = "Contact the LLM Gateway team";
+
+export default function Image() {
+	return ogImage({
+		eyebrow: "Contact",
+		title: "Talk to the LLM Gateway Team",
+		subtitle:
+			"Email support, the Discord community, GitHub issues, and enterprise sales — pick the channel that fits.",
+	});
+}

--- a/apps/ui/src/app/contact/page.tsx
+++ b/apps/ui/src/app/contact/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 		"Contact the LLM Gateway team: email support, Discord community, GitHub issues, and enterprise sales. Company details and postal address included.",
 	alternates: { canonical: "/contact" },
 	openGraph: {
-		title: "Contact | LLM Gateway",
+		title: "Contact LLM Gateway",
 		description:
 			"Contact the LLM Gateway team: email support, Discord community, GitHub issues, and enterprise sales.",
 		url: "https://llmgateway.io/contact",

--- a/apps/ui/src/app/layout.tsx
+++ b/apps/ui/src/app/layout.tsx
@@ -79,7 +79,6 @@ export const metadata: Metadata = {
 		title: "LLM Gateway - Unified API for Multiple LLM Providers",
 		description:
 			"Route, manage, and analyze LLM requests across 40+ providers through one unified API.",
-		images: ["/opengraph.png?v=2"],
 		creator: "@llmgateway",
 	},
 	robots: {

--- a/apps/ui/src/app/partners/page.tsx
+++ b/apps/ui/src/app/partners/page.tsx
@@ -40,7 +40,7 @@ const BASE_URL = "https://llmgateway.io";
 
 const title = "Partners — Infrastructure Behind LLM Gateway";
 const description =
-	"Meet the inference partners powering LLM Gateway, starting with launch partner SCX.ai — Australian sovereign AI serving open models from renewable-powered infrastructure in Sydney.";
+	"Meet the inference partners powering LLM Gateway, starting with launch partner SCX.ai — Australian sovereign AI serving open models from Sydney.";
 
 export const metadata: Metadata = {
 	title,

--- a/apps/ui/src/app/ref/[orgId]/page.tsx
+++ b/apps/ui/src/app/ref/[orgId]/page.tsx
@@ -48,7 +48,12 @@ export async function generateMetadata({
 		title,
 		description,
 		robots: { index: false, follow: false },
-		openGraph: { title, description, type: "website" },
+		openGraph: {
+			title,
+			description,
+			type: "website",
+			images: ["/opengraph.png?v=2"],
+		},
 		twitter: { card: "summary_large_image", title, description },
 	};
 }

--- a/apps/ui/src/content/legal/privacy.md
+++ b/apps/ui/src/content/legal/privacy.md
@@ -3,7 +3,7 @@ id: "2"
 slug: "privacy"
 date: "2026-08-20"
 title: "Privacy Policy"
-description: "Read LLM Gateway’s Privacy Policy to understand how we collect, use, share, and protect your data, our roles as controller and processor, AI provider routing, your GDPR and CCPA rights, data retention, and international transfers."
+description: "How LLM Gateway collects, uses, shares, and protects your data: controller and processor roles, AI provider routing, GDPR and CCPA rights, and retention."
 ---
 
 # Privacy Policy

--- a/apps/ui/src/content/legal/terms.md
+++ b/apps/ui/src/content/legal/terms.md
@@ -3,7 +3,7 @@ id: "1"
 slug: "terms"
 date: "2026-08-18"
 title: "Terms Of Use"
-description: "Review the Terms of Use for LLM Gateway. Learn about account eligibility, billing, credits, AI outputs, acceptable use, warranties, liability, and dispute resolution when using our multi-provider AI gateway platform."
+description: "Terms of Use for LLM Gateway: account eligibility, billing and credits, AI outputs, acceptable use, warranties, liability, and dispute resolution."
 ---
 
 # Terms of Use


### PR DESCRIPTION
## Problem

The monthly SEO + AI-SEO audit (`seo-audit` / `ai-seo` marketing skills, run against the live sites) found:

- **Missing `og:image` on 10 indexable pages.** Any page that sets `openGraph: { title, description, url }` without `images` replaces the whole inherited block, so both the root layout's PNG and an ancestor `opengraph-image.tsx` are dropped. Affected: DevPass `/pricing`, `/models`, `/leaderboard`, `/data/[year]`; Lounge `/escape`; Airside `/legal/terms`, `/legal/privacy`; llmgateway.io `/about`, `/contact`, `/ref/[orgId]`.
- **Wrong `twitter:image`** on pages with a per-page OG image (`/providers`, `/guides`, `/add-provider`, DevPass `/compare`): the root `twitter.images` overrode it with the generic PNG.
- **Inherited-only OG** on DevPass `/coding-models`, `/guides`, legal pages and most Lounge studios: `og:title`/`og:url` pointed at the homepage.
- Titles with a doubled brand (`Pricing — DevPass | DevPass by LLM Gateway`), several titles 75–110 chars, descriptions up to 240 chars.
- Lounge `/realtime` had no H1; `/group`, `/login`, `/signup` (Lounge and DevPass) had two; `/skills`, `/projects`, `/org/*` were indexable app pages with the homepage's title and no canonical; sitemap lacked `/leaderboard`, `/realtime`, `/escape`.
- DevPass `/models`, `/data/<year>` and `/claude-code-alternative` were only reachable via the sitemap (no nav/footer links).
- No machine-readable `pricing.md` for DevPass or Lounge (llmgateway.io and Airside already have one).

Crawlability was clean everywhere: robots allow AI bots, sitemaps and `llms.txt` present on all four hosts.

## Approach

- One shared OG template per app (`apps/code/src/lib/og.tsx`, `apps/playground/src/lib/og.tsx`, `apps/airside/src/lib/og.tsx`; `apps/ui` already had `lib/og.tsx`) and a thin `opengraph-image.tsx` next to every DevPass marketing page, every Lounge studio page, the Airside legal pages and ui `/about` + `/contact`. Airside's root OG now uses the shared template too.
- Root layouts no longer set `twitter.images`, so Next auto-fills `twitter:image` from each page's `og:image`.
- Every page with an inherited-only OG block gets its own `openGraph` (title/description/url); titles and descriptions trimmed; duplicated brand suffixes removed.
- Lounge: `realtime` variant added to `PlaygroundSeoSection`; visible group-chat header and the auth brand-panel headline demoted from `h1`; `skills`/`projects`/`org` marked noindex; sitemap entries added.
- DevPass: brand-panel headline demoted on login/signup; footer links to model directory, guides, census, leaderboard and the Claude Code alternative page.
- `public/pricing.md` for DevPass and Lounge; `llms.txt` key-page lists expanded and cross-linked.

## Verification

- `pnpm format`, `turbo run build --filter=code --filter=playground --filter=airside --filter=ui` pass; all new OG routes build static (`○`) except DevPass `/data/[year]` which stays dynamic like the existing `/profiles/[username]` route (works in production today).
- Started the four standalone builds locally and fetched all 22 OG routes (200 `image/png`) plus the page HTML: every audited page now has matching `og:image`/`twitter:image`, one H1, and titles/descriptions within limits.

New OG cards (DevPass pricing and census, Lounge image studio and Sandbox Escape, Airside terms, llmgateway.io about):

<img width="1200" alt="Six of the new OpenGraph cards" src="https://raw.githubusercontent.com/theopenco/llmgateway/e92c48acdc9e7cd9e9ae2e64176a1307f897da3c/og-cards.jpg" />

https://claude.ai/code/session_01Et1cqRATZrE7m53HUAsCiw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added social preview images across Airside, DevPass, Lounge, and LLM Gateway pages.
  - Added pricing guides for DevPass and Lounge.
  - Expanded discoverability links for models, guides, comparisons, census data, studios, and leaderboards.
  - Added setup and SEO content for realtime voice features.

- **Improvements**
  - Refined page titles and descriptions across products.
  - Added canonical URLs, Open Graph details, and sitemap entries.
  - Configured indexing controls for private areas and improved heading structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->