### PR TITLE
fix(shared): guard oversized model fetch

### DIFF
--- a/apps/playground/src/lib/fetch-models.ts
+++ b/apps/playground/src/lib/fetch-models.ts
@@ -1,5 +1,7 @@
 import { cache } from "react";
 
+import { fetchModelsResponseFromApi } from "@llmgateway/shared/components";
+
 export interface ApiProvider {
 	id: string;
 	createdAt: string;
@@ -89,12 +91,7 @@ const API_URL =
 
 export const fetchModels = cache(async (): Promise<ApiModel[]> => {
 	try {
-		// The models payload exceeds Next's 2MB fetch-cache entry limit, so a
-		// revalidate cache can never refresh — a stale disk entry would be
-		// served forever. Fetch fresh; React cache() still dedupes per render.
-		const response = await fetch(`${API_URL}/internal/models`, {
-			cache: "no-store",
-		});
+		const response = await fetchModelsResponseFromApi(API_URL);
 		if (!response.ok) {
 			console.error("Failed to fetch models:", response.statusText);
 			return [];

--- a/packages/shared/src/components/models-directory/api-types.spec.ts
+++ b/packages/shared/src/components/models-directory/api-types.spec.ts
@@ -1,0 +1,32 @@
+import { Buffer } from "node:buffer";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fetchModelsResponseFromApi } from "./api-types";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("fetchModelsResponseFromApi", () => {
+	it("bypasses Next's data cache for oversized catalogues", async () => {
+		const body = JSON.stringify({
+			models: [{ id: "large-model", description: "x".repeat(2 * 1024 * 1024) }],
+		});
+		expect(Buffer.byteLength(body)).toBeGreaterThan(2 * 1024 * 1024);
+
+		const fetchMock = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response(body));
+
+		const response = await fetchModelsResponseFromApi(
+			"https://api.example.com",
+		);
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://api.example.com/internal/models",
+			{ cache: "no-store" },
+		);
+		expect(await response.text()).toBe(body);
+	});
+});

--- a/packages/shared/src/components/models-directory/api-types.ts
+++ b/packages/shared/src/components/models-directory/api-types.ts
@@ -154,6 +154,12 @@ type NextFetchInit = RequestInit & { next?: { revalidate?: number } };
 const MODELS_MEMO_TTL_MS = 60_000;
 const modelsMemo = new Map<string, { data: ApiModel[]; fetchedAt: number }>();
 
+export function fetchModelsResponseFromApi(
+	apiBackendUrl: string,
+): Promise<Response> {
+	return fetch(`${apiBackendUrl}/internal/models`, { cache: "no-store" });
+}
+
 export async function fetchModelsFromApi(
 	apiBackendUrl: string,
 ): Promise<ApiModel[]> {
@@ -162,8 +168,7 @@ export async function fetchModelsFromApi(
 		return memo.data;
 	}
 	try {
-		const init: NextFetchInit = { cache: "no-store" };
-		const response = await fetch(`${apiBackendUrl}/internal/models`, init);
+		const response = await fetchModelsResponseFromApi(apiBackendUrl);
 		if (!response.ok) {
 			console.error("Failed to fetch models:", response.statusText);
 			return memo?.data ?? [];


### PR DESCRIPTION
## Problem

The model catalogue exceeds Next.js's 2 MB Data Cache entry limit. The cache opt-out was duplicated across server consumers and had no regression coverage, allowing one caller to drift back to a persistent cache write.

## Approach

- centralize the catalogue response fetch with `cache: "no-store"`
- reuse it in the shared models loader and playground
- cover a payload above the Next.js limit with a regression test

## Verification

- `pnpm format`
- `pnpm exec vitest run packages/shared/src/components/models-directory/api-types.spec.ts --no-file-parallelism`
- `pnpm build`
- launched the built playground against a 2,217,337-byte local catalogue fixture; `/` returned 200 and emitted no Data Cache size warning


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Model catalogue requests now consistently retrieve up-to-date model information instead of relying on cached responses.
  - Model listings continue to preserve response handling, premium labels, and fallback behavior.

- **Tests**
  - Added coverage for large model catalogues and request caching behavior to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->