### PR TITLE
fix(gateway): forward response cache headers

### DIFF
--- a/apps/gateway/src/responses/responses-route.spec.ts
+++ b/apps/gateway/src/responses/responses-route.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { responses } from "./responses.js";
 
@@ -48,7 +48,73 @@ vi.mock("./tools/response-state.js", () => ({
 	storeResponse: vi.fn(),
 }));
 
-describe("responses streaming lifecycle", () => {
+describe("responses route", () => {
+	beforeEach(() => {
+		mocks.appRequest.mockReset();
+	});
+
+	it.each([
+		{
+			stream: false,
+			innerBody: JSON.stringify({
+				id: "chatcmpl_cached",
+				created: 1,
+				model: "gpt-4o-mini",
+				choices: [
+					{
+						message: { role: "assistant", content: "hello" },
+						finish_reason: "stop",
+					},
+				],
+				usage: {
+					prompt_tokens: 1,
+					completion_tokens: 1,
+					total_tokens: 2,
+				},
+			}),
+		},
+		{
+			stream: true,
+			innerBody:
+				'data: {"model":"gpt-4o-mini","choices":[]}\n\ndata: [DONE]\n\n',
+		},
+	])(
+		"forwards and surfaces cache headers for stream=$stream",
+		async ({ stream, innerBody }) => {
+			mocks.appRequest.mockResolvedValue(
+				new Response(innerBody, {
+					status: 200,
+					headers: { "x-llmgateway-cache": "HIT" },
+				}),
+			);
+
+			const response = await responses.request("/", {
+				method: "POST",
+				headers: {
+					authorization: "Bearer test-token",
+					"content-type": "application/json",
+					"x-no-cache": "true",
+				},
+				body: JSON.stringify({
+					model: "gpt-4o-mini",
+					input: "hello",
+					stream,
+					store: false,
+				}),
+			});
+
+			expect(response.status).toBe(200);
+			expect(response.headers.get("x-llmgateway-cache")).toBe("HIT");
+			expect(mocks.appRequest).toHaveBeenCalledWith(
+				"/v1/chat/completions",
+				expect.objectContaining({
+					headers: expect.objectContaining({ "x-no-cache": "true" }),
+				}),
+			);
+			await response.text();
+		},
+	);
+
 	it("emits response.created before an early response.failed", async () => {
 		mocks.appRequest.mockResolvedValue(
 			new Response(

--- a/apps/gateway/src/responses/responses.ts
+++ b/apps/gateway/src/responses/responses.ts
@@ -424,6 +424,9 @@ responses.post("/", async (c) => {
 		"x-debug": c.req.header("x-debug") ?? "",
 		"HTTP-Referer": c.req.header("HTTP-Referer") ?? "",
 		...internalApiOriginHeaders("responses"),
+		...(c.req.header("x-no-cache") !== undefined
+			? { "x-no-cache": c.req.header("x-no-cache")! }
+			: {}),
 	};
 
 	// Pass Responses API context via in-memory Map (not headers) so the chat
@@ -466,6 +469,11 @@ responses.post("/", async (c) => {
 				response.status as ContentfulStatusCode,
 			);
 		}
+	}
+
+	const innerCacheStatus = response.headers.get("x-llmgateway-cache");
+	if (innerCacheStatus) {
+		c.header("x-llmgateway-cache", innerCacheStatus);
 	}
 
 	// Handle streaming response


### PR DESCRIPTION
## Problem

`/v1/responses` dropped the `x-no-cache` request header on its internal chat-completions hop and did not expose the resulting `x-llmgateway-cache` response header.

## Changes

- forward `x-no-cache` when present
- surface `x-llmgateway-cache` from the internal response
- cover streaming and non-streaming requests

## Verification

- `pnpm exec vitest run apps/gateway/src/responses/responses-route.spec.ts`
- `pnpm format`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Responses API requests now honor the `x-no-cache` request header.
  - Cache status information is exposed through the `x-llmgateway-cache` response header for both streaming and non-streaming responses.

- **Bug Fixes**
  - Improved forwarding of cache-control headers between the Responses API and internal requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->