### PR TITLE
fix(gateway): replay cached responses intact

### DIFF
--- a/apps/docs/content/features/caching/gateway-caching.mdx
+++ b/apps/docs/content/features/caching/gateway-caching.mdx
@@ -115,33 +115,9 @@ The default cache duration is 60 seconds. Adjust this based on your use case—l
 
 ## Identifying Cached Responses
 
-A cache hit replays the stored response body, so it is byte-identical to the original — same `id`, same content. Two markers tell you it was a replay:
+A cache hit replays the stored response body byte-for-byte — including the original `id`, metadata, usage, and cost fields. Check the `x-llmgateway-cache: HIT` response header to tell it apart from the original response. The header is set on every lane, including `/v1/messages` and `/v1/responses`.
 
-- the `x-llmgateway-cache: HIT` response header (set on every lane, including `/v1/messages`, which has no metadata envelope)
-- `metadata.cached: true` on the response body (and on the final metadata chunk of a streamed replay)
-
-All cost fields are zeroed on a replay, because no upstream call was made:
-
-```json
-{
-	"usage": {
-		"prompt_tokens": 12,
-		"completion_tokens": 48,
-		"total_tokens": 60,
-		"cost": 0,
-		"cost_details": {
-			"total_cost": 0,
-			"input_cost": 0,
-			"output_cost": 0
-		}
-	},
-	"metadata": {
-		"cached": true
-	}
-}
-```
-
-Token counts are **not** zeroed — they still describe the completion you are receiving, and are what the dashboard records for analytics. Note that any prompt-caching fields (`prompt_tokens_details.cached_tokens`, `cache_write_tokens`) describe the _original_ upstream call, not the replay.
+Because the body is unchanged, its usage and cost fields describe the original upstream call. The cache-hit log row records zero cost, and no provider charge is incurred for the replay.
 
 ## Bypassing the Cache for a Single Request
 

