### PR TITLE
fix(gateway): 400 on conflicting domain filters

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -11079,6 +11079,83 @@ describe("api", () => {
 		});
 	});
 
+	describe("web_search domain filter validation", () => {
+		// allowed_domains and blocked_domains are mutually exclusive. Without
+		// request-time validation the gateway silently keeps allowed_domains
+		// and drops blocked_domains when preparing the provider request.
+		test("rejects web_search tool with both allowed_domains and blocked_domains", async () => {
+			await db.insert(tables.apiKey).values({
+				id: "token-id-ws-domains",
+				...hashApiKeyForStorage("real-token-ws-domains"),
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token-ws-domains",
+				},
+				body: JSON.stringify({
+					model: "gpt-4o",
+					messages: [{ role: "user", content: "Hello!" }],
+					tools: [
+						{
+							type: "web_search",
+							allowed_domains: ["anthropic.com"],
+							blocked_domains: ["example.com"],
+						},
+					],
+				}),
+			});
+
+			expect(res.status).toBe(400);
+			const json = await res.json();
+			expect(json.error?.code).toBe("unsupported_parameter_combination");
+			expect(json.error?.param).toBe("tools");
+			expect(json.error?.message).toContain("allowed_domains");
+			expect(json.error?.message).toContain("blocked_domains");
+		});
+
+		test("rejects /v1/messages web_search server tool with both domain filters", async () => {
+			await db.insert(tables.apiKey).values({
+				id: "token-id-ws-domains-msgs",
+				...hashApiKeyForStorage("real-token-ws-domains-msgs"),
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+
+			const res = await app.request("/v1/messages", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token-ws-domains-msgs",
+				},
+				body: JSON.stringify({
+					model: "anthropic/claude-sonnet-4-6",
+					max_tokens: 1024,
+					messages: [{ role: "user", content: "Hello!" }],
+					tools: [
+						{
+							type: "web_search_20250305",
+							name: "web_search",
+							allowed_domains: ["anthropic.com"],
+							blocked_domains: ["example.com"],
+						},
+					],
+				}),
+			});
+
+			expect(res.status).toBe(400);
+			const body = await res.text();
+			expect(body).toContain("allowed_domains");
+			expect(body).toContain("blocked_domains");
+		});
+	});
+
 	describe("native /v1/messages reasoning controls for Ling-3.0-flash", () => {
 		// Ling-3.0-flash is a hybrid reasoning model that thinks by default; its
 		// only reasoning control is the vLLM chat-template flag `enable_thinking`

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -11119,6 +11119,82 @@ describe("api", () => {
 			expect(json.error?.message).toContain("blocked_domains");
 		});
 
+		test("rejects a conflicting duplicate web_search tool entry", async () => {
+			// Only the first web_search entry is extracted; a later conflicting
+			// duplicate must still be rejected, not silently discarded.
+			await db.insert(tables.apiKey).values({
+				id: "token-id-ws-domains-dup",
+				...hashApiKeyForStorage("real-token-ws-domains-dup"),
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token-ws-domains-dup",
+				},
+				body: JSON.stringify({
+					model: "gpt-4o",
+					messages: [{ role: "user", content: "Hello!" }],
+					tools: [
+						{
+							type: "web_search",
+							allowed_domains: ["anthropic.com"],
+						},
+						{
+							type: "web_search",
+							allowed_domains: ["anthropic.com"],
+							blocked_domains: ["example.com"],
+						},
+					],
+				}),
+			});
+
+			expect(res.status).toBe(400);
+			const json = await res.json();
+			expect(json.error?.code).toBe("unsupported_parameter_combination");
+			expect(json.error?.param).toBe("tools");
+		});
+
+		test("rejects /v1/responses web_search tool with both domain filters", async () => {
+			await db.insert(tables.apiKey).values({
+				id: "token-id-ws-domains-resp",
+				...hashApiKeyForStorage("real-token-ws-domains-resp"),
+				projectId: "project-id",
+				description: "Test API Key",
+				createdBy: "user-id",
+			});
+
+			const res = await app.request("/v1/responses", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token-ws-domains-resp",
+				},
+				body: JSON.stringify({
+					model: "gpt-4o",
+					input: [{ role: "user", content: "Hello!" }],
+					tools: [
+						{
+							type: "web_search",
+							allowed_domains: ["anthropic.com"],
+							blocked_domains: ["example.com"],
+						},
+					],
+				}),
+			});
+
+			expect(res.status).toBe(400);
+			const json = await res.json();
+			expect(json.error?.code).toBe("unsupported_parameter_combination");
+			expect(json.error?.param).toBe("tools");
+			expect(json.error?.message).toContain("allowed_domains");
+			expect(json.error?.message).toContain("blocked_domains");
+		});
+
 		test("rejects /v1/messages web_search server tool with both domain filters", async () => {
 			await db.insert(tables.apiKey).values({
 				id: "token-id-ws-domains-msgs",
@@ -11150,9 +11226,13 @@ describe("api", () => {
 			});
 
 			expect(res.status).toBe(400);
-			const body = await res.text();
-			expect(body).toContain("allowed_domains");
-			expect(body).toContain("blocked_domains");
+			// The messages route wraps the inner chat error in Anthropic's
+			// envelope, which carries only type + message (no code/param).
+			const json = await res.json();
+			expect(json.type).toBe("error");
+			expect(json.error?.type).toBe("invalid_request_error");
+			expect(json.error?.message).toContain("allowed_domains");
+			expect(json.error?.message).toContain("blocked_domains");
 		});
 	});
 

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1886,6 +1886,27 @@ chat.openapi(completions, async (c) => {
 		}
 	}
 
