### PR TITLE
fix(gateway): drop invalid referer source value

### DIFF
--- a/apps/gateway/src/chat/tools/validate-source.spec.ts
+++ b/apps/gateway/src/chat/tools/validate-source.spec.ts
@@ -1,0 +1,50 @@
+import { HTTPException } from "hono/http-exception";
+import { describe, expect, it } from "vitest";
+
+import { validateSource } from "@/chat/tools/validate-source.js";
+
+describe("validateSource", () => {
+	it("returns undefined when neither value is present", () => {
+		expect(validateSource(undefined)).toBeUndefined();
+		expect(validateSource(undefined, undefined)).toBeUndefined();
+	});
+
+	it("normalizes a valid explicit x-source", () => {
+		expect(validateSource("https://www.example.com/app")).toBe(
+			"example.com/app",
+		);
+		expect(validateSource("my-app")).toBe("my-app");
+	});
+
+	it("throws 400 on an invalid explicit x-source", () => {
+		try {
+			validateSource("http://localhost:3000/page?x=1");
+			expect.unreachable("expected HTTPException");
+		} catch (e) {
+			expect(e).toBeInstanceOf(HTTPException);
+			expect((e as HTTPException).status).toBe(400);
+		}
+		expect(() => validateSource("my_app")).toThrow(HTTPException);
+	});
+
+	it("throws on an invalid x-source even when a valid referer exists", () => {
+		expect(() => validateSource("bad value", "https://example.com")).toThrow(
+			HTTPException,
+		);
+	});
+
+	it("uses a valid referer when x-source is absent", () => {
+		expect(validateSource(undefined, "https://www.example.com/page")).toBe(
+			"example.com/page",
+		);
+	});
+
+	it("drops an invalid referer instead of throwing", () => {
+		expect(
+			validateSource(undefined, "http://localhost:3000/page?x=1"),
+		).toBeUndefined();
+		expect(
+			validateSource(undefined, "https://example.com/a_b"),
+		).toBeUndefined();
+	});
+});

--- a/apps/gateway/src/chat/tools/validate-source.spec.ts
+++ b/apps/gateway/src/chat/tools/validate-source.spec.ts
@@ -33,6 +33,13 @@ describe("validateSource", () => {
 		);
 	});
 
+	it("treats an empty x-source as absent instead of throwing", () => {
+		expect(validateSource("")).toBeUndefined();
+		expect(validateSource("", "https://www.example.com/page")).toBe(
+			"example.com/page",
+		);
+	});
+
 	it("uses a valid referer when x-source is absent", () => {
 		expect(validateSource(undefined, "https://www.example.com/page")).toBe(
 			"example.com/page",

--- a/apps/gateway/src/chat/tools/validate-source.ts
+++ b/apps/gateway/src/chat/tools/validate-source.ts
@@ -20,6 +20,8 @@ export function validateSource(
 	source: string | undefined,
 	referer?: string | undefined,
 ): string | undefined {
+	// An empty x-source carries no attribution intent; treat it as absent
+	// (like on main, which never 400ed on it) so fallbacks still apply.
 	if (source) {
 		const normalized = normalizeSource(source);
 		if (normalized === undefined) {

--- a/apps/gateway/src/chat/tools/validate-source.ts
+++ b/apps/gateway/src/chat/tools/validate-source.ts
@@ -1,35 +1,40 @@
 import { HTTPException } from "hono/http-exception";
 
 /**
- * Validates and normalizes the x-source header with HTTP-Referer fallback
- * Strips http(s):// and www. if present
- * Validates allowed characters: a-zA-Z0-9, -, ., /
+ * Strips http(s):// and www., then checks allowed characters:
+ * a-zA-Z0-9, -, ., /
+ * Returns the normalized value, or undefined if invalid.
+ */
+function normalizeSource(value: string): string | undefined {
+	const normalized = value.replace(/^https?:\/\//, "").replace(/^www\./, "");
+
+	return /^[a-zA-Z0-9./-]+$/.test(normalized) ? normalized : undefined;
+}
+
+/**
+ * Validates and normalizes the x-source header with HTTP-Referer fallback.
+ * An invalid explicit x-source throws 400 (the caller deliberately set it);
+ * an invalid implicit referer is dropped so later fallbacks can apply.
  */
 export function validateSource(
 	source: string | undefined,
 	referer?: string | undefined,
 ): string | undefined {
-	// Use x-source if available, otherwise fallback to HTTP-Referer
-	const sourceToValidate = source ?? referer;
-
-	if (!sourceToValidate) {
-		return undefined;
+	if (source) {
+		const normalized = normalizeSource(source);
+		if (normalized === undefined) {
+			throw new HTTPException(400, {
+				message:
+					"Invalid x-source header: only alphanumeric characters, hyphens, dots, and slashes are allowed",
+			});
+		}
+		return normalized;
 	}
 
-	// Strip http:// or https:// if present
-	let normalized = sourceToValidate.replace(/^https?:\/\//, "");
-
-	// Strip www. if present
-	normalized = normalized.replace(/^www\./, "");
-
-	// Validate allowed characters: a-zA-Z0-9, -, ., /
-	const allowedPattern = /^[a-zA-Z0-9./-]+$/;
-	if (!allowedPattern.test(normalized)) {
-		throw new HTTPException(400, {
-			message:
-				"Invalid x-source header: only alphanumeric characters, hyphens, dots, and slashes are allowed",
-		});
+	if (referer) {
+		// Telemetry-only fallback: drop invalid values instead of failing the request
+		return normalizeSource(referer);
 	}
 
-	return normalized;
+	return undefined;
 }


### PR DESCRIPTION
## Problem

`validateSource` (`apps/gateway/src/chat/tools/validate-source.ts`) throws a 400 whenever the resolved source value fails its character check — regardless of whether the value came from an explicit `x-source` header or from the implicit `HTTP-Referer` fallback. A caller who never set `x-source` but whose client sends a browser-style Referer with a port, query string, or underscore (e.g. `http://localhost:3000/page?x=1`) had their entire inference request rejected over a telemetry-only attribution value. This affected every lane that resolves a source: chat completions (and the /v1/messages, /v1/responses, images and AI SDK re-dispatches through it), embeddings, OCR, speech, transcriptions, rerank, moderations, and realtime client secrets.

## Fix

Split the two origins inside `validateSource`:

- An explicit `x-source` header that fails validation still throws 400 — the caller deliberately set it, so loud failure remains the contract.
- The `HTTP-Referer` fallback is now sanitized leniently: an invalid value is dropped (returns `undefined`), so the request proceeds and the later fallbacks (User-Agent / X-Title coding-agent detection) still apply.

All call sites pass `(x-source, referer)` into this one helper, so no caller changes were needed.

## Verification

- New `apps/gateway/src/chat/tools/validate-source.spec.ts` (6 tests, pure): explicit invalid `x-source` → 400 (also when a valid referer is present), invalid referer → dropped, valid referer → normalized and used, valid `x-source` → normalized.
- `pnpm format` and full `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Empty `x-source` values now fall back to the HTTP referrer instead of returning an error.
  - Invalid explicit `x-source` values continue to return an HTTP 400 error.
  - Invalid referrer values are now ignored, allowing other fallback behavior to apply.
  - Source values are normalized consistently by removing protocol and `www.` prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->