--- a/apps/gateway/src/anthropic/anthropic.ts
+++ b/apps/gateway/src/anthropic/anthropic.ts
@@ -1157,9 +1157,8 @@ anthropic.openapi(messages, async (c) => {
 	}
 
 	// Surface gateway response-cache replays to native Anthropic clients. The
-	// Anthropic response body has no metadata envelope to carry the marker the
-	// inner /v1/chat/completions puts on `metadata.cached`, so forward the
-	// header instead — without it a replayed body (same id, same usage) is
+	// Anthropic response body has no metadata envelope for a replay marker, so
+	// forward the header — without it a replayed body (same id, same usage) is
 	// indistinguishable from a fresh sample.
 	const innerCacheStatus = response.headers.get("x-llmgateway-cache");
 	if (innerCacheStatus) {

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -6971,8 +6971,9 @@ describe("api", () => {
 		expect(res.status).toBe(200);
 	});
 
-	// gateway response cache hits make no upstream call, so they must be free
-	test("/v1/chat/completions cached responses are free", async () => {
+	// Gateway response cache hits make no upstream call, so their log rows are
+	// free even though the original response body is replayed byte-for-byte.
+	test("/v1/chat/completions replays cached responses verbatim", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id-cache",
 			...hashApiKeyForStorage("real-token-cache"),
@@ -7029,7 +7030,8 @@ describe("api", () => {
 			process.env.NODE_ENV = originalNodeEnv;
 		}
 		expect(firstRes.status).toBe(200);
-		const firstJson = await firstRes.json();
+		const firstBody = await firstRes.text();
+		const firstJson = JSON.parse(firstBody);
 		expect(firstRes.headers.get("x-llmgateway-cache")).toBeNull();
 		expect(firstJson.metadata.cached).toBeUndefined();
 		expect(firstJson.usage.cost).toBeGreaterThan(0);
@@ -7044,19 +7046,11 @@ describe("api", () => {
 		const secondRes = await makeRequest();
 		expect(secondRes.status).toBe(200);
 
-		// A replay must be distinguishable from a fresh sample: same body, same
-		// id, so the marker is the only signal a caller has.
+		// The header is the only replay marker because the stored response body is
+		// returned unchanged.
 		expect(secondRes.headers.get("x-llmgateway-cache")).toBe("HIT");
-		const secondJson = await secondRes.json();
-		expect(secondJson.metadata.cached).toBe(true);
-		// ...and it must not report the original call's cost, which the caller
-		// was not charged for.
-		expect(secondJson.usage.cost).toBe(0);
-		expect(secondJson.usage.cost_details.total_cost).toBe(0);
-		expect(secondJson.usage.cost_details.input_cost).toBe(0);
-		expect(secondJson.usage.cost_details.output_cost).toBe(0);
-		// Token counts still describe the returned completion.
-		expect(secondJson.usage.prompt_tokens).toBeGreaterThan(0);
+		const secondBody = await secondRes.text();
+		expect(secondBody).toBe(firstBody);
 
 		const afterSecond = await waitForLogs(2);
 		expect(afterSecond.length).toBe(2);
@@ -7084,6 +7078,75 @@ describe("api", () => {
 
 		const afterBypass = await waitForLogs(3);
 		expect(afterBypass.filter((log) => log.cached).length).toBe(1);
+	});
+
+	test("/v1/responses forwards cache controls", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id-responses-cache",
+			...hashApiKeyForStorage("real-token-responses-cache"),
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-responses-cache",
+			...encryptProviderKeyForStorage(
+				"sk-test-key",
+				"provider-key-id-responses-cache",
+				"org-id",
+			),
+			provider: "openai",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		await db
+			.update(tables.project)
+			.set({ cachingEnabled: true })
+			.where(eq(tables.project.id, "project-id"));
+
+		const body = JSON.stringify({
+			model: "openai/gpt-4o-mini",
+			input: `Cache this response! ${randomUUID()}`,
+		});
+		const makeRequest = (headers: Record<string, string> = {}) =>
+			app.request("/v1/responses", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token-responses-cache",
+					...headers,
+				},
+				body,
+			});
+
+		const originalNodeEnv = process.env.NODE_ENV;
+		let firstRes: Response;
+		try {
+			process.env.NODE_ENV = "development";
+			firstRes = await makeRequest();
+		} finally {
+			process.env.NODE_ENV = originalNodeEnv;
+		}
+		expect(firstRes.status).toBe(200);
+		expect(firstRes.headers.get("x-llmgateway-cache")).toBeNull();
+		const firstBody = await firstRes.text();
+		await waitForLogs(1);
+
+		const replayRes = await makeRequest();
+		expect(replayRes.status).toBe(200);
+		expect(replayRes.headers.get("x-llmgateway-cache")).toBe("HIT");
+		expect(await replayRes.text()).toBe(firstBody);
+		const afterReplay = await waitForLogs(2);
+		expect(afterReplay.filter((log) => log.cached)).toHaveLength(1);
+
+		const bypassRes = await makeRequest({ "x-no-cache": "true" });
+		expect(bypassRes.status).toBe(200);
+		expect(bypassRes.headers.get("x-llmgateway-cache")).toBeNull();
+		await bypassRes.text();
+		const afterBypass = await waitForLogs(3);
+		expect(afterBypass.filter((log) => log.cached)).toHaveLength(1);
 	});
 
 	// GHSA-h9ww-f95j-h54c: cache keys are project-scoped, so a byte-identical
@@ -7197,7 +7260,7 @@ describe("api", () => {
 		expect(attackerJson.metadata.cached).toBeUndefined();
 	});
 
-	test("/v1/chat/completions streaming cache hits are marked and free", async () => {
+	test("/v1/chat/completions replays cached streams verbatim", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id-cache-stream",
 			...hashApiKeyForStorage("real-token-cache-stream"),
@@ -7245,11 +7308,13 @@ describe("api", () => {
 			chunks.find((chunk) => chunk?.usage?.cost !== undefined);
 
 		const originalNodeEnv = process.env.NODE_ENV;
+		let firstBody = "";
 		try {
 			process.env.NODE_ENV = "development";
 			const firstRes = await makeRequest();
 			expect(firstRes.status).toBe(200);
 			const first = await readAll(firstRes.body);
+			firstBody = first.fullContent ?? "";
 			expect(firstRes.headers.get("x-llmgateway-cache")).toBeNull();
 			expect(findCostChunk(first.chunks).usage.cost).toBeGreaterThan(0);
 		} finally {
@@ -7262,15 +7327,12 @@ describe("api", () => {
 		expect(secondRes.headers.get("x-llmgateway-cache")).toBe("HIT");
 
 		const replay = await readAll(secondRes.body);
-		const metadataChunk = replay.chunks.find(
-			(chunk: any) => chunk?.metadata !== undefined,
-		);
-		expect(metadataChunk.metadata.cached).toBe(true);
+		expect(replay.fullContent).toBe(firstBody);
 
-		// The stored chunks carry the original call's cost; the replay must not.
+		// The wire usage remains unchanged; billing uses the zero-cost cache-hit
+		// log row below.
 		const replayCostChunk = findCostChunk(replay.chunks);
-		expect(replayCostChunk.usage.cost).toBe(0);
-		expect(replayCostChunk.usage.cost_details.total_cost).toBe(0);
+		expect(replayCostChunk.usage.cost).toBeGreaterThan(0);
 		expect(replayCostChunk.usage.prompt_tokens).toBeGreaterThan(0);
 
 		const logs = await waitForLogs(2);

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -317,11 +317,8 @@ import {
 } from "./tools/tokenizer.js";
 import {
 	applyExtendedUsageFields,
-	stripRequestScopedMetadataFromOpenAiResponse,
 	toResponseMetadataExtras,
 	transformResponseToOpenai,
-	withCurrentRequestMetadataOnOpenAiResponse,
-	zeroCostsOnCachedResponseUsage,
 } from "./tools/transform-response-to-openai.js";
 import {
 	type AnthropicToolSearchState,
@@ -1503,10 +1500,6 @@ const completions = createRoute({
 							organization_id: z.string().optional(),
 							project_id: z.string().optional(),
 							discount: z.number().nullable().optional(),
-							cached: z.boolean().optional().openapi({
-								description:
-									"True when the response was replayed from the gateway response cache instead of being generated upstream. Omitted otherwise.",
-							}),
 							routing: z
 								.array(
 									z.object({
@@ -6405,6 +6398,7 @@ chat.openapi(completions, async (c) => {
 
 	if (cachingEnabled) {
 		const cachePayload = {
+			apiOrigin,
 			provider: usedProvider,
 			model: usedInternalModel,
 			messages,
@@ -6431,6 +6425,12 @@ chat.openapi(completions, async (c) => {
 			const cachedStreamingResponse =
 				await getStreamingCache(streamingCacheKey);
 			if (cachedStreamingResponse?.metadata.completed) {
+				if (logIdOverride && cachedStreamingResponse.metadata.responseId) {
+					c.header(
+						"x-llmgateway-cache-response-id",
+						cachedStreamingResponse.metadata.responseId,
+					);
+				}
 				// Extract final content and metadata from cached chunks
 				let fullContent = "";
 				let fullReasoningContent = "";
@@ -6656,42 +6656,7 @@ chat.openapi(completions, async (c) => {
 							?.toolResults ?? null,
 				});
 
-				const cachedResponseMetadata = {
-					...buildFinalResponseMetadata(costs.discount ?? null),
-					cached: true,
-				};
 				c.header("x-llmgateway-cache", "HIT");
-				let hasMetadataChunk = false;
-				for (
-					let chunkIndex = cachedStreamingResponse.chunks.length - 1;
-					chunkIndex >= 0;
-					chunkIndex--
-				) {
-					const chunk = cachedStreamingResponse.chunks[chunkIndex];
-					if (!chunk) {
-						continue;
-					}
-					const isMetadataChunk = (() => {
-						if (chunk.data === "[DONE]") {
-							return false;
-						}
-						try {
-							const parsed: unknown = JSON.parse(chunk.data);
-							return (
-								typeof parsed === "object" &&
-								parsed !== null &&
-								!Array.isArray(parsed) &&
-								("usage" in parsed || "metadata" in parsed)
-							);
-						} catch {
-							return false;
-						}
-					})();
-					if (isMetadataChunk) {
-						hasMetadataChunk = true;
-						break;
-					}
-				}
 
 				// Return cached streaming response by replaying chunks with original timing
 				return streamSSE(
@@ -6711,58 +6676,8 @@ chat.openapi(completions, async (c) => {
 								});
 							}
 
-							let data = chunk.data;
-							if (hasMetadataChunk && chunk.data !== "[DONE]") {
-								let parsed: Record<string, unknown> | undefined;
-								try {
-									const parsedValue: unknown = JSON.parse(chunk.data);
-									if (
-										typeof parsedValue === "object" &&
-										parsedValue !== null &&
-										!Array.isArray(parsedValue) &&
-										("usage" in parsedValue || "metadata" in parsedValue)
-									) {
-										parsed = parsedValue;
-									}
-								} catch {
-									parsed = undefined;
-								}
-								if (parsed) {
-									const metadata =
-										typeof parsed.metadata === "object" &&
-										parsed.metadata !== null &&
-										!Array.isArray(parsed.metadata)
-											? parsed.metadata
-											: {};
-									data = JSON.stringify({
-										...parsed,
-										// The replay is free; the stored chunk still carries the
-										// original call's cost.
-										...(parsed.usage
-											? {
-													usage: zeroCostsOnCachedResponseUsage(
-														parsed.usage as Record<string, unknown>,
-													),
-												}
-											: {}),
-										metadata: {
-											...metadata,
-											...cachedResponseMetadata,
-										},
-									});
-								}
-							} else if (!hasMetadataChunk && chunk.data === "[DONE]") {
-								// No usage/metadata chunk in the cached stream — emit a
-								// synthetic metadata chunk before [DONE] so consumers always
-								// receive logId, organizationId, projectId, and discount.
-								await stream.writeSSE({
-									data: JSON.stringify({ metadata: cachedResponseMetadata }),
-									id: `${chunk.eventId}-metadata`,
-								});
-							}
-
 							await stream.writeSSE({
-								data,
+								data: chunk.data,
 								id: String(chunk.eventId),
 								event: chunk.event,
 							});
@@ -6785,6 +6700,10 @@ chat.openapi(completions, async (c) => {
 			cacheKey = generateCacheKey(project.id, cachePayload);
 			const cachedResponse = cacheKey ? await getCache(cacheKey) : null;
 			if (cachedResponse) {
+				const cachedResponseId = cachedResponse.metadata?.log_id;
+				if (logIdOverride && typeof cachedResponseId === "string") {
+					c.header("x-llmgateway-cache-response-id", cachedResponseId);
+				}
 				// Log the cached request
 				const duration = 0; // No processing time needed
 
@@ -6822,26 +6741,9 @@ chat.openapi(completions, async (c) => {
 					},
 				);
 
-				// A replay is served from Redis with no upstream call, so it is free
-				// and must not report the original call's cost. Mark it explicitly
-				// too — byte-identical bodies are otherwise indistinguishable from a
-				// fresh sample, and the replayed usage (e.g. a prompt-cache write)
-				// describes the original request, not this one.
-				const responseForCurrentRequest =
-					withCurrentRequestMetadataOnOpenAiResponse(
-						{
-							...cachedResponse,
-							usage: zeroCostsOnCachedResponseUsage(cachedResponse.usage),
-						},
-						requestId,
-						{
-							logId: finalLogId,
-							organizationId: project.organizationId,
-							projectId: apiKey.projectId,
-							discount: cachedCosts.discount ?? null,
-							cached: true,
-						},
-					);
+				// The body is the cached response verbatim. The response header marks
+				// the hit, while the new log row below records this request as free.
+				const responseForCurrentRequest = cachedResponse;
 				c.header("x-llmgateway-cache", "HIT");
 
 				// Extract plugin IDs for logging (cached non-streaming)
@@ -12194,6 +12096,7 @@ chat.openapi(completions, async (c) => {
 								metadata: {
 									model: usedInternalModel,
 									provider: usedProvider,
+									responseId: finalLogId,
 									finishReason: finishReason,
 									totalChunks: streamingChunks.length,
 									duration: duration,
@@ -14568,11 +14471,7 @@ chat.openapi(completions, async (c) => {
 	}
 
 	if (cachingEnabled && cacheKey && !stream && !hasEmptyNonStreamingResponse) {
-		await setCache(
-			cacheKey,
-			stripRequestScopedMetadataFromOpenAiResponse(transformedResponse),
-			cacheDuration,
-		);
+		await setCache(cacheKey, transformedResponse, cacheDuration);
 	}
 
 	// For image generation models with streaming requested, convert to SSE format

--- a/apps/gateway/src/chat/tools/transform-response-to-openai.spec.ts
+++ b/apps/gateway/src/chat/tools/transform-response-to-openai.spec.ts
@@ -3,8 +3,6 @@ import { describe, expect, test, vi } from "vitest";
 import {
 	applyExtendedUsageFields,
 	transformResponseToOpenai,
-	stripRequestScopedMetadataFromOpenAiResponse,
-	withCurrentRequestMetadataOnOpenAiResponse,
 } from "./transform-response-to-openai.js";
 
 import type { Provider } from "@llmgateway/models";
@@ -608,41 +606,6 @@ describe("transformResponseToOpenai", () => {
 		},
 	);
 
-	test("strips request-scoped metadata before caching", () => {
-		const response = stripRequestScopedMetadataFromOpenAiResponse({
-			metadata: {
-				request_id: "req_old",
-				log_id: "log-old",
-				organization_id: "org-old",
-				project_id: "project-old",
-				discount: 0.2,
-				routing: [
-					{
-						provider: "openai",
-						model: "gpt-4o-mini",
-						status_code: 500,
-						error_type: "upstream_error",
-						succeeded: false,
-						apiKeyHash: "hash-a",
-						logId: "log-a",
-					},
-				],
-			},
-		});
-
-		expect(response.metadata).toEqual({
-			routing: [
-				{
-					provider: "openai",
-					model: "gpt-4o-mini",
-					status_code: 500,
-					error_type: "upstream_error",
-					succeeded: false,
-				},
-			],
-		});
-	});
-
 	test("emits extended usage fields", () => {
 		const response = transformResponseToOpenai(
 			"openai",
@@ -942,54 +905,5 @@ describe("transformResponseToOpenai", () => {
 		});
 		expect(usage.cost).toBeUndefined();
 		expect(usage.cost_details).toBeUndefined();
-	});
-
-	test("applies the current request id to cached responses", () => {
-		const response = withCurrentRequestMetadataOnOpenAiResponse(
-			{
-				metadata: {
-					request_id: "req_old",
-					log_id: "log-old",
-					organization_id: "org-old",
-					project_id: "project-old",
-					discount: 0.2,
-					routing: [
-						{
-							provider: "openai",
-							model: "gpt-4o-mini",
-							status_code: 500,
-							error_type: "upstream_error",
-							succeeded: false,
-							apiKeyHash: "hash-a",
-							logId: "log-a",
-						},
-					],
-				},
-			},
-			"req_new",
-			{
-				logId: "log-new",
-				organizationId: "org-new",
-				projectId: "project-new",
-				discount: 0.1,
-			},
-		);
-
-		expect(response.metadata).toEqual({
-			request_id: "req_new",
-			log_id: "log-new",
-			organization_id: "org-new",
-			project_id: "project-new",
-			discount: 0.1,
-			routing: [
-				{
-					provider: "openai",
-					model: "gpt-4o-mini",
-					status_code: 500,
-					error_type: "upstream_error",
-					succeeded: false,
-				},
-			],
-		});
 	});
 });

--- a/apps/gateway/src/chat/tools/transform-response-to-openai.ts
+++ b/apps/gateway/src/chat/tools/transform-response-to-openai.ts
@@ -43,11 +43,6 @@ export interface ResponseMetadataExtras {
 	 * an org-level default (e.g. the DevPass flex setting) stays visible.
 	 */
 	usedServiceTier?: "flex" | "priority" | null;
-	/**
-	 * True when the body is a gateway response-cache replay rather than a fresh
-	 * upstream call. Only emitted on hits, so a missing key means "not cached".
-	 */
-	cached?: boolean;
 }
 
 export function toResponseMetadataExtras(
@@ -70,39 +65,7 @@ export function toResponseMetadataExtras(
 		...(extras.requestedServiceTier || extras.usedServiceTier
 			? { used_service_tier: extras.usedServiceTier ?? null }
 			: {}),
-		...(extras.cached ? { cached: true } : {}),
 	};
-}
-
-/**
- * Zero the cost fields of a gateway response-cache replay.
- *
- * A cache hit never reaches a provider, so it is free — but the stored body
- * still carries the cost of the original (uncached) call, which made replays
- * report a full charge to the caller. Token counts are left untouched: they
- * still describe the completion being returned and are what the log row keeps
- * for analytics.
- */
-export function zeroCostsOnCachedResponseUsage(
-	usage: Record<string, unknown> | undefined | null,
-): Record<string, unknown> | undefined | null {
-	if (!usage || typeof usage !== "object") {
-		return usage;
-	}
-
-	const next: Record<string, unknown> = { ...usage };
-	if (typeof next.cost === "number") {
-		next.cost = 0;
-	}
-	const costDetails = next.cost_details;
-	if (costDetails && typeof costDetails === "object") {
-		next.cost_details = Object.fromEntries(
-			Object.entries(costDetails as Record<string, unknown>).map(
-				([key, value]) => [key, typeof value === "number" ? 0 : value],
-			),
-		);
-	}
-	return next;
 }
 
 export function applyExtendedUsageFields(
@@ -269,72 +232,6 @@ function buildMetadata(
 		...(usedRegion && { used_region: usedRegion }),
 		underlying_used_model: usedModel,
 		...(routing && { routing }),
-	};
-}
-
-function sanitizeRoutingAttempts(
-	routing: RoutingAttempt[] | null | undefined,
-): RoutingAttempt[] | undefined {
-	if (!routing) {
-		return undefined;
-	}
-
-	return routing.map(
-		({ apiKeyHash: _apiKeyHash, logId: _logId, ...attempt }) => ({
-			...attempt,
-		}),
-	);
-}
-
-export function stripRequestScopedMetadataFromOpenAiResponse<
-	T extends {
-		metadata?: Record<string, unknown> | null;
-	},
->(response: T): T {
-	const metadata = response.metadata;
-	if (!metadata || typeof metadata !== "object") {
-		return response;
-	}
-
-	const nextMetadata = { ...metadata };
-	delete nextMetadata.request_id;
-	delete nextMetadata.log_id;
-	delete nextMetadata.organization_id;
-	delete nextMetadata.project_id;
-	delete nextMetadata.discount;
-
-	if (Array.isArray(metadata.routing)) {
-		nextMetadata.routing = sanitizeRoutingAttempts(
-			metadata.routing as RoutingAttempt[],
-		);
-	}
-
-	return {
-		...response,
-		metadata: nextMetadata,
-	};
-}
-
-export function withCurrentRequestMetadataOnOpenAiResponse<
-	T extends {
-		metadata?: Record<string, unknown> | null;
-	},
->(response: T, requestId: string, extras?: ResponseMetadataExtras): T {
-	const sanitizedResponse =
-		stripRequestScopedMetadataFromOpenAiResponse(response);
-	const metadata = sanitizedResponse.metadata;
-
-	if (!metadata || typeof metadata !== "object") {
-		return sanitizedResponse;
-	}
-
-	return {
-		...sanitizedResponse,
-		metadata: {
-			...metadata,
-			request_id: requestId,
-			...toResponseMetadataExtras(extras),
-		},
 	};
 }
 

--- a/apps/gateway/src/responses/responses.ts
+++ b/apps/gateway/src/responses/responses.ts
@@ -411,7 +411,6 @@ responses.post("/", async (c) => {
 	// Generate log ID with resp_ prefix — this is both the log entry's primary key
 	// and the Responses API response ID
 	const logId = `resp_${shortid(24)}`;
-	const state = createStreamingState(req.model, logId, req, toolRegistry);
 
 	// Make internal request to the existing chat completions endpoint
 	const internalHeaders: Record<string, string> = {
@@ -424,6 +423,9 @@ responses.post("/", async (c) => {
 		"x-debug": c.req.header("x-debug") ?? "",
 		"HTTP-Referer": c.req.header("HTTP-Referer") ?? "",
 		...internalApiOriginHeaders("responses"),
+		...(c.req.header("x-no-cache") !== undefined
+			? { "x-no-cache": c.req.header("x-no-cache")! }
+			: {}),
 	};
 
 	// Pass Responses API context via in-memory Map (not headers) so the chat
@@ -468,8 +470,21 @@ responses.post("/", async (c) => {
 		}
 	}
 
+	const cacheStatus = response.headers.get("x-llmgateway-cache");
+	if (cacheStatus) {
+		c.header("x-llmgateway-cache", cacheStatus);
+	}
+	const responseId =
+		response.headers.get("x-llmgateway-cache-response-id") ?? logId;
+
 	// Handle streaming response
 	if (req.stream) {
+		const state = createStreamingState(
+			req.model,
+			responseId,
+			req,
+			toolRegistry,
+		);
 		if (!response.body) {
 			return c.json(
 				{
@@ -496,6 +511,9 @@ responses.post("/", async (c) => {
 				}
 				if (typeof chunk?.model === "string" && chunk.model) {
 					state.model = chunk.model;
+				}
+				if (typeof chunk?.created === "number") {
+					state.createdAt = chunk.created;
 				}
 				const createdEvent = createResponseCreatedEvent(state);
 				await stream.writeSSE({
@@ -549,9 +567,9 @@ responses.post("/", async (c) => {
 						);
 						const completedResponse = completedData.response;
 						await storeResponse(
-							logId,
+							responseId,
 							{
-								id: logId,
+								id: responseId,
 								input: inputItems,
 								output: buildFinalOutputItems(state),
 								instructions: req.instructions,
@@ -653,7 +671,7 @@ responses.post("/", async (c) => {
 	const responsesResponse = convertChatResponseToResponses(
 		chatJson,
 		req.model,
-		logId,
+		responseId,
 		req,
 		toolRegistry,
 	);
@@ -663,9 +681,9 @@ responses.post("/", async (c) => {
 	// them) so chaining preserves reasoning like OpenAI's stored responses do.
 	if (shouldStore) {
 		await storeResponse(
-			logId,
+			responseId,
 			{
-				id: logId,
+				id: responseId,
 				input: inputItems,
 				output: responsesResponse.output,
 				instructions: req.instructions,

--- a/apps/gateway/src/responses/tools/convert-chat-to-responses.ts
+++ b/apps/gateway/src/responses/tools/convert-chat-to-responses.ts
@@ -1,5 +1,6 @@
 import { shortid } from "@llmgateway/db";
 
+import { responseItemId } from "./response-item-id.js";
 import { toResponsesToolCallItem } from "./tool-registry.js";
 
 import type { ToolRegistry } from "./tool-registry.js";
@@ -308,6 +309,7 @@ export function convertChatResponseToResponses(
 	request?: ResponsesEchoRequest,
 	toolRegistry?: ToolRegistry,
 ): ResponsesApiResponse {
+	const resolvedResponseId = responseId ?? `resp_${shortid(24)}`;
 	const choice = chatResponse.choices?.[0];
 	const message = choice?.message;
 	const output: ResponsesApiOutput[] = [];
@@ -334,7 +336,7 @@ export function convertChatResponseToResponses(
 				id:
 					typeof detail.id === "string" && detail.id
 						? detail.id
-						: `rs_${shortid(24)}`,
+						: responseItemId("rs", resolvedResponseId, index),
 				summary:
 					index === 0 && message?.reasoning
 						? [{ type: "summary_text", text: message.reasoning }]
@@ -345,7 +347,7 @@ export function convertChatResponseToResponses(
 	} else if (message?.reasoning) {
 		output.push({
 			type: "reasoning",
-			id: `rs_${shortid(24)}`,
+			id: responseItemId("rs", resolvedResponseId, output.length),
 			summary: [{ type: "summary_text", text: message.reasoning }],
 		});
 	}
@@ -392,9 +394,10 @@ export function convertChatResponseToResponses(
 	const buildMessageItem = (
 		item: { text: string; phase?: string },
 		isLast: boolean,
+		outputIndex: number,
 	): ResponsesApiOutput => ({
 		type: "message",
-		id: `msg_${shortid(24)}`,
+		id: responseItemId("msg", resolvedResponseId, outputIndex),
 		role: "assistant",
 		content: [
 			{
@@ -422,6 +425,7 @@ export function convertChatResponseToResponses(
 				buildMessageItem(
 					messageItems[nextMessage]!,
 					nextMessage === messageItems.length - 1,
+					output.length,
 				),
 			);
 			nextMessage++;
@@ -432,7 +436,7 @@ export function convertChatResponseToResponses(
 		emitMessagesUpTo(callIndex);
 		output.push(
 			toResponsesToolCallItem(toolRegistry, {
-				id: `fc_${shortid(24)}`,
+				id: responseItemId("fc", resolvedResponseId, output.length),
 				callId: toolCall.id,
 				name: toolCall.function.name,
 				arguments: toolCall.function.arguments,
@@ -453,7 +457,7 @@ export function convertChatResponseToResponses(
 		}
 		output.push({
 			type: "image_generation_call",
-			id: `ig_${shortid(24)}`,
+			id: responseItemId("ig", resolvedResponseId, output.length),
 			status: "completed",
 			result: match[1],
 		});
@@ -499,7 +503,7 @@ export function convertChatResponseToResponses(
 	const created = chatResponse.created ?? Math.floor(Date.now() / 1000);
 
 	return {
-		id: responseId ?? `resp_${shortid(24)}`,
+		id: resolvedResponseId,
 		object: "response",
 		created_at: created,
 		completed_at: status === "completed" ? created : null,

--- a/apps/gateway/src/responses/tools/convert-streaming-to-responses.ts
+++ b/apps/gateway/src/responses/tools/convert-streaming-to-responses.ts
@@ -6,6 +6,7 @@ import {
 	resolveReasoningContext,
 	stripEncryptedReasoningContent,
 } from "./convert-chat-to-responses.js";
+import { responseItemId } from "./response-item-id.js";
 import { toResponsesToolCallItem } from "./tool-registry.js";
 
 import type { ResponsesEchoRequest } from "./convert-chat-to-responses.js";
@@ -102,14 +103,15 @@ export function createStreamingState(
 	request?: ResponsesEchoRequest,
 	toolRegistry?: ToolRegistry,
 ): StreamingState {
+	const resolvedResponseId = responseId ?? `resp_${shortid(24)}`;
 	return {
-		responseId: responseId ?? `resp_${shortid(24)}`,
+		responseId: resolvedResponseId,
 		model,
 		createdAt: Math.floor(Date.now() / 1000),
 		outputItemIndex: 0,
 		messageItems: [],
-		messageId: `msg_${shortid(24)}`,
-		reasoningId: `rs_${shortid(24)}`,
+		messageId: responseItemId("msg", resolvedResponseId, 0),
+		reasoningId: responseItemId("rs", resolvedResponseId, 0),
 		fullReasoning: [],
 		reasoningItems: [],
 		reasoningStarted: false,
@@ -392,7 +394,11 @@ export function processStreamChunk(
 						? detail.id
 						: state.reasoningItems.length === 0
 							? state.reasoningId
-							: `rs_${shortid(24)}`;
+							: responseItemId(
+									"rs",
+									state.responseId,
+									state.reasoningItems.length,
+								);
 				const outputIndex = state.outputItemIndex++;
 				state.reasoningItems.push({
 					id,
@@ -423,10 +429,11 @@ export function processStreamChunk(
 		for (const tc of delta.tool_calls) {
 			const existing = state.toolCalls.get(tc.index);
 			if (!existing) {
-				const callId = tc.id ?? `call_${shortid(24)}`;
 				const name = tc.function?.name ?? "";
-				const fcId = `fc_${shortid(24)}`;
 				const tcOutputIndex = state.outputItemIndex++;
+				const callId =
+					tc.id ?? responseItemId("call", state.responseId, tcOutputIndex);
+				const fcId = responseItemId("fc", state.responseId, tcOutputIndex);
 				state.toolCalls.set(tc.index, {
 					id: fcId,
 					callId,
@@ -483,7 +490,11 @@ export function processStreamChunk(
 				id:
 					state.messageItems.length === 0
 						? state.messageId
-						: `msg_${shortid(24)}`,
+						: responseItemId(
+								"msg",
+								state.responseId,
+								state.messageItems.length,
+							),
 				// Reserve this item's output index so later items (e.g. tool calls
 				// following pre-tool commentary) don't claim the same index.
 				outputIndex: state.outputItemIndex++,

--- a/apps/gateway/src/responses/tools/response-item-id.ts
+++ b/apps/gateway/src/responses/tools/response-item-id.ts
@@ -1,0 +1,13 @@
+import { createHash } from "node:crypto";
+
+export function responseItemId(
+	prefix: string,
+	responseId: string,
+	index: number,
+): string {
+	const suffix = createHash("sha256")
+		.update(`${responseId}:${prefix}:${index}`)
+		.digest("hex")
+		.slice(0, 24);
+	return `${prefix}_${suffix}`;
+}

--- a/packages/cache/src/cache.spec.ts
+++ b/packages/cache/src/cache.spec.ts
@@ -15,7 +15,7 @@ describe("generateCacheKey", () => {
 
 	it("prefixes the key with the tenant scope", () => {
 		expect(generateCacheKey("project-a", payload)).toMatch(
-			/^project-a:[0-9a-f]{64}$/,
+			/^project-a:v2:[0-9a-f]{64}$/,
 		);
 	});
 

--- a/packages/cache/src/cache.ts
+++ b/packages/cache/src/cache.ts
@@ -20,7 +20,9 @@ export function generateCacheKey(
 		.createHash("sha256")
 		.update(JSON.stringify(payload))
 		.digest("hex");
-	return `${scope}:${hash}`;
+	// Version the wire-response cache so entries written before replay became
+	// byte-identical cannot be returned in the old, request-rewritten shape.
+	return `${scope}:v2:${hash}`;
 }
 
 export async function setCache(
@@ -71,6 +73,7 @@ interface StreamingCacheData {
 	metadata: {
 		model: string;
 		provider: string;
+		responseId?: string;
 		finishReason: string | null;
 		totalChunks: number;
 		duration: number;


### PR DESCRIPTION
## Problem

Gateway cache hits rewrote response metadata and cost fields, so replay bodies differed from the original. The Responses adapter also dropped cache controls and rebuilt response IDs.

## Changes

- replay cached chat bodies and stream chunks unchanged while keeping cache-hit log rows zero-cost
- version cache entries, scope keys by API surface, and preserve stable Responses IDs
- forward `x-no-cache` and surface `x-llmgateway-cache` on `/v1/responses`
- update caching docs and regression coverage

## Verification

- `pnpm format`
- `pnpm build`
- `pnpm exec vitest run packages/cache/src/cache.spec.ts --no-file-parallelism`
- `pnpm exec vitest run apps/gateway/src/responses/responses.spec.ts apps/gateway/src/responses/openresponses-compliance.spec.ts --no-file-parallelism`
- `pnpm exec vitest run apps/gateway/src/api.spec.ts --no-file-parallelism -t 'replays cached responses verbatim|replays cached streams verbatim|/v1/responses forwards cache controls'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added response caching support for the Responses API, including streaming requests.
  - Cached responses now replay byte-for-byte, preserving original response details.
  - Cache hits are identified consistently with the `x-llmgateway-cache: HIT` header.
  - Responses and response items now use stable, deterministic identifiers.

- **Bug Fixes**
  - Cache replays no longer rewrite metadata, usage, costs, or response content.
  - Cache keys are now tenant-scoped and versioned to prevent incompatible entries from being reused.
  - Added support for bypassing the cache with `x-no-cache`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->