+	// allowed_domains and blocked_domains are mutually exclusive; providers
+	// accept only one, and silently preferring one would drop the caller's
+	// other filter.
+	if (
+		webSearchTool?.allowed_domains?.length &&
+		webSearchTool.blocked_domains?.length
+	) {
+		return c.json(
+			{
+				error: {
+					message:
+						"The web_search tool cannot specify both allowed_domains and blocked_domains. Use one or the other.",
+					type: "invalid_request_error",
+					param: "tools",
+					code: "unsupported_parameter_combination",
+				},
+			},
+			400,
+		);
+	}
+
 	// A tool_choice that only forces web search says nothing about function
 	// tools, so it must not make a request look like it needs function-tool
 	// support — that would filter out providers that can search but not call

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -1860,6 +1860,31 @@ chat.openapi(completions, async (c) => {
 	// The web_search tool is a special tool that enables native web search for providers that support it
 	let webSearchTool: WebSearchTool | undefined;
 	if (tools && Array.isArray(tools)) {
+		// allowed_domains and blocked_domains are mutually exclusive; providers
+		// accept only one, and silently preferring one would drop the caller's
+		// other filter. Check every entry — only the first web_search tool is
+		// extracted below, so a conflicting duplicate must be rejected here.
+		if (
+			tools.some(
+				(tool: any) =>
+					tool.type === "web_search" &&
+					tool.allowed_domains?.length &&
+					tool.blocked_domains?.length,
+			)
+		) {
+			return c.json(
+				{
+					error: {
+						message:
+							"The web_search tool cannot specify both allowed_domains and blocked_domains. Use one or the other.",
+						type: "invalid_request_error",
+						param: "tools",
+						code: "unsupported_parameter_combination",
+					},
+				},
+				400,
+			);
+		}
 		const webSearchToolIndex = tools.findIndex(
 			(tool: any) => tool.type === "web_search",
 		);
@@ -1884,27 +1909,6 @@ chat.openapi(completions, async (c) => {
 			// Remove the web_search tool from the tools array so it's not sent as a regular tool
 			tools.splice(webSearchToolIndex, 1);
 		}
-	}
-
-	// allowed_domains and blocked_domains are mutually exclusive; providers
-	// accept only one, and silently preferring one would drop the caller's
-	// other filter.
-	if (
-		webSearchTool?.allowed_domains?.length &&
-		webSearchTool.blocked_domains?.length
-	) {
-		return c.json(
-			{
-				error: {
-					message:
-						"The web_search tool cannot specify both allowed_domains and blocked_domains. Use one or the other.",
-					type: "invalid_request_error",
-					param: "tools",
-					code: "unsupported_parameter_combination",
-				},
-			},
-			400,
-		);
 	}
 
 	// A tool_choice that only forces web search says nothing about function


### PR DESCRIPTION
## Problem

The `web_search` tool accepts `allowed_domains` and `blocked_domains`, documented as mutually exclusive (`packages/models/src/types.ts`). But when a caller sent both, the gateway silently kept `allowed_domains` and dropped `blocked_domains` at request-preparation time (`packages/actions/src/prepare-request-body.ts`, Anthropic path) — no 400, no warning. The caller's blocklist just vanished.

## Fix

Add request-time validation in the chat completions handler that returns a 400 with `code: "unsupported_parameter_combination"` (same envelope as the existing `n` + `stream` + tools guard) when a `web_search` tool carries both non-empty domain filters.

The check sits right after the web_search tool extraction, which every lane funnels through: `/v1/responses` passes the tool object through unchanged and `/v1/messages` translates `web_search_20250305` into the same internal tool before delegating to the inner chat completions handler, so all three surfaces reject the combination.

The precedence logic in `prepare-request-body.ts` stays in place as defense in depth.

## Verification

- New specs in `apps/gateway/src/api.spec.ts` ("web_search domain filter validation"): both-filters requests 400 on `/v1/chat/completions` and `/v1/messages` — both pass against an isolated stack.
- Existing web_search-related specs (n-parameter exemptions, `/v1/messages` server tool forwarding, cache behavior) and the full `responses.spec.ts` (79 tests) still pass.
- `pnpm format` and `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Web search requests that include both allowed and blocked domain filters are now rejected with a clear HTTP 400 validation error.
  * The validation applies consistently to chat completions and messages API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->