### PR TITLE
chore(models): schedule Together retirements

### DIFF
--- a/packages/models/src/models/google.ts
+++ b/packages/models/src/models/google.ts
@@ -2569,6 +2569,7 @@ export const googleModels = [
 			{
 				providerId: "together-ai",
 				externalId: "google/gemma-4-31b-it",
+				deactivatedAt: new Date("2026-09-15"),
 				inputPrice: "0.39e-6",
 				outputPrice: "0.97e-6",
 				requestPrice: "0",

--- a/packages/models/src/models/openai.ts
+++ b/packages/models/src/models/openai.ts
@@ -893,6 +893,7 @@ export const openaiModels = [
 			{
 				providerId: "together-ai",
 				externalId: "openai/gpt-oss-20b",
+				deactivatedAt: new Date("2026-09-15"),
 				inputPrice: "0.05e-6",
 				outputPrice: "0.2e-6",
 				requestPrice: "0",


### PR DESCRIPTION
## Problem

Together AI will retire two serverless model deployments on September 15, 2026.

## Changes

- schedule `google/gemma-4-31b-it` for deactivation on Together AI
- schedule `openai/gpt-oss-20b` for deactivation on Together AI
- leave every other provider mapping for both root models unchanged

The recommended replacement models already exist in the catalogue.

## Verification

- `pnpm format`
- `pnpm exec vitest run --no-file-parallelism packages/models/src/model-metadata.spec.ts packages/models/src/providers.spec.ts packages/models/src/realtime-models.spec.ts apps/gateway/src/lib/costs.spec.ts` (153 tests)
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Model Availability**
  * The Together AI deployment of `gemma-4-31b-it` is marked as deactivated effective September 15, 2026.
  * The Together AI deployment of `gpt-oss-20b` is marked as deactivated effective September 15, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->