### PR TITLE
fix(gateway): include missing fields in cache key

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -7158,6 +7158,19 @@ describe("api", () => {
 		});
 		expect(sensitiveRes.status).toBe(200);
 		expect(sensitiveRes.headers.get("x-llmgateway-cache")).toBeNull();
+
+		// Semantically equivalent inputs must still share the primed entry:
+		// plugins: [] behaves like omitted, and reasoning.context "auto" is
+		// documented as equivalent to omitting the field.
+		const emptyPluginsRes = await makeRequest({ plugins: [] });
+		expect(emptyPluginsRes.status).toBe(200);
+		expect(emptyPluginsRes.headers.get("x-llmgateway-cache")).toBe("HIT");
+
+		const autoContextRes = await makeRequest({
+			reasoning: { context: "auto" },
+		});
+		expect(autoContextRes.status).toBe(200);
+		expect(autoContextRes.headers.get("x-llmgateway-cache")).toBe("HIT");
 	});
 
 	// GHSA-h9ww-f95j-h54c: cache keys are project-scoped, so a byte-identical

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -7086,6 +7086,80 @@ describe("api", () => {
 		expect(afterBypass.filter((log) => log.cached).length).toBe(1);
 	});
 
+	// Requests differing only in an upstream-forwarded field must not share a
+	// cache entry — e.g. a response-healed body must never be replayed to a
+	// request that did not enable the plugin.
+	test("/v1/chat/completions cache key includes plugins and sensitive_word_check", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id-cache-fields",
+			...hashApiKeyForStorage("real-token-cache-fields"),
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id-cache-fields",
+			...encryptProviderKeyForStorage(
+				"sk-test-key",
+				"provider-key-id-cache-fields",
+				"org-id",
+			),
+			provider: "openai",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		await db
+			.update(tables.project)
+			.set({ cachingEnabled: true })
+			.where(eq(tables.project.id, "project-id"));
+
+		const basePayload = {
+			model: "openai/gpt-4o-mini",
+			messages: [{ role: "user", content: `Cache field test ${randomUUID()}` }],
+		};
+
+		const makeRequest = (extra: Record<string, unknown> = {}) =>
+			app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token-cache-fields",
+				},
+				body: JSON.stringify({ ...basePayload, ...extra }),
+			});
+
+		// Prime the cache (setCache is a no-op under NODE_ENV=test).
+		const originalNodeEnv = process.env.NODE_ENV;
+		try {
+			process.env.NODE_ENV = "development";
+			const primeRes = await makeRequest();
+			expect(primeRes.status).toBe(200);
+			expect(primeRes.headers.get("x-llmgateway-cache")).toBeNull();
+		} finally {
+			process.env.NODE_ENV = originalNodeEnv;
+		}
+
+		// Byte-identical replay hits, proving the entry is primed...
+		const replayRes = await makeRequest();
+		expect(replayRes.status).toBe(200);
+		expect(replayRes.headers.get("x-llmgateway-cache")).toBe("HIT");
+
+		// ...so any miss below is caused by the differing field alone.
+		const pluginsRes = await makeRequest({
+			plugins: [{ id: "response-healing" }],
+		});
+		expect(pluginsRes.status).toBe(200);
+		expect(pluginsRes.headers.get("x-llmgateway-cache")).toBeNull();
+
+		const sensitiveRes = await makeRequest({
+			sensitive_word_check: { status: "ENABLE" },
+		});
+		expect(sensitiveRes.status).toBe(200);
+		expect(sensitiveRes.headers.get("x-llmgateway-cache")).toBeNull();
+	});
+
 	// GHSA-h9ww-f95j-h54c: cache keys are project-scoped, so a byte-identical
 	// request from another organization must never replay a victim's cached
 	// response.

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -6419,7 +6419,9 @@ chat.openapi(completions, async (c) => {
 			webSearchTool,
 			reasoning_effort,
 			reasoning_max_tokens,
-			reasoning_context,
+			// Schema documents omitting reasoning.context as equivalent to "auto"
+			reasoning_context:
+				reasoning_context === "auto" ? undefined : reasoning_context,
 			prompt_cache_key,
 			prompt_cache_retention,
 			prompt_cache_options,
@@ -6429,7 +6431,7 @@ chat.openapi(completions, async (c) => {
 			effort,
 			image_config,
 			sensitive_word_check,
-			plugins,
+			plugins: plugins?.length ? plugins : undefined,
 		};
 
 		if (stream) {

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -6419,11 +6419,17 @@ chat.openapi(completions, async (c) => {
 			webSearchTool,
 			reasoning_effort,
 			reasoning_max_tokens,
+			reasoning_context,
 			prompt_cache_key,
 			prompt_cache_retention,
 			prompt_cache_options,
 			n,
 			service_tier,
+			verbosity,
+			effort,
+			image_config,
+			sensitive_word_check,
+			plugins,
 		};
 
 		if (stream) {


### PR DESCRIPTION
## Problem

The gateway response-cache key payload (built once in `apps/gateway/src/chat/chat.ts` and shared by the streaming/non-streaming cache reads and both write sites) omitted several schema-accepted, upstream-forwarded parameters that change the response. Requests differing only in these fields collided on a single cache entry:

- `verbosity`
- `effort` (Anthropic computational effort)
- `reasoning.context` (extracted as `reasoning_context`, mirroring the existing `reasoning.effort` merge)
- `image_config` — different aspect ratios/sizes/qualities/seeds shared one cached image response
- `sensitive_word_check`
- `plugins` — response healing runs before the cache write, so a healed body was cached and replayed to requests that never enabled the plugin (and vice versa)

## Fix

Add the six fields to the cache key payload. It is constructed in exactly one place and reused by `generateStreamingCacheKey`/`generateCacheKey` reads and the `setStreamingCache`/`setCache` writes, so read and write stay in sync.

No cache-invalidation storm on deploy: `generateCacheKey` hashes `JSON.stringify(payload)`, and `JSON.stringify` drops `undefined` object values. All six fields are optional with no schema defaults, so requests that never set them serialize to the exact same string as before and keep their existing cache keys.

## Verification

- Added a regression test in `apps/gateway/src/api.spec.ts`: primes the cache, proves a byte-identical replay HITs, then asserts requests differing only in `plugins` or `sensitive_word_check` miss. (`verbosity`/`effort`/`image_config` are per-model validated and can't run against the mock provider; they take the identical code path.)
- Ran `apps/gateway/src/api.spec.ts` against an isolated worktree DB stack: 195 passed, 2 skipped.
- `packages/cache/src/cache.spec.ts` tests the hash function generically, not the field list — no changes needed.
- `pnpm format` and `pnpm build` pass.

## Note

The cache-key field list in docs PR #3877 (`apps/docs` gateway-caching.mdx) should gain these fields once both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)