### PR TITLE
fix(devpass): stop retries after cancellation

### DIFF
--- a/apps/api/src/lib/pending-renewal.spec.ts
+++ b/apps/api/src/lib/pending-renewal.spec.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-import { voidPendingCycleRenewalInvoices } from "./pending-renewal.js";
+import {
+	getPendingCycleRenewalInvoices,
+	voidPendingCycleRenewalInvoices,
+} from "./pending-renewal.js";
 
 import type * as PaymentsModule from "@/routes/payments.js";
 
@@ -34,11 +37,89 @@ function mockInvoiceLists(opts: {
 	);
 }
 
-describe("voidPendingCycleRenewalInvoices", () => {
+describe("pending cycle-renewal invoices", () => {
 	beforeEach(() => {
 		stripeMock.invoices.list.mockReset();
 		stripeMock.invoices.finalizeInvoice.mockReset();
 		stripeMock.invoices.voidInvoice.mockReset();
+	});
+
+	test("finds a draft cycle renewal on a later page", async () => {
+		stripeMock.invoices.list.mockImplementation(
+			(params: { status: "draft" | "open"; starting_after?: string }) => {
+				if (params.status === "open") {
+					return Promise.resolve({ data: [], has_more: false });
+				}
+				if (!params.starting_after) {
+					return Promise.resolve({
+						data: [
+							{
+								id: "in_draft_manual",
+								status: "draft",
+								billing_reason: "manual",
+							},
+						],
+						has_more: true,
+					});
+				}
+				expect(params.starting_after).toBe("in_draft_manual");
+				return Promise.resolve({
+					data: [
+						{
+							id: "in_draft_cycle_later",
+							status: "draft",
+							billing_reason: "subscription_cycle",
+						},
+					],
+					has_more: false,
+				});
+			},
+		);
+
+		const pending = await getPendingCycleRenewalInvoices(SUB_ID);
+
+		expect(pending.map((invoice) => invoice.id)).toEqual([
+			"in_draft_cycle_later",
+		]);
+	});
+
+	test("finds an open cycle renewal on a later page", async () => {
+		stripeMock.invoices.list.mockImplementation(
+			(params: { status: "draft" | "open"; starting_after?: string }) => {
+				if (params.status === "draft") {
+					return Promise.resolve({ data: [], has_more: false });
+				}
+				if (!params.starting_after) {
+					return Promise.resolve({
+						data: [
+							{
+								id: "in_open_update",
+								status: "open",
+								billing_reason: "subscription_update",
+							},
+						],
+						has_more: true,
+					});
+				}
+				expect(params.starting_after).toBe("in_open_update");
+				return Promise.resolve({
+					data: [
+						{
+							id: "in_open_cycle_later",
+							status: "open",
+							billing_reason: "subscription_cycle",
+						},
+					],
+					has_more: false,
+				});
+			},
+		);
+
+		const pending = await getPendingCycleRenewalInvoices(SUB_ID);
+
+		expect(pending.map((invoice) => invoice.id)).toEqual([
+			"in_open_cycle_later",
+		]);
 	});
 
 	test("finalizes without a payment attempt and voids a draft cycle-renewal invoice", async () => {

--- a/apps/api/src/lib/pending-renewal.ts
+++ b/apps/api/src/lib/pending-renewal.ts
@@ -4,26 +4,50 @@ import { logger } from "@llmgateway/logger";
 
 import type Stripe from "stripe";
 
+async function listInvoicesByStatus(
+	subscriptionId: string,
+	status: "draft" | "open",
+): Promise<Stripe.Invoice[]> {
+	const stripe = getStripe();
+	const invoices: Stripe.Invoice[] = [];
+	let startingAfter: string | undefined;
+
+	do {
+		const page = await stripe.invoices.list({
+			subscription: subscriptionId,
+			status,
+			limit: 100,
+			...(startingAfter ? { starting_after: startingAfter } : {}),
+		});
+		invoices.push(...page.data);
+
+		if (!page.has_more) {
+			break;
+		}
+
+		const lastInvoice = page.data.at(-1);
+		if (!lastInvoice) {
+			throw new Error(
+				`Stripe returned an empty invoice page with has_more for subscription ${subscriptionId}`,
+			);
+		}
+		startingAfter = lastInvoice.id;
+	} while (true);
+
+	return invoices;
+}
+
 // Stripe drafts a subscription's cycle-renewal invoice at the period boundary
 // and only finalizes and charges it about an hour later. Callers use this list
 // to detect a renewal already in progress before replacing or ending its cycle.
 export async function getPendingCycleRenewalInvoices(
 	subscriptionId: string,
 ): Promise<Stripe.Invoice[]> {
-	const stripe = getStripe();
 	const [drafts, open] = await Promise.all([
-		stripe.invoices.list({
-			subscription: subscriptionId,
-			status: "draft",
-			limit: 10,
-		}),
-		stripe.invoices.list({
-			subscription: subscriptionId,
-			status: "open",
-			limit: 10,
-		}),
+		listInvoicesByStatus(subscriptionId, "draft"),
+		listInvoicesByStatus(subscriptionId, "open"),
 	]);
-	return [...drafts.data, ...open.data].filter(
+	return [...drafts, ...open].filter(
 		(invoice) => invoice.billing_reason === "subscription_cycle" && invoice.id,
 	);
 }
@@ -31,7 +55,8 @@ export async function getPendingCycleRenewalInvoices(
 // Drafts are finalized without a payment attempt and then voided because
 // auto-generated subscription drafts cannot be deleted. Open invoices are
 // voided directly. Failures are logged and swallowed: an upgrade must continue,
-// and an immediate cancellation already stops automatic collection.
+// and the renewal webhook's staleness guard handles a charge that races an
+// upgrade before the invoice can be voided.
 export async function voidPendingCycleRenewalInvoices(
 	subscriptionId: string,
 	pendingInvoices?: Stripe.Invoice[],

--- a/apps/api/src/lib/pending-renewal.ts
+++ b/apps/api/src/lib/pending-renewal.ts
@@ -5,46 +5,52 @@ import { logger } from "@llmgateway/logger";
 import type Stripe from "stripe";
 
 // Stripe drafts a subscription's cycle-renewal invoice at the period boundary
-// and only finalizes and charges it about an hour later. An immediate tier
-// upgrade re-anchors the billing cycle (`billing_cycle_anchor: "now"`) and
-// charges the full new-tier price, so a still-pending renewal invoice bills a
-// cycle the upgrade replaces — left alone it would double-charge the customer
-// and its `invoice.payment_succeeded` webhook would clobber the freshly reset
-// org state. Call this before re-anchoring to kill any such invoice: drafts
-// are finalized without a payment attempt and then voided (auto-generated
-// subscription drafts cannot be deleted), open invoices are voided directly.
-// Failures are logged and swallowed — a Stripe hiccup here must not block the
-// upgrade, and the renewal webhook's staleness guard is the backstop for any
-// charge that slips through.
+// and only finalizes and charges it about an hour later. Callers use this list
+// to detect a renewal already in progress before replacing or ending its cycle.
+export async function getPendingCycleRenewalInvoices(
+	subscriptionId: string,
+): Promise<Stripe.Invoice[]> {
+	const stripe = getStripe();
+	const [drafts, open] = await Promise.all([
+		stripe.invoices.list({
+			subscription: subscriptionId,
+			status: "draft",
+			limit: 10,
+		}),
+		stripe.invoices.list({
+			subscription: subscriptionId,
+			status: "open",
+			limit: 10,
+		}),
+	]);
+	return [...drafts.data, ...open.data].filter(
+		(invoice) => invoice.billing_reason === "subscription_cycle" && invoice.id,
+	);
+}
+
+// Drafts are finalized without a payment attempt and then voided because
+// auto-generated subscription drafts cannot be deleted. Open invoices are
+// voided directly. Failures are logged and swallowed: an upgrade must continue,
+// and an immediate cancellation already stops automatic collection.
 export async function voidPendingCycleRenewalInvoices(
 	subscriptionId: string,
+	pendingInvoices?: Stripe.Invoice[],
 ): Promise<void> {
 	const stripe = getStripe();
 	let pending: Stripe.Invoice[];
 	try {
-		const [drafts, open] = await Promise.all([
-			stripe.invoices.list({
-				subscription: subscriptionId,
-				status: "draft",
-				limit: 10,
-			}),
-			stripe.invoices.list({
-				subscription: subscriptionId,
-				status: "open",
-				limit: 10,
-			}),
-		]);
-		pending = [...drafts.data, ...open.data];
+		pending =
+			pendingInvoices ?? (await getPendingCycleRenewalInvoices(subscriptionId));
 	} catch (error) {
 		logger.error(
-			`Failed to list pending invoices for subscription ${subscriptionId} before re-anchoring its billing cycle`,
+			`Failed to list pending cycle-renewal invoices for subscription ${subscriptionId}`,
 			error instanceof Error ? error : new Error(String(error)),
 		);
 		return;
 	}
 
 	for (const invoice of pending) {
-		if (invoice.billing_reason !== "subscription_cycle" || !invoice.id) {
+		if (!invoice.id) {
 			continue;
 		}
 		try {
@@ -57,12 +63,12 @@ export async function voidPendingCycleRenewalInvoices(
 			if (finalized.status === "open") {
 				await stripe.invoices.voidInvoice(invoice.id);
 				logger.info(
-					`Voided pending cycle-renewal invoice ${invoice.id} on subscription ${subscriptionId} superseded by an immediate upgrade`,
+					`Voided pending cycle-renewal invoice ${invoice.id} on subscription ${subscriptionId}`,
 				);
 			}
 		} catch (error) {
 			logger.error(
-				`Failed to void pending cycle-renewal invoice ${invoice.id} on subscription ${subscriptionId}; the renewal webhook's staleness guard will skip its credit reset`,
+				`Failed to void pending cycle-renewal invoice ${invoice.id} on subscription ${subscriptionId}`,
 				error instanceof Error ? error : new Error(String(error)),
 			);
 		}

--- a/apps/api/src/routes/dev-plans.spec.ts
+++ b/apps/api/src/routes/dev-plans.spec.ts
@@ -1010,6 +1010,7 @@ describe("dev plan tier changes", () => {
 		});
 
 		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ success: true, immediate: true });
 		expect(stripeMock.subscriptions.cancel).toHaveBeenCalledWith(
 			SUBSCRIPTION_ID,
 			{ invoice_now: false, prorate: false },
@@ -1051,6 +1052,7 @@ describe("dev plan tier changes", () => {
 		});
 
 		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ success: true, immediate: true });
 		expect(stripeMock.subscriptions.cancel).toHaveBeenCalledWith(
 			SUBSCRIPTION_ID,
 			{ invoice_now: false, prorate: false },
@@ -1077,12 +1079,62 @@ describe("dev plan tier changes", () => {
 		});
 
 		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ success: true, immediate: false });
 		expect(stripeMock.subscriptions.update).toHaveBeenCalledWith(
 			SUBSCRIPTION_ID,
 			{ cancel_at_period_end: true },
 		);
 		expect(stripeMock.subscriptions.cancel).not.toHaveBeenCalled();
 		expect(stripeMock.invoices.voidInvoice).not.toHaveBeenCalled();
+	});
+
+	it("falls back to immediate cancellation when invoice lookup fails", async () => {
+		stripeMock.subscriptions.retrieve.mockResolvedValue(
+			retrievedSubscription(),
+		);
+		stripeMock.invoices.list.mockRejectedValue(new Error("stripe unavailable"));
+
+		const res = await app.request("/dev-plans/cancel", {
+			method: "POST",
+			headers: { Cookie: token, "Content-Type": "application/json" },
+			body: JSON.stringify({}),
+		});
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ success: true, immediate: true });
+		expect(stripeMock.subscriptions.cancel).toHaveBeenCalledWith(
+			SUBSCRIPTION_ID,
+			{ invoice_now: false, prorate: false },
+		);
+		expect(stripeMock.subscriptions.update).not.toHaveBeenCalled();
+	});
+
+	it("audits cancellation while self-healing an ended subscription", async () => {
+		stripeMock.subscriptions.retrieve.mockResolvedValue(
+			retrievedSubscription({ status: "canceled" }),
+		);
+
+		const res = await app.request("/dev-plans/cancel", {
+			method: "POST",
+			headers: { Cookie: token, "Content-Type": "application/json" },
+			body: JSON.stringify({}),
+		});
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ success: true, immediate: true });
+		expect(stripeMock.subscriptions.cancel).not.toHaveBeenCalled();
+		expect(stripeMock.subscriptions.update).not.toHaveBeenCalled();
+
+		const auditLog = await db.query.auditLog.findFirst({
+			where: {
+				organizationId: { eq: ORG_ID },
+				action: { eq: "dev_plan.cancel" },
+			},
+		});
+		expect(auditLog).toMatchObject({
+			resourceType: "dev_plan",
+			resourceId: SUBSCRIPTION_ID,
+		});
 	});
 
 	it("self-heals an ended subscription on resume instead of failing", async () => {

--- a/apps/api/src/routes/dev-plans.spec.ts
+++ b/apps/api/src/routes/dev-plans.spec.ts
@@ -38,6 +38,7 @@ const stripeMock = vi.hoisted(() => ({
 	subscriptions: {
 		retrieve: vi.fn(),
 		update: vi.fn(),
+		cancel: vi.fn(),
 	},
 	invoices: {
 		list: vi.fn(),
@@ -980,6 +981,108 @@ describe("dev plan tier changes", () => {
 		});
 		expect(org?.devPlan).toBe("lite");
 		expect(org?.devPlanTierChangeClaimedAt).toBeNull();
+	});
+
+	it("cancels an overdue subscription immediately and voids its renewal invoice", async () => {
+		stripeMock.subscriptions.retrieve.mockResolvedValue(
+			retrievedSubscription({ status: "past_due" }),
+		);
+		stripeMock.invoices.list.mockImplementation(
+			(params: { status: "draft" | "open" }) =>
+				Promise.resolve({
+					data:
+						params.status === "open"
+							? [
+									{
+										id: "in_failed_renewal",
+										status: "open",
+										billing_reason: "subscription_cycle",
+									},
+								]
+							: [],
+				}),
+		);
+
+		const res = await app.request("/dev-plans/cancel", {
+			method: "POST",
+			headers: { Cookie: token, "Content-Type": "application/json" },
+			body: JSON.stringify({}),
+		});
+
+		expect(res.status).toBe(200);
+		expect(stripeMock.subscriptions.cancel).toHaveBeenCalledWith(
+			SUBSCRIPTION_ID,
+			{ invoice_now: false, prorate: false },
+		);
+		expect(stripeMock.subscriptions.update).not.toHaveBeenCalled();
+		expect(stripeMock.invoices.voidInvoice).toHaveBeenCalledWith(
+			"in_failed_renewal",
+		);
+	});
+
+	it("cancels immediately when an active subscription has a pending renewal", async () => {
+		stripeMock.subscriptions.retrieve.mockResolvedValue(
+			retrievedSubscription(),
+		);
+		stripeMock.invoices.list.mockImplementation(
+			(params: { status: "draft" | "open" }) =>
+				Promise.resolve({
+					data:
+						params.status === "draft"
+							? [
+									{
+										id: "in_pending_renewal",
+										status: "draft",
+										billing_reason: "subscription_cycle",
+									},
+								]
+							: [],
+				}),
+		);
+		stripeMock.invoices.finalizeInvoice.mockResolvedValue({
+			id: "in_pending_renewal",
+			status: "open",
+		});
+
+		const res = await app.request("/dev-plans/cancel", {
+			method: "POST",
+			headers: { Cookie: token, "Content-Type": "application/json" },
+			body: JSON.stringify({}),
+		});
+
+		expect(res.status).toBe(200);
+		expect(stripeMock.subscriptions.cancel).toHaveBeenCalledWith(
+			SUBSCRIPTION_ID,
+			{ invoice_now: false, prorate: false },
+		);
+		expect(stripeMock.subscriptions.update).not.toHaveBeenCalled();
+		expect(stripeMock.invoices.finalizeInvoice).toHaveBeenCalledWith(
+			"in_pending_renewal",
+			{ auto_advance: false },
+		);
+		expect(stripeMock.invoices.voidInvoice).toHaveBeenCalledWith(
+			"in_pending_renewal",
+		);
+	});
+
+	it("keeps a paid subscription active until period end", async () => {
+		stripeMock.subscriptions.retrieve.mockResolvedValue(
+			retrievedSubscription(),
+		);
+
+		const res = await app.request("/dev-plans/cancel", {
+			method: "POST",
+			headers: { Cookie: token, "Content-Type": "application/json" },
+			body: JSON.stringify({}),
+		});
+
+		expect(res.status).toBe(200);
+		expect(stripeMock.subscriptions.update).toHaveBeenCalledWith(
+			SUBSCRIPTION_ID,
+			{ cancel_at_period_end: true },
+		);
+		expect(stripeMock.subscriptions.cancel).not.toHaveBeenCalled();
+		expect(stripeMock.invoices.voidInvoice).not.toHaveBeenCalled();
 	});
 
 	it("self-heals an ended subscription on resume instead of failing", async () => {

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -691,6 +691,7 @@ const cancel = createRoute({
 				"application/json": {
 					schema: z.object({
 						success: z.boolean(),
+						immediate: z.boolean(),
 					}),
 				},
 			},
@@ -738,46 +739,59 @@ devPlans.openapi(cancel, async (c) => {
 		const stripe = getStripe();
 		const subscriptionId = personalOrg.devPlanStripeSubscriptionId;
 		const subscription = await stripe.subscriptions.retrieve(subscriptionId);
-
-		if (
+		const alreadyEnded =
 			subscription.status === "canceled" ||
-			subscription.status === "incomplete_expired"
-		) {
+			subscription.status === "incomplete_expired";
+		let immediate = alreadyEnded;
+
+		if (alreadyEnded) {
 			await resetEndedDevPlan(personalOrg.id);
-			return c.json({ success: true });
-		}
-
-		const overdueStatuses: Stripe.Subscription.Status[] = [
-			"past_due",
-			"unpaid",
-			"incomplete",
-			"paused",
-		];
-		let pendingRenewalInvoices: Stripe.Invoice[] | undefined;
-		if (!overdueStatuses.includes(subscription.status)) {
-			pendingRenewalInvoices =
-				await getPendingCycleRenewalInvoices(subscriptionId);
-		}
-
-		if (
-			overdueStatuses.includes(subscription.status) ||
-			(pendingRenewalInvoices?.length ?? 0) > 0
-		) {
-			// Stripe advances the period before collecting its renewal invoice. If
-			// that invoice is unpaid, scheduling cancellation at period end grants
-			// an unpaid extra cycle and leaves Smart Retries running until then.
-			await stripe.subscriptions.cancel(subscriptionId, {
-				invoice_now: false,
-				prorate: false,
-			});
-			await voidPendingCycleRenewalInvoices(
-				subscriptionId,
-				pendingRenewalInvoices,
-			);
 		} else {
-			await stripe.subscriptions.update(subscriptionId, {
-				cancel_at_period_end: true,
-			});
+			const overdueStatuses: Stripe.Subscription.Status[] = [
+				"past_due",
+				"unpaid",
+				"incomplete",
+				"paused",
+			];
+			let pendingRenewalInvoices: Stripe.Invoice[] | undefined;
+			let invoiceLookupFailed = false;
+			if (!overdueStatuses.includes(subscription.status)) {
+				try {
+					pendingRenewalInvoices =
+						await getPendingCycleRenewalInvoices(subscriptionId);
+				} catch (error) {
+					invoiceLookupFailed = true;
+					logger.error(
+						`Failed to inspect pending invoices while cancelling subscription ${subscriptionId}`,
+						error instanceof Error ? error : new Error(String(error)),
+					);
+				}
+			}
+
+			immediate =
+				overdueStatuses.includes(subscription.status) ||
+				invoiceLookupFailed ||
+				(pendingRenewalInvoices?.length ?? 0) > 0;
+
+			if (immediate) {
+				// Stripe advances the period before collecting its renewal invoice. If
+				// that invoice is unpaid, scheduling cancellation at period end grants
+				// an unpaid extra cycle and leaves Smart Retries running until then.
+				// A lookup failure also falls back to immediate cancellation so an
+				// ancillary Stripe outage cannot block the user's cancellation.
+				await stripe.subscriptions.cancel(subscriptionId, {
+					invoice_now: false,
+					prorate: false,
+				});
+				await voidPendingCycleRenewalInvoices(
+					subscriptionId,
+					pendingRenewalInvoices,
+				);
+			} else {
+				await stripe.subscriptions.update(subscriptionId, {
+					cancel_at_period_end: true,
+				});
+			}
 		}
 
 		await logAuditEvent({
@@ -791,13 +805,16 @@ devPlans.openapi(cancel, async (c) => {
 			},
 		});
 
-		// Wait for webhook to process
-		await new Promise((resolve) => {
-			setTimeout(resolve, 3000);
-		});
+		if (!alreadyEnded) {
+			// Wait for webhook to process
+			await new Promise((resolve) => {
+				setTimeout(resolve, 3000);
+			});
+		}
 
 		return c.json({
 			success: true,
+			immediate,
 		});
 	} catch (error) {
 		logger.error(

--- a/apps/api/src/routes/dev-plans.ts
+++ b/apps/api/src/routes/dev-plans.ts
@@ -5,7 +5,10 @@ import { z } from "zod";
 import { assertOrganizationNotHighRisk } from "@/lib/account-risk.js";
 import { readApiKeyMask } from "@/lib/api-key-mask.js";
 import { assertCreditPurchaseAllowed } from "@/lib/credit-purchase-guard.js";
-import { voidPendingCycleRenewalInvoices } from "@/lib/pending-renewal.js";
+import {
+	getPendingCycleRenewalInvoices,
+	voidPendingCycleRenewalInvoices,
+} from "@/lib/pending-renewal.js";
 import {
 	computeSelfRefundEligibility,
 	executeSelfRefund,
@@ -732,19 +735,57 @@ devPlans.openapi(cancel, async (c) => {
 	}
 
 	try {
-		await getStripe().subscriptions.update(
-			personalOrg.devPlanStripeSubscriptionId,
-			{
+		const stripe = getStripe();
+		const subscriptionId = personalOrg.devPlanStripeSubscriptionId;
+		const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+
+		if (
+			subscription.status === "canceled" ||
+			subscription.status === "incomplete_expired"
+		) {
+			await resetEndedDevPlan(personalOrg.id);
+			return c.json({ success: true });
+		}
+
+		const overdueStatuses: Stripe.Subscription.Status[] = [
+			"past_due",
+			"unpaid",
+			"incomplete",
+			"paused",
+		];
+		let pendingRenewalInvoices: Stripe.Invoice[] | undefined;
+		if (!overdueStatuses.includes(subscription.status)) {
+			pendingRenewalInvoices =
+				await getPendingCycleRenewalInvoices(subscriptionId);
+		}
+
+		if (
+			overdueStatuses.includes(subscription.status) ||
+			(pendingRenewalInvoices?.length ?? 0) > 0
+		) {
+			// Stripe advances the period before collecting its renewal invoice. If
+			// that invoice is unpaid, scheduling cancellation at period end grants
+			// an unpaid extra cycle and leaves Smart Retries running until then.
+			await stripe.subscriptions.cancel(subscriptionId, {
+				invoice_now: false,
+				prorate: false,
+			});
+			await voidPendingCycleRenewalInvoices(
+				subscriptionId,
+				pendingRenewalInvoices,
+			);
+		} else {
+			await stripe.subscriptions.update(subscriptionId, {
 				cancel_at_period_end: true,
-			},
-		);
+			});
+		}
 
 		await logAuditEvent({
 			organizationId: personalOrg.id,
 			userId: user.id,
 			action: "dev_plan.cancel",
 			resourceType: "dev_plan",
-			resourceId: personalOrg.devPlanStripeSubscriptionId,
+			resourceId: subscriptionId,
 			metadata: {
 				tier: personalOrg.devPlan,
 			},

--- a/apps/code/src/app/dashboard/(main)/billing/BillingClient.tsx
+++ b/apps/code/src/app/dashboard/(main)/billing/BillingClient.tsx
@@ -220,9 +220,16 @@ export default function BillingClient({
 	const handleCancel = async (): Promise<void> => {
 		setIsCancelling(true);
 		try {
-			await cancelMutation.mutateAsync({});
+			const result = await cancelMutation.mutateAsync({});
 			if (posthogKey) {
 				posthog.capture("dev_plan_cancelled");
+			}
+			if (result.immediate) {
+				await invalidateStatus();
+				toast.success("Subscription cancelled", {
+					description: "Your subscription has ended.",
+				});
+				return;
 			}
 			toast.success("Subscription cancelled", {
 				description: renewWhen


### PR DESCRIPTION
## Problem

Cancelling an overdue DevPass subscription could schedule it for the next period end, leaving Stripe retries active. Immediate cancellations could also leave the dashboard confirmation stale.

## Approach

- cancel overdue or pending-renewal subscriptions immediately and void unpaid cycle invoices
- paginate draft/open invoice discovery and fall back to immediate cancellation if discovery fails
- retain period-end cancellation for healthy paid subscriptions
- audit already-ended subscription self-healing
- return cancellation timing so the dashboard refreshes and reports immediate endings correctly

## Verification

- `pnpm format`
- `pnpm build --force`
- targeted API tests: 55 passed
- isolated local API and dashboard flow in light and dark themes

## UI

| Theme | Before | After |
| --- | --- | --- |
| Light | <img src="https://raw.githubusercontent.com/theopenco/llmgateway/1012b9241b269de07b4e6579006c37a96a73f931/before-light.png" width="420" alt="Before immediate cancellation handling, light theme"> | <img src="https://raw.githubusercontent.com/theopenco/llmgateway/1012b9241b269de07b4e6579006c37a96a73f931/after-light.png" width="420" alt="After immediate cancellation handling, light theme"> |
| Dark | <img src="https://raw.githubusercontent.com/theopenco/llmgateway/1012b9241b269de07b4e6579006c37a96a73f931/before-dark.png" width="420" alt="Before immediate cancellation handling, dark theme"> | <img src="https://raw.githubusercontent.com/theopenco/llmgateway/1012b9241b269de07b4e6579006c37a96a73f931/after-dark.png" width="420" alt="After immediate cancellation handling, dark theme"> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved development-plan cancellation handling for overdue subscriptions or those with pending renewal invoices.
  - Eligible subscriptions can be canceled immediately, with pending renewal invoices handled appropriately.
  - Paid, active subscriptions continue through the current billing period before cancellation.
  - Cancellation responses now indicate whether the subscription ended immediately or is scheduled to end later.
  - Added clear confirmation messaging when a subscription ends immediately.

- **Bug Fixes**
  - Restored completed or expired subscriptions to a consistent development-plan state.
  - Prevented unintended billing actions during cancellation and added fallback handling when invoice details cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->