### PR TITLE
refactor(db): reuse shared API key hash in demo seed

### DIFF
--- a/packages/db/src/seed-demo.ts
+++ b/packages/db/src/seed-demo.ts
@@ -15,35 +15,20 @@
  */
 /* eslint-disable no-console -- a seed script's output is its user interface */
 /* eslint-disable no-mixed-operators -- arithmetic-heavy synthetic data shaping */
-import {
-	createHmac,
-	randomBytes,
-	randomInt as cryptoRandomInt,
-	scrypt,
-} from "crypto";
+import { randomBytes, randomInt as cryptoRandomInt, scrypt } from "crypto";
 
 import { eq, inArray } from "drizzle-orm";
 
-import { maskToken } from "@llmgateway/shared/mask-token";
+import {
+	getApiKeyFingerprint,
+	hashApiKeyForStorage,
+} from "@llmgateway/shared/api-key-hash";
 
 import { closeDatabase, db, tables } from "./index.js";
 
 import type { PgTable } from "drizzle-orm/pg-core";
 
 const ORG_ID = "ed-demo-org";
-
-/**
- * Mirrors `getApiKeyFingerprint` from @llmgateway/shared. Inlined rather than
- * imported because that package's entrypoint pulls in React components, which
- * a plain `node` seed process cannot resolve.
- */
-function apiKeyFingerprint(token: string): string {
-	const secret =
-		(process.env.GATEWAY_API_KEY_HASH_SECRET ?? "").split(",")[0].trim() ||
-		"llmgateway-dev-api-key-hash-secret";
-	// lgtm[js/insufficient-password-hash]
-	return createHmac("sha256", secret).update(token).digest("hex");
-}
 
 /**
  * Upsert on the `id` primary key. Rows are written one at a time because the
@@ -566,8 +551,7 @@ async function seedDemo() {
 		const { note: _note, token, ...row } = k;
 		await upsertById(tables.apiKey, {
 			...row,
-			tokenHash: apiKeyFingerprint(token),
-			tokenMasked: maskToken(token),
+			...hashApiKeyForStorage(token),
 			status: "active",
 			keyType: "user",
 		});
@@ -607,7 +591,7 @@ async function seedDemo() {
 	const masterToken = "llmgmkdev_enterprise_demo_master_key";
 	await upsertById(tables.masterKey, {
 		id: "ed-master-key",
-		tokenHash: apiKeyFingerprint(masterToken),
+		tokenHash: getApiKeyFingerprint(masterToken),
 		maskedToken: `${masterToken.slice(0, 14)}...${masterToken.slice(-4)}`,
 		description: "Team onboarding automation",
 		status: "active",


### PR DESCRIPTION
## Summary

- Replace the inlined HMAC fingerprint in `packages/db/src/seed-demo.ts` with `hashApiKeyForStorage` / `getApiKeyFingerprint` from `@llmgateway/shared/api-key-hash`. The inline copy's justification (shared entrypoint pulls in React) is stale: `seed-demo-analytics.ts` already imports that subpath.
- Drops the duplicated hardcoded dev hash secret; the shared helper now owns the fallback.

## Context

Triggered by CodeQL alert 109 (`js/insufficient-password-hash`). It is a false positive: gateway API keys are high-entropy random bearer tokens, not passwords, and keyed HMAC-SHA256 is the production scheme. The same finding on the shared helper (alerts 48 and 106) is already dismissed. This change removes the duplicate location rather than adding another suppression.

## Test plan

- [x] `pnpm format`
- [x] `turbo run build --filter=@llmgateway/db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized demo API-key hashing and masking with the shared key-management behavior.
  * Demo API keys continue to be stored with hashed and masked values for secure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->