### PR TITLE
fix(gateway): guard images endpoint routing

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -109,7 +109,7 @@ describe("api", () => {
 		expect(JSON.stringify(json)).toContain("/v1/audio/speech");
 	});
 
-	test("/v1/images/generations is blocked for dev-plan orgs via the chat-completions guard", async () => {
+	test("/v1/images/generations is blocked for dev-plan orgs", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id",
 			...hashApiKeyForStorage("real-token"),
@@ -136,6 +136,122 @@ describe("api", () => {
 		const json = await res.json();
 		expect(JSON.stringify(json)).toContain(
 			"Image generation is not available for coding plans",
+		);
+	});
+
+	test("/v1/images/edits is blocked for dev-plan orgs", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			...hashApiKeyForStorage("real-token"),
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await harness.setDevPlan({ devPlan: "pro" });
+
+		const res = await app.request("/v1/images/edits", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "gemini-3-pro-image",
+				prompt: "Make it cinematic",
+				images: [{ image_url: "data:image/png;base64,aGVsbG8=" }],
+			}),
+		});
+
+		expect(res.status).toBe(403);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain(
+			"Image generation is not available for coding plans",
+		);
+	});
+
+	test("/v1/images/generations rejects dynamic route models", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			...hashApiKeyForStorage("real-token"),
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		const res = await app.request("/v1/images/generations", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "dynamic/my-route",
+				prompt: "A watercolor of a city skyline",
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain(
+			"Dynamic routes are not supported for image generation",
+		);
+	});
+
+	test("/v1/images/generations rejects custom provider model strings", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			...hashApiKeyForStorage("real-token"),
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		const res = await app.request("/v1/images/generations", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "my-custom-provider/some-model",
+				prompt: "A watercolor of a city skyline",
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain(
+			"Custom providers are not supported for image generation",
+		);
+	});
+
+	test("/v1/images/edits rejects dynamic route models", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			...hashApiKeyForStorage("real-token"),
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		const res = await app.request("/v1/images/edits", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "dynamic/my-route",
+				prompt: "Make it cinematic",
+				images: [{ image_url: "data:image/png;base64,aGVsbG8=" }],
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain(
+			"Dynamic routes are not supported for image generation",
 		);
 	});
 

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -226,6 +226,89 @@ describe("api", () => {
 		);
 	});
 
