### PR TITLE
docs(legal): clarify refund and signup terms

### DIFF
--- a/apps/code/src/app/legal/terms/page.tsx
+++ b/apps/code/src/app/legal/terms/page.tsx
@@ -25,7 +25,7 @@ export default function TermsPage() {
 			<p>
 				<strong>Effective Date:</strong> April 26, 2026
 				<br />
-				<strong>Last Updated:</strong> August 18, 2026
+				<strong>Last Updated:</strong> September 4, 2026
 			</p>
 			<LegalSummary variant="terms" />
 			<p>
@@ -130,9 +130,28 @@ export default function TermsPage() {
 				Billing is processed securely through <strong>Stripe</strong>, as
 				described in the Base Terms. By subscribing, you authorize us to charge
 				your payment method for the selected plan and any applicable taxes. All
-				fees are non-refundable except where required by law. You may cancel at
-				any time; your plan remains active until the end of the current billing
-				period.
+				fees are generally non-refundable except where required by law or under
+				the limited goodwill refund option below. You may cancel at any time;
+				your plan remains active until the end of the current billing period.
+			</p>
+			<p>
+				<strong>Limited first-month goodwill refund.</strong> Once you start
+				using your included allowance, you are not entitled to a refund because
+				each processed request causes us to incur real, non-recoverable AI
+				provider costs. As a limited goodwill exception, we may make a full
+				self-service refund available for your initial DevPass plan payment if
+				you request it from your billing dashboard within 14 days of purchase
+				and have used less than 20% of the monthly allowance. The payment and
+				account must also meet the eligibility requirements shown in the billing
+				dashboard. Once usage reaches 20% or more, a refund is not available.
+				Any reference to a &ldquo;first-month guarantee&rdquo; means only this
+				limited goodwill option and does not create a broader right to a refund.
+			</p>
+			<p>
+				If the refund option is available, select <strong>Refund</strong> on the
+				eligible charge in your billing dashboard. An approved refund ends your
+				DevPass subscription and access immediately, and any unused allowance
+				for that billing period is forfeited. There is no cancellation fee.
 			</p>
 			<p>
 				<strong>Plan changes.</strong> You may change tiers at any time from

--- a/apps/code/src/app/signup/page.tsx
+++ b/apps/code/src/app/signup/page.tsx
@@ -346,6 +346,16 @@ function SignupForm() {
 							newUserCallbackPath={returnUrl}
 							requestSignUp
 						/>
+						<p className="text-center text-xs leading-relaxed text-muted-foreground">
+							By signing up, you agree to the{" "}
+							<Link
+								href="/legal/terms"
+								className="underline underline-offset-4 hover:text-foreground"
+							>
+								DevPass Terms of Use
+							</Link>
+							.
+						</p>
 					</div>
 
 					<p className="mt-6 text-center text-sm text-muted-foreground">

--- a/apps/code/src/components/LegalSummary.tsx
+++ b/apps/code/src/components/LegalSummary.tsx
@@ -39,7 +39,9 @@ const termsCards: SummaryCard[] = [
 			<>
 				Lite, Pro and Max each include a monthly usage allowance measured in
 				provider cost. Allowances reset every cycle and don&rsquo;t roll over,
-				except when you upgrade mid-cycle.
+				except when you upgrade mid-cycle. Fees are generally non-refundable
+				once usage begins; a first-payment refund within 14 days may be offered
+				as goodwill only while usage remains below 20%.
 			</>
 		),
 	},

--- a/apps/playground/src/app/signup/page.tsx
+++ b/apps/playground/src/app/signup/page.tsx
@@ -260,6 +260,16 @@ function Signup() {
 							errorCallbackPath="/signup"
 							requestSignUp
 						/>
+						<p className="text-center text-xs leading-relaxed text-muted-foreground">
+							By signing up, you agree to the{" "}
+							<Link
+								href="https://llmgateway.io/legal/terms"
+								className="underline underline-offset-4 hover:text-foreground"
+							>
+								LLM Gateway Terms of Use
+							</Link>{" "}
+							governing Lounge and Chat plans.
+						</p>
 					</div>
 
 					<p className="mt-6 text-center text-sm text-muted-foreground">

--- a/apps/ui/src/app/signup/page.tsx
+++ b/apps/ui/src/app/signup/page.tsx
@@ -296,6 +296,16 @@ export default function Signup() {
 					newUserCallbackPath="/dashboard"
 					requestSignUp
 				/>
+				<p className="text-center text-xs leading-relaxed text-muted-foreground">
+					By signing up, you agree to the{" "}
+					<Link
+						href="/legal/terms"
+						className="underline underline-offset-4 hover:text-foreground"
+					>
+						LLM Gateway Terms of Use
+					</Link>
+					.
+				</p>
 			</div>
 
 			<p className="mt-6 text-center text-sm text-muted-foreground">

--- a/apps/ui/src/components/legal/legal-summary.tsx
+++ b/apps/ui/src/components/legal/legal-summary.tsx
@@ -129,8 +129,9 @@ const termsCards: SummaryCard[] = [
 		body: (
 			<>
 				There&apos;s a free plan with generous limits. You can buy credits that
-				are consumed as you make requests. Credits are non-refundable except
-				where the law requires otherwise.
+				are consumed as you make requests. Credits and fees are generally
+				non-refundable once usage begins because provider charges are incurred.
+				Any refund option is a limited goodwill exception.
 			</>
 		),
 	},

--- a/apps/ui/src/content/legal/terms.md
+++ b/apps/ui/src/content/legal/terms.md
@@ -1,7 +1,7 @@
 ---
 id: "1"
 slug: "terms"
-date: "2026-08-18"
+date: "2026-09-04"
 title: "Terms Of Use"
 description: "Terms of Use for LLM Gateway: account eligibility, billing and credits, AI outputs, acceptable use, warranties, liability, and dispute resolution."
 ---
@@ -9,7 +9,7 @@ description: "Terms of Use for LLM Gateway: account eligibility, billing and cre
 # Terms of Use
 
 **Effective Date:** June 11, 2026  
-**Last Updated:** August 18, 2026
+**Last Updated:** September 4, 2026
 
 Welcome to **LLM Gateway** (“we”, “our”, or “us”), operated by **Polar Lights LLC**, 16192 Coastal Highway, Lewes, DE 19958, United States. These Terms of Use (“Terms”) form a binding legal agreement between you (“you” or “Customer”) and LLM Gateway and govern your access to and use of the LLM Gateway platform, including our website **[llmgateway.io](https://llmgateway.io)**, APIs, SDKs, dashboards, and any related products or services (collectively, the “Service”).
 
@@ -66,7 +66,7 @@ LLM Gateway offers free and paid plans, including pay-as-you-go (“PAYG”) usa
 
 You agree to the following billing terms:
 
-- **Credits and fees are non-refundable** and are consumed as you use the Service, except where a refund is required by applicable law. Unused credits may expire as described at the point of purchase.
+- **Credits and fees are generally non-refundable**, except where a refund is required by applicable law or we expressly make a limited product-specific refund option available. Because AI providers charge us when requests are processed, starting to consume credits or included usage does not entitle you to a refund. Any voluntary refund option is a goodwill exception, is subject to its stated eligibility requirements, and does not create a general right to a refund. Unused credits may expire as described at the point of purchase.
 - Billing is processed by **Stripe**. You authorize us (and our payment processor) to **charge your payment method** for all applicable fees, including recurring and usage-based charges, and to **automatically replenish credits** if you enable auto-recharge.
 - All fees are **exclusive of taxes**. You are responsible for all applicable taxes, duties, and similar charges, other than taxes based on our net income.
 - You are responsible for all charges incurred under your account, including charges resulting from unauthorized use of your credentials or API keys.
@@ -154,7 +154,7 @@ The organization is responsible for its users' compliance with these Terms and f
 
 ## 11. Suspension and Termination
 
-You may cancel your account at any time through the dashboard. Cancellation does not entitle you to a refund of any prepaid fees or credits.
+You may cancel your account at any time through the dashboard. Cancellation does not entitle you to a refund of any prepaid fees or credits. Any limited refund option is governed by Section 4 and the supplemental terms for the applicable product.
 
 We may **suspend or terminate** your access to all or part of the Service, with or without notice, if:
 
@@ -195,7 +195,7 @@ Your use of the Service and any AI outputs is **entirely at your own risk**. Som
 
 These limitations apply regardless of whether the claim is based in contract, tort (including negligence), strict liability, or any other theory, and apply even if any remedy fails of its essential purpose. The parties agree these limitations reflect a reasonable allocation of risk and are an essential basis of the bargain. Some jurisdictions do not allow certain limitations, so some of the above may not apply to you.
 
-**Exclusive remedy.** To the fullest extent permitted by law, your **sole and exclusive remedy** for any dissatisfaction with, or loss or damage arising from, the Service is to stop using the Service and, where applicable, terminate your account. Any refund, where one is required by law, is limited as set out in Section 4 and is your only monetary remedy.
+**Exclusive remedy.** To the fullest extent permitted by law, your **sole and exclusive remedy** for any dissatisfaction with, or loss or damage arising from, the Service is to stop using the Service and, where applicable, terminate your account. Any refund required by law or expressly made available under Section 4 is your only monetary remedy.
 
 ---
 


### PR DESCRIPTION
## Problem

DevPass advertised a first-month refund option while its supplemental terms said all fees were non-refundable. Signup pages also did not state which terms govern account creation.

## Approach

- clarify that usage does not create a refund entitlement because provider costs are incurred
- define the under-20%, 14-day first-payment refund as a limited goodwill exception and explain its immediate cancellation effect
- align the base terms and plain-English legal summaries
- add applicable terms consent notices to LLM Gateway, DevPass, and Lounge signup flows

## Verification

- `pnpm format`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Legal & Policy**
  - Updated the Terms of Use with a September 4, 2026 revision date.
  - Clarified that fees and credits are generally non-refundable after usage begins.
  - Added eligibility details for a limited first-payment goodwill refund within 14 days and below 20% usage.

- **Signup**
  - Added Terms of Use agreement notices with links to the applicable terms on signup pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->