### PR TITLE
docs(costs): clarify response fields

### DIFF
--- a/apps/docs/content/features/cost-breakdown.mdx
+++ b/apps/docs/content/features/cost-breakdown.mdx
@@ -17,7 +17,7 @@ LLM Gateway provides real-time cost information for each API request directly in
 
 ## Response Format
 
-When cost breakdown is enabled, your API responses will include additional cost fields in the `usage` object:
+API responses include cost fields in the `usage` object:
 
 ```json
 {


### PR DESCRIPTION
## Problem

The cost breakdown docs imply that response cost fields require an opt-in, although they are returned automatically.

## Change

State directly that API responses include cost fields in the `usage` object.

## Verification

- `pnpm format`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that API responses include cost fields in the `usage` object without requiring cost breakdown to be enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->