### PR TITLE
fix(gateway): forward safety identifiers

### DIFF
--- a/apps/gateway/src/embeddings/embeddings.spec.ts
+++ b/apps/gateway/src/embeddings/embeddings.spec.ts
@@ -195,6 +195,56 @@ describe("embeddings", () => {
 		expect(embeddingLog?.reasoningContent).toBeNull();
 	});
 
+	test("/v1/embeddings replaces client user with the organization identifier", async () => {
+		await db.insert(tables.apiKey).values({
+			id: "token-id-embeddings-safety",
+			...hashApiKeyForStorage("real-token-embeddings-safety"),
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+
+		await db.insert(tables.providerKey).values({
+			id: "provider-key-embeddings-safety",
+			...encryptProviderKeyForStorage(
+				"openai-token",
+				"provider-key-embeddings-safety",
+				"org-id",
+			),
+			provider: "openai",
+			organizationId: "org-id",
+			baseUrl: harness.mockServerUrl,
+		});
+
+		const [organization] = await db
+			.select({ safetyIdentifier: tables.organization.safetyIdentifier })
+			.from(tables.organization)
+			.where(eq(tables.organization.id, "org-id"));
+
+		const res = await app.request("/v1/embeddings", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token-embeddings-safety",
+			},
+			body: JSON.stringify({
+				model: "text-embedding-3-small",
+				input: "safety attribution input",
+				user: "client-controlled-user",
+			}),
+		});
+
+		expect(res.status).toBe(200);
+		const logs = await waitForLogs(1);
+		const embeddingLog = logs.find(
+			(log) => log.usedModel === "openai/text-embedding-3-small",
+		);
+		expect(organization?.safetyIdentifier).toBeTruthy();
+		expect(embeddingLog?.upstreamRequest).toMatchObject({
+			user: organization?.safetyIdentifier,
+		});
+	});
+
 	test("/v1/embeddings returns upstream error when no alternate key is available", async () => {
 		resetFailOnceCounter();
 

--- a/apps/gateway/src/embeddings/embeddings.ts
+++ b/apps/gateway/src/embeddings/embeddings.ts
@@ -110,7 +110,7 @@ const embeddingRequestSchema = z.object({
 	}),
 	user: z.string().optional().openapi({
 		description:
-			"Stable end-user identifier forwarded to OpenAI for abuse monitoring.",
+			"Accepted for OpenAI compatibility. Upstream abuse attribution always uses LLM Gateway's opaque organization identifier.",
 	}),
 });
 
@@ -505,7 +505,6 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 		model: requestedModel,
 		encoding_format,
 		dimensions,
-		user,
 	} = validationResult.data;
 
 	const match = findEmbeddingMapping(requestedModel);
@@ -981,9 +980,6 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 			if (dimensions !== undefined) {
 				requestBody.dimensions = dimensions;
 			}
