### PR TITLE
fix(gateway): honor credential base URL on side routes

### DIFF
--- a/apps/gateway/src/chat/tools/openai-content-filter.spec.ts
+++ b/apps/gateway/src/chat/tools/openai-content-filter.spec.ts
@@ -176,6 +176,40 @@ describe("checkOpenAIContentFilter", () => {
 		).rejects.toThrowError(abortError);
 	});
 
+	it("moderates through the env base URL of the OpenAI credential", async () => {
+		process.env.LLM_OPENAI_API_KEY = "sk-openai-test";
+		process.env.LLM_OPENAI_BASE_URL = "https://proxy.example.com";
+		const requestedUrls: string[] = [];
+		vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+			requestedUrls.push(String(input));
+			return new Response(
+				JSON.stringify({
+					id: "modr-text",
+					model: "omni-moderation-latest",
+					results: [{ flagged: false, categories: {}, category_scores: {} }],
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		});
+
+		try {
+			await checkOpenAIContentFilter(
+				[{ role: "user", content: "hello" }],
+				{
+					requestId: "request-id",
+					organizationId: "org-id",
+					projectId: "project-id",
+					apiKeyId: "api-key-id",
+				},
+				undefined,
+			);
+		} finally {
+			delete process.env.LLM_OPENAI_BASE_URL;
+		}
+
+		expect(requestedUrls).toEqual(["https://proxy.example.com/v1/moderations"]);
+	});
+
 	it("submits one moderation request for text and one per image", async () => {
 		process.env.LLM_OPENAI_API_KEY = "sk-openai-test";
 		const requestBodies: Array<{ model: string; input: unknown }> = [];

--- a/apps/gateway/src/chat/tools/openai-content-filter.spec.ts
+++ b/apps/gateway/src/chat/tools/openai-content-filter.spec.ts
@@ -178,7 +178,7 @@ describe("checkOpenAIContentFilter", () => {
 
 	it("moderates through the env base URL of the OpenAI credential", async () => {
 		process.env.LLM_OPENAI_API_KEY = "sk-openai-test";
-		process.env.LLM_OPENAI_BASE_URL = "https://proxy.example.com";
+		process.env.LLM_OPENAI_BASE_URL = "https://proxy.example.com/";
 		const requestedUrls: string[] = [];
 		vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
 			requestedUrls.push(String(input));

--- a/apps/gateway/src/chat/tools/openai-content-filter.ts
+++ b/apps/gateway/src/chat/tools/openai-content-filter.ts
@@ -378,6 +378,8 @@ interface ContentFilterCredential {
  */
 async function resolveContentFilterCredential(): Promise<ContentFilterCredential> {
 	const defaultBaseUrl = getProviderDefaultBaseUrl("openai") ?? "";
+	const moderationUrl = (baseUrl: string) =>
+		`${baseUrl.replace(/\/+$/, "")}${OPENAI_MODERATION_PATH}`;
 	if (await hasManagedProviderCredential("openai")) {
 		const managedKey = await findManagedProviderKey("openai", {
 			selectionScope: OPENAI_MODERATION_MODEL,
@@ -389,16 +391,15 @@ async function resolveContentFilterCredential(): Promise<ContentFilterCredential
 		}
 		return {
 			providerToken: readProviderKey(managedKey),
-			moderationUrl: `${managedKey.config?.baseUrl ?? defaultBaseUrl}${OPENAI_MODERATION_PATH}`,
+			moderationUrl: moderationUrl(
+				managedKey.config?.baseUrl ?? defaultBaseUrl,
+			),
 		};
 	}
 	const env = getProviderEnv("openai", { advanceRoundRobin: false });
 	const baseUrl =
 		getProviderEnvValue("openai", "baseUrl", env.configIndex) ?? defaultBaseUrl;
-	return {
-		providerToken: env.token,
-		moderationUrl: `${baseUrl}${OPENAI_MODERATION_PATH}`,
-	};
+	return { providerToken: env.token, moderationUrl: moderationUrl(baseUrl) };
 }
 
 async function runOpenAIContentFilterRequest(

--- a/apps/gateway/src/chat/tools/openai-content-filter.ts
+++ b/apps/gateway/src/chat/tools/openai-content-filter.ts
@@ -4,8 +4,13 @@ import {
 } from "@/lib/cached-queries.js";
 import { isCancellationError, isTimeoutError } from "@/lib/timeout-config.js";
 
-import { getProviderHeaders, readProviderKey } from "@llmgateway/actions";
+import {
+	getProviderDefaultBaseUrl,
+	getProviderHeaders,
+	readProviderKey,
+} from "@llmgateway/actions";
 import { logger } from "@llmgateway/logger";
+import { getProviderEnvValue } from "@llmgateway/models";
 
 import { extractErrorCause } from "./extract-error-cause.js";
 import { getProviderEnv } from "./get-provider-env.js";
@@ -68,7 +73,7 @@ interface OpenAIContentFilterRequestResult {
 }
 
 const OPENAI_MODERATION_MODEL = "omni-moderation-latest";
-const OPENAI_MODERATION_URL = "https://api.openai.com/v1/moderations";
+const OPENAI_MODERATION_PATH = "/v1/moderations";
 const OPENAI_MODERATION_TIMEOUT_MS = 60_000;
 const DEFAULT_OPENAI_MODERATION_SCORE_THRESHOLD = 0.75;
 
@@ -359,13 +364,20 @@ function createFailedOpenAIContentFilterResult(
 	};
 }
 
+interface ContentFilterCredential {
+	providerToken: string;
+	moderationUrl: string;
+}
+
 /**
  * The OpenAI credential the moderation call runs on. A managed credential
  * supersedes the env vars for its provider entirely, so once one exists the
  * environment is never read — and a provider whose managed credentials cannot
- * serve the call has no env key left to fall back to.
+ * serve the call has no env key left to fall back to. The base URL follows
+ * the same credential, so a proxied deployment moderates through its proxy.
  */
-async function resolveContentFilterToken(): Promise<string> {
+async function resolveContentFilterCredential(): Promise<ContentFilterCredential> {
+	const defaultBaseUrl = getProviderDefaultBaseUrl("openai") ?? "";
 	if (await hasManagedProviderCredential("openai")) {
 		const managedKey = await findManagedProviderKey("openai", {
 			selectionScope: OPENAI_MODERATION_MODEL,
@@ -375,15 +387,24 @@ async function resolveContentFilterToken(): Promise<string> {
 				"No managed credential available for provider: openai (content filter)",
 			);
 		}
-		return readProviderKey(managedKey);
+		return {
+			providerToken: readProviderKey(managedKey),
+			moderationUrl: `${managedKey.config?.baseUrl ?? defaultBaseUrl}${OPENAI_MODERATION_PATH}`,
+		};
 	}
-	return getProviderEnv("openai", { advanceRoundRobin: false }).token;
+	const env = getProviderEnv("openai", { advanceRoundRobin: false });
+	const baseUrl =
+		getProviderEnvValue("openai", "baseUrl", env.configIndex) ?? defaultBaseUrl;
+	return {
+		providerToken: env.token,
+		moderationUrl: `${baseUrl}${OPENAI_MODERATION_PATH}`,
+	};
 }
 
 async function runOpenAIContentFilterRequest(
 	request: OpenAIModerationRequest,
 	context: GatewayContentFilterContext,
-	providerToken: string,
+	credential: ContentFilterCredential,
 	signal: AbortSignal,
 ): Promise<OpenAIContentFilterRequestResult> {
 	const startTime = Date.now();
@@ -391,12 +412,12 @@ async function runOpenAIContentFilterRequest(
 	let upstreamText: string;
 
 	try {
-		upstreamResponse = await fetch(OPENAI_MODERATION_URL, {
+		upstreamResponse = await fetch(credential.moderationUrl, {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
 				"X-Client-Request-Id": context.requestId,
-				...getProviderHeaders("openai", providerToken, {
+				...getProviderHeaders("openai", credential.providerToken, {
 					requestId: context.requestId,
 				}),
 			},
@@ -523,10 +544,10 @@ export async function checkOpenAIContentFilter(
 		// vars for their provider, so once OpenAI has one the moderation call
 		// uses it and never reads `LLM_OPENAI_API_KEY`; when none can serve it,
 		// this throws and the filter fails open below.
-		const token = await resolveContentFilterToken();
+		const credential = await resolveContentFilterCredential();
 		const moderationResults = await Promise.all(
 			moderationRequests.map((request) =>
-				runOpenAIContentFilterRequest(request, context, token, signal),
+				runOpenAIContentFilterRequest(request, context, credential, signal),
 			),
 		);
 

--- a/apps/gateway/src/chat/tools/resolve-platform-credential.spec.ts
+++ b/apps/gateway/src/chat/tools/resolve-platform-credential.spec.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getCredentialSetting } from "./resolve-platform-credential.js";
+
+import type { InferSelectModel, tables } from "@llmgateway/db";
+
+type ProviderKeyRow = InferSelectModel<typeof tables.providerKey>;
+
+function row(config?: Record<string, string>): ProviderKeyRow {
+	return { id: "key-id", config: config ?? null } as unknown as ProviderKeyRow;
+}
+
+afterEach(() => {
+	delete process.env.LLM_OPENAI_BASE_URL;
+	delete process.env.LLM_GOOGLE_CLOUD_PROJECT;
+});
+
+describe("getCredentialSetting", () => {
+	it("reads the env var on the env-credential path", () => {
+		process.env.LLM_OPENAI_BASE_URL = "https://proxy.example.com";
+		expect(getCredentialSetting("openai", "baseUrl", {})).toBe(
+			"https://proxy.example.com",
+		);
+	});
+
+	it("never reads env for a BYOK key", () => {
+		process.env.LLM_OPENAI_BASE_URL = "https://proxy.example.com";
+		process.env.LLM_GOOGLE_CLOUD_PROJECT = "platform-project";
+		expect(
+			getCredentialSetting("openai", "baseUrl", { providerKey: row() }),
+		).toBeUndefined();
+		expect(
+			getCredentialSetting("google-vertex", "project", {
+				providerKey: row(),
+			}),
+		).toBeUndefined();
+		expect(
+			getCredentialSetting(
+				"google-vertex",
+				"region",
+				{ providerKey: row() },
+				{ defaultValue: "global" },
+			),
+		).toBe("global");
+	});
+
+	it("reads a managed credential's own config, never env", () => {
+		process.env.LLM_OPENAI_BASE_URL = "https://proxy.example.com";
+		expect(
+			getCredentialSetting("openai", "baseUrl", {
+				managedKey: row({ baseUrl: "https://managed.example.com" }),
+			}),
+		).toBe("https://managed.example.com");
+		expect(
+			getCredentialSetting("openai", "baseUrl", { managedKey: row() }),
+		).toBeUndefined();
+	});
+});

--- a/apps/gateway/src/chat/tools/resolve-platform-credential.ts
+++ b/apps/gateway/src/chat/tools/resolve-platform-credential.ts
@@ -167,27 +167,37 @@ export async function resolvePlatformCredential(
  * One of a provider's credential settings (`baseUrl`, `project`, `region`, …)
  * for the credential actually serving the request.
  *
- * A managed credential carries its own settings and never falls back to the
- * environment, mirroring how a BYOK key is self-contained. Requests still on
- * the env-var path read the provider's `LLM_*` var as before.
+ * A database-backed credential is self-contained and never falls back to the
+ * environment: a managed credential carries its settings in `config`, and a
+ * BYOK key carries them in its own columns/options (`baseUrl`,
+ * `google_vertex_project_id`, …) which the caller reads first. Only requests on
+ * the env-var path read the provider's `LLM_*` var. This mirrors
+ * `getProviderEndpoint`'s `skipEnvVars`, so an org's own key is never sent to
+ * the deployment's proxy or stamped with the platform's GCP project.
  *
  * Endpoints that call `getProviderEndpoint` don't need this — passing
  * `managedCredentialOptions(managedKey)` covers them. It exists for the
- * endpoints (embeddings, speech, OCR, transcriptions, video) that build their
- * upstream URL themselves.
+ * endpoints (embeddings, speech, OCR, transcriptions, video, realtime,
+ * moderations) that build their upstream URL themselves.
  */
 export function getCredentialSetting(
 	provider: Provider,
 	key: string,
-	managedKey: ProviderKeyRow | undefined,
+	credential: {
+		providerKey?: ProviderKeyRow;
+		managedKey?: ProviderKeyRow;
+	},
 	options: {
 		configIndex?: number;
 		defaultValue?: string;
 		variant?: EnvVarVariant;
 	} = {},
 ): string | undefined {
-	if (managedKey) {
-		return managedKey.config?.[key] ?? options.defaultValue;
+	if (credential.providerKey) {
+		return options.defaultValue;
+	}
+	if (credential.managedKey) {
+		return credential.managedKey.config?.[key] ?? options.defaultValue;
 	}
 	return getProviderEnvValue(
 		provider,

--- a/apps/gateway/src/embeddings/embeddings.ts
+++ b/apps/gateway/src/embeddings/embeddings.ts
@@ -850,21 +850,19 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 			});
 		}
 
-		// Env baseUrl override: LLM_<PROVIDER>_BASE_URL can redirect upstream
-		// traffic to proxies, regional endpoints, or test mocks. Applies to
-		// any provider — getProviderEnvValue returns undefined for providers
-		// that don't declare a baseUrl env in packages/models/src/providers.ts,
-		// so the ?? chain falls through safely. providerKey.baseUrl still wins
-		// when set, so BYOK callers can opt out by configuring their own.
-		const envBaseUrl = getCredentialSetting(providerId, "baseUrl", managedKey, {
-			configIndex,
-			variant: envVariant,
-		});
+		const credential = { providerKey, managedKey };
 		const resolvedBaseUrl =
 			providerKey?.baseUrl ??
-			envBaseUrl ??
-			getProviderDefaultBaseUrl(providerId) ??
-			"https://api.openai.com";
+			getCredentialSetting(providerId, "baseUrl", credential, {
+				configIndex,
+				variant: envVariant,
+			}) ??
+			getProviderDefaultBaseUrl(providerId);
+		if (!resolvedBaseUrl) {
+			throw new HTTPException(500, {
+				message: `No base URL set for provider: ${providerId}`,
+			});
+		}
 
 		let upstreamUrl: string;
 		let requestBody: Record<string, unknown>;
@@ -919,7 +917,7 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 			}
 			const vertexProjectId =
 				providerKey?.options?.google_vertex_project_id ??
-				getCredentialSetting("google-vertex", "project", managedKey, {
+				getCredentialSetting("google-vertex", "project", credential, {
 					configIndex,
 					variant: envVariant,
 				});
@@ -948,7 +946,7 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 				};
 			}
 			const vertexRegion =
-				getCredentialSetting("google-vertex", "region", managedKey, {
+				getCredentialSetting("google-vertex", "region", credential, {
 					configIndex,
 					defaultValue: "global",
 					variant: envVariant,

--- a/apps/gateway/src/moderations/moderations.ts
+++ b/apps/gateway/src/moderations/moderations.ts
@@ -5,7 +5,10 @@ import { createLogEntry } from "@/chat/tools/create-log-entry.js";
 import { extractCustomHeaders } from "@/chat/tools/extract-custom-headers.js";
 import { getFinishReasonFromError } from "@/chat/tools/get-finish-reason-from-error.js";
 import { getProviderEnv } from "@/chat/tools/get-provider-env.js";
-import { resolvePlatformCredential } from "@/chat/tools/resolve-platform-credential.js";
+import {
+	getCredentialSetting,
+	resolvePlatformCredential,
+} from "@/chat/tools/resolve-platform-credential.js";
 import { shouldRetryAlternateKey } from "@/chat/tools/retry-with-fallback.js";
 import { validateSource } from "@/chat/tools/validate-source.js";
 import {
@@ -41,7 +44,11 @@ import { assertOrganizationUsable } from "@/lib/organization-access.js";
 import { assertSpendLimit } from "@/lib/spend-limit.js";
 import { createCombinedSignal, isTimeoutError } from "@/lib/timeout-config.js";
 
-import { getProviderHeaders, readProviderKey } from "@llmgateway/actions";
+import {
+	getProviderDefaultBaseUrl,
+	getProviderHeaders,
+	readProviderKey,
+} from "@llmgateway/actions";
 import { shortid } from "@llmgateway/db";
 import { models } from "@llmgateway/models";
 
@@ -652,12 +659,20 @@ moderations.openapi(createModeration, async (c): Promise<any> => {
 		});
 	}
 
-	// Moderation has never honored LLM_OPENAI_BASE_URL, so only the credential's
-	// own base URL overrides the default here.
 	const resolvedBaseUrl =
 		providerKey?.baseUrl ??
-		managedKey?.config?.baseUrl ??
-		"https://api.openai.com";
+		getCredentialSetting(
+			"openai",
+			"baseUrl",
+			{ providerKey, managedKey },
+			{ configIndex, variant: envVariant },
+		) ??
+		getProviderDefaultBaseUrl("openai");
+	if (!resolvedBaseUrl) {
+		throw new HTTPException(500, {
+			message: "No base URL set for provider: openai",
+		});
+	}
 	const upstreamUrl = `${resolvedBaseUrl}/v1/moderations`;
 	const requestBody = {
 		input,

--- a/apps/gateway/src/moderations/moderations.ts
+++ b/apps/gateway/src/moderations/moderations.ts
@@ -659,21 +659,25 @@ moderations.openapi(createModeration, async (c): Promise<any> => {
 		});
 	}
 
-	const resolvedBaseUrl =
-		providerKey?.baseUrl ??
-		getCredentialSetting(
-			"openai",
-			"baseUrl",
-			{ providerKey, managedKey },
-			{ configIndex, variant: envVariant },
-		) ??
-		getProviderDefaultBaseUrl("openai");
-	if (!resolvedBaseUrl) {
-		throw new HTTPException(500, {
-			message: "No base URL set for provider: openai",
-		});
-	}
-	const upstreamUrl = `${resolvedBaseUrl}/v1/moderations`;
+	// Resolved per attempt: a credential rotation below can switch to a
+	// managed key or env index with its own base URL.
+	const resolveUpstreamUrl = (): string => {
+		const resolvedBaseUrl =
+			providerKey?.baseUrl ??
+			getCredentialSetting(
+				"openai",
+				"baseUrl",
+				{ providerKey, managedKey },
+				{ configIndex, variant: envVariant },
+			) ??
+			getProviderDefaultBaseUrl("openai");
+		if (!resolvedBaseUrl) {
+			throw new HTTPException(500, {
+				message: "No base URL set for provider: openai",
+			});
+		}
+		return `${resolvedBaseUrl.replace(/\/+$/, "")}/v1/moderations`;
+	};
 	const requestBody = {
 		input,
 		model: upstreamModel,
@@ -772,7 +776,7 @@ moderations.openapi(createModeration, async (c): Promise<any> => {
 
 			try {
 				const fetchSignal = createCombinedSignal(controller);
-				upstreamResponse = await fetch(upstreamUrl, {
+				upstreamResponse = await fetch(resolveUpstreamUrl(), {
 					method: "POST",
 					// SSRF: never follow redirects on an authenticated provider request. A
 					// tenant-supplied baseUrl could 3xx to an internal host at request time,

--- a/apps/gateway/src/ocr/ocr.ts
+++ b/apps/gateway/src/ocr/ocr.ts
@@ -50,6 +50,7 @@ import { assertSpendLimit } from "@/lib/spend-limit.js";
 import { createCombinedSignal, isTimeoutError } from "@/lib/timeout-config.js";
 
 import {
+	getProviderDefaultBaseUrl,
 	getProviderHeaders,
 	providerKeyLabel,
 	readProviderKey,
@@ -704,12 +705,20 @@ ocr.openapi(createOcr, async (c): Promise<any> => {
 			});
 		}
 
-		const envBaseUrl = getCredentialSetting(providerId, "baseUrl", managedKey, {
-			configIndex,
-			variant: envVariant,
-		});
 		const resolvedBaseUrl =
-			providerKey?.baseUrl ?? envBaseUrl ?? "https://api.mistral.ai";
+			providerKey?.baseUrl ??
+			getCredentialSetting(
+				providerId,
+				"baseUrl",
+				{ providerKey, managedKey },
+				{ configIndex, variant: envVariant },
+			) ??
+			getProviderDefaultBaseUrl(providerId);
+		if (!resolvedBaseUrl) {
+			throw new HTTPException(500, {
+				message: `No base URL set for provider: ${providerId}`,
+			});
+		}
 
 		return {
 			providerKey,

--- a/apps/gateway/src/realtime/connect-upstream.spec.ts
+++ b/apps/gateway/src/realtime/connect-upstream.spec.ts
@@ -79,6 +79,27 @@ describe("resolveUpstreamTarget", () => {
 		);
 	});
 
+	it("ignores the env base-URL override for a BYOK key", () => {
+		process.env.LLM_OPENAI_BASE_URL = "https://proxy.example.com/";
+		const target = resolveUpstreamTarget({
+			...buildPreflight("openai", "gpt-realtime-2.1-mini"),
+			providerKey: { id: "byok-key", baseUrl: null },
+		} as unknown as RealtimePreflightResult);
+		expect(target.url).toBe(
+			"wss://api.openai.com/v1/realtime?model=gpt-realtime-2.1-mini",
+		);
+	});
+
+	it("strips a trailing slash from the configured base URL", () => {
+		process.env.LLM_OPENAI_BASE_URL = "https://proxy.example.com/";
+		const target = resolveUpstreamTarget(
+			buildPreflight("openai", "gpt-realtime-2.1-mini"),
+		);
+		expect(target.url).toBe(
+			"wss://proxy.example.com/v1/realtime?model=gpt-realtime-2.1-mini",
+		);
+	});
+
 	it("leaves the OpenAI URL and headers unchanged", () => {
 		const target = resolveUpstreamTarget(
 			buildPreflight("openai", "gpt-realtime-2.1-mini"),

--- a/apps/gateway/src/realtime/connect-upstream.ts
+++ b/apps/gateway/src/realtime/connect-upstream.ts
@@ -31,15 +31,17 @@ export function resolveUpstreamTarget(
 ): UpstreamTarget {
 	const providerId = preflight.match.mapping.providerId as Provider;
 
-	// Base URL of the platform credential serving the session: the managed
-	// credential's own config when one is active, the provider's env var
-	// otherwise. BYOK base URLs are rejected in preflight.
+	// Base URL of the credential serving the session: the managed credential's
+	// own config when one is active, the provider's env var on the env path. A
+	// BYOK key always uses the provider default: custom BYOK base URLs are
+	// rejected in preflight, and the deployment's proxy must not receive an
+	// org's own key.
 	const credentialBaseUrl = getCredentialSetting(
 		providerId,
 		"baseUrl",
-		preflight.managedKey,
+		{ providerKey: preflight.providerKey, managedKey: preflight.managedKey },
 		{ configIndex: preflight.configIndex, variant: preflight.envVariant },
-	);
+	)?.replace(/\/+$/, "");
 
 	if (providerId === "google-ai-studio") {
 		const baseUrl =

--- a/apps/gateway/src/rerank/rerank.ts
+++ b/apps/gateway/src/rerank/rerank.ts
@@ -689,20 +689,20 @@ rerank.openapi(createRerank, async (c): Promise<any> => {
 			});
 		}
 
-		// Base URL of the platform credential serving the attempt: the managed
-		// credential's own config when one is active, the provider's env var
-		// otherwise. A BYOK key's base URL still wins when set.
-		const envBaseUrl = getCredentialSetting(
-			providerId as Provider,
-			"baseUrl",
-			managedKeyInner,
-			{ configIndex, variant: envVariant },
-		);
 		const resolvedBaseUrl =
 			providerKeyInner?.baseUrl ??
-			envBaseUrl ??
-			getProviderDefaultBaseUrl(providerId) ??
-			"https://api.openai.com";
+			getCredentialSetting(
+				providerId as Provider,
+				"baseUrl",
+				{ providerKey: providerKeyInner, managedKey: managedKeyInner },
+				{ configIndex, variant: envVariant },
+			) ??
+			getProviderDefaultBaseUrl(providerId);
+		if (!resolvedBaseUrl) {
+			throw new HTTPException(500, {
+				message: `No base URL set for provider: ${providerId}`,
+			});
+		}
 
 		let upstreamUrl: string;
 		let requestBody: Record<string, unknown>;

--- a/apps/gateway/src/speech/speech.ts
+++ b/apps/gateway/src/speech/speech.ts
@@ -880,15 +880,19 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 			throw new HTTPException(500, { message: "No token" });
 		}
 
-		const envBaseUrl = getCredentialSetting(providerId, "baseUrl", managedKey, {
-			configIndex,
-			variant: envVariant,
-		});
+		const credential = { providerKey, managedKey };
 		const resolvedBaseUrl =
 			providerKey?.baseUrl ??
-			envBaseUrl ??
-			PROVIDER_BASE_URL_DEFAULTS[providerId] ??
-			"https://generativelanguage.googleapis.com";
+			getCredentialSetting(providerId, "baseUrl", credential, {
+				configIndex,
+				variant: envVariant,
+			}) ??
+			PROVIDER_BASE_URL_DEFAULTS[providerId];
+		if (!resolvedBaseUrl) {
+			throw new HTTPException(500, {
+				message: `No base URL set for provider: ${providerId}`,
+			});
+		}
 
 		const elevenLabsOutputFormat =
 			ELEVENLABS_OUTPUT_FORMATS[responseFormat] ?? "mp3_44100_128";
@@ -908,7 +912,7 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 		} else if (isGoogleVertex) {
 			const vertexProjectId =
 				providerKey?.options?.google_vertex_project_id ??
-				getCredentialSetting("google-vertex", "project", managedKey, {
+				getCredentialSetting("google-vertex", "project", credential, {
 					configIndex,
 					variant: envVariant,
 				});
@@ -928,7 +932,7 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 				});
 			}
 			const vertexRegion =
-				getCredentialSetting("google-vertex", "region", managedKey, {
+				getCredentialSetting("google-vertex", "region", credential, {
 					configIndex,
 					defaultValue: "global",
 					variant: envVariant,

--- a/apps/gateway/src/transcriptions/transcriptions.ts
+++ b/apps/gateway/src/transcriptions/transcriptions.ts
@@ -50,6 +50,7 @@ import { assertSpendLimit } from "@/lib/spend-limit.js";
 import { createCombinedSignal, isTimeoutError } from "@/lib/timeout-config.js";
 
 import {
+	getProviderDefaultBaseUrl,
 	getProviderHeaders,
 	providerKeyLabel,
 	readProviderKey,
@@ -741,12 +742,20 @@ transcriptions.openapi(createTranscription, async (c): Promise<any> => {
 			});
 		}
 
-		const envBaseUrl = getCredentialSetting(providerId, "baseUrl", managedKey, {
-			configIndex,
-			variant: envVariant,
-		});
 		const resolvedBaseUrl =
-			providerKey?.baseUrl ?? envBaseUrl ?? "https://api.x.ai";
+			providerKey?.baseUrl ??
+			getCredentialSetting(
+				providerId,
+				"baseUrl",
+				{ providerKey, managedKey },
+				{ configIndex, variant: envVariant },
+			) ??
+			getProviderDefaultBaseUrl(providerId);
+		if (!resolvedBaseUrl) {
+			throw new HTTPException(500, {
+				message: `No base URL set for provider: ${providerId}`,
+			});
+		}
 
 		return {
 			providerKey,

--- a/apps/gateway/src/videos/videos.spec.ts
+++ b/apps/gateway/src/videos/videos.spec.ts
@@ -1595,6 +1595,7 @@ describe("videos", () => {
 				provider: "google-vertex",
 				organizationId: "org-id",
 				baseUrl: mockServerUrl,
+				options: { google_vertex_project_id: "test-project" },
 			});
 
 			const createRes = await app.request("/v1/videos", {
@@ -1828,6 +1829,7 @@ describe("videos", () => {
 				provider: "google-vertex",
 				organizationId: "org-id",
 				baseUrl: mockServerUrl,
+				options: { google_vertex_project_id: "test-project" },
 			});
 
 			const createRes = await app.request("/v1/videos", {
@@ -1913,6 +1915,7 @@ describe("videos", () => {
 				provider: "google-vertex",
 				organizationId: "org-id",
 				baseUrl: mockServerUrl,
+				options: { google_vertex_project_id: "test-project" },
 			});
 
 			const createRes = await app.request("/v1/videos", {
@@ -1987,6 +1990,7 @@ describe("videos", () => {
 				provider: "google-vertex",
 				organizationId: "org-id",
 				baseUrl: mockServerUrl,
+				options: { google_vertex_project_id: "test-project" },
 			});
 
 			const createRes = await app.request("/v1/videos", {
@@ -2070,6 +2074,7 @@ describe("videos", () => {
 				provider: "google-vertex",
 				organizationId: "org-id",
 				baseUrl: mockServerUrl,
+				options: { google_vertex_project_id: "provider-project" },
 			});
 
 			const createRes = await app.request("/v1/videos", {
@@ -2196,6 +2201,7 @@ describe("videos", () => {
 				provider: "google-vertex",
 				organizationId: "org-id",
 				baseUrl: mockServerUrl,
+				options: { google_vertex_project_id: "test-project" },
 			});
 
 			const createRes = await app.request("/v1/videos", {

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -1535,6 +1535,79 @@ function addRequestedVideoMetadata(
 	};
 }
 
+const DEFAULT_VERTEX_VIDEO_REGION = "us-central1";
+
+/**
+ * Settings of a BYOK key serving video generation. The key is self-contained
+ * and env vars never apply (mirrors getProviderEndpoint's skipEnvVars), so the
+ * deployment's proxy or GCP project is never used with an org's own key.
+ * Vertex output written to the platform bucket targets the storage project
+ * instead, so the key's own project is only required without a bucket.
+ */
+function resolveByokVideoProviderSettings(
+	providerId: Provider,
+	providerKey: InferSelectModel<typeof tables.providerKey>,
+): {
+	baseUrl: string | null;
+	vertexProjectId?: string;
+	vertexRegion?: string;
+	hasVertexProject: boolean;
+} {
+	const baseUrl =
+		providerKey.baseUrl ?? getDefaultVideoProviderBaseUrl(providerId);
+	if (!isGoogleVertexVideoProvider(providerId)) {
+		return { baseUrl, hasVertexProject: true };
+	}
+	const vertexProjectId = providerKey.options?.google_vertex_project_id;
+	return {
+		baseUrl,
+		vertexProjectId,
+		vertexRegion: DEFAULT_VERTEX_VIDEO_REGION,
+		hasVertexProject: Boolean(
+			vertexProjectId || getGoogleVertexVideoOutputBucket(),
+		),
+	};
+}
+
+function resolveByokVideoProviderContext(
+	providerId: Provider,
+	providerKey: InferSelectModel<typeof tables.providerKey>,
+	requestId: string,
+): ProviderContext {
+	const settings = resolveByokVideoProviderSettings(providerId, providerKey);
+	if (!settings.baseUrl) {
+		throw new HTTPException(400, {
+			message: `No base URL set for provider: ${providerId}`,
+		});
+	}
+	if (!settings.hasVertexProject) {
+		throw new HTTPException(400, {
+			message: `Google Vertex video generation requires google_vertex_project_id on the provider key`,
+		});
+	}
+	return {
+		providerId,
+		baseUrl: settings.baseUrl,
+		token: readProviderKey(providerKey),
+		requestId,
+		usedMode: "api-keys",
+		configIndex: null,
+		providerKeyId: providerKey.id,
+		providerKeyLabel: providerKeyLabel(providerKey),
+		vertexProjectId: settings.vertexProjectId,
+		vertexRegion: settings.vertexRegion,
+		vertexTokenType: resolveVideoVertexTokenType(providerId, providerKey, null),
+	};
+}
+
+function hasByokVideoConfiguration(
+	providerId: Provider,
+	providerKey: InferSelectModel<typeof tables.providerKey>,
+): boolean {
+	const settings = resolveByokVideoProviderSettings(providerId, providerKey);
+	return Boolean(settings.baseUrl) && settings.hasVertexProject;
+}
+
 async function resolveProviderContext(
 	providerId: Provider,
 	project: InferSelectModel<typeof tables.project>,
@@ -1543,13 +1616,6 @@ async function resolveProviderContext(
 	selectionScope: string,
 ): Promise<ProviderContext> {
 	const defaultBaseUrl = getDefaultVideoProviderBaseUrl(providerId);
-	const sharedVertexProjectId = isGoogleVertexVideoProvider(providerId)
-		? getProviderEnvValue(providerId, "project")
-		: undefined;
-	const sharedVertexRegion = isGoogleVertexVideoProvider(providerId)
-		? (getProviderEnvValue(providerId, "region", undefined, "us-central1") ??
-			"us-central1")
-		: undefined;
 
 	// Which env-var variant (`__ENTERPRISE` / `__PLANS` overrides) applies to
 	// this org's env-credential reads. Undefined = base vars only.
@@ -1570,41 +1636,7 @@ async function resolveProviderContext(
 			});
 		}
 
-		const baseUrl =
-			providerKey.baseUrl ??
-			getProviderEnvValue(providerId, "baseUrl") ??
-			defaultBaseUrl;
-		if (!baseUrl) {
-			throw new HTTPException(400, {
-				message: `No base URL set for provider: ${providerId}`,
-			});
-		}
-
-		if (isGoogleVertexVideoProvider(providerId) && !sharedVertexProjectId) {
-			throw new HTTPException(500, {
-				message: `${providerId} project environment variable is required for video generation`,
-			});
-		}
-
-		const providerContext: ProviderContext = {
-			providerId,
-			baseUrl,
-			token: readProviderKey(providerKey),
-			requestId,
-			usedMode: "api-keys",
-			configIndex: null,
-			providerKeyId: providerKey.id,
-			providerKeyLabel: providerKeyLabel(providerKey),
-			vertexProjectId: sharedVertexProjectId,
-			vertexRegion: sharedVertexRegion,
-			vertexTokenType: resolveVideoVertexTokenType(
-				providerId,
-				providerKey,
-				null,
-			),
-		};
-
-		return providerContext;
+		return resolveByokVideoProviderContext(providerId, providerKey, requestId);
 	}
 
 	if (project.mode === "credits") {
@@ -1625,41 +1657,7 @@ async function resolveProviderContext(
 		getVideoProviderKeyFilter(providerId),
 	);
 	if (providerKey) {
-		const baseUrl =
-			providerKey.baseUrl ??
-			getProviderEnvValue(providerId, "baseUrl") ??
-			defaultBaseUrl;
-		if (!baseUrl) {
-			throw new HTTPException(400, {
-				message: `No base URL set for provider: ${providerId}`,
-			});
-		}
-
-		if (isGoogleVertexVideoProvider(providerId) && !sharedVertexProjectId) {
-			throw new HTTPException(500, {
-				message: `${providerId} project environment variable is required for video generation`,
-			});
-		}
-
-		const providerContext: ProviderContext = {
-			providerId,
-			baseUrl,
-			token: readProviderKey(providerKey),
-			requestId,
-			usedMode: "api-keys",
-			configIndex: null,
-			providerKeyId: providerKey.id,
-			providerKeyLabel: providerKeyLabel(providerKey),
-			vertexProjectId: sharedVertexProjectId,
-			vertexRegion: sharedVertexRegion,
-			vertexTokenType: resolveVideoVertexTokenType(
-				providerId,
-				providerKey,
-				null,
-			),
-		};
-
-		return providerContext;
+		return resolveByokVideoProviderContext(providerId, providerKey, requestId);
 	}
 
 	// A provider with any managed credential is served only by those: its
@@ -1708,11 +1706,12 @@ async function resolvePlatformVideoProviderContext(
 	const configIndex = platformCredential.configIndex;
 
 	const readSetting = (key: string, defaultValue?: string) =>
-		getCredentialSetting(providerId, key, managedKey, {
-			configIndex,
-			defaultValue,
-			variant: envVariant,
-		});
+		getCredentialSetting(
+			providerId,
+			key,
+			{ managedKey },
+			{ configIndex, defaultValue, variant: envVariant },
+		);
 
 	const baseUrl = readSetting("baseUrl") ?? defaultBaseUrl;
 	if (!baseUrl) {
@@ -1725,7 +1724,8 @@ async function resolvePlatformVideoProviderContext(
 		? readSetting("project")
 		: undefined;
 	const vertexRegion = isGoogleVertexVideoProvider(providerId)
-		? (readSetting("region", "us-central1") ?? "us-central1")
+		? (readSetting("region", DEFAULT_VERTEX_VIDEO_REGION) ??
+			DEFAULT_VERTEX_VIDEO_REGION)
 		: undefined;
 
 	if (isGoogleVertexVideoProvider(providerId) && !vertexProjectId) {
@@ -1770,12 +1770,7 @@ async function hasVideoProviderConfiguration(
 			getVideoProviderKeyFilter(providerId),
 		);
 		return Boolean(
-			providerKey &&
-			(providerKey.baseUrl ??
-				getProviderEnvValue(providerId, "baseUrl") ??
-				defaultBaseUrl) &&
-			(!isGoogleVertexVideoProvider(providerId) ||
-				Boolean(getProviderEnvValue(providerId, "project"))),
+			providerKey && hasByokVideoConfiguration(providerId, providerKey),
 		);
 	}
 
@@ -1795,13 +1790,7 @@ async function hasVideoProviderConfiguration(
 		getVideoProviderKeyFilter(providerId),
 	);
 	if (providerKey) {
-		return Boolean(
-			(providerKey.baseUrl ??
-				getProviderEnvValue(providerId, "baseUrl") ??
-				defaultBaseUrl) &&
-			(!isGoogleVertexVideoProvider(providerId) ||
-				Boolean(getProviderEnvValue(providerId, "project"))),
-		);
+		return hasByokVideoConfiguration(providerId, providerKey);
 	}
 
 	return await hasPlatformVideoConfiguration(
@@ -2754,10 +2743,10 @@ async function resolveVideoJobProviderContext(job: VideoJobRecord): Promise<{
 			});
 		}
 
-		const baseUrl =
-			providerKey.baseUrl ??
-			getProviderEnvValue(providerId, "baseUrl") ??
-			defaultBaseUrl;
+		const { baseUrl } = resolveByokVideoProviderSettings(
+			providerId,
+			providerKey,
+		);
 		if (!baseUrl) {
 			throw new HTTPException(400, {
 				message: `No base URL set for provider: ${providerId}`,

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -1538,11 +1538,12 @@ function addRequestedVideoMetadata(
 const DEFAULT_VERTEX_VIDEO_REGION = "us-central1";
 
 /**
- * Settings of a BYOK key serving video generation. The key is self-contained
- * and env vars never apply (mirrors getProviderEndpoint's skipEnvVars), so the
- * deployment's proxy or GCP project is never used with an org's own key.
- * Vertex output written to the platform bucket targets the storage project
- * instead, so the key's own project is only required without a bucket.
+ * Settings of a BYOK key serving video generation. The key is self-contained:
+ * `LLM_*` env vars are never applied implicitly (mirrors getProviderEndpoint's
+ * skipEnvVars), so the deployment's proxy or GCP project only reaches an org's
+ * own key when the key itself is configured for it. Vertex output written to
+ * the platform bucket targets the storage project instead, so the key's own
+ * project is only required without a bucket.
  */
 function resolveByokVideoProviderSettings(
 	providerId: Provider,
@@ -1564,7 +1565,9 @@ function resolveByokVideoProviderSettings(
 		vertexProjectId,
 		vertexRegion: DEFAULT_VERTEX_VIDEO_REGION,
 		hasVertexProject: Boolean(
-			vertexProjectId || getGoogleVertexVideoOutputBucket(),
+			vertexProjectId ||
+			(getGoogleVertexVideoOutputBucket() &&
+				process.env.GOOGLE_CLOUD_PROJECT?.trim()),
 		),
 	};
 }
@@ -1576,7 +1579,7 @@ function resolveByokVideoProviderContext(
 ): ProviderContext {
 	const settings = resolveByokVideoProviderSettings(providerId, providerKey);
 	if (!settings.baseUrl) {
-		throw new HTTPException(400, {
+		throw new HTTPException(500, {
 			message: `No base URL set for provider: ${providerId}`,
 		});
 	}

--- a/apps/worker/src/services/video-jobs.ts
+++ b/apps/worker/src/services/video-jobs.ts
@@ -291,10 +291,9 @@ async function resolveVideoProviderContext(
 			throw new Error(`No API key set for provider: ${job.usedProvider}`);
 		}
 
-		const baseUrl =
-			providerKey.baseUrl ??
-			getProviderEnvValue(providerId, "baseUrl") ??
-			defaultBaseUrl;
+		// A BYOK key is self-contained: the deployment's env base URL never
+		// applies to an org's own key (mirrors the gateway's skipEnvVars).
+		const baseUrl = providerKey.baseUrl ?? defaultBaseUrl;
 		if (!baseUrl) {
 			throw new Error(`No base URL set for provider: ${job.usedProvider}`);
 		}


### PR DESCRIPTION
## Problem

Chat, Responses, Images, the native Anthropic route and the AI SDK route all resolve upstream URLs through `getProviderEndpoint`, which skips every `LLM_*` env var once a database-backed credential (BYOK or managed) is active. The routes that build their own URLs did not:

- **Embeddings, speech, transcriptions, OCR, rerank, videos (gateway + worker), realtime**: a BYOK key with no base URL of its own fell back to the deployment's `LLM_<PROVIDER>_BASE_URL`, so an organization's own OpenAI / Google key was sent to the platform's proxy. Embeddings, speech and videos also stamped the platform's `LLM_GOOGLE_CLOUD_PROJECT` / region into a BYOK Vertex request path; videos ignored the key's `google_vertex_project_id` entirely.
- **Moderations and the internal content filter** always hit `api.openai.com`, ignoring `LLM_OPENAI_BASE_URL` and a managed credential's base URL, while still sending that credential's key.
- Embeddings and rerank fell back to `api.openai.com`, OCR to `api.mistral.ai`, for any provider missing a default base URL, posting another provider's key there.

## Approach

- `getCredentialSetting` now takes `{ providerKey, managedKey }` and returns only the default for a BYOK key, the managed row's `config` for a managed key, and env otherwise. Every self-built route passes the active credential.
- Video BYOK resolution moves into one helper: base URL from the key or the provider default, Vertex project from `google_vertex_project_id`. The key's project is only required when no output bucket is configured, since the bucket path targets the storage project anyway.
- Moderations and the content filter resolve the base URL from the same credential that supplies the token.
- Missing default base URLs now raise a 500 instead of picking a wrong host. Realtime strips a trailing slash from a configured base URL.

## Verification

- `pnpm format`, `pnpm build`.
- Unit specs for embeddings, speech, transcriptions, OCR, videos, realtime and the content filter pass on an isolated stack. Six video fixtures gained `google_vertex_project_id` on their BYOK keys since env no longer supplies it. New specs cover the helper, the realtime BYOK path and the content-filter base URL.

## Not included

The dashboard only exposes a base URL field for the `llmgateway` and custom providers, and no API route edits a key's base URL, although the docs claim both. Left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved provider connection settings across chat, embeddings, moderation, OCR, reranking, speech, transcription, video, and real-time requests.
  * Support for configured provider base URLs and provider-specific defaults is now more consistent.
  * Bring-your-own-key configurations now use their own settings without unintentionally inheriting deployment environment overrides.
  * Moderation requests can use a configured proxy or custom base URL.
  * Trailing slashes are handled correctly when constructing upstream WebSocket URLs.

* **Bug Fixes**
  * Requests now return a clear internal error when no provider base URL can be resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->