### PR TITLE
fix(gateway): forward cache headers on responses

### DIFF
--- a/apps/gateway/src/middleware/cors.spec.ts
+++ b/apps/gateway/src/middleware/cors.spec.ts
@@ -138,4 +138,37 @@ describe("corsMiddleware", () => {
 		);
 		expect(res.headers.get("Access-Control-Allow-Methods")).toContain("POST");
 	});
+
+	it("allows gateway control headers and exposes the cache marker", async () => {
+		process.env.GATEWAY_CORS_ORIGINS = "https://www.typingmind.com";
+
+		const preflight = await app.request("/v1/chat/completions", {
+			method: "OPTIONS",
+			headers: {
+				Origin: "https://www.typingmind.com",
+				"Access-Control-Request-Method": "POST",
+				"Access-Control-Request-Headers": "x-no-cache,x-session-id",
+			},
+		});
+
+		const allowHeaders = preflight.headers.get("Access-Control-Allow-Headers");
+		for (const header of [
+			"x-no-cache",
+			"x-no-fallback",
+			"x-session-id",
+			"x-session-affinity",
+			"session_id",
+			"session-id",
+		]) {
+			expect(allowHeaders).toContain(header);
+		}
+
+		const res = await app.request("/v1/models", {
+			headers: { Origin: "https://www.typingmind.com" },
+		});
+
+		expect(res.headers.get("Access-Control-Expose-Headers")).toContain(
+			"x-llmgateway-cache",
+		);
+	});
 });

--- a/apps/gateway/src/middleware/cors.ts
+++ b/apps/gateway/src/middleware/cors.ts
@@ -63,9 +63,15 @@ export const corsMiddleware: MiddlewareHandler = async (c, next) => {
 			"Cache-Control",
 			"x-api-key",
 			"mcp-session-id",
+			"x-no-cache",
+			"x-no-fallback",
+			"x-session-id",
+			"x-session-affinity",
+			"session_id",
+			"session-id",
 		],
 		allowMethods: ["POST", "GET", "OPTIONS", "PUT", "PATCH", "DELETE"],
-		exposeHeaders: ["Content-Length", "mcp-session-id"],
+		exposeHeaders: ["Content-Length", "mcp-session-id", "x-llmgateway-cache"],
 		maxAge: 600,
 	})(c, next);
 };

--- a/apps/gateway/src/responses/responses-route.spec.ts
+++ b/apps/gateway/src/responses/responses-route.spec.ts
@@ -83,3 +83,106 @@ describe("responses streaming lifecycle", () => {
 		expect(eventTypes).toEqual(["response.created", "response.failed"]);
 	});
 });
+
+describe("responses header passthrough", () => {
+	it("forwards cache/session headers and copies x-llmgateway-cache back", async () => {
+		mocks.appRequest.mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					id: "chatcmpl_test",
+					object: "chat.completion",
+					created: 1,
+					model: "gpt-4o-mini",
+					choices: [
+						{
+							index: 0,
+							message: { role: "assistant", content: "hi" },
+							finish_reason: "stop",
+						},
+					],
+					usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+				}),
+				{
+					status: 200,
+					headers: {
+						"content-type": "application/json",
+						"x-llmgateway-cache": "HIT",
+					},
+				},
+			),
+		);
+
+		const response = await responses.request("/", {
+			method: "POST",
+			headers: {
+				authorization: "Bearer test-token",
+				"content-type": "application/json",
+				"x-no-cache": "true",
+				"x-no-fallback": "true",
+				"x-session-affinity": "session-abc",
+			},
+			body: JSON.stringify({
+				model: "gpt-4o-mini",
+				input: "hello",
+				store: false,
+			}),
+		});
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("x-llmgateway-cache")).toBe("HIT");
+
+		const [, init] = mocks.appRequest.mock.calls.at(-1) as [
+			string,
+			{ headers: Record<string, string> },
+		];
+		expect(init.headers["x-no-cache"]).toBe("true");
+		expect(init.headers["x-no-fallback"]).toBe("true");
+		expect(init.headers["x-session-affinity"]).toBe("session-abc");
+	});
+
+	it("omits opt-out headers the caller did not send", async () => {
+		mocks.appRequest.mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					id: "chatcmpl_test",
+					object: "chat.completion",
+					created: 1,
+					model: "gpt-4o-mini",
+					choices: [
+						{
+							index: 0,
+							message: { role: "assistant", content: "hi" },
+							finish_reason: "stop",
+						},
+					],
+					usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+
+		const response = await responses.request("/", {
+			method: "POST",
+			headers: {
+				authorization: "Bearer test-token",
+				"content-type": "application/json",
+			},
+			body: JSON.stringify({
+				model: "gpt-4o-mini",
+				input: "hello",
+				store: false,
+			}),
+		});
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("x-llmgateway-cache")).toBeNull();
+
+		const [, init] = mocks.appRequest.mock.calls.at(-1) as [
+			string,
+			{ headers: Record<string, string> },
+		];
+		expect("x-no-cache" in init.headers).toBe(false);
+		expect("x-no-fallback" in init.headers).toBe(false);
+		expect("x-session-affinity" in init.headers).toBe(false);
+	});
+});