-			if (user !== undefined) {
-				requestBody.user = user;
-			}
 		} else {
 			upstreamUrl = `${resolvedBaseUrl}/v1/embeddings`;
 			requestBody = {
@@ -996,8 +992,8 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 			if (dimensions !== undefined) {
 				requestBody.dimensions = dimensions;
 			}
-			if (user !== undefined) {
-				requestBody.user = user;
+			if (providerId === "openai" || providerId === "azure") {
+				requestBody.user = retryOrganization.safetyIdentifier;
 			}
 		}
 

--- a/apps/gateway/src/realtime/preflight-credentials.spec.ts
+++ b/apps/gateway/src/realtime/preflight-credentials.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "vitest";
 import { createGatewayApiTestHarness } from "@/test-utils/gateway-api-test-harness.js";
 
 import { encryptProviderKeyForStorage } from "@llmgateway/actions";
-import { cdb, db, tables } from "@llmgateway/db";
+import { cdb, db, eq, tables } from "@llmgateway/db";
 import { hashApiKeyForStorage } from "@llmgateway/shared/api-key-hash";
 
 import { runRealtimePreflight } from "./preflight.js";
@@ -59,6 +59,11 @@ describe("realtime preflight with managed credentials", () => {
 		// Health failures must attribute to the credential actually sent.
 		expect(result.trackedKeyHealthId).toBe("managed-openai");
 		expect(result.envVarName).toBeUndefined();
+		const [organization] = await db
+			.select({ safetyIdentifier: tables.organization.safetyIdentifier })
+			.from(tables.organization)
+			.where(eq(tables.organization.id, "org-id"));
+		expect(result.safetyIdentifier).toBe(organization?.safetyIdentifier);
 		// A managed credential is the platform's own key: the org is billed for
 		// the session exactly as it was on the env-var path.
 		expect(result.usedMode).toBe("credits");

--- a/apps/gateway/src/realtime/preflight.ts
+++ b/apps/gateway/src/realtime/preflight.ts
@@ -1,5 +1,3 @@
-import { createHash } from "node:crypto";
-
 import { HTTPException } from "hono/http-exception";
 
 import { resolvePlatformCredential } from "@/chat/tools/resolve-platform-credential.js";
@@ -81,29 +79,10 @@ export interface RealtimePreflightResult {
 	 */
 	clientIp: string | undefined;
 	/**
-	 * Stable, privacy-preserving end-user identifier forwarded upstream via the
-	 * OpenAI-Safety-Identifier header (a hash, never a raw internal id).
+	 * Stable, privacy-preserving identifier forwarded upstream via the
+	 * OpenAI-Safety-Identifier header.
 	 */
 	safetyIdentifier: string;
-}
-
-/**
- * Derive the opaque `OpenAI-Safety-Identifier` for a session. It is keyed on the
- * tenant (organization + project) rather than on the API key: keys are rotatable
- * credentials, so deriving from one would reset the upstream abuse-tracking
- * identity on every rotation, and no part of a credential should ever be fed
- * into a fast digest. Both ids are 20-character CSPRNG nanoids (~119 bits each),
- * so a plain digest needs no salt or pepper: there is no small input space to
- * enumerate, and the hash exists only to keep internal ids off the wire.
- */
-function deriveSafetyIdentifier(
-	organizationId: string,
-	projectId: string,
-): string {
-	return createHash("sha256")
-		.update(`realtime-safety-identifier:${organizationId}:${projectId}`)
-		.digest("hex")
-		.slice(0, 32);
 }
 
 export function getAvailableCredits(organization: Organization): number {
@@ -419,6 +398,6 @@ async function runRealtimePreflightInner(
 		usedMode: providerKey ? "api-keys" : "credits",
 		allowedTranscriptionModelIds,
 		clientIp: input.clientIp,
-		safetyIdentifier: deriveSafetyIdentifier(organization.id, project.id),
+		safetyIdentifier: organization.safetyIdentifier,
 	};
 }

--- a/packages/actions/src/prepare-request-body.safety-identifier.spec.ts
+++ b/packages/actions/src/prepare-request-body.safety-identifier.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "vitest";
 
+import { providers } from "@llmgateway/models";
+
 import { prepareRequestBody } from "./prepare-request-body.js";
 
 import type {
@@ -15,6 +17,8 @@ async function prepare(options: {
 	provider: ProviderId;
 	model: string;
 	useResponsesApi?: boolean;
+	imageGenerations?: boolean;
+	messages?: Parameters<typeof prepareRequestBody>[4];
 	safetyIdentifier?: string;
 }) {
 	return (await prepareRequestBody(
@@ -22,7 +26,7 @@ async function prepare(options: {
 		options.model,
 		null,
 		options.model,
-		[{ role: "user", content: "Hello!" }],
+		options.messages ?? [{ role: "user", content: "Hello!" }],
 		false,
 		undefined,
 		undefined,
@@ -40,7 +44,7 @@ async function prepare(options: {
 		undefined,
 		undefined,
 		undefined,
-		false,
+		options.imageGenerations ?? false,
 		undefined,
 		undefined,
 		options.useResponsesApi ?? false,
@@ -58,6 +62,23 @@ async function prepare(options: {
 }
 
 describe("prepareRequestBody - safety identifier", () => {
+	test("covers every provider advertised as forwarding identifiers", () => {
+		expect(
+			providers
+				.filter((provider) => provider.forwardsSafetyIdentifier)
+				.map((provider) => provider.id)
+				.sort(),
+		).toEqual(
+			[
+				"anthropic",
+				"azure",
+				"azure-anthropic",
+				"openai",
+				"vertex-anthropic",
+			].sort(),
+		);
+	});
+
 	test("forwards safety_identifier to OpenAI chat completions", async () => {
 		const body = await prepare({
 			provider: "openai",
@@ -85,7 +106,7 @@ describe("prepareRequestBody - safety identifier", () => {
 		expect(body.safety_identifier).toBeUndefined();
 	});
 
-	test("forwards safety_identifier to Azure only on the Responses path", async () => {
+	test("uses Azure's safety fields on Responses and legacy chat paths", async () => {
 		const responsesBody = await prepare({
 			provider: "azure",
 			model: "gpt-5.5",
@@ -99,10 +120,15 @@ describe("prepareRequestBody - safety identifier", () => {
 		});
 
 		expect(responsesBody.safety_identifier).toBe(SAFETY_IDENTIFIER);
+		expect(chatBody.user).toBe(SAFETY_IDENTIFIER);
 		expect(chatBody.safety_identifier).toBeUndefined();
 	});
 
-	test.each([["anthropic"], ["vertex-anthropic"]] as const)(
+	test.each([
+		["anthropic"],
+		["vertex-anthropic"],
+		["azure-anthropic"],
+	] as const)(
 		"maps the identifier onto metadata.user_id for %s",
 		async (provider) => {
 			const body = await prepare({
@@ -123,6 +149,49 @@ describe("prepareRequestBody - safety identifier", () => {
 
 		expect(body.metadata).toBeUndefined();
 	});
+
+	test.each([["openai"], ["azure"]] as const)(
+		"maps the identifier onto user for %s image generations",
+		async (provider) => {
+			const body = await prepare({
+				provider,
+				model: "gpt-image-2",
+				imageGenerations: true,
+				safetyIdentifier: SAFETY_IDENTIFIER,
+			});
+
+			expect(body.user).toBe(SAFETY_IDENTIFIER);
+		},
+	);
+
+	test.each([["openai"], ["azure"]] as const)(
+		"maps the identifier onto multipart user for %s image edits",
+		async (provider) => {
+			const body = await prepare({
+				provider,
+				model: "gpt-image-2",
+				imageGenerations: true,
+				messages: [
+					{
+						role: "user",
+						content: [
+							{
+								type: "image_url",
+								image_url: {
+									url: "data:image/png;base64,iVBORw0KGgo=",
+								},
+							},
+							{ type: "text", text: "Edit this image" },
+						],
+					},
+				],
+				safetyIdentifier: SAFETY_IDENTIFIER,
+			});
+
+			expect(body).toBeInstanceOf(FormData);
+			expect((body as unknown as FormData).get("user")).toBe(SAFETY_IDENTIFIER);
+		},
+	);
 
 	test.each([["aws-bedrock"], ["google-ai-studio"]] as const)(
 		"sends no identifier to %s, which has no equivalent field",

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -180,6 +180,7 @@ function getProviderMapping(
 interface OpenAIImageRequest {
 	model: string;
 	prompt: string;
+	user?: string;
 	size?: string;
 	quality?: OpenAIImageQuality;
 	n?: number;
@@ -1455,6 +1456,7 @@ export async function prepareRequestBody(
 		const openaiImageRequest: OpenAIImageRequest = {
 			model: usedExternalId,
 			prompt,
+			...(safety_identifier !== undefined && { user: safety_identifier }),
 			...(openaiSize && { size: openaiSize }),
 			...(openaiQuality && { quality: openaiQuality }),
 			...(image_config?.n && { n: image_config.n }),
@@ -1466,6 +1468,9 @@ export async function prepareRequestBody(
 			const formData = new FormData();
 			formData.append("model", openaiImageRequest.model);
 			formData.append("prompt", openaiImageRequest.prompt);
+			if (openaiImageRequest.user !== undefined) {
+				formData.append("user", openaiImageRequest.user);
+			}
 			if (openaiImageRequest.size) {
 				formData.append("size", openaiImageRequest.size);
 			}
@@ -2450,6 +2455,18 @@ export async function prepareRequestBody(
 				return responsesBody;
 			} else {
 				// Use regular chat completions format
+				if (usedProvider === "openai" || usedProvider === "azure") {
+					if (safety_identifier !== undefined) {
+						if (usedProvider === "openai") {
+							requestBody.safety_identifier = safety_identifier;
+						} else {
+							// Azure's deployment-based APIs predate safety_identifier but
+							// accept `user` for the same abuse-attribution purpose.
+							requestBody.user = safety_identifier;
+						}
+					}
+				}
+
 				if (usedProvider === "openai") {
 					if (supportedServiceTier) {
 						requestBody.service_tier = supportedServiceTier;
@@ -2466,11 +2483,6 @@ export async function prepareRequestBody(
 							: undefined);
 					if (upstreamCacheKey !== undefined) {
 						requestBody.prompt_cache_key = upstreamCacheKey;
-					}
-					// Azure is excluded here for the same reason as the cache key
-					// above; it gets `safety_identifier` on the Responses path only.
-					if (safety_identifier !== undefined) {
-						requestBody.safety_identifier = safety_identifier;
 					}
 					if (
 						prompt_cache_retention !== undefined &&

--- a/packages/models/src/types.ts
+++ b/packages/models/src/types.ts
@@ -385,6 +385,7 @@ export interface BaseRequestBody {
 
 export interface OpenAIRequestBody extends BaseRequestBody {
 	messages: OpenAIMessage[];
+	user?: string;
 	tools?: OpenAITool[];
 	tool_choice?: ToolChoiceType;
 	prompt_cache_key?: string;


### PR DESCRIPTION
## Problem

Safety attribution was inconsistent across gateway paths. Image requests bypassed identifier forwarding, embeddings trusted a caller-controlled `user`, Realtime derived a path-specific value, and Azure chat omitted its compatible attribution field.

## Approach

- forward the organization’s opaque identifier through OpenAI and Azure chat, Responses, image, and embedding requests
- keep Anthropic variants mapped to `metadata.user_id` and reuse the stored identifier for the Realtime header
- ignore caller-controlled embedding attribution and add a catalogue invariant plus path-specific regressions
- leave APIs without a documented abuse-attribution field unchanged

## Verification

- `pnpm format`
- `pnpm exec vitest run packages/actions/src/prepare-request-body.safety-identifier.spec.ts --no-file-parallelism`
- `pnpm exec vitest run apps/gateway/src/embeddings/embeddings.spec.ts apps/gateway/src/realtime/preflight-credentials.spec.ts apps/gateway/src/realtime/connect-upstream.spec.ts --no-file-parallelism`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized safety attribution across embeddings, chat, image generation, image editing, and realtime requests.
  * Client-provided user identifiers are no longer forwarded to upstream providers; requests now use the organization’s safety identifier.
  * Improved Azure compatibility by mapping safety identifiers to the appropriate upstream user field.
  * Updated API documentation to clarify user-field handling and safety attribution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->