### PR TITLE
feat(ui): compare dashboard usage

### DIFF
--- a/apps/ui/src/components/dashboard/dashboard-client.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-client.tsx
@@ -378,7 +378,7 @@ export function DashboardClient({
 
 	const updateComparisonInUrl = (
 		newMode: UsageComparisonMode,
-		customRange?: UsageDateRange,
+		selectedRange?: UsageDateRange,
 	) => {
 		const params = new URLSearchParams(searchParams.toString());
 		if (newMode === "off") {
@@ -387,9 +387,15 @@ export function DashboardClient({
 			params.delete("compareTo");
 		} else {
 			params.set("compare", newMode);
-			if (newMode === "custom" && customRange) {
-				params.set("compareFrom", format(customRange.from, "yyyy-MM-dd"));
-				params.set("compareTo", format(customRange.to, "yyyy-MM-dd"));
+			if (newMode === "custom" && selectedRange) {
+				params.set("compareFrom", format(selectedRange.from, "yyyy-MM-dd"));
+				params.set("compareTo", format(selectedRange.to, "yyyy-MM-dd"));
+			} else if (
+				(newMode === "previous-week" || newMode === "previous-month") &&
+				selectedRange
+			) {
+				params.set("compareFrom", format(selectedRange.from, "yyyy-MM-dd"));
+				params.delete("compareTo");
 			} else {
 				params.delete("compareFrom");
 				params.delete("compareTo");

--- a/apps/ui/src/components/dashboard/dashboard-client.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-client.tsx
@@ -36,6 +36,11 @@ import { Overview } from "@/components/dashboard/overview";
 import { RecentActivityCard } from "@/components/dashboard/recent-activity-card";
 import { ReferralBanner } from "@/components/dashboard/referral-banner";
 import {
+	parseUsageComparisonMode,
+	resolveUsageComparisonRange,
+} from "@/components/dashboard/usage-comparison";
+import { UsageComparisonPicker } from "@/components/dashboard/usage-comparison-picker";
+import {
 	DateRangePicker,
 	getDateRangeFromParams,
 } from "@/components/date-range-picker";
@@ -60,6 +65,10 @@ import { cn } from "@/lib/utils";
 
 import { useDisplayTimeZone } from "@llmgateway/shared";
 
+import type {
+	UsageComparisonMode,
+	UsageDateRange,
+} from "@/components/dashboard/usage-comparison";
 import type { ActivitT } from "@/types/activity";
 
 interface DashboardClientProps {
@@ -225,6 +234,17 @@ export function DashboardClient({
 	const metricParam = searchParams.get("metric");
 	const metric = (metricParam === "requests" ? "requests" : "costs") as
 		"costs" | "requests";
+	const costView =
+		searchParams.get("costView") === "breakdown" ? "breakdown" : "total";
+	const requestedComparisonMode = parseUsageComparisonMode(
+		searchParams.get("compare"),
+	);
+	const comparisonMode = rangeDays <= 366 ? requestedComparisonMode : "off";
+	const comparisonRange = resolveUsageComparisonRange(
+		comparisonMode,
+		{ from, to },
+		searchParams,
+	);
 
 	// If no from/to params exist, add them to the URL immediately
 	useEffect(() => {
@@ -293,6 +313,34 @@ export function DashboardClient({
 		},
 	);
 
+	const {
+		data: comparisonData,
+		isLoading: isComparisonLoading,
+		isError: isComparisonError,
+	} = api.useQuery(
+		"get",
+		"/activity",
+		{
+			params: {
+				query: {
+					from: comparisonRange
+						? format(comparisonRange.from, "yyyy-MM-dd")
+						: fromStr,
+					to: comparisonRange
+						? format(comparisonRange.to, "yyyy-MM-dd")
+						: toStr,
+					timezone: displayTimeZone,
+					...(selectedProject?.id ? { projectId: selectedProject.id } : {}),
+				},
+			},
+		},
+		{
+			enabled: !!selectedProject?.id && comparisonRange !== null,
+			refetchOnWindowFocus: false,
+			staleTime: 1000 * 60 * 5,
+		},
+	);
+
 	// Get API keys data to check plan limits
 	const { data: apiKeysData } = api.useQuery(
 		"get",
@@ -315,7 +363,39 @@ export function DashboardClient({
 	const updateMetricInUrl = (newMetric: "costs" | "requests") => {
 		const params = new URLSearchParams(searchParams.toString());
 		params.set("metric", newMetric);
-		router.push(`${buildUrl()}?${params.toString()}`);
+		router.push(`${buildUrl()}?${params.toString()}`, { scroll: false });
+	};
+
+	const updateCostViewInUrl = (newView: "total" | "breakdown") => {
+		const params = new URLSearchParams(searchParams.toString());
+		if (newView === "total") {
+			params.delete("costView");
+		} else {
+			params.set("costView", newView);
+		}
+		router.push(`${buildUrl()}?${params.toString()}`, { scroll: false });
+	};
+
+	const updateComparisonInUrl = (
+		newMode: UsageComparisonMode,
+		customRange?: UsageDateRange,
+	) => {
+		const params = new URLSearchParams(searchParams.toString());
+		if (newMode === "off") {
+			params.delete("compare");
+			params.delete("compareFrom");
+			params.delete("compareTo");
+		} else {
+			params.set("compare", newMode);
+			if (newMode === "custom" && customRange) {
+				params.set("compareFrom", format(customRange.from, "yyyy-MM-dd"));
+				params.set("compareTo", format(customRange.to, "yyyy-MM-dd"));
+			} else {
+				params.delete("compareFrom");
+				params.delete("compareTo");
+			}
+		}
+		router.push(`${buildUrl()}?${params.toString()}`, { scroll: false });
 	};
 
 	// Mode-normalized rows: cost/requestCount reflect the selected billing view
@@ -326,6 +406,9 @@ export function DashboardClient({
 		applyUsageModeToDaily(day, usageMode),
 	);
 	const prevActivityData = (prevData?.activity ?? []).map((day) =>
+		applyUsageModeToDaily(day, usageMode),
+	);
+	const comparisonActivityData = comparisonData?.activity.map((day) =>
 		applyUsageModeToDaily(day, usageMode),
 	);
 
@@ -825,34 +908,70 @@ export function DashboardClient({
 											<CardTitle>Usage Overview</CardTitle>
 											<CardDescription>
 												{metric === "costs"
-													? "Daily inference spend (provider list price)"
+													? costView === "total"
+														? "Daily total inference spend (provider list price)"
+														: "Daily inference spend by token type"
 													: "Daily request volume"}
 											</CardDescription>
 										</div>
-										<div className="inline-flex items-center rounded-lg border border-border/60 bg-muted/40 p-0.5">
-											{(["costs", "requests"] as const).map((option) => (
-												<button
-													key={option}
-													type="button"
-													onClick={() => updateMetricInUrl(option)}
-													className={cn(
-														"rounded-md px-3 py-1 text-xs font-medium capitalize transition-colors",
-														metric === option
-															? "bg-background text-foreground shadow-sm"
-															: "text-muted-foreground hover:text-foreground",
-													)}
-												>
-													{option}
-												</button>
-											))}
+										<div className="flex flex-wrap items-center justify-end gap-2">
+											<div className="inline-flex items-center rounded-lg border border-border/60 bg-muted/40 p-0.5">
+												{(["costs", "requests"] as const).map((option) => (
+													<button
+														key={option}
+														type="button"
+														onClick={() => updateMetricInUrl(option)}
+														className={cn(
+															"rounded-md px-3 py-1 text-xs font-medium capitalize transition-colors",
+															metric === option
+																? "bg-background text-foreground shadow-sm"
+																: "text-muted-foreground hover:text-foreground",
+														)}
+													>
+														{option}
+													</button>
+												))}
+											</div>
+											{metric === "costs" && (
+												<div className="inline-flex items-center rounded-lg border border-border/60 bg-muted/40 p-0.5">
+													{(["total", "breakdown"] as const).map((option) => (
+														<button
+															key={option}
+															type="button"
+															onClick={() => updateCostViewInUrl(option)}
+															className={cn(
+																"rounded-md px-3 py-1 text-xs font-medium capitalize transition-colors",
+																costView === option
+																	? "bg-background text-foreground shadow-sm"
+																	: "text-muted-foreground hover:text-foreground",
+															)}
+														>
+															{option}
+														</button>
+													))}
+												</div>
+											)}
+											<UsageComparisonPicker
+												mode={comparisonMode}
+												currentRange={{ from, to }}
+												comparisonRange={comparisonRange}
+												disabled={rangeDays > 366}
+												onChange={updateComparisonInUrl}
+											/>
 										</div>
 									</div>
 								</CardHeader>
 								<CardContent className="pl-2">
 									<Overview
 										data={activityData}
+										comparisonData={comparisonActivityData}
+										comparisonRange={comparisonRange}
+										comparisonMode={comparisonMode}
 										isLoading={isLoading}
+										isComparisonLoading={isComparisonLoading}
+										isComparisonError={isComparisonError}
 										metric={metric}
+										costView={costView}
 									/>
 								</CardContent>
 							</Card>

--- a/apps/ui/src/components/dashboard/overview.tsx
+++ b/apps/ui/src/components/dashboard/overview.tsx
@@ -5,81 +5,259 @@ import { useSearchParams } from "next/navigation";
 import {
 	Area,
 	AreaChart,
-	Legend,
+	CartesianGrid,
 	ResponsiveContainer,
 	Tooltip,
 	XAxis,
 	YAxis,
 } from "recharts";
 
+import { formatUsageDateRange } from "@/components/dashboard/usage-comparison";
 import { getDateRangeFromParams } from "@/components/date-range-picker";
 
 import { useDisplayTimeZone } from "@llmgateway/shared";
 
+import type {
+	UsageComparisonMode,
+	UsageDateRange,
+} from "@/components/dashboard/usage-comparison";
 import type { DailyActivity } from "@/types/activity";
 
 interface OverviewProps {
 	data?: DailyActivity[];
+	comparisonData?: DailyActivity[];
+	comparisonRange?: UsageDateRange | null;
+	comparisonMode?: UsageComparisonMode;
 	isLoading?: boolean;
+	isComparisonLoading?: boolean;
+	isComparisonError?: boolean;
 	metric?: "costs" | "requests";
+	costView?: "total" | "breakdown";
 }
 
-const CustomTooltip = ({
+interface ChartPoint {
+	index: number;
+	currentDate?: string;
+	comparisonDate?: string;
+	currentCost?: number;
+	comparisonCost?: number;
+	currentRequests?: number;
+	comparisonRequests?: number;
+	currentInputCost?: number;
+	comparisonInputCost?: number;
+	currentOutputCost?: number;
+	comparisonOutputCost?: number;
+	currentCachedInputCost?: number;
+	comparisonCachedInputCost?: number;
+}
+
+const COLORS = {
+	current: "#3b82f6",
+	comparison: "#94a3b8",
+	input: "#3b82f6",
+	output: "#f59e0b",
+	cached: "#10b981",
+} as const;
+
+function dateKeys(range: UsageDateRange): string[] {
+	const days = differenceInCalendarDays(range.to, range.from) + 1;
+	return Array.from({ length: days }, (_, index) =>
+		format(addDays(range.from, index), "yyyy-MM-dd"),
+	);
+}
+
+function formatCost(value: number): string {
+	return `$${value.toLocaleString("en-US", {
+		minimumFractionDigits: 2,
+		maximumFractionDigits: value !== 0 && Math.abs(value) < 1 ? 4 : 2,
+	})}`;
+}
+
+function formatAxisCost(value: number): string {
+	if (value >= 1_000_000) {
+		return `$${(value / 1_000_000).toFixed(1)}M`;
+	}
+	if (value >= 1_000) {
+		return `$${(value / 1_000).toFixed(1)}K`;
+	}
+	if (value > 0 && value < 1) {
+		return `$${value.toFixed(2)}`;
+	}
+	return `$${value.toFixed(0)}`;
+}
+
+function comparisonName(mode: UsageComparisonMode | undefined): string {
+	switch (mode) {
+		case "previous-period":
+			return "Previous period";
+		case "previous-week":
+			return "Previous week";
+		case "previous-month":
+			return "Previous month";
+		case "custom":
+			return "Comparison";
+		default:
+			return "Comparison";
+	}
+}
+
+function TooltipSection({
+	date,
+	label,
+	point,
+	metric,
+	costView,
+	comparison = false,
+}: {
+	date: string;
+	label: string;
+	point: ChartPoint;
+	metric: "costs" | "requests";
+	costView: "total" | "breakdown";
+	comparison?: boolean;
+}) {
+	const prefix = comparison ? "comparison" : "current";
+	const totalCost = point[`${prefix}Cost`];
+	const requests = point[`${prefix}Requests`];
+	const inputCost = point[`${prefix}InputCost`];
+	const outputCost = point[`${prefix}OutputCost`];
+	const cachedInputCost = point[`${prefix}CachedInputCost`];
+
+	return (
+		<div
+			className={comparison ? "mt-2 border-t border-border/60 pt-2" : undefined}
+		>
+			<div className="flex items-baseline justify-between gap-6">
+				<p className="text-xs font-medium text-muted-foreground">{label}</p>
+				<p className="text-xs tabular-nums text-muted-foreground">
+					{format(parseISO(date), "MMM d, yyyy")}
+				</p>
+			</div>
+			{metric === "requests" ? (
+				<p className="mt-1 text-sm font-medium tabular-nums">
+					{(requests ?? 0).toLocaleString()} requests
+				</p>
+			) : costView === "total" ? (
+				<p className="mt-1 text-sm font-medium tabular-nums">
+					{formatCost(totalCost ?? 0)} total cost
+				</p>
+			) : (
+				<div className="mt-1 space-y-1">
+					{[
+						{ label: "Input", value: inputCost ?? 0, color: COLORS.input },
+						{ label: "Output", value: outputCost ?? 0, color: COLORS.output },
+						{
+							label: "Cached input",
+							value: cachedInputCost ?? 0,
+							color: COLORS.cached,
+						},
+					].map((item) => (
+						<div
+							key={item.label}
+							className="flex items-center justify-between gap-6 text-sm"
+						>
+							<span className="flex items-center gap-1.5 text-muted-foreground">
+								<span
+									className="h-2 w-2 rounded-full"
+									style={{ backgroundColor: item.color }}
+								/>
+								{item.label}
+							</span>
+							<span className="font-medium tabular-nums">
+								{formatCost(item.value)}
+							</span>
+						</div>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function CustomTooltip({
 	active,
 	payload,
-	label,
 	metric,
+	costView,
+	comparisonMode,
 }: {
-	active: boolean;
-	payload: { value: number; name?: string; dataKey?: string }[];
-	label: string;
-	metric?: "costs" | "requests";
-}) => {
-	if (active && payload && payload.length) {
-		return (
-			<div className="rounded-lg border bg-popover text-popover-foreground p-2 shadow-sm">
-				<p className="font-medium">
-					{label && format(parseISO(label), "MMM d, yyyy")}
-				</p>
-				{metric === "costs" ? (
-					<>
-						{payload.map((entry) => (
-							<p key={entry.dataKey} className="text-sm">
-								<span
-									className="inline-block w-2 h-2 rounded-full mr-1.5"
-									style={{
-										backgroundColor:
-											entry.dataKey === "inputCost"
-												? "#3b82f6"
-												: entry.dataKey === "outputCost"
-													? "#f59e0b"
-													: "#10b981",
-									}}
-								/>
-								<span className="font-medium">${entry.value.toFixed(4)}</span>{" "}
-								{entry.name}
-							</p>
-						))}
-					</>
-				) : (
-					<p className="text-sm">
-						<span className="font-medium">{payload[0]?.value}</span> Requests
-					</p>
-				)}
-			</div>
-		);
+	active?: boolean;
+	payload?: { payload: ChartPoint }[];
+	metric: "costs" | "requests";
+	costView: "total" | "breakdown";
+	comparisonMode?: UsageComparisonMode;
+}) {
+	const point = payload?.[0]?.payload;
+	if (!active || !point) {
+		return null;
 	}
-	return null;
-};
+
+	return (
+		<div className="min-w-56 rounded-lg border bg-popover p-3 text-popover-foreground shadow-md">
+			{point.currentDate && (
+				<TooltipSection
+					date={point.currentDate}
+					label="Current"
+					point={point}
+					metric={metric}
+					costView={costView}
+				/>
+			)}
+			{point.comparisonDate && (
+				<TooltipSection
+					date={point.comparisonDate}
+					label={comparisonName(comparisonMode)}
+					point={point}
+					metric={metric}
+					costView={costView}
+					comparison
+				/>
+			)}
+		</div>
+	);
+}
+
+function LegendItem({
+	color,
+	label,
+	dashed = false,
+}: {
+	color: string;
+	label: string;
+	dashed?: boolean;
+}) {
+	return (
+		<span className="inline-flex items-center gap-1.5">
+			<span
+				className="inline-block h-0.5 w-4"
+				style={
+					dashed
+						? {
+								backgroundImage: `repeating-linear-gradient(to right, ${color} 0 5px, transparent 5px 8px)`,
+							}
+						: { backgroundColor: color }
+				}
+			/>
+			{label}
+		</span>
+	);
+}
 
 export function Overview({
 	data,
+	comparisonData,
+	comparisonRange,
+	comparisonMode,
 	isLoading = false,
+	isComparisonLoading = false,
+	isComparisonError = false,
 	metric = "costs",
+	costView = "total",
 }: OverviewProps) {
 	const searchParams = useSearchParams();
 	const { timeZone: displayTimeZone } = useDisplayTimeZone();
-	const { from, to } = getDateRangeFromParams(searchParams, displayTimeZone);
+	const currentRange = getDateRangeFromParams(searchParams, displayTimeZone);
+	const hasComparison = Boolean(comparisonRange);
 
 	if (isLoading) {
 		return (
@@ -97,74 +275,128 @@ export function Overview({
 		);
 	}
 
-	const totalDays = differenceInCalendarDays(to, from) + 1;
-	const dateRange: string[] = [];
-
-	for (let i = 0; i < totalDays; i++) {
-		const date = addDays(from, i);
-		dateRange.push(format(date, "yyyy-MM-dd"));
-	}
-
-	const dataByDate = new Map(data.map((day) => [day.date, day]));
-
-	const chartData = dateRange.map((date) => {
-		const day = dataByDate.get(date);
-		if (day) {
+	const currentKeys = dateKeys(currentRange);
+	const comparisonKeys = comparisonRange ? dateKeys(comparisonRange) : [];
+	const currentByDate = new Map(data.map((day) => [day.date, day]));
+	const comparisonByDate = new Map(
+		(comparisonData ?? []).map((day) => [day.date, day]),
+	);
+	const pointCount = Math.max(currentKeys.length, comparisonKeys.length);
+	const chartData: ChartPoint[] = Array.from(
+		{ length: pointCount },
+		(_, index) => {
+			const currentDate = currentKeys[index];
+			const comparisonDate = comparisonKeys[index];
+			const current = currentDate ? currentByDate.get(currentDate) : undefined;
+			const comparison = comparisonDate
+				? comparisonByDate.get(comparisonDate)
+				: undefined;
 			return {
-				date,
-				name: format(parseISO(date), "MMM d"),
-				total: day.requestCount,
-				tokens: day.totalTokens,
-				cost: day.cost,
-				inputCost: day.inputCost,
-				outputCost: day.outputCost,
-				cachedInputCost: day.cachedInputCost ?? 0,
-				savings: day.discountSavings,
+				index,
+				currentDate,
+				comparisonDate,
+				currentCost: current?.cost ?? 0,
+				comparisonCost: comparisonData ? (comparison?.cost ?? 0) : undefined,
+				currentRequests: current?.requestCount ?? 0,
+				comparisonRequests: comparisonData
+					? (comparison?.requestCount ?? 0)
+					: undefined,
+				currentInputCost: current?.inputCost ?? 0,
+				comparisonInputCost: comparisonData
+					? (comparison?.inputCost ?? 0)
+					: undefined,
+				currentOutputCost: current?.outputCost ?? 0,
+				comparisonOutputCost: comparisonData
+					? (comparison?.outputCost ?? 0)
+					: undefined,
+				currentCachedInputCost: current?.cachedInputCost ?? 0,
+				comparisonCachedInputCost: comparisonData
+					? (comparison?.cachedInputCost ?? 0)
+					: undefined,
 			};
-		}
+		},
+	);
 
-		return {
-			date,
-			name: format(parseISO(date), "MMM d"),
-			total: 0,
-			tokens: 0,
-			cost: 0,
-			inputCost: 0,
-			outputCost: 0,
-			cachedInputCost: 0,
-			savings: 0,
-		};
-	});
-
-	if (metric === "costs") {
-		return (
+	const comparisonLabel = comparisonRange
+		? formatUsageDateRange(comparisonRange)
+		: null;
+	return (
+		<div>
+			<div className="mb-3 flex min-h-5 flex-wrap items-center gap-x-4 gap-y-2 px-4 text-xs text-muted-foreground">
+				{metric === "costs" && costView === "breakdown" ? (
+					<>
+						<LegendItem color={COLORS.input} label="Input" />
+						<LegendItem color={COLORS.output} label="Output" />
+						<LegendItem color={COLORS.cached} label="Cached input" />
+						{hasComparison && (
+							<LegendItem
+								color={COLORS.current}
+								label={`Current · ${formatUsageDateRange(currentRange)}`}
+							/>
+						)}
+					</>
+				) : (
+					<LegendItem
+						color={COLORS.current}
+						label={`Current · ${formatUsageDateRange(currentRange)}`}
+					/>
+				)}
+				{hasComparison && comparisonLabel && (
+					<LegendItem
+						color={COLORS.comparison}
+						label={`${comparisonName(comparisonMode)} · ${comparisonLabel}`}
+						dashed
+					/>
+				)}
+				{isComparisonLoading && (
+					<span className="animate-pulse">Loading comparison…</span>
+				)}
+				{isComparisonError && (
+					<span className="text-destructive">
+						Comparison could not be loaded
+					</span>
+				)}
+			</div>
 			<ResponsiveContainer width="100%" height={350}>
 				<AreaChart
 					data={chartData}
-					margin={{
-						top: 5,
-						right: 10,
-						left: 10,
-						bottom: 0,
-					}}
+					margin={{ top: 5, right: 10, left: 10, bottom: 0 }}
 				>
 					<defs>
+						<linearGradient id="gradientCurrent" x1="0" y1="0" x2="0" y2="1">
+							<stop offset="5%" stopColor={COLORS.current} stopOpacity={0.45} />
+							<stop
+								offset="95%"
+								stopColor={COLORS.current}
+								stopOpacity={0.03}
+							/>
+						</linearGradient>
 						<linearGradient id="gradientInput" x1="0" y1="0" x2="0" y2="1">
-							<stop offset="5%" stopColor="#3b82f6" stopOpacity={0.8} />
-							<stop offset="95%" stopColor="#3b82f6" stopOpacity={0.05} />
+							<stop offset="5%" stopColor={COLORS.input} stopOpacity={0.45} />
+							<stop offset="95%" stopColor={COLORS.input} stopOpacity={0.03} />
 						</linearGradient>
 						<linearGradient id="gradientOutput" x1="0" y1="0" x2="0" y2="1">
-							<stop offset="5%" stopColor="#f59e0b" stopOpacity={0.8} />
-							<stop offset="95%" stopColor="#f59e0b" stopOpacity={0.05} />
+							<stop offset="5%" stopColor={COLORS.output} stopOpacity={0.45} />
+							<stop offset="95%" stopColor={COLORS.output} stopOpacity={0.03} />
 						</linearGradient>
 						<linearGradient id="gradientCached" x1="0" y1="0" x2="0" y2="1">
-							<stop offset="5%" stopColor="#10b981" stopOpacity={0.8} />
-							<stop offset="95%" stopColor="#10b981" stopOpacity={0.05} />
+							<stop offset="5%" stopColor={COLORS.cached} stopOpacity={0.45} />
+							<stop offset="95%" stopColor={COLORS.cached} stopOpacity={0.03} />
 						</linearGradient>
 					</defs>
+					<CartesianGrid
+						strokeDasharray="3 3"
+						vertical={false}
+						opacity={0.45}
+					/>
 					<XAxis
-						dataKey="date"
-						tickFormatter={(value: string) => format(parseISO(value), "MMM d")}
+						dataKey="index"
+						tickFormatter={(value: number) => {
+							const date = chartData[value]?.currentDate;
+							return date
+								? format(parseISO(date), "MMM d")
+								: `Day ${value + 1}`;
+						}}
 						stroke="#888888"
 						fontSize={12}
 						tickLine={false}
@@ -175,123 +407,118 @@ export function Overview({
 						fontSize={12}
 						tickLine={false}
 						axisLine={false}
-						tickFormatter={(value: number) => `$${value}`}
+						tickFormatter={(value: number) =>
+							metric === "costs"
+								? formatAxisCost(value)
+								: value.toLocaleString()
+						}
 					/>
 					<Tooltip
 						content={
 							<CustomTooltip
-								active={true}
-								payload={[{ value: 0 }]}
-								label="tooltip"
-								metric="costs"
+								metric={metric}
+								costView={costView}
+								comparisonMode={comparisonMode}
 							/>
 						}
-						cursor={{
-							fill: "color-mix(in srgb, currentColor 15%, transparent)",
-						}}
+						cursor={{ stroke: "currentColor", strokeOpacity: 0.15 }}
 					/>
-					<Legend
-						verticalAlign="top"
-						align="left"
-						iconType="circle"
-						wrapperStyle={{ paddingBottom: 20 }}
-					/>
-					<Area
-						type="linear"
-						dataKey="inputCost"
-						name="Input"
-						stroke="#3b82f6"
-						strokeWidth={2}
-						fill="url(#gradientInput)"
-						fillOpacity={0.4}
-						dot={false}
-					/>
-					<Area
-						type="linear"
-						dataKey="outputCost"
-						name="Output"
-						stroke="#f59e0b"
-						strokeWidth={2}
-						fill="url(#gradientOutput)"
-						fillOpacity={0.4}
-						dot={false}
-					/>
-					<Area
-						type="linear"
-						dataKey="cachedInputCost"
-						name="Cached Input"
-						stroke="#10b981"
-						strokeWidth={2}
-						fill="url(#gradientCached)"
-						fillOpacity={0.4}
-						dot={false}
-					/>
+					{metric === "costs" && costView === "breakdown" && (
+						<Area
+							type="linear"
+							dataKey="currentInputCost"
+							stroke={COLORS.input}
+							strokeWidth={2}
+							fill="url(#gradientInput)"
+							dot={pointCount === 1}
+							isAnimationActive={false}
+						/>
+					)}
+					{metric === "costs" && costView === "breakdown" && (
+						<Area
+							type="linear"
+							dataKey="currentOutputCost"
+							stroke={COLORS.output}
+							strokeWidth={2}
+							fill="url(#gradientOutput)"
+							dot={pointCount === 1}
+							isAnimationActive={false}
+						/>
+					)}
+					{metric === "costs" && costView === "breakdown" && (
+						<Area
+							type="linear"
+							dataKey="currentCachedInputCost"
+							stroke={COLORS.cached}
+							strokeWidth={2}
+							fill="url(#gradientCached)"
+							dot={pointCount === 1}
+							isAnimationActive={false}
+						/>
+					)}
+					{metric === "costs" && costView === "breakdown" && hasComparison && (
+						<Area
+							type="linear"
+							dataKey="comparisonInputCost"
+							stroke={COLORS.input}
+							strokeWidth={1.5}
+							strokeDasharray="5 4"
+							fill="none"
+							dot={pointCount === 1}
+							isAnimationActive={false}
+						/>
+					)}
+					{metric === "costs" && costView === "breakdown" && hasComparison && (
+						<Area
+							type="linear"
+							dataKey="comparisonOutputCost"
+							stroke={COLORS.output}
+							strokeWidth={1.5}
+							strokeDasharray="5 4"
+							fill="none"
+							dot={pointCount === 1}
+							isAnimationActive={false}
+						/>
+					)}
+					{metric === "costs" && costView === "breakdown" && hasComparison && (
+						<Area
+							type="linear"
+							dataKey="comparisonCachedInputCost"
+							stroke={COLORS.cached}
+							strokeWidth={1.5}
+							strokeDasharray="5 4"
+							fill="none"
+							dot={pointCount === 1}
+							isAnimationActive={false}
+						/>
+					)}
+					{(metric !== "costs" || costView === "total") && (
+						<Area
+							type="linear"
+							dataKey={metric === "costs" ? "currentCost" : "currentRequests"}
+							stroke={COLORS.current}
+							strokeWidth={2.25}
+							fill="url(#gradientCurrent)"
+							dot={pointCount === 1}
+							isAnimationActive={false}
+						/>
+					)}
+					{(metric !== "costs" || costView === "total") && hasComparison && (
+						<Area
+							type="linear"
+							dataKey={
+								metric === "costs" ? "comparisonCost" : "comparisonRequests"
+							}
+							stroke={COLORS.comparison}
+							strokeWidth={2}
+							strokeDasharray="6 5"
+							fill="none"
+							dot={pointCount === 1}
+							isAnimationActive={false}
+						/>
+					)}
 				</AreaChart>
 			</ResponsiveContainer>
-		);
-	}
-
-	return (
-		<ResponsiveContainer width="100%" height={350}>
-			<AreaChart
-				data={chartData}
-				margin={{
-					top: 5,
-					right: 10,
-					left: 10,
-					bottom: 0,
-				}}
-			>
-				<defs>
-					<linearGradient id="gradientRequests" x1="0" y1="0" x2="0" y2="1">
-						<stop offset="5%" stopColor="#3b82f6" stopOpacity={0.8} />
-						<stop offset="95%" stopColor="#3b82f6" stopOpacity={0.05} />
-					</linearGradient>
-				</defs>
-				<XAxis
-					dataKey="date"
-					tickFormatter={(value: string) => format(parseISO(value), "MMM d")}
-					stroke="#888888"
-					fontSize={12}
-					tickLine={false}
-					axisLine={false}
-				/>
-				<YAxis
-					stroke="#888888"
-					fontSize={12}
-					tickLine={false}
-					axisLine={false}
-				/>
-				<Tooltip
-					content={
-						<CustomTooltip
-							active={true}
-							payload={[{ value: 0 }]}
-							label="tooltip"
-							metric="requests"
-						/>
-					}
-					cursor={{
-						fill: "color-mix(in srgb, currentColor 15%, transparent)",
-					}}
-				/>
-				<Legend
-					verticalAlign="top"
-					align="left"
-					iconType="circle"
-					wrapperStyle={{ paddingBottom: 20 }}
-				/>
-				<Area
-					type="linear"
-					dataKey="total"
-					name="Requests"
-					stroke="#3b82f6"
-					strokeWidth={2}
-					fill="url(#gradientRequests)"
-					fillOpacity={0.4}
-					dot={false}
-				/>
-			</AreaChart>
-		</ResponsiveContainer>
+		</div>
 	);
 }

--- a/apps/ui/src/components/dashboard/usage-comparison-picker.tsx
+++ b/apps/ui/src/components/dashboard/usage-comparison-picker.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { Check, ChevronDown, GitCompare } from "lucide-react";
+import { addDays, differenceInCalendarDays, subDays } from "date-fns";
+import { Check, ChevronDown, ChevronLeft, GitCompare } from "lucide-react";
 import { useState } from "react";
 
 import { DayRangePicker } from "@/components/date-range-picker";
 import { Button } from "@/lib/components/button";
+import { Calendar } from "@/lib/components/calendar";
 import {
 	Popover,
 	PopoverContent,
@@ -14,9 +16,15 @@ import { cn } from "@/lib/utils";
 
 import {
 	formatUsageDateRange,
+	resolveUsageComparisonRange,
 	type UsageComparisonMode,
 	type UsageDateRange,
 } from "./usage-comparison";
+
+type StartDateMode = Extract<
+	UsageComparisonMode,
+	"previous-week" | "previous-month"
+>;
 
 const OPTIONS: {
 	value: Exclude<UsageComparisonMode, "custom">;
@@ -50,7 +58,7 @@ interface UsageComparisonPickerProps {
 	currentRange: UsageDateRange;
 	comparisonRange: UsageDateRange | null;
 	disabled?: boolean;
-	onChange: (mode: UsageComparisonMode, customRange?: UsageDateRange) => void;
+	onChange: (mode: UsageComparisonMode, selectedRange?: UsageDateRange) => void;
 }
 
 function triggerLabel(
@@ -60,10 +68,94 @@ function triggerLabel(
 	if (mode === "off") {
 		return "Compare";
 	}
-	if (mode === "custom" && comparisonRange) {
+	if (comparisonRange && mode === "custom") {
 		return formatUsageDateRange(comparisonRange);
 	}
+	if (comparisonRange && mode === "previous-week") {
+		return `Week · ${formatUsageDateRange(comparisonRange)}`;
+	}
+	if (comparisonRange && mode === "previous-month") {
+		return `Month · ${formatUsageDateRange(comparisonRange)}`;
+	}
 	return OPTIONS.find((option) => option.value === mode)?.label ?? "Compare";
+}
+
+function ComparisonStartPicker({
+	mode,
+	currentRange,
+	start,
+	onStartChange,
+	onBack,
+	onSelect,
+}: {
+	mode: StartDateMode;
+	currentRange: UsageDateRange;
+	start: Date;
+	onStartChange: (start: Date) => void;
+	onBack: () => void;
+	onSelect: (range: UsageDateRange) => void;
+}) {
+	const rangeDays = differenceInCalendarDays(
+		currentRange.to,
+		currentRange.from,
+	);
+	const selectedRange = {
+		from: start,
+		to: addDays(start, rangeDays),
+	};
+	const latestStart = subDays(currentRange.from, 1);
+
+	return (
+		<div className="space-y-3">
+			<div className="flex items-start gap-2 px-3 pt-3 sm:px-0 sm:pt-0">
+				<Button
+					type="button"
+					variant="ghost"
+					size="icon"
+					className="-ml-2 h-8 w-8"
+					onClick={onBack}
+					aria-label="Back to comparison options"
+				>
+					<ChevronLeft className="h-4 w-4" />
+				</Button>
+				<div>
+					<p className="text-sm font-medium">
+						{mode === "previous-week" ? "Week" : "Month"} comparison
+					</p>
+					<p className="text-xs text-muted-foreground">
+						Choose a start date for the {rangeDays + 1}-day comparison
+					</p>
+				</div>
+			</div>
+			<div className="rounded-md border border-border/60 bg-muted/30 px-3 py-2">
+				<p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+					Comparison range
+				</p>
+				<p className="mt-0.5 text-sm font-medium tabular-nums">
+					{formatUsageDateRange(selectedRange)}
+				</p>
+			</div>
+			<Calendar
+				mode="single"
+				selected={start}
+				onSelect={(day) => {
+					if (day) {
+						onStartChange(day);
+					}
+				}}
+				defaultMonth={start}
+				disabled={{ after: latestStart }}
+				showOutsideDays={false}
+				className="p-0"
+			/>
+			<div className="flex items-center justify-between border-t px-3 pt-3 sm:px-0">
+				<p className="text-xs text-muted-foreground">Ends automatically</p>
+				<Button type="button" size="sm" onClick={() => onSelect(selectedRange)}>
+					Compare
+				</Button>
+			</div>
+		</div>
+	);
 }
 
 export function UsageComparisonPicker({
@@ -75,7 +167,12 @@ export function UsageComparisonPicker({
 }: UsageComparisonPickerProps) {
 	const [open, setOpen] = useState(false);
 	const [showCustom, setShowCustom] = useState(false);
+	const [startDateMode, setStartDateMode] = useState<StartDateMode | null>(
+		null,
+	);
+	const [comparisonStart, setComparisonStart] = useState(currentRange.from);
 	const customDefault = comparisonRange ?? currentRange;
+	const showCalendar = showCustom || startDateMode !== null;
 
 	return (
 		<Popover
@@ -84,6 +181,7 @@ export function UsageComparisonPicker({
 				setOpen(nextOpen);
 				if (!nextOpen) {
 					setShowCustom(false);
+					setStartDateMode(null);
 				}
 			}}
 		>
@@ -114,7 +212,7 @@ export function UsageComparisonPicker({
 				align="end"
 				className={cn(
 					"p-0",
-					showCustom
+					showCalendar
 						? "max-h-[var(--radix-popover-content-available-height)] w-[calc(100vw-2rem)] overflow-y-auto p-3 sm:w-auto"
 						: "w-80",
 				)}
@@ -127,6 +225,18 @@ export function UsageComparisonPicker({
 						onCancel={() => setShowCustom(false)}
 						onSelect={(from, to) => {
 							onChange("custom", { from, to });
+							setOpen(false);
+						}}
+					/>
+				) : startDateMode ? (
+					<ComparisonStartPicker
+						mode={startDateMode}
+						currentRange={currentRange}
+						start={comparisonStart}
+						onStartChange={setComparisonStart}
+						onBack={() => setStartDateMode(null)}
+						onSelect={(range) => {
+							onChange(startDateMode, range);
 							setOpen(false);
 						}}
 					/>
@@ -143,6 +253,23 @@ export function UsageComparisonPicker({
 								key={option.value}
 								type="button"
 								onClick={() => {
+									if (
+										option.value === "previous-week" ||
+										option.value === "previous-month"
+									) {
+										const defaultRange =
+											mode === option.value && comparisonRange
+												? comparisonRange
+												: resolveUsageComparisonRange(
+														option.value,
+														currentRange,
+													);
+										if (defaultRange) {
+											setComparisonStart(defaultRange.from);
+										}
+										setStartDateMode(option.value);
+										return;
+									}
 									onChange(option.value);
 									setOpen(false);
 								}}

--- a/apps/ui/src/components/dashboard/usage-comparison-picker.tsx
+++ b/apps/ui/src/components/dashboard/usage-comparison-picker.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { Check, ChevronDown, GitCompare } from "lucide-react";
+import { useState } from "react";
+
+import { DayRangePicker } from "@/components/date-range-picker";
+import { Button } from "@/lib/components/button";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/lib/components/popover";
+import { cn } from "@/lib/utils";
+
+import {
+	formatUsageDateRange,
+	type UsageComparisonMode,
+	type UsageDateRange,
+} from "./usage-comparison";
+
+const OPTIONS: {
+	value: Exclude<UsageComparisonMode, "custom">;
+	label: string;
+	description: string;
+}[] = [
+	{
+		value: "off",
+		label: "No comparison",
+		description: "Show only the selected range",
+	},
+	{
+		value: "previous-period",
+		label: "Previous period",
+		description: "The same number of days immediately before",
+	},
+	{
+		value: "previous-week",
+		label: "Week over week",
+		description: "The selected dates shifted back 7 days",
+	},
+	{
+		value: "previous-month",
+		label: "Month over month",
+		description: "The selected dates shifted back one month",
+	},
+];
+
+interface UsageComparisonPickerProps {
+	mode: UsageComparisonMode;
+	currentRange: UsageDateRange;
+	comparisonRange: UsageDateRange | null;
+	disabled?: boolean;
+	onChange: (mode: UsageComparisonMode, customRange?: UsageDateRange) => void;
+}
+
+function triggerLabel(
+	mode: UsageComparisonMode,
+	comparisonRange: UsageDateRange | null,
+): string {
+	if (mode === "off") {
+		return "Compare";
+	}
+	if (mode === "custom" && comparisonRange) {
+		return formatUsageDateRange(comparisonRange);
+	}
+	return OPTIONS.find((option) => option.value === mode)?.label ?? "Compare";
+}
+
+export function UsageComparisonPicker({
+	mode,
+	currentRange,
+	comparisonRange,
+	disabled = false,
+	onChange,
+}: UsageComparisonPickerProps) {
+	const [open, setOpen] = useState(false);
+	const [showCustom, setShowCustom] = useState(false);
+	const customDefault = comparisonRange ?? currentRange;
+
+	return (
+		<Popover
+			open={open}
+			onOpenChange={(nextOpen) => {
+				setOpen(nextOpen);
+				if (!nextOpen) {
+					setShowCustom(false);
+				}
+			}}
+		>
+			<PopoverTrigger asChild>
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					disabled={disabled}
+					title={
+						disabled
+							? "Comparison is unavailable for all-time ranges"
+							: undefined
+					}
+					className={cn(
+						"max-w-[220px]",
+						mode !== "off" && "border-primary/40 bg-primary/5 text-foreground",
+					)}
+				>
+					<GitCompare className="h-3.5 w-3.5" />
+					<span className="truncate">
+						{triggerLabel(mode, comparisonRange)}
+					</span>
+					<ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent
+				align="end"
+				className={cn(
+					"p-0",
+					showCustom
+						? "max-h-[var(--radix-popover-content-available-height)] w-[calc(100vw-2rem)] overflow-y-auto p-3 sm:w-auto"
+						: "w-80",
+				)}
+			>
+				{showCustom ? (
+					<DayRangePicker
+						from={customDefault.from}
+						to={customDefault.to}
+						applyLabel="Compare"
+						onCancel={() => setShowCustom(false)}
+						onSelect={(from, to) => {
+							onChange("custom", { from, to });
+							setOpen(false);
+						}}
+					/>
+				) : (
+					<div className="p-1">
+						<div className="px-2 pb-2 pt-2">
+							<p className="text-sm font-medium">Compare usage</p>
+							<p className="text-xs text-muted-foreground">
+								Overlay ranges by elapsed day
+							</p>
+						</div>
+						{OPTIONS.map((option) => (
+							<button
+								key={option.value}
+								type="button"
+								onClick={() => {
+									onChange(option.value);
+									setOpen(false);
+								}}
+								className="flex w-full items-start gap-3 rounded-md px-2 py-2 text-left transition-colors hover:bg-accent"
+							>
+								<span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center">
+									{mode === option.value && <Check className="h-3.5 w-3.5" />}
+								</span>
+								<span>
+									<span className="block text-sm font-medium">
+										{option.label}
+									</span>
+									<span className="block text-xs text-muted-foreground">
+										{option.description}
+									</span>
+								</span>
+							</button>
+						))}
+						<button
+							type="button"
+							onClick={() => setShowCustom(true)}
+							className="flex w-full items-start gap-3 rounded-md px-2 py-2 text-left transition-colors hover:bg-accent"
+						>
+							<span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center">
+								{mode === "custom" && <Check className="h-3.5 w-3.5" />}
+							</span>
+							<span>
+								<span className="block text-sm font-medium">Custom range</span>
+								<span className="block text-xs text-muted-foreground">
+									Choose exact comparison days
+								</span>
+							</span>
+						</button>
+					</div>
+				)}
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/apps/ui/src/components/dashboard/usage-comparison-picker.tsx
+++ b/apps/ui/src/components/dashboard/usage-comparison-picker.tsx
@@ -146,7 +146,7 @@ function ComparisonStartPicker({
 				defaultMonth={start}
 				disabled={{ after: latestStart }}
 				showOutsideDays={false}
-				className="p-0"
+				className="relative p-0"
 			/>
 			<div className="flex items-center justify-between border-t px-3 pt-3 sm:px-0">
 				<p className="text-xs text-muted-foreground">Ends automatically</p>

--- a/apps/ui/src/components/dashboard/usage-comparison-picker.tsx
+++ b/apps/ui/src/components/dashboard/usage-comparison-picker.tsx
@@ -103,7 +103,7 @@ function ComparisonStartPicker({
 		from: start,
 		to: addDays(start, rangeDays),
 	};
-	const latestStart = subDays(currentRange.from, 1);
+	const latestStart = subDays(currentRange.from, rangeDays + 1);
 
 	return (
 		<div className="space-y-3">
@@ -237,6 +237,7 @@ export function UsageComparisonPicker({
 						onBack={() => setStartDateMode(null)}
 						onSelect={(range) => {
 							onChange(startDateMode, range);
+							setStartDateMode(null);
 							setOpen(false);
 						}}
 					/>

--- a/apps/ui/src/components/dashboard/usage-comparison.spec.ts
+++ b/apps/ui/src/components/dashboard/usage-comparison.spec.ts
@@ -30,6 +30,23 @@ describe("usage comparison ranges", () => {
 		});
 	});
 
+	it("uses a selected start date and preserves the current range length", () => {
+		const selectedStart = new URLSearchParams("compareFrom=2026-06-02");
+
+		expect(
+			resolveUsageComparisonRange("previous-week", current, selectedStart),
+		).toEqual({
+			from: new Date("2026-06-02T00:00:00"),
+			to: new Date("2026-06-08T00:00:00"),
+		});
+		expect(
+			resolveUsageComparisonRange("previous-month", current, selectedStart),
+		).toEqual({
+			from: new Date("2026-06-02T00:00:00"),
+			to: new Date("2026-06-08T00:00:00"),
+		});
+	});
+
 	it("accepts only complete ordered custom day ranges", () => {
 		const valid = new URLSearchParams(
 			"compareFrom=2026-06-02&compareTo=2026-06-05",

--- a/apps/ui/src/components/dashboard/usage-comparison.spec.ts
+++ b/apps/ui/src/components/dashboard/usage-comparison.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	formatUsageDateRange,
+	parseUsageComparisonMode,
+	resolveUsageComparisonRange,
+} from "./usage-comparison";
+
+const current = {
+	from: new Date("2026-08-10T00:00:00"),
+	to: new Date("2026-08-16T00:00:00"),
+};
+
+describe("usage comparison ranges", () => {
+	it("resolves an immediately preceding period of equal length", () => {
+		expect(resolveUsageComparisonRange("previous-period", current)).toEqual({
+			from: new Date("2026-08-03T00:00:00"),
+			to: new Date("2026-08-09T00:00:00"),
+		});
+	});
+
+	it("shifts the selected dates by a week or month", () => {
+		expect(resolveUsageComparisonRange("previous-week", current)).toEqual({
+			from: new Date("2026-08-03T00:00:00"),
+			to: new Date("2026-08-09T00:00:00"),
+		});
+		expect(resolveUsageComparisonRange("previous-month", current)).toEqual({
+			from: new Date("2026-07-10T00:00:00"),
+			to: new Date("2026-07-16T00:00:00"),
+		});
+	});
+
+	it("accepts only complete ordered custom day ranges", () => {
+		const valid = new URLSearchParams(
+			"compareFrom=2026-06-02&compareTo=2026-06-05",
+		);
+		const reversed = new URLSearchParams(
+			"compareFrom=2026-06-05&compareTo=2026-06-02",
+		);
+
+		expect(resolveUsageComparisonRange("custom", current, valid)).toEqual({
+			from: new Date("2026-06-02T00:00:00"),
+			to: new Date("2026-06-05T00:00:00"),
+		});
+		expect(resolveUsageComparisonRange("custom", current, reversed)).toBeNull();
+	});
+
+	it("falls back to off for unknown modes", () => {
+		expect(parseUsageComparisonMode("quarter-over-quarter")).toBe("off");
+	});
+
+	it("formats compact range labels", () => {
+		expect(formatUsageDateRange(current)).toBe("Aug 10–16, 2026");
+	});
+});

--- a/apps/ui/src/components/dashboard/usage-comparison.spec.ts
+++ b/apps/ui/src/components/dashboard/usage-comparison.spec.ts
@@ -30,21 +30,32 @@ describe("usage comparison ranges", () => {
 		});
 	});
 
-	it("uses a selected start date and preserves the current range length", () => {
-		const selectedStart = new URLSearchParams("compareFrom=2026-06-02");
+	it("accepts the latest non-overlapping named comparison", () => {
+		const selectedStart = new URLSearchParams("compareFrom=2026-08-03");
 
 		expect(
 			resolveUsageComparisonRange("previous-week", current, selectedStart),
 		).toEqual({
-			from: new Date("2026-06-02T00:00:00"),
-			to: new Date("2026-06-08T00:00:00"),
+			from: new Date("2026-08-03T00:00:00"),
+			to: new Date("2026-08-09T00:00:00"),
 		});
 		expect(
 			resolveUsageComparisonRange("previous-month", current, selectedStart),
 		).toEqual({
-			from: new Date("2026-06-02T00:00:00"),
-			to: new Date("2026-06-08T00:00:00"),
+			from: new Date("2026-08-03T00:00:00"),
+			to: new Date("2026-08-09T00:00:00"),
 		});
+	});
+
+	it("rejects named comparisons that overlap the current range", () => {
+		const selectedStart = new URLSearchParams("compareFrom=2026-08-04");
+
+		expect(
+			resolveUsageComparisonRange("previous-week", current, selectedStart),
+		).toBeNull();
+		expect(
+			resolveUsageComparisonRange("previous-month", current, selectedStart),
+		).toBeNull();
 	});
 
 	it("accepts only complete ordered custom day ranges", () => {

--- a/apps/ui/src/components/dashboard/usage-comparison.ts
+++ b/apps/ui/src/components/dashboard/usage-comparison.ts
@@ -1,4 +1,10 @@
-import { differenceInCalendarDays, format, subDays, subMonths } from "date-fns";
+import {
+	addDays,
+	differenceInCalendarDays,
+	format,
+	subDays,
+	subMonths,
+} from "date-fns";
 
 export type UsageComparisonMode =
 	"off" | "previous-period" | "previous-week" | "previous-month" | "custom";
@@ -39,6 +45,12 @@ export function resolveUsageComparisonRange(
 	current: UsageDateRange,
 	searchParams?: SearchParamsReader,
 ): UsageDateRange | null {
+	const selectedStart = parseDay(searchParams?.get("compareFrom") ?? null);
+	const rangeDays = differenceInCalendarDays(current.to, current.from);
+	const rangeFromStart = selectedStart
+		? { from: selectedStart, to: addDays(selectedStart, rangeDays) }
+		: null;
+
 	switch (mode) {
 		case "previous-period": {
 			const days = differenceInCalendarDays(current.to, current.from) + 1;
@@ -48,15 +60,19 @@ export function resolveUsageComparisonRange(
 			};
 		}
 		case "previous-week":
-			return {
-				from: subDays(current.from, 7),
-				to: subDays(current.to, 7),
-			};
+			return (
+				rangeFromStart ?? {
+					from: subDays(current.from, 7),
+					to: subDays(current.to, 7),
+				}
+			);
 		case "previous-month":
-			return {
-				from: subMonths(current.from, 1),
-				to: subMonths(current.to, 1),
-			};
+			return (
+				rangeFromStart ?? {
+					from: subMonths(current.from, 1),
+					to: subMonths(current.to, 1),
+				}
+			);
 		case "custom": {
 			const from = parseDay(searchParams?.get("compareFrom") ?? null);
 			const to = parseDay(searchParams?.get("compareTo") ?? null);

--- a/apps/ui/src/components/dashboard/usage-comparison.ts
+++ b/apps/ui/src/components/dashboard/usage-comparison.ts
@@ -60,6 +60,9 @@ export function resolveUsageComparisonRange(
 			};
 		}
 		case "previous-week":
+			if (rangeFromStart && rangeFromStart.to >= current.from) {
+				return null;
+			}
 			return (
 				rangeFromStart ?? {
 					from: subDays(current.from, 7),
@@ -67,6 +70,9 @@ export function resolveUsageComparisonRange(
 				}
 			);
 		case "previous-month":
+			if (rangeFromStart && rangeFromStart.to >= current.from) {
+				return null;
+			}
 			return (
 				rangeFromStart ?? {
 					from: subMonths(current.from, 1),

--- a/apps/ui/src/components/dashboard/usage-comparison.ts
+++ b/apps/ui/src/components/dashboard/usage-comparison.ts
@@ -1,0 +1,79 @@
+import { differenceInCalendarDays, format, subDays, subMonths } from "date-fns";
+
+export type UsageComparisonMode =
+	"off" | "previous-period" | "previous-week" | "previous-month" | "custom";
+
+export interface UsageDateRange {
+	from: Date;
+	to: Date;
+}
+
+interface SearchParamsReader {
+	get: (name: string) => string | null;
+}
+
+export function parseUsageComparisonMode(
+	value: string | null,
+): UsageComparisonMode {
+	switch (value) {
+		case "previous-period":
+		case "previous-week":
+		case "previous-month":
+		case "custom":
+			return value;
+		default:
+			return "off";
+	}
+}
+
+function parseDay(value: string | null): Date | null {
+	if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+		return null;
+	}
+	const date = new Date(`${value}T00:00:00`);
+	return format(date, "yyyy-MM-dd") === value ? date : null;
+}
+
+export function resolveUsageComparisonRange(
+	mode: UsageComparisonMode,
+	current: UsageDateRange,
+	searchParams?: SearchParamsReader,
+): UsageDateRange | null {
+	switch (mode) {
+		case "previous-period": {
+			const days = differenceInCalendarDays(current.to, current.from) + 1;
+			return {
+				from: subDays(current.from, days),
+				to: subDays(current.from, 1),
+			};
+		}
+		case "previous-week":
+			return {
+				from: subDays(current.from, 7),
+				to: subDays(current.to, 7),
+			};
+		case "previous-month":
+			return {
+				from: subMonths(current.from, 1),
+				to: subMonths(current.to, 1),
+			};
+		case "custom": {
+			const from = parseDay(searchParams?.get("compareFrom") ?? null);
+			const to = parseDay(searchParams?.get("compareTo") ?? null);
+			return from && to && from <= to ? { from, to } : null;
+		}
+		case "off":
+		default:
+			return null;
+	}
+}
+
+export function formatUsageDateRange({ from, to }: UsageDateRange): string {
+	if (from.getFullYear() === to.getFullYear()) {
+		if (from.getMonth() === to.getMonth()) {
+			return `${format(from, "MMM d")}–${format(to, "d, yyyy")}`;
+		}
+		return `${format(from, "MMM d")}–${format(to, "MMM d, yyyy")}`;
+	}
+	return `${format(from, "MMM d, yyyy")}–${format(to, "MMM d, yyyy")}`;
+}

--- a/apps/ui/src/components/date-range-picker.tsx
+++ b/apps/ui/src/components/date-range-picker.tsx
@@ -17,11 +17,13 @@ import {
 	subWeeks,
 	subYears,
 } from "date-fns";
-import { ChevronDownIcon, ChevronLeftIcon } from "lucide-react";
+import { ChevronDownIcon } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useMemo, useState } from "react";
 
 import { GENERATED_RANGE_PARAM } from "@/hooks/useZonedRangeDefaults";
+import { Button } from "@/lib/components/button";
+import { Calendar } from "@/lib/components/calendar";
 import { Input } from "@/lib/components/input";
 import {
 	Popover,
@@ -36,6 +38,8 @@ import {
 	useDisplayTimeZone,
 } from "@llmgateway/shared";
 
+import type { DateRange } from "react-day-picker";
+
 interface DatePreset {
 	label: string;
 	value: string;
@@ -46,21 +50,6 @@ interface DateRangePickerProps {
 	buildUrl: (path?: string) => string;
 	path?: string;
 }
-
-const MONTH_NAMES = [
-	"Jan",
-	"Feb",
-	"Mar",
-	"Apr",
-	"May",
-	"Jun",
-	"Jul",
-	"Aug",
-	"Sep",
-	"Oct",
-	"Nov",
-	"Dec",
-];
 
 function getQuarterLabel(date: Date): string {
 	return `Q${getQuarter(date)} ${format(date, "yyyy")}`;
@@ -227,132 +216,80 @@ function getDateRangeFromParams(
 	};
 }
 
-function compareMonth(a: Date, b: Date): number {
-	// eslint-disable-next-line no-mixed-operators
-	const aMonths = a.getFullYear() * 12 + a.getMonth();
-	// eslint-disable-next-line no-mixed-operators
-	const bMonths = b.getFullYear() * 12 + b.getMonth();
-	return aMonths - bMonths;
-}
-
-interface MonthRangePickerProps {
+interface DayRangePickerProps {
 	from: Date;
 	to: Date;
 	onSelect: (from: Date, to: Date) => void;
+	onCancel?: () => void;
+	applyLabel?: string;
 }
 
-function MonthRangePicker({ from, to, onSelect }: MonthRangePickerProps) {
+export function DayRangePicker({
+	from,
+	to,
+	onSelect,
+	onCancel,
+	applyLabel = "Apply range",
+}: DayRangePickerProps) {
 	const { timeZone } = useDisplayTimeZone();
-	// The display zone's calendar day, so "future month" is judged against the
-	// same clock the ranges are written in.
 	const today = new Date(`${formatDayKey(new Date(), timeZone)}T00:00:00`);
-	const [leftYear, setLeftYear] = useState(() => today.getFullYear() - 1);
-	const [pendingFrom, setPendingFrom] = useState<Date | null>(null);
-	const [hoverMonth, setHoverMonth] = useState<Date | null>(null);
-	const rightYear = leftYear + 1;
-
-	const handleMonthClick = (year: number, monthIdx: number) => {
-		if (
-			year > today.getFullYear() ||
-			(year === today.getFullYear() && monthIdx > today.getMonth())
-		) {
-			return;
-		}
-		const clicked = new Date(year, monthIdx, 1);
-		if (!pendingFrom) {
-			setPendingFrom(clicked);
-		} else {
-			const [start, end] =
-				clicked < pendingFrom ? [clicked, pendingFrom] : [pendingFrom, clicked];
-			onSelect(startOfMonth(start), endOfMonth(end));
-			setPendingFrom(null);
-			setHoverMonth(null);
-		}
-	};
-
-	const getEffectiveRange = (): { lo: Date; hi: Date } => {
-		if (pendingFrom && hoverMonth) {
-			return pendingFrom <= hoverMonth
-				? { lo: pendingFrom, hi: hoverMonth }
-				: { lo: hoverMonth, hi: pendingFrom };
-		}
-		return { lo: from, hi: to };
-	};
-
-	const isFutureMonth = (year: number, monthIdx: number) =>
-		year > today.getFullYear() ||
-		(year === today.getFullYear() && monthIdx > today.getMonth());
-
-	const renderYearPanel = (year: number) => {
-		const { lo, hi } = getEffectiveRange();
-		return (
-			<div className="flex-1 min-w-0">
-				<div className="mb-2 text-center text-sm font-medium">{year}</div>
-				<div className="grid grid-cols-3 gap-1">
-					{MONTH_NAMES.map((name, idx) => {
-						const d = new Date(year, idx, 1);
-						const disabled = isFutureMonth(year, idx);
-						const inRange =
-							!disabled && compareMonth(d, lo) >= 0 && compareMonth(d, hi) <= 0;
-						const isStart =
-							!disabled && year === lo.getFullYear() && idx === lo.getMonth();
-						const isEnd =
-							!disabled && year === hi.getFullYear() && idx === hi.getMonth();
-						return (
-							<button
-								key={name}
-								type="button"
-								disabled={disabled}
-								onClick={() => handleMonthClick(year, idx)}
-								onMouseEnter={() => {
-									if (pendingFrom) {
-										setHoverMonth(new Date(year, idx, 1));
-									}
-								}}
-								onMouseLeave={() => {
-									if (pendingFrom) {
-										setHoverMonth(null);
-									}
-								}}
-								className={cn(
-									"rounded px-2 py-1.5 text-sm transition-colors",
-									disabled
-										? "cursor-not-allowed opacity-30"
-										: "cursor-pointer hover:bg-accent",
-									inRange && "bg-accent/40",
-									(isStart || isEnd) &&
-										"bg-primary text-primary-foreground hover:bg-primary/90",
-								)}
-							>
-								{name}
-							</button>
-						);
-					})}
-				</div>
-			</div>
-		);
-	};
+	const [range, setRange] = useState<DateRange | undefined>({ from, to });
+	const canApply = Boolean(range?.from && range.to);
 
 	return (
-		<div>
-			<div className="flex items-start gap-3">
-				<button
-					type="button"
-					onClick={() => setLeftYear((y) => y - 1)}
-					className="mt-1 rounded p-1 hover:bg-accent"
-				>
-					<ChevronLeftIcon className="h-4 w-4" />
-				</button>
-				<div className="flex flex-1 gap-6">
-					{renderYearPanel(leftYear)}
-					{renderYearPanel(rightYear)}
+		<div className="space-y-3">
+			<div className="grid grid-cols-2 gap-2 px-3 pt-3 sm:px-0 sm:pt-0">
+				<div className="rounded-md border border-border/60 bg-muted/30 px-3 py-2">
+					<p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+						From
+					</p>
+					<p className="mt-0.5 text-sm font-medium tabular-nums">
+						{range?.from ? format(range.from, "MMM d, yyyy") : "Select a day"}
+					</p>
+				</div>
+				<div className="rounded-md border border-border/60 bg-muted/30 px-3 py-2">
+					<p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+						To
+					</p>
+					<p className="mt-0.5 text-sm font-medium tabular-nums">
+						{range?.to ? format(range.to, "MMM d, yyyy") : "Select a day"}
+					</p>
 				</div>
 			</div>
-			{pendingFrom && (
-				<p className="mt-2 text-center text-xs text-muted-foreground">
-					Select end month
+			<Calendar
+				mode="range"
+				selected={range}
+				onSelect={setRange}
+				defaultMonth={range?.from}
+				disabled={{ after: today }}
+				numberOfMonths={2}
+				showOutsideDays={false}
+				className="p-0 max-sm:[&_.rdp-month~.rdp-month]:hidden"
+			/>
+			<div className="flex items-center justify-between border-t px-3 pt-3 sm:px-0">
+				<p className="text-xs text-muted-foreground">
+					Select a start and end day
 				</p>
-			)}
+				<div className="flex items-center gap-2">
+					{onCancel && (
+						<Button type="button" variant="ghost" size="sm" onClick={onCancel}>
+							Cancel
+						</Button>
+					)}
+					<Button
+						type="button"
+						size="sm"
+						disabled={!canApply}
+						onClick={() => {
+							if (range?.from && range.to) {
+								onSelect(range.from, range.to);
+							}
+						}}
+					>
+						{applyLabel}
+					</Button>
+				</div>
+			</div>
 		</div>
 	);
 }
@@ -441,7 +378,12 @@ export function DateRangePicker({ buildUrl, path }: DateRangePickerProps) {
 				</button>
 			</PopoverTrigger>
 			<PopoverContent
-				className={cn("p-0", showCalendar ? "w-[500px]" : "w-72")}
+				className={cn(
+					"p-0",
+					showCalendar
+						? "max-h-[var(--radix-popover-content-available-height)] w-[calc(100vw-2rem)] overflow-y-auto p-3 sm:w-auto"
+						: "w-72",
+				)}
 				align="start"
 			>
 				{!showCalendar ? (
@@ -471,34 +413,13 @@ export function DateRangePicker({ buildUrl, path }: DateRangePickerProps) {
 						</div>
 					</div>
 				) : (
-					<div className="p-4">
-						<div className="mb-4 flex items-center gap-4">
-							<div>
-								<p className="text-xs text-muted-foreground">From</p>
-								<p className="text-sm font-medium">
-									{format(from, "MMM d, yyyy")}
-								</p>
-							</div>
-							<span className="text-muted-foreground">–</span>
-							<div>
-								<p className="text-xs text-muted-foreground">To</p>
-								<p className="text-sm font-medium">
-									{format(to, "MMM d, yyyy")}
-								</p>
-							</div>
-						</div>
-						<MonthRangePicker
+					<div>
+						<DayRangePicker
 							from={from}
 							to={to}
 							onSelect={handleCustomSelect}
+							onCancel={() => setShowCalendar(false)}
 						/>
-						<button
-							type="button"
-							onClick={() => setShowCalendar(false)}
-							className="mt-3 text-xs text-muted-foreground hover:text-foreground"
-						>
-							← Back to presets
-						</button>
 					</div>
 				)}
 			</PopoverContent>


### PR DESCRIPTION
## Summary

- add total and token-cost views to the dashboard usage chart
- overlay current usage with previous-period, weekly, monthly, or exact custom ranges
- allow weekly and monthly comparisons to start on a selected date while preserving their duration and ending before the active range
- replace month-only custom ranges with exact day selection across desktop and mobile

## Verification

- `pnpm format`
- `pnpm build` (19/19 tasks)
- `pnpm exec vitest run apps/ui/src/components/dashboard/usage-comparison.spec.ts --no-file-parallelism` (7/7 passed)
- `pnpm exec vitest run --no-file-parallelism --reporter=dot` (5,892 passed; one fixed-port fixture mismatch under the isolated stack)
- `pnpm exec vitest run apps/api/src/routes/logs.spec.ts --no-file-parallelism` (24/24 passed with the fixture's expected gateway URL)
- exercised total/breakdown, preset/custom comparisons, selectable weekly/monthly start dates, exact-day ranges, tooltips, light/dark themes, and mobile layout locally

## Screenshots

| Theme | Before | After |
| --- | --- | --- |
| Light | ![Dashboard before the comparison controls](https://raw.githubusercontent.com/theopenco/llmgateway/0f94260b2738e0da73b9bea089c9fdf44a467275/before-light.png) | ![Dashboard with a weekly total-cost comparison](https://raw.githubusercontent.com/theopenco/llmgateway/0f94260b2738e0da73b9bea089c9fdf44a467275/after-light.png) |
| Dark | ![Dashboard before the comparison controls in dark mode](https://raw.githubusercontent.com/theopenco/llmgateway/0f94260b2738e0da73b9bea089c9fdf44a467275/before-dark.png) | ![Dashboard with the cost breakdown comparison in dark mode](https://raw.githubusercontent.com/theopenco/llmgateway/0f94260b2738e0da73b9bea089c9fdf44a467275/after-dark.png) |

### Comparison start dates

| Weekly · Light | Monthly · Dark |
| --- | --- |
| ![Choose a weekly comparison start date](https://raw.githubusercontent.com/theopenco/llmgateway/0f94260b2738e0da73b9bea089c9fdf44a467275/start-picker-light.png) | ![Choose a monthly comparison start date in dark mode](https://raw.githubusercontent.com/theopenco/llmgateway/0f94260b2738e0da73b9bea089c9fdf44a467275/start-picker-dark.png) |

### Exact-day ranges

| Desktop | Mobile |
| --- | --- |
| ![Exact-day dashboard range picker](https://raw.githubusercontent.com/theopenco/llmgateway/0f94260b2738e0da73b9bea089c9fdf44a467275/day-picker-desktop.png) | ![Exact custom comparison range on mobile](https://raw.githubusercontent.com/theopenco/llmgateway/0f94260b2738e0da73b9bea089c9fdf44a467275/comparison-picker-mobile.png) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dashboard usage comparisons for previous periods, weeks, months, and custom date ranges.
  - Added selectable total and cost-breakdown views.
  - Updated charts to display current and comparison-period activity with tooltips and visual overlays.
  - Added start-date selection for weekly and monthly comparisons.
  - Replaced the month-based selector with a day-based custom date range picker.

- **Bug Fixes**
  - Prevented overlapping comparison ranges and improved handling of invalid or unavailable comparison data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