--- a/apps/gateway/src/responses/responses.ts
+++ b/apps/gateway/src/responses/responses.ts
@@ -56,11 +56,58 @@ import {
 import { extractAdditionalTools } from "./tools/tool-registry.js";
 
 import type { ServerTypes } from "@/vars.js";
+import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 
 const zstdDecompressAsync = promisify(zstdDecompress);
 
 export const responses = new Hono<ServerTypes>();
+
+/**
+ * Headers forwarded onto the internal chat completions call. Mirrors the
+ * `/v1/messages` and `/v4/ai` hops: presence-sensitive opt-outs (x-no-cache,
+ * x-no-fallback) and the sticky-session headers the chat handler reads are
+ * only set when the caller actually sent them.
+ */
+function forwardedHeaders(c: Context<ServerTypes>): Record<string, string> {
+	const optional = [
+		"x-no-fallback",
+		"x-no-cache",
+		"x-session-id",
+		"x-session-affinity",
+		"session_id",
+		"session-id",
+	];
+
+	return {
+		"Content-Type": "application/json",
+		Authorization: c.req.header("Authorization") ?? "",
+		"x-api-key": c.req.header("x-api-key") ?? "",
+		"User-Agent": c.req.header("User-Agent") ?? "",
+		"x-request-id": c.req.header("x-request-id") ?? "",
+		"x-source": c.req.header("x-source") ?? "",
+		"x-debug": c.req.header("x-debug") ?? "",
+		"HTTP-Referer": c.req.header("HTTP-Referer") ?? "",
+		...internalApiOriginHeaders("responses"),
+		...Object.fromEntries(
+			optional
+				.map((name) => [name, c.req.header(name)])
+				.filter((entry): entry is [string, string] => entry[1] !== undefined),
+		),
+	};
+}
+
+/**
+ * Surface gateway response-cache replays: copy the inner handler's
+ * x-llmgateway-cache marker onto the outgoing response so callers can tell a
+ * replay from a fresh sample.
+ */
+function forwardCacheStatusHeader(c: Context<ServerTypes>, response: Response) {
+	const innerCacheStatus = response.headers.get("x-llmgateway-cache");
+	if (innerCacheStatus) {
+		c.header("x-llmgateway-cache", innerCacheStatus);
+	}
+}
 
 /**
  * Extract and validate the API token from request headers.
@@ -414,17 +461,7 @@ responses.post("/", async (c) => {
 	const state = createStreamingState(req.model, logId, req, toolRegistry);
 
 	// Make internal request to the existing chat completions endpoint
-	const internalHeaders: Record<string, string> = {
-		"Content-Type": "application/json",
-		Authorization: c.req.header("Authorization") ?? "",
-		"x-api-key": c.req.header("x-api-key") ?? "",
-		"User-Agent": c.req.header("User-Agent") ?? "",
-		"x-request-id": c.req.header("x-request-id") ?? "",
-		"x-source": c.req.header("x-source") ?? "",
-		"x-debug": c.req.header("x-debug") ?? "",
-		"HTTP-Referer": c.req.header("HTTP-Referer") ?? "",
-		...internalApiOriginHeaders("responses"),
-	};
+	const internalHeaders: Record<string, string> = forwardedHeaders(c);
 
 	// Pass Responses API context via in-memory Map (not headers) so the chat
 	// handler logs this request under the resp_ id the client sees. Response
@@ -467,6 +504,8 @@ responses.post("/", async (c) => {
 			);
 		}
 	}
+
+	forwardCacheStatusHeader(c, response);
 
 	// Handle streaming response
 	if (req.stream) {
@@ -857,17 +896,7 @@ responses.post("/compact", async (c) => {
 
 	const compactionId = `resp_${shortid(24)}`;
 
-	const internalHeaders: Record<string, string> = {
-		"Content-Type": "application/json",
-		Authorization: c.req.header("Authorization") ?? "",
-		"x-api-key": c.req.header("x-api-key") ?? "",
-		"User-Agent": c.req.header("User-Agent") ?? "",
-		"x-request-id": c.req.header("x-request-id") ?? "",
-		"x-source": c.req.header("x-source") ?? "",
-		"x-debug": c.req.header("x-debug") ?? "",
-		"HTTP-Referer": c.req.header("HTTP-Referer") ?? "",
-		...internalApiOriginHeaders("responses"),
-	};
+	const internalHeaders: Record<string, string> = forwardedHeaders(c);
 
 	const contextKey = compactionId;
 	setResponsesContext(contextKey, { logId: compactionId });
@@ -906,6 +935,8 @@ responses.post("/compact", async (c) => {
 			);
 		}
 	}
+
+	forwardCacheStatusHeader(c, response);
 
 	const chatJson = await response.json();
 	const createdAt = Math.floor(Date.now() / 1000);


### PR DESCRIPTION
## Problem

The `/v1/responses` translator forwards only a fixed header allowlist onto the inner `/v1/chat/completions` call. It dropped:

- `x-no-cache` — responses-originated requests fully participate in the gateway response cache, so agent workloads on `/v1/responses` could get silent cached replays with no opt-out;
- `x-no-fallback` — a hard provider pin (`provider/model` + `x-no-fallback`) silently kept falling back;
- the sticky-session headers the chat handler reads (`x-session-id`, `x-session-affinity`, `session_id`, `session-id`) — sessions from coding agents never pinned to a provider, hurting upstream prompt-cache hit rates.

It also never copied the `x-llmgateway-cache` response header back, so a replayed body was indistinguishable from a fresh sample.

The sibling hops already do all of this: `/v1/messages` (`anthropic.ts`) and `/v4/ai` (`aisdk.ts`, whose comment claims it "mirrors the `/v1/messages` and `/v1/responses` hops" — until now false for responses).

## Fix

In `apps/gateway/src/responses/responses.ts`:

- Extracted the duplicated header block into a `forwardedHeaders()` helper (same presence-sensitive style as `aisdk.ts`) that additionally forwards `x-no-cache`, `x-no-fallback` and the four session headers, only when the caller actually sent them. Used at both forwarding sites: the main `POST /` handler and `POST /compact`.
- Added `forwardCacheStatusHeader()` which copies `x-llmgateway-cache` from the inner response onto the outgoing response. It runs before the streaming/non-streaming branch in the main handler (covering both lanes) and in the compaction handler.

## Verification

- Extended `apps/gateway/src/responses/responses-route.spec.ts` (mocked `app.request` harness) with two tests: headers are forwarded and `x-llmgateway-cache` is copied back; opt-out headers are omitted when the caller did not send them.
- All responses unit specs pass against an isolated stack (127 tests across `responses-route`, `responses`, `openresponses-compliance`, `tool-registry`, `response-state`).
- `pnpm format` and full `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Gateway requests now preserve supported cache-control and session-affinity headers when forwarding requests.
  - Responses expose the gateway cache status, helping clients identify when a response was served from cache.
  - Cross-origin requests can use the supported gateway control headers and access cache-status information.

- **Bug Fixes**
  - Improved consistency of header forwarding across standard and compact response endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->