### PR TITLE
fix(gateway): consistent rate-limit error headers

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -7878,6 +7878,87 @@ describe("api", () => {
 		expect(json.error.type).toBe("rate_limit_error");
 	});
 
+	// When both RPM and RPD are exhausted, the headers must describe a single
+	// window: the one with the longest wait (RPD), not RPM's limit with RPD's
+	// reset. Both sliding windows are pre-seeded to full because a live request
+	// blocked by RPM never increments RPD.
+	test("/v1/chat/completions provider-cap 429 with both windows blocked describes the slowest window", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			...hashApiKeyForStorage("real-token"),
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			...encryptProviderKeyForStorage(
+				"studio-db-key",
+				"provider-key-id",
+				"org-id",
+			),
+			provider: "google-ai-studio",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		await db.insert(tables.rateLimit).values({
+			id: "rate-limit-studio-both-windows",
+			organizationId: "org-id",
+			provider: "google-ai-studio",
+			model: "gemini-2.5-flash-lite",
+			maxRpm: 1,
+			maxRpd: 3,
+		});
+
+		const now = Date.now();
+		const rpmKey =
+			"rate_limit:provider_cap:rpm:org-id:google-ai-studio:gemini-2.5-flash-lite";
+		const rpdKey =
+			"rate_limit:provider_cap:rpd:org-id:google-ai-studio:gemini-2.5-flash-lite";
+		await redisClient.zadd(rpmKey, now, `${now}:rpm-1`);
+		for (let i = 0; i < 3; i++) {
+			await redisClient.zadd(rpdKey, now, `${now}:rpd-${i}`);
+		}
+
+		const res = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+				"x-no-fallback": "true",
+			},
+			body: JSON.stringify({
+				model: "google-ai-studio/gemini-2.5-flash-lite",
+				messages: [{ role: "user", content: "Both windows blocked" }],
+			}),
+		});
+		expect(res.status).toBe(429);
+
+		// RPD's wait (~1 day) dominates RPM's (~60s), so every header pair must
+		// come from the RPD window: limit 3, reset ~86400s.
+		const retryAfter = Number(res.headers.get("Retry-After"));
+		expect(retryAfter).toBeGreaterThan(60);
+		expect(retryAfter).toBeLessThanOrEqual(86400);
+		expect(res.headers.get("RateLimit-Limit")).toBe("3");
+		expect(res.headers.get("RateLimit-Reset")).toBe(String(retryAfter));
+		expect(res.headers.get("X-RateLimit-Limit")).toBe("3");
+		expect(Number(res.headers.get("X-RateLimit-Reset"))).toBeGreaterThan(
+			Math.floor(Date.now() / 1000) + 60,
+		);
+		expect(res.headers.get("X-RateLimit-Limit-Provider-RPM")).toBe("1");
+		expect(res.headers.get("X-RateLimit-Remaining-Provider-RPM")).toBe("0");
+		expect(res.headers.get("X-RateLimit-Limit-Provider-RPD")).toBe("3");
+		expect(res.headers.get("X-RateLimit-Remaining-Provider-RPD")).toBe("0");
+
+		const json = await res.json();
+		expect(json.error.type).toBe("rate_limit_error");
+		expect(json.error.message).toContain(
+			"1 requests per minute and 3 requests per day",
+		);
+	});
+
 	// Non-streaming responses are cached in OpenAI format, so the stored
 	// finish_reason is normalized (e.g. "stop"). The cache-hit log must classify
 	// it using the OpenAI mapping, not the upstream provider's native format —

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -7805,6 +7805,79 @@ describe("api", () => {
 		}
 	});
 