+	test("/v1/images/generations rejects catalogue model ids behind custom provider prefixes", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			...hashApiKeyForStorage("real-token"),
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		const res = await app.request("/v1/images/generations", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "my-custom-provider/gemini-3-pro-image",
+				prompt: "A watercolor of a city skyline",
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain(
+			"Custom providers are not supported for image generation",
+		);
+	});
+
+	test("/v1/images/generations rejects region-suffixed text models", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			...hashApiKeyForStorage("real-token"),
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		const res = await app.request("/v1/images/generations", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "openai/gpt-4o-mini:us-east",
+				prompt: "A watercolor of a city skyline",
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain("is a chat model");
+	});
+
+	test("/v1/images/edits rejects custom provider model strings", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			...hashApiKeyForStorage("real-token"),
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		const res = await app.request("/v1/images/edits", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+			},
+			body: JSON.stringify({
+				model: "my-custom-provider/some-model",
+				prompt: "Make it cinematic",
+				images: [{ image_url: "data:image/png;base64,aGVsbG8=" }],
+			}),
+		});
+
+		expect(res.status).toBe(400);
+		const json = await res.json();
+		expect(JSON.stringify(json)).toContain(
+			"Custom providers are not supported for image generation",
+		);
+	});
+
 	test("/v1/images/edits rejects dynamic route models", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id",

--- a/apps/gateway/src/images/images.ts
+++ b/apps/gateway/src/images/images.ts
@@ -18,7 +18,8 @@ import { validateModelOutput } from "@/lib/validate-model-output.js";
 import { parseDataUrl, processImageUrl } from "@llmgateway/actions";
 import { shortid } from "@llmgateway/db";
 import { logger, toError } from "@llmgateway/logger";
-import { models } from "@llmgateway/models";
+import { models, providers } from "@llmgateway/models";
+import { parseDynamicRouteModel } from "@llmgateway/shared/dynamic-route";
 
 import type { ServerTypes } from "@/vars.js";
 import type { Context } from "hono";
@@ -86,6 +87,7 @@ interface ImageClientErrorLogRequest {
 interface ImageClientErrorLogContext {
 	apiKey: NonNullable<Awaited<ReturnType<typeof findApiKeyByToken>>>;
 	project: NonNullable<Awaited<ReturnType<typeof findProjectById>>>;
+	organization: Awaited<ReturnType<typeof findOrganizationById>>;
 	requestId: string;
 	retentionLevel: "retain" | "none";
 }
@@ -458,9 +460,28 @@ async function resolveImageClientErrorLogContext(
 	return {
 		apiKey,
 		project,
+		organization,
 		requestId,
 		retentionLevel: organization?.retentionLevel ?? "none",
 	};
+}
+
+// Defense in depth: the chat handler already blocks image-emitting models on
+// dev plans, but the images endpoints should reject dev-plan orgs directly,
+// matching the sibling endpoints (embeddings, speech, videos, ...). Requests
+// whose credentials cannot be resolved fall through so the chat handler
+// produces the canonical auth error.
+async function assertNotDevPlan(
+	getLogContext: () => Promise<ImageClientErrorLogContext | null>,
+): Promise<void> {
+	const logContext = await getLogContext();
+	const organization = logContext?.organization;
+	if (organization?.kind === "devpass" && organization.devPlan !== "none") {
+		throw new HTTPException(403, {
+			message:
+				"Image generation is not available for coding plans. Coding plans only include text-based inference.",
+		});
+	}
 }
 
 async function logImageClientError(
@@ -573,9 +594,18 @@ async function logImageClientError(
 // Reject non-image models up front. Image generation forwards to
 // /v1/chat/completions (which accepts text and image models), so without this
 // guard a text-only model would be forwarded and produce a chat completion the
-// images endpoint can't turn into an image. Unknown models are left to the chat
-// handler to reject as "model not found".
+// images endpoint can't turn into an image. Unknown catalogue models are left
+// to the chat handler to reject as "model not found", but dynamic routes and
+// custom-provider model strings must be rejected here: the chat handler would
+// happily route them, and the images endpoints do not support dynamic routes
+// or custom providers.
 function assertImageModel(model: string): void {
+	if (parseDynamicRouteModel(model) !== undefined) {
+		throw new HTTPException(400, {
+			message:
+				"Dynamic routes are not supported for image generation. Request an image generation model directly.",
+		});
+	}
 	const slashIdx = model.indexOf("/");
 	const modelKey = slashIdx > 0 ? model.slice(slashIdx + 1) : model;
 	if (modelKey === "auto" || modelKey === "custom") {
@@ -584,6 +614,18 @@ function assertImageModel(model: string): void {
 	const modelInfo = models.find((m) => m.id === model || m.id === modelKey);
 	if (modelInfo) {
 		validateModelOutput(modelInfo, modelKey, ["image"]);
+		return;
+	}
+	// A prefix that is not a known catalogue provider would be classified as a
+	// custom provider by the chat handler (see parseModelInput); custom
+	// providers are not supported for image generation.
+	if (slashIdx > 0) {
+		const providerCandidate = model.slice(0, slashIdx);
+		if (!providers.some((p) => p.id === providerCandidate)) {
+			throw new HTTPException(400, {
+				message: `Unknown provider ${providerCandidate}. Custom providers are not supported for image generation.`,
+			});
+		}
 	}
 }
 
@@ -706,6 +748,8 @@ images.openapi(generations, async (c): Promise<any> => {
 	}
 
 	const request = validationResult.data;
+
+	await assertNotDevPlan(getLogContext);
 
 	// Resolve "auto" model to a default image generation model
 	const model = request.model === "auto" ? "gemini-3-pro-image" : request.model;
@@ -1051,6 +1095,9 @@ async function processImageEdit(
 		quality: request.quality,
 		aspect_ratio: request.aspect_ratio,
 	};
+
+	await assertNotDevPlan(getLogContext);
+
 	const { imageResults, imageCount } = await (async () => {
 		try {
 			const imageUrls: string[] = [];

--- a/apps/gateway/src/images/images.ts
+++ b/apps/gateway/src/images/images.ts
@@ -607,18 +607,11 @@ function assertImageModel(model: string): void {
 		});
 	}
 	const slashIdx = model.indexOf("/");
-	const modelKey = slashIdx > 0 ? model.slice(slashIdx + 1) : model;
-	if (modelKey === "auto" || modelKey === "custom") {
-		return;
-	}
-	const modelInfo = models.find((m) => m.id === model || m.id === modelKey);
-	if (modelInfo) {
-		validateModelOutput(modelInfo, modelKey, ["image"]);
-		return;
-	}
 	// A prefix that is not a known catalogue provider would be classified as a
 	// custom provider by the chat handler (see parseModelInput); custom
-	// providers are not supported for image generation.
+	// providers are not supported for image generation. Checked before the
+	// catalogue lookup so a custom provider reusing a catalogue model name
+	// (e.g. "myproxy/gemini-3-pro-image") is still rejected.
 	if (slashIdx > 0) {
 		const providerCandidate = model.slice(0, slashIdx);
 		if (!providers.some((p) => p.id === providerCandidate)) {
@@ -627,6 +620,21 @@ function assertImageModel(model: string): void {
 			});
 		}
 	}
+	let modelKey = slashIdx > 0 ? model.slice(slashIdx + 1) : model;
+	if (modelKey === "auto" || modelKey === "custom") {
+		return;
+	}
+	// Provider-prefixed models may carry a ":region" suffix (see
+	// parseModelInput); strip it so the catalogue lookup still matches.
+	if (slashIdx > 0 && modelKey.includes(":")) {
+		modelKey = modelKey.slice(0, modelKey.lastIndexOf(":"));
+	}
+	const modelInfo = models.find((m) => m.id === modelKey);
+	if (modelInfo) {
+		validateModelOutput(modelInfo, modelKey, ["image"]);
+	}
+	// Unknown catalogue models fall through so the chat handler rejects them
+	// with its canonical "model not found" error.
 }
 
 async function forwardToChatCompletions(


### PR DESCRIPTION
## Problem

The `/v1/images/generations` and `/v1/images/edits` endpoints forward requests to the internal `/v1/chat/completions` handler. `assertImageModel` deliberately passes unknown model strings through so the chat handler produces the canonical "model not found" error — but this also let two model-string forms through that the chat handler routes happily:

- `dynamic/<name>` (dynamic routes)
- `<customProvider>/<model>` (org custom providers)

This contradicts the documented contract (#3877): the images endpoints do not route to custom providers or dynamic routes.

Separately, unlike its six sibling endpoints (embeddings, rerank, OCR, speech, transcriptions, videos), the images endpoints had no direct dev-plan gate — they relied indirectly on the chat handler blocking image-emitting models on dev plans.

## Fix

- `assertImageModel` now 400s `dynamic/`-prefixed model strings and model strings whose provider prefix is not a known catalogue provider (which `parseModelInput` would otherwise classify as a custom provider). Known-provider prefixes and unknown bare model ids still fall through to the chat handler for the canonical error.
- Added the same explicit 403 dev-plan gate the sibling endpoints carry (`kind === "devpass" && devPlan !== "none"`), on generations and both edits paths (JSON and multipart), as defense in depth. Requests with unresolvable credentials fall through so the chat handler still produces the canonical auth error.

## Verification

- `apps/gateway/src/api.spec.ts` extended: dev-plan 403 on both endpoints, dynamic-route 400 on both endpoints, custom-provider 400 on generations. Full file run against an isolated Postgres/Redis stack: 198 passed, 2 skipped, 0 failed.
- `pnpm format` and full `pnpm build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Image generation and editing requests now reject unsupported dynamic-route and custom-provider model formats with clearer 400 errors.
  - Region-specific text models are rejected for image requests with an appropriate “chat model” error.
  - Image editing is now blocked for organizations on development plans, returning a 403 response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->