### PR TITLE
fix(airside): align theme switcher

### DIFF
--- a/apps/airside/src/components/ThemeToggle.tsx
+++ b/apps/airside/src/components/ThemeToggle.tsx
@@ -1,35 +1,69 @@
 "use client";
 
-import { MoonStar, SunDim } from "lucide-react";
+import { Monitor, Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 
-import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
-export function ThemeToggle() {
-	const { resolvedTheme, setTheme } = useTheme();
+interface ThemeToggleProps {
+	className?: string;
+	size?: "default" | "compact";
+}
+
+const THEME_OPTIONS = [
+	{ value: "light", label: "Light", Icon: Sun },
+	{ value: "dark", label: "Dark", Icon: Moon },
+	{ value: "system", label: "System (default)", Icon: Monitor },
+] as const;
+
+export function ThemeToggle({ className, size = "default" }: ThemeToggleProps) {
+	const { theme, setTheme } = useTheme();
 	const [mounted, setMounted] = useState(false);
 
-	useEffect(() => {
-		setMounted(true);
-	}, []);
+	useEffect(() => setMounted(true), []);
 
-	if (!mounted) {
-		return <Button variant="ghost" size="icon" aria-label="Toggle theme" />;
-	}
+	const sizeClasses =
+		size === "compact"
+			? { root: "h-7 gap-0.5 p-0.5", button: "size-6", icon: "size-3.5" }
+			: { root: "h-8 gap-1 p-1", button: "size-6", icon: "size-4" };
+
+	// Default to "system" until mounted to keep SSR markup stable.
+	const active = mounted ? (theme ?? "system") : "system";
 
 	return (
-		<Button
-			variant="ghost"
-			size="icon"
-			aria-label="Toggle theme"
-			onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
-		>
-			{resolvedTheme === "dark" ? (
-				<SunDim className="size-4" />
-			) : (
-				<MoonStar className="size-4" />
+		<div
+			aria-label="Theme"
+			className={cn(
+				"inline-flex items-center rounded-full border border-zinc-200 bg-white transition-colors dark:border-zinc-800 dark:bg-zinc-950",
+				sizeClasses.root,
+				className,
 			)}
-		</Button>
+			role="radiogroup"
+		>
+			{THEME_OPTIONS.map(({ value, label, Icon }) => {
+				const isActive = mounted && active === value;
+				return (
+					<button
+						aria-checked={isActive}
+						aria-label={label}
+						className={cn(
+							"flex items-center justify-center rounded-full transition-colors",
+							sizeClasses.button,
+							isActive
+								? "bg-zinc-100 text-zinc-900 dark:bg-zinc-800 dark:text-white"
+								: "text-zinc-400 hover:text-zinc-700 dark:text-zinc-500 dark:hover:text-zinc-200",
+						)}
+						key={value}
+						onClick={() => setTheme(value)}
+						role="radio"
+						title={label}
+						type="button"
+					>
+						<Icon className={sizeClasses.icon} strokeWidth={1.5} />
+					</button>
+				);
+			})}
+		</div>
 	);
 }

--- a/apps/airside/src/components/providers.tsx
+++ b/apps/airside/src/components/providers.tsx
@@ -36,7 +36,7 @@ export function Providers({ children, config }: ProvidersProps) {
 		<AppConfigProvider config={config}>
 			<ThemeProvider
 				attribute="class"
-				defaultTheme="dark"
+				defaultTheme="system"
 				enableSystem
 				storageKey="theme"
 			>


### PR DESCRIPTION
## Problem

Airside used a two-state theme button and defaulted new sessions to dark, unlike the other apps.

## Changes

- use the existing three-state theme switcher pattern
- support Auto/system, Light, and Dark selections
- default new sessions to Auto/system

## Verification

- `pnpm format`
- `pnpm build`