+	test("/v1/chat/completions pinned no-fallback provider-cap 429 carries rate-limit headers", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			...hashApiKeyForStorage("real-token"),
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-id",
+			...encryptProviderKeyForStorage(
+				"studio-db-key",
+				"provider-key-id",
+				"org-id",
+			),
+			provider: "google-ai-studio",
+			organizationId: "org-id",
+			baseUrl: mockServerUrl,
+		});
+
+		await db.insert(tables.rateLimit).values({
+			id: "rate-limit-studio-no-fallback",
+			organizationId: "org-id",
+			provider: "google-ai-studio",
+			model: "gemini-2.5-flash-lite",
+			maxRpm: 1,
+		});
+
+		const makeRequest = (content: string) =>
+			app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+					"x-no-fallback": "true",
+				},
+				body: JSON.stringify({
+					model: "google-ai-studio/gemini-2.5-flash-lite",
+					messages: [{ role: "user", content }],
+				}),
+			});
+
+		const firstRes = await makeRequest("Provider cap slot one");
+		expect(firstRes.status).toBe(200);
+
+		const secondRes = await makeRequest("Provider cap slot two");
+		expect(secondRes.status).toBe(429);
+
+		const retryAfter = Number(secondRes.headers.get("Retry-After"));
+		expect(retryAfter).toBeGreaterThanOrEqual(1);
+		expect(retryAfter).toBeLessThanOrEqual(60);
+		// Draft RateLimit-* fields (Reset is delta-seconds) plus legacy X-
+		// variants (epoch reset), matching the org limiter's header set.
+		expect(secondRes.headers.get("RateLimit-Limit")).toBe("1");
+		expect(secondRes.headers.get("RateLimit-Remaining")).toBe("0");
+		expect(secondRes.headers.get("RateLimit-Reset")).toBe(String(retryAfter));
+		expect(secondRes.headers.get("X-RateLimit-Limit")).toBe("1");
+		expect(secondRes.headers.get("X-RateLimit-Remaining")).toBe("0");
+		expect(Number(secondRes.headers.get("X-RateLimit-Reset"))).toBeGreaterThan(
+			Math.floor(Date.now() / 1000),
+		);
+		expect(secondRes.headers.get("X-RateLimit-Limit-Provider")).toBe("1");
+		expect(secondRes.headers.get("X-RateLimit-Remaining-Provider")).toBe("0");
+		expect(secondRes.headers.get("X-RateLimit-Limit-Provider-RPM")).toBe("1");
+		expect(secondRes.headers.get("X-RateLimit-Remaining-Provider-RPM")).toBe(
+			"0",
+		);
+
+		const json = await secondRes.json();
+		expect(json.error.type).toBe("rate_limit_error");
+	});
+
 	// Non-streaming responses are cached in OpenAI format, so the stored
 	// finish_reason is normalized (e.g. "stop"). The cache-hit log must classify
 	// it using the OpenAI mapping, not the upstream provider's native format —

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -392,9 +392,20 @@ function setProviderRateLimitExceededHeaders(
 	c: Context<ServerTypes>,
 	result: ProviderRateLimitResult,
 ): void {
-	const primaryWindow = result.blockedBy[0] ?? "rpm";
+	// When several windows are blocked, describe the one with the longest wait
+	// so limit and reset headers refer to the same policy.
+	const primaryWindow = result.blockedBy.reduce(
+		(slowest, window) =>
+			(result.limits[window].retryAfter ?? 0) >
+			(result.limits[slowest].retryAfter ?? 0)
+				? window
+				: slowest,
+		result.blockedBy[0] ?? "rpm",
+	);
 	const retryAfter =
-		result.retryAfter ?? providerRateLimitWindows[primaryWindow].seconds;
+		result.limits[primaryWindow].retryAfter ??
+		result.retryAfter ??
+		providerRateLimitWindows[primaryWindow].seconds;
 	const limit = result.limits[primaryWindow].limit;
 
 	c.header("Retry-After", String(retryAfter));

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -101,6 +101,7 @@ import {
 	peekProviderRateLimit,
 	pickNonRateLimitedCandidates,
 	providerRateLimitWindows,
+	type ProviderRateLimitResult,
 } from "@/lib/provider-rate-limit.js";
 import { getResponsesContext } from "@/lib/responses-context.js";
 import { getResolvedRoutingConfig } from "@/lib/routing-config-loader.js";
@@ -337,10 +338,75 @@ import type {
 import type { OriginalRequestParams } from "./tools/resolve-provider-context.js";
 import type { ServerTypes } from "@/vars.js";
 import type { RoutingCredentialSource } from "@llmgateway/shared/routing-telemetry";
+import type { Context } from "hono";
 
 const _derivedProjectId = getVertexAnthropicProjectId();
 if (_derivedProjectId && !process.env.LLM_VERTEX_ANTHROPIC_PROJECT) {
 	process.env.LLM_VERTEX_ANTHROPIC_PROJECT = _derivedProjectId;
+}
+
+/**
+ * Emit the provider-scoped rate-limit headers (X-RateLimit-*-Provider plus the
+ * per-window RPM/RPD variants) for every configured window.
+ */
+function setProviderScopedRateLimitHeaders(
+	c: Context<ServerTypes>,
+	limits: ProviderRateLimitResult["limits"],
+): void {
+	const entries = Object.entries(limits) as Array<
+		[
+			keyof typeof providerRateLimitWindows,
+			ProviderRateLimitResult["limits"][keyof ProviderRateLimitResult["limits"]],
+		]
+	>;
+	const primary = entries.find(([, limit]) => limit.limit > 0);
+
+	if (primary) {
+		c.header("X-RateLimit-Limit-Provider", primary[1].limit.toString());
+		c.header("X-RateLimit-Remaining-Provider", primary[1].remaining.toString());
+	}
+
+	for (const [window, limit] of entries) {
+		if (limit.limit === 0) {
+			continue;
+		}
+
+		c.header(
+			`X-RateLimit-Limit-Provider-${providerRateLimitWindows[window].headerSuffix}`,
+			limit.limit.toString(),
+		);
+		c.header(
+			`X-RateLimit-Remaining-Provider-${providerRateLimitWindows[window].headerSuffix}`,
+			limit.remaining.toString(),
+		);
+	}
+}
+
+/**
+ * Emit the full rate-limit-exceeded header set for a provider-cap 429,
+ * matching the org limiter (middleware/org-rate-limit.ts): Retry-After plus
+ * the draft RateLimit-* fields (Reset is delta-seconds) alongside the legacy
+ * X- variants (epoch reset).
+ */
+function setProviderRateLimitExceededHeaders(
+	c: Context<ServerTypes>,
+	result: ProviderRateLimitResult,
+): void {
+	const primaryWindow = result.blockedBy[0] ?? "rpm";
+	const retryAfter =
+		result.retryAfter ?? providerRateLimitWindows[primaryWindow].seconds;
+	const limit = result.limits[primaryWindow].limit;
+
+	c.header("Retry-After", String(retryAfter));
+	c.header("RateLimit-Limit", String(limit));
+	c.header("RateLimit-Remaining", "0");
+	c.header("RateLimit-Reset", String(retryAfter));
+	c.header("X-RateLimit-Limit", String(limit));
+	c.header("X-RateLimit-Remaining", "0");
+	c.header(
+		"X-RateLimit-Reset",
+		String(Math.floor(Date.now() / 1000) + retryAfter),
+	);
 }
 
 /**
@@ -4459,6 +4525,9 @@ chat.openapi(completions, async (c) => {
 
 		if (rateLimitPeek.rateLimited) {
 			if (noFallback) {
+				setProviderScopedRateLimitHeaders(c, rateLimitPeek.limits);
+				setProviderRateLimitExceededHeaders(c, rateLimitPeek);
+
 				const blockedLimits = rateLimitPeek.blockedBy
 					.map(
 						(window) =>
@@ -5961,56 +6030,13 @@ chat.openapi(completions, async (c) => {
 			modelInfo.id,
 		);
 
-		const providerRateLimitEntries = Object.entries(
-			providerRateLimitResult.limits,
-		) as Array<
-			[
-				keyof typeof providerRateLimitWindows,
-				(typeof providerRateLimitResult.limits)[keyof typeof providerRateLimitResult.limits],
-			]
-		>;
-		const primaryProviderRateLimit = providerRateLimitEntries.find(
-			([, limit]) => limit.limit > 0,
-		);
-
-		if (primaryProviderRateLimit) {
-			c.header(
-				"X-RateLimit-Limit-Provider",
-				primaryProviderRateLimit[1].limit.toString(),
-			);
-			c.header(
-				"X-RateLimit-Remaining-Provider",
-				primaryProviderRateLimit[1].remaining.toString(),
-			);
-		}
-
-		for (const [window, limit] of providerRateLimitEntries) {
-			if (limit.limit === 0) {
-				continue;
-			}
-
-			c.header(
-				`X-RateLimit-Limit-Provider-${providerRateLimitWindows[window].headerSuffix}`,
-				limit.limit.toString(),
-			);
-			c.header(
-				`X-RateLimit-Remaining-Provider-${providerRateLimitWindows[window].headerSuffix}`,
-				limit.remaining.toString(),
-			);
-		}
+		setProviderScopedRateLimitHeaders(c, providerRateLimitResult.limits);
 
 		// Race condition: between peek and consume, the window may have filled.
 		// Only hard-block if the user explicitly requested this provider with no-fallback.
 		if (!providerRateLimitResult.allowed) {
 			if (noFallback && requestedProvider) {
-				const retryAfter = providerRateLimitResult.retryAfter;
-				if (retryAfter) {
-					c.header("Retry-After", retryAfter.toString());
-					c.header("RateLimit-Reset", retryAfter.toString());
-					const resetTime = Math.floor(Date.now() / 1000) + retryAfter;
-					c.header("X-RateLimit-Reset", resetTime.toString());
-				}
-				c.header("RateLimit-Remaining", "0");
+				setProviderRateLimitExceededHeaders(c, providerRateLimitResult);
 
 				const blockedLimits = providerRateLimitResult.blockedBy
 					.map(
@@ -13535,6 +13561,10 @@ chat.openapi(completions, async (c) => {
 					type: "upstream_error",
 					param: null,
 					code: "all_providers_failed",
+					requestedProvider,
+					usedProvider,
+					requestedModel: initialRequestedModel,
+					usedInternalModel,
 				},
 			},
 			502,

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -3622,6 +3622,14 @@ describe("fallback and error status code handling", () => {
 			});
 
 			expect(res.status).toBe(502);
+			// The all-attempts-exhausted 502 carries the same diagnostic fields as
+			// the terminal-error path.
+			const json = await res.json();
+			expect(json.error.type).toBe("upstream_error");
+			expect(json.error.code).toBe("all_providers_failed");
+			expect(json.error.usedProvider).toBe("together-ai");
+			expect(json.error.requestedModel).toBe("glm-4.7");
+			expect(json.error.usedInternalModel).toBeTruthy();
 
 			const logs = await waitForLogs(1);
 			expect(logs).toHaveLength(1);


### PR DESCRIPTION
## Problem

Three error/header consistency gaps on the gateway chat path:

1. **Early provider-cap rejection** (pinned provider + `x-no-fallback` with an exhausted provider rate-limit cap): the 429 was thrown with no headers at all, even though `retryAfter` and the per-window limit state were available.
2. **Post-routing race-path provider 429** (window filled between peek and consume): emitted a partial, mixed header set — `RateLimit-Remaining`, `RateLimit-Reset`, `X-RateLimit-Reset` but no `RateLimit-Limit` / `X-RateLimit-Limit` / `X-RateLimit-Remaining`.
3. **Non-streaming all-attempts-exhausted 502** (`code: "all_providers_failed"`): returned no diagnostic fields, while the sibling terminal-error path includes `requestedProvider`, `usedProvider`, `requestedModel`, and `usedInternalModel`.

## Fix

- Added two small shared helpers in `apps/gateway/src/chat/chat.ts`:
  - `setProviderScopedRateLimitHeaders` — the existing `X-RateLimit-*-Provider` (+ per-window RPM/RPD) emission, extracted from the consume path and reused by the early rejection.
  - `setProviderRateLimitExceededHeaders` — the full 429 set matching the org limiter (`middleware/org-rate-limit.ts`): `Retry-After`, draft `RateLimit-Limit`/`RateLimit-Remaining`/`RateLimit-Reset` (delta-seconds), and legacy `X-RateLimit-Limit`/`X-RateLimit-Remaining`/`X-RateLimit-Reset` (unix epoch).
- Both provider-429 sites now emit that full, consistent set. Headers are set on the context before the `HTTPException` throw, so `app.onError` → `renderGatewayError` → `c.json` carries them (same mechanism the race path already relied on).
- The all-attempts-exhausted 502 now includes the same diagnostic fields as the terminal-error path. The 502 status and `type`/`code` are unchanged — changing the status would be a contract decision and is out of scope.

## Verification

- New spec: `api.spec.ts` — pinned no-fallback provider-cap 429 asserts the full draft + legacy + provider-scoped header set.
- Extended spec: `fallback.spec.ts` — the IAM allow_providers 502 test (which exercises the all-attempts-exhausted path) now asserts `code: "all_providers_failed"` plus the diagnostic fields.
- Ran both spec files against an isolated per-worktree stack: `fallback.spec.ts` 64/64 passed; the two rate-limit tests in `api.spec.ts` passed.
- `pnpm format`, `pnpm lint`, and full `pnpm build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)