### PR TITLE
fix(gateway): reject null responses

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -13795,6 +13795,9 @@ chat.openapi(completions, async (c) => {
 		} else {
 			json = await readBodyWithClientAbort(res.json());
 		}
+		if (json === null || typeof json !== "object" || Array.isArray(json)) {
+			throw new TypeError("Provider response body must be a JSON object");
+		}
 	} catch (bodyError) {
 		// Re-throw non-Error values (mirrors the fetch catch above).
 		if (!(bodyError instanceof Error)) {

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -713,6 +713,38 @@ describe("fallback and error status code handling", () => {
 			expect(log.requestedModel).toBe("llmgateway/custom");
 		});
 
+		test("null upstream response body is classified as upstream_error (502), not an unhandled 500", async () => {
+			await setupCustomKeys();
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+				},
+				body: JSON.stringify({
+					model: "llmgateway/custom",
+					messages: [{ role: "user", content: "TRIGGER_NULL_BODY" }],
+				}),
+			});
+
+			expect(res.status).toBe(502);
+			const json = await res.json();
+			expect(json).toHaveProperty("error");
+			expect(json.error.type).toBe("upstream_error");
+			expect(json.error.code).toBe("fetch_failed");
+
+			const logs = await waitForLogs(1);
+			expect(logs.length).toBe(1);
+
+			const log = logs[0];
+			expect(log.finishReason).toBe("upstream_error");
+			expect(log.hasError).toBe(true);
+			expect(log.errorDetails?.responseText).toBe(
+				"Provider response body must be a JSON object",
+			);
+		});
+
 		test("mid-body failure marks the routed provider attempt as failed, not a succeeded routing attempt", async () => {
 			await setupMultiProviderKeys();
 

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -1212,6 +1212,10 @@ mockOpenAIServer.post("/v1/chat/completions", async (c) => {
 		});
 	}
 
+	if (hasUserMessageTrigger(chatMessages, "TRIGGER_NULL_BODY")) {
+		return c.json(null);
+	}
+
 	// Simulate an upstream that returns response headers (200) and a partial
 	// body, then hangs forever without finishing it. The gateway's res.json()
 	// blocks waiting for the rest, letting a test abort the client mid-read to


### PR DESCRIPTION
## Problem

A provider can return a successful HTTP response whose decoded JSON body is `null`. The response parser then dereferences the body and produces an unhandled 500.

## Changes

- validate decoded provider bodies before parsing
- route non-object JSON bodies through the existing 502 upstream-error path
- add an integration regression case for a `null` provider response

## Verification

- `pnpm test:unit apps/gateway/src/fallback.spec.ts` (65 passed)
- `pnpm format`
- `pnpm build` (19/19 tasks successful)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of invalid upstream chat responses, including empty or non-object JSON bodies.
  - These responses are now consistently reported as upstream errors with the appropriate gateway error status and details.

- **Tests**
  - Added coverage to verify error classification, response status, logged error metadata, and handling of null provider responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->