### PR TITLE
feat: redesign dashboard charts

### DIFF
--- a/apps/api/src/routes/public-chat-support.ts
+++ b/apps/api/src/routes/public-chat-support.ts
@@ -68,28 +68,23 @@ const MAX_CONTEXT_MESSAGES = 30;
 
 const DOCS_BASE_URL = "https://docs.llmgateway.io";
 
-const BASE_SYSTEM_PROMPT = `You are the LLM Gateway support assistant. You ONLY answer questions related to LLM Gateway — the unified API gateway for multiple LLM providers — and its products (the dashboard at llmgateway.io, DevPass at devpass.llmgateway.io, the docs at docs.llmgateway.io, and Lounge, the AI chat app at lounge.llmgateway.io).
+const BASE_SYSTEM_PROMPT = `You are the LLM Gateway support assistant. You ONLY answer questions about the public LLM Gateway product suite:
+- AI Gateway: the unified API, model and provider catalogue, routing, and developer features.
+- Dashboard and Observability: API keys, configuration, usage, cost, reliability, security, teams, and billing.
+- DevPass and DevPass Code: flat-price coding plans, supported coding agents, setup, usage, and plan limits.
+- Lounge: chat, projects, group chat, media studios, voice calls, memberships, and credits.
+- Airside: the provider console for carrier claims, crew, model listings, fare filings, routing, and traffic.
+- Documentation: API reference, guides, integrations, migrations, and self-hosting.
 
-Your knowledge covers:
-- Getting started, quick start, and setup
-- API endpoints: /v1/chat/completions, /v1/messages, /v1/models, /v1/moderations, /v1/videos
-- Features: routing, caching, response healing, vision, image generation, video generation, web search, reasoning, guardrails, audit logs, cost breakdown, data retention, metadata, custom providers, API keys, moderations
-- Guides: Cursor, Cline, Claude Code, Codex CLI, OpenCode, Autohand, CLI, MCP, n8n, Agent Skills, OpenClaw
-- Integrations: AWS Bedrock, Azure
-- Migrations: from OpenRouter, LiteLLM, Vercel AI Gateway
-- Learning: dashboard, API keys, playground, billing, activity, usage metrics, model usage, transactions, team, org preferences, preferences, provider keys, referrals, security events, guardrails, audit logs, policies
-- DevPass subscription plans
-- Lounge (chat) subscription plans
-- Self-hosting
-- Rate limits and resources
+Do not mix product rules. DevPass plans, Lounge memberships, and AI Gateway pay-as-you-go usage are separate. Use the live product overviews below as the authority on product scope, plans, and pricing.
 
 When answering:
-1. Be concise and helpful.
-2. Link to relevant pages using the real URLs listed in the "Available pages" section below. Never invent URLs.
-3. When you are unsure of an answer or need exact details, use the \`fetchPage\` tool to read the most relevant page before answering. Prefer grounding your answer in fetched content.
-4. If the question is NOT related to LLM Gateway, politely decline and suggest they ask about LLM Gateway features instead.
-5. Do not make up features or capabilities. If unsure after checking the docs, direct them to ${DOCS_BASE_URL} or suggest contacting support at contact@llmgateway.io.
-6. Keep responses short — ideally under 200 words.`;
+1. Identify the relevant product, then answer concisely.
+2. Link only to real URLs from the "Available pages" section below. Never invent URLs.
+3. Use the \`fetchPage\` tool for exact or uncertain details and ground the answer in the fetched page.
+4. If the question is unrelated to LLM Gateway, politely decline and invite a product question.
+5. Never invent features or capabilities. If the docs do not answer the question, link to ${DOCS_BASE_URL} or suggest contact@llmgateway.io.
+6. Keep responses under 200 words when possible.`;
 
 async function buildSystemPrompt(): Promise<string> {
 	const [urls, overviews] = await Promise.all([
@@ -99,15 +94,15 @@ async function buildSystemPrompt(): Promise<string> {
 
 	let prompt = BASE_SYSTEM_PROMPT;
 
-	// Inline the llms.txt product overviews (DevPass and Lounge plans, pricing,
-	// key pages) so plan questions are answerable without a tool call.
+	// Inline each product's llms.txt overview so scope and plan questions are
+	// answerable without a tool call.
 	if (overviews.length > 0) {
 		const overviewSections = overviews
 			.map((o) => `--- ${o.url} ---\n${o.content}`)
 			.join("\n\n");
 		prompt += `
 
-Product overviews (live llms.txt files — authoritative on DevPass and Lounge plans and pricing):
+Product overviews (live llms.txt files — authoritative on product scope, plans, pricing, and key pages):
 
 ${overviewSections}`;
 	}
@@ -116,7 +111,7 @@ ${overviewSections}`;
 		const urlList = urls.map((u) => `- ${u}`).join("\n");
 		prompt += `
 
-Available pages (sourced from the live sitemaps and llms.txt files of llmgateway.io, devpass.llmgateway.io, docs.llmgateway.io and lounge.llmgateway.io). Use these for accurate links and as targets for the \`fetchPage\` tool:
+Available pages (sourced from the live LLM Gateway, DevPass, Lounge, Airside, and documentation sites). Use these for accurate links and as targets for the \`fetchPage\` tool:
 ${urlList}`;
 	}
 
@@ -549,7 +544,7 @@ publicChatSupport.post("/", async (c) => {
 		tools: {
 			fetchPage: tool({
 				description:
-					"Fetch the readable text content of an LLM Gateway page (llmgateway.io, devpass/docs/lounge.llmgateway.io) to ground your answer in accurate, up-to-date information. Pass a full https URL from the available pages list.",
+					"Fetch an approved LLM Gateway, DevPass, Lounge, Airside, or documentation page to ground an answer in current information. Pass a full https URL from the available pages list.",
 				inputSchema: z.object({
 					url: z
 						.string()

--- a/apps/api/src/utils/chat-support-knowledge.spec.ts
+++ b/apps/api/src/utils/chat-support-knowledge.spec.ts
@@ -146,4 +146,29 @@ describe("selectKnowledgeUrls", () => {
 		expect(selected).toHaveLength(600);
 		expect(selected.slice(0, guideUrls.length)).toEqual(guideUrls);
 	});
+
+	test("keeps later products when the first sitemap has 600 guides", () => {
+		const mainGuides = Array.from(
+			{ length: 600 },
+			(_, index) => `https://llmgateway.io/guides/guide-${index}`,
+		);
+		const laterProducts = [
+			"https://devpass.llmgateway.io/guides/getting-started",
+			"https://docs.llmgateway.io/quick-start",
+			"https://lounge.llmgateway.io/group",
+			"https://airside.llmgateway.io/legal/terms",
+		];
+
+		const selected = selectKnowledgeUrls(
+			[],
+			[mainGuides, ...laterProducts.map((url) => [url])],
+			600,
+		);
+
+		expect(selected).toHaveLength(600);
+		expect(selected.slice(0, laterProducts.length + 1)).toEqual([
+			mainGuides[0],
+			...laterProducts,
+		]);
+	});
 });

--- a/apps/api/src/utils/chat-support-knowledge.spec.ts
+++ b/apps/api/src/utils/chat-support-knowledge.spec.ts
@@ -1,6 +1,27 @@
 import { describe, expect, test } from "vitest";
 
-import { isAllowedKnowledgeUrl } from "./chat-support-knowledge.js";
+import {
+	KNOWLEDGE_LLMS_TXT,
+	KNOWLEDGE_SITEMAPS,
+	isAllowedKnowledgeUrl,
+	selectKnowledgeUrls,
+} from "./chat-support-knowledge.js";
+
+test("indexes every public product", () => {
+	expect(KNOWLEDGE_SITEMAPS).toEqual([
+		"https://llmgateway.io/sitemap.xml",
+		"https://devpass.llmgateway.io/sitemap.xml",
+		"https://docs.llmgateway.io/sitemap.xml",
+		"https://lounge.llmgateway.io/sitemap.xml",
+		"https://airside.llmgateway.io/sitemap.xml",
+	]);
+	expect(KNOWLEDGE_LLMS_TXT).toEqual([
+		"https://llmgateway.io/llms.txt",
+		"https://devpass.llmgateway.io/llms.txt",
+		"https://lounge.llmgateway.io/llms.txt",
+		"https://airside.llmgateway.io/llms.txt",
+	]);
+});
 
 describe("isAllowedKnowledgeUrl", () => {
 	test("allows the product domains over https", () => {
@@ -12,8 +33,21 @@ describe("isAllowedKnowledgeUrl", () => {
 		);
 		expect(isAllowedKnowledgeUrl("https://devpass.llmgateway.io/")).toBe(true);
 		expect(isAllowedKnowledgeUrl("https://lounge.llmgateway.io/")).toBe(true);
+		expect(isAllowedKnowledgeUrl("https://airside.llmgateway.io/")).toBe(true);
 		// Kept allowed after the move: the old host still 301s to lounge.
 		expect(isAllowedKnowledgeUrl("https://chat.llmgateway.io/")).toBe(true);
+	});
+
+	test("rejects user-generated Lounge shares", () => {
+		expect(
+			isAllowedKnowledgeUrl("https://lounge.llmgateway.io/share/public-chat"),
+		).toBe(false);
+		expect(
+			isAllowedKnowledgeUrl("https://chat.llmgateway.io/share/public-chat"),
+		).toBe(false);
+		expect(isAllowedKnowledgeUrl("https://lounge.llmgateway.io/group")).toBe(
+			true,
+		);
 	});
 
 	test("rejects other hosts", () => {
@@ -22,6 +56,12 @@ describe("isAllowedKnowledgeUrl", () => {
 			false,
 		);
 		expect(isAllowedKnowledgeUrl("https://notllmgateway.io/")).toBe(false);
+		expect(isAllowedKnowledgeUrl("https://preview.llmgateway.io/")).toBe(false);
+		expect(
+			isAllowedKnowledgeUrl(
+				"https://internal.llmgateway.io/public/chats/share/public-chat",
+			),
+		).toBe(false);
 	});
 
 	test("rejects non-https schemes", () => {
@@ -34,5 +74,76 @@ describe("isAllowedKnowledgeUrl", () => {
 	test("rejects malformed urls", () => {
 		expect(isAllowedKnowledgeUrl("not a url")).toBe(false);
 		expect(isAllowedKnowledgeUrl("")).toBe(false);
+	});
+});
+
+describe("selectKnowledgeUrls", () => {
+	test("keeps every product represented when one sitemap exceeds the limit", () => {
+		const priorityUrls = [
+			"https://llmgateway.io/llms.txt",
+			"https://airside.llmgateway.io/llms.txt",
+		];
+		const mainUrls = Array.from(
+			{ length: 700 },
+			(_, index) => `https://llmgateway.io/models/model-${index}`,
+		);
+		const groups = [
+			mainUrls,
+			["https://devpass.llmgateway.io/guides"],
+			["https://docs.llmgateway.io/quick-start"],
+			["https://lounge.llmgateway.io/group"],
+			["https://airside.llmgateway.io/legal/terms"],
+		];
+
+		const selected = selectKnowledgeUrls(priorityUrls, groups, 600);
+
+		expect(selected).toHaveLength(600);
+		expect(selected.slice(0, 7)).toEqual([
+			...priorityUrls,
+			groups[1]![0],
+			mainUrls[0],
+			groups[2]![0],
+			groups[3]![0],
+			groups[4]![0],
+		]);
+		expect(selected).toEqual(selectKnowledgeUrls(priorityUrls, groups, 600));
+	});
+
+	test("deduplicates URLs and drops excluded pages", () => {
+		const selected = selectKnowledgeUrls(
+			["https://llmgateway.io/llms.txt"],
+			[
+				[
+					"https://llmgateway.io/llms.txt",
+					"https://lounge.llmgateway.io/share/public-chat",
+				],
+				["https://docs.llmgateway.io/quick-start"],
+			],
+		);
+
+		expect(selected).toEqual([
+			"https://llmgateway.io/llms.txt",
+			"https://docs.llmgateway.io/quick-start",
+		]);
+	});
+
+	test("keeps guides that follow a large catalogue section", () => {
+		const catalogueUrls = Array.from(
+			{ length: 700 },
+			(_, index) => `https://llmgateway.io/models/model-${index}`,
+		);
+		const guideUrls = [
+			"https://llmgateway.io/guides/devpass-code",
+			"https://llmgateway.io/guides/codex-cli",
+		];
+
+		const selected = selectKnowledgeUrls(
+			[],
+			[[...catalogueUrls, ...guideUrls]],
+			600,
+		);
+
+		expect(selected).toHaveLength(600);
+		expect(selected.slice(0, guideUrls.length)).toEqual(guideUrls);
 	});
 });

--- a/apps/api/src/utils/chat-support-knowledge.ts
+++ b/apps/api/src/utils/chat-support-knowledge.ts
@@ -128,15 +128,41 @@ export function selectKnowledgeUrls(
 	for (const url of priorityUrls) {
 		add(url);
 	}
-	for (const urls of urlGroups) {
-		for (const url of urls) {
+	const guideGroups = urlGroups.map((urls) =>
+		urls.filter((url) => {
 			try {
 				const { pathname } = new URL(url);
-				if (pathname === "/guides" || pathname.startsWith("/guides/")) {
-					add(url);
-				}
+				return (
+					(pathname === "/guides" || pathname.startsWith("/guides/")) &&
+					isAllowedKnowledgeUrl(url)
+				);
 			} catch {
-				// Invalid URLs are discarded by add during the normal selection pass.
+				return false;
+			}
+		}),
+	);
+
+	// Reserve representation for each product before a guide-heavy sitemap can
+	// consume the remaining budget.
+	for (const guides of guideGroups) {
+		add(guides[0]);
+	}
+	for (let index = 0; index < urlGroups.length; index += 1) {
+		if (guideGroups[index]!.length === 0) {
+			add(urlGroups[index]!.find((url) => isAllowedKnowledgeUrl(url)));
+		}
+	}
+
+	const guideRounds = Math.max(0, ...guideGroups.map((urls) => urls.length));
+	for (
+		let index = 0;
+		index < guideRounds && selected.length < limit;
+		index += 1
+	) {
+		for (const guides of guideGroups) {
+			add(guides[index]);
+			if (selected.length >= limit) {
+				break;
 			}
 		}
 	}

--- a/apps/api/src/utils/chat-support-knowledge.ts
+++ b/apps/api/src/utils/chat-support-knowledge.ts
@@ -5,20 +5,21 @@ import { logger } from "@llmgateway/logger";
 // Domains whose sitemaps are crawled to build the support assistant's
 // knowledge of every public page across the product suite. The agent links to
 // these URLs and can fetch their content on demand to ground answers.
-const KNOWLEDGE_SITEMAPS = [
+export const KNOWLEDGE_SITEMAPS = [
 	"https://llmgateway.io/sitemap.xml",
 	"https://devpass.llmgateway.io/sitemap.xml",
 	"https://docs.llmgateway.io/sitemap.xml",
 	"https://lounge.llmgateway.io/sitemap.xml",
+	"https://airside.llmgateway.io/sitemap.xml",
 ];
 
-// llms.txt overviews are short, curated markdown summaries of a product —
-// plans, pricing, and key pages. Their content is inlined into the support
-// assistant's system prompt so plan questions (DevPass tiers, Lounge/chat
-// plans) are answerable without a tool call.
-const KNOWLEDGE_LLMS_TXT = [
+// Short, curated product summaries inlined into the system prompt so product
+// scope, plans, pricing, and key pages are available without a tool call.
+export const KNOWLEDGE_LLMS_TXT = [
+	"https://llmgateway.io/llms.txt",
 	"https://devpass.llmgateway.io/llms.txt",
 	"https://lounge.llmgateway.io/llms.txt",
+	"https://airside.llmgateway.io/llms.txt",
 ];
 
 // Only pages on these hosts may be fetched by the agent's grounding tool.
@@ -30,16 +31,17 @@ const ALLOWED_HOSTS = [
 	"docs.llmgateway.io",
 	"lounge.llmgateway.io",
 	"chat.llmgateway.io",
+	"airside.llmgateway.io",
 ];
 
-const URLS_CACHE_KEY = "chat_support_knowledge_urls";
-const OVERVIEWS_CACHE_KEY = "chat_support_knowledge_overviews";
+const URLS_CACHE_KEY = "chat_support_knowledge_urls_v2";
+const OVERVIEWS_CACHE_KEY = "chat_support_knowledge_overviews_v2";
 const URLS_CACHE_TTL_SECONDS = 60 * 60 * 6; // 6 hours
 const PAGE_CACHE_TTL_SECONDS = 60 * 60 * 24; // 24 hours
 const FETCH_TIMEOUT_MS = 8000;
 const MAX_URLS = 600;
 const MAX_PAGE_CHARS = 6000;
-const MAX_OVERVIEW_CHARS = 4000;
+const MAX_OVERVIEW_CHARS = 6000;
 
 function extractLocs(xml: string): string[] {
 	const matches = xml.matchAll(/<loc>\s*([^<\s]+)\s*<\/loc>/gi);
@@ -80,7 +82,7 @@ async function collectSitemapUrls(sitemapUrl: string): Promise<string[]> {
 	const locs = extractLocs(xml);
 	const isIndex = /<sitemapindex/i.test(xml);
 	if (!isIndex) {
-		return locs;
+		return locs.filter((loc) => isAllowedKnowledgeUrl(loc));
 	}
 
 	// A sitemap index could reference arbitrary external URLs; only follow
@@ -91,9 +93,65 @@ async function collectSitemapUrls(sitemapUrl: string): Promise<string[]> {
 	const nested = await Promise.all(
 		nestedUrls.map((nestedUrl) => fetchText(nestedUrl)),
 	);
-	return nested.flatMap((nestedXml) =>
-		nestedXml ? extractLocs(nestedXml) : [],
-	);
+	return nested
+		.flatMap((nestedXml) => (nestedXml ? extractLocs(nestedXml) : []))
+		.filter((loc) => isAllowedKnowledgeUrl(loc));
+}
+
+// Keep curated overviews and guides first, then take one URL from each sitemap
+// per round. Large catalogues cannot crowd guides or smaller products out of
+// the fixed prompt budget.
+export function selectKnowledgeUrls(
+	priorityUrls: readonly string[],
+	urlGroups: readonly (readonly string[])[],
+	limit = MAX_URLS,
+): string[] {
+	if (limit <= 0) {
+		return [];
+	}
+
+	const selected: string[] = [];
+	const seen = new Set<string>();
+	const add = (url: string | undefined): void => {
+		if (
+			!url ||
+			selected.length >= limit ||
+			seen.has(url) ||
+			!isAllowedKnowledgeUrl(url)
+		) {
+			return;
+		}
+		seen.add(url);
+		selected.push(url);
+	};
+
+	for (const url of priorityUrls) {
+		add(url);
+	}
+	for (const urls of urlGroups) {
+		for (const url of urls) {
+			try {
+				const { pathname } = new URL(url);
+				if (pathname === "/guides" || pathname.startsWith("/guides/")) {
+					add(url);
+				}
+			} catch {
+				// Invalid URLs are discarded by add during the normal selection pass.
+			}
+		}
+	}
+
+	const rounds = Math.max(0, ...urlGroups.map((urls) => urls.length));
+	for (let index = 0; index < rounds && selected.length < limit; index += 1) {
+		for (const urls of urlGroups) {
+			add(urls[index]);
+			if (selected.length >= limit) {
+				break;
+			}
+		}
+	}
+
+	return selected;
 }
 
 export async function getKnowledgeUrls(): Promise<string[]> {
@@ -109,11 +167,7 @@ export async function getKnowledgeUrls(): Promise<string[]> {
 	const results = await Promise.all(
 		KNOWLEDGE_SITEMAPS.map((sitemap) => collectSitemapUrls(sitemap)),
 	);
-	// The llms.txt overviews are listed first so they are always fetchable
-	// targets even when the sitemap list gets truncated at MAX_URLS.
-	const urls = Array.from(
-		new Set([...KNOWLEDGE_LLMS_TXT, ...results.flat()]),
-	).slice(0, MAX_URLS);
+	const urls = selectKnowledgeUrls(KNOWLEDGE_LLMS_TXT, results);
 
 	if (urls.length > 0) {
 		try {
@@ -136,9 +190,8 @@ export interface KnowledgeOverview {
 	content: string;
 }
 
-// Fetches the llms.txt product overviews (DevPass and Lounge plans/pricing)
-// so they can be inlined into the support assistant's system prompt. Cached in
-// Redis alongside the URL list; failures degrade to an empty list.
+// Fetches the llms.txt product overviews for the support assistant's system
+// prompt. Cached in Redis alongside the URL list; failures degrade gracefully.
 export async function getKnowledgeOverviews(): Promise<KnowledgeOverview[]> {
 	try {
 		const cached = await redisClient.get(OVERVIEWS_CACHE_KEY);
@@ -179,13 +232,18 @@ export async function getKnowledgeOverviews(): Promise<KnowledgeOverview[]> {
 
 export function isAllowedKnowledgeUrl(url: string): boolean {
 	try {
-		const { hostname, protocol } = new URL(url);
+		const { hostname, pathname, protocol } = new URL(url);
 		if (protocol !== "https:") {
 			return false;
 		}
-		return ALLOWED_HOSTS.some(
-			(host) => hostname === host || hostname.endsWith(`.${host}`),
-		);
+		if (
+			(hostname === "lounge.llmgateway.io" ||
+				hostname === "chat.llmgateway.io") &&
+			(pathname === "/share" || pathname.startsWith("/share/"))
+		) {
+			return false;
+		}
+		return ALLOWED_HOSTS.some((host) => hostname === host);
 	} catch {
 		return false;
 	}

--- a/apps/ui/src/app/rankings/page.tsx
+++ b/apps/ui/src/app/rankings/page.tsx
@@ -11,7 +11,10 @@ import {
 	type ModelDefinition,
 } from "@llmgateway/models";
 
-import type { RankingsModelMeta } from "@/components/rankings/rankings-content";
+import type {
+	RankingsAppStat,
+	RankingsModelMeta,
+} from "@/components/rankings/rankings-content";
 import type { Metadata } from "next";
 
 // The rankings list pulls in recharts; load it lazily so the chart library
@@ -26,7 +29,7 @@ export const revalidate = 300;
 
 const title = "LLM Rankings — Top Models by Real Usage";
 const description =
-	"Live LLM rankings from real traffic routed through LLM Gateway: top models by token volume, week-over-week trends, and provider market share.";
+	"Live LLM rankings from real traffic routed through LLM Gateway: top models and apps by token volume, usage trends, and provider market share.";
 
 export const metadata: Metadata = {
 	title,
@@ -47,6 +50,10 @@ export const metadata: Metadata = {
 
 interface PublicModelStats {
 	models: Array<{ modelId: string; totalTokens: number }>;
+}
+
+interface PublicApps {
+	apps: RankingsAppStat[];
 }
 
 export default async function RankingsPage() {
@@ -74,14 +81,18 @@ export default async function RankingsPage() {
 		};
 	}
 
-	// Server-side snapshot for structured data only; the interactive list
-	// fetches (the same cached) stats client-side per selected window.
-	const stats = await fetchServerData<PublicModelStats>(
-		"GET",
-		"/public/models/stats",
-		{ params: { query: { window: "7d" } } },
-	);
+	// The model snapshot feeds structured data while the app snapshot renders in
+	// the rankings sidebar. Interactive model stats are fetched client-side.
+	const [stats, apps] = await Promise.all([
+		fetchServerData<PublicModelStats>("GET", "/public/models/stats", {
+			params: { query: { window: "7d" } },
+		}),
+		fetchServerData<PublicApps>("GET", "/public/apps", {
+			params: { query: { limit: "5" } },
+		}),
+	]);
 	const topModels = (stats?.models ?? []).slice(0, 10);
+	const topApps = apps?.apps ?? [];
 
 	const breadcrumbSchema = {
 		"@context": "https://schema.org",
@@ -140,14 +151,15 @@ export default async function RankingsPage() {
 							LLM Rankings
 						</h1>
 						<p className="mt-4 text-muted-foreground md:text-lg">
-							Which models developers actually run in production. Ranked by real
-							token volume routed through LLM Gateway — not benchmarks, not
-							vibes.
+							Which models and apps developers actually use in production.
+							Ranked by real token volume routed through LLM Gateway — not
+							benchmarks, not vibes.
 						</p>
 					</div>
 					<RankingsContent
 						modelMeta={modelMeta}
 						providerNames={providerNames}
+						topApps={topApps}
 					/>
 				</div>
 			</div>

--- a/apps/ui/src/components/apps/app-logo.tsx
+++ b/apps/ui/src/components/apps/app-logo.tsx
@@ -1,0 +1,47 @@
+import { cn } from "@/lib/utils";
+
+import type React from "react";
+
+export function AppLogo({
+	Icon,
+	name,
+	size = "md",
+}: {
+	Icon?: React.FC<React.SVGProps<SVGSVGElement>>;
+	name: string;
+	size?: "sm" | "md" | "lg";
+}) {
+	const dim =
+		size === "lg" ? "h-14 w-14" : size === "sm" ? "h-9 w-9" : "h-12 w-12";
+	const iconDim =
+		size === "lg" ? "h-8 w-8" : size === "sm" ? "h-5 w-5" : "h-7 w-7";
+	if (Icon) {
+		return (
+			<div
+				className={cn(
+					"flex shrink-0 items-center justify-center rounded-xl border border-border/40 bg-muted text-foreground",
+					dim,
+				)}
+				aria-hidden
+			>
+				<Icon className={iconDim} aria-hidden focusable={false} />
+			</div>
+		);
+	}
+	const initial = name
+		.replace(/^https?:\/\//, "")
+		.charAt(0)
+		.toUpperCase();
+	return (
+		<div
+			className={cn(
+				"flex shrink-0 items-center justify-center rounded-xl border border-border/40 bg-muted font-display font-semibold text-muted-foreground",
+				dim,
+				size === "lg" ? "text-xl" : "text-base",
+			)}
+			aria-hidden
+		>
+			{initial || "?"}
+		</div>
+	);
+}

--- a/apps/ui/src/components/apps/apps-grid.tsx
+++ b/apps/ui/src/components/apps/apps-grid.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from "react";
 
 import { cn } from "@/lib/utils";
 
+import { AppLogo } from "./app-logo";
 import { getAppMetadata, type AppMetadata } from "./app-metadata";
 
 interface AppStat {
@@ -72,48 +73,6 @@ function formatRelative(iso: string | null): string | null {
 	}
 	const months = Math.floor(days / 30);
 	return `${months}mo ago`;
-}
-
-function AppLogo({
-	Icon,
-	name,
-	size = "md",
-}: {
-	Icon?: React.FC<React.SVGProps<SVGSVGElement>>;
-	name: string;
-	size?: "sm" | "md" | "lg";
-}) {
-	const dim =
-		size === "lg" ? "h-14 w-14" : size === "sm" ? "h-9 w-9" : "h-12 w-12";
-	const iconDim =
-		size === "lg" ? "h-8 w-8" : size === "sm" ? "h-5 w-5" : "h-7 w-7";
-	if (Icon) {
-		return (
-			<div
-				className={cn(
-					"flex items-center justify-center rounded-xl bg-muted text-foreground border border-border/40",
-					dim,
-				)}
-			>
-				<Icon className={iconDim} />
-			</div>
-		);
-	}
-	const initial = name
-		.replace(/^https?:\/\//, "")
-		.charAt(0)
-		.toUpperCase();
-	return (
-		<div
-			className={cn(
-				"flex items-center justify-center rounded-xl bg-muted border border-border/40 font-display font-semibold text-muted-foreground",
-				dim,
-				size === "lg" ? "text-xl" : "text-base",
-			)}
-		>
-			{initial || "?"}
-		</div>
-	);
 }
 
 function PodiumCard({

--- a/apps/ui/src/components/dashboard/overview.tsx
+++ b/apps/ui/src/components/dashboard/overview.tsx
@@ -3,8 +3,8 @@
 import { addDays, differenceInCalendarDays, format, parseISO } from "date-fns";
 import { useSearchParams } from "next/navigation";
 import {
-	Area,
-	AreaChart,
+	Bar,
+	BarChart,
 	CartesianGrid,
 	ResponsiveContainer,
 	Tooltip,
@@ -220,23 +220,41 @@ function CustomTooltip({
 function LegendItem({
 	color,
 	label,
-	dashed = false,
+	opacity = 1,
 }: {
 	color: string;
 	label: string;
-	dashed?: boolean;
+	opacity?: number;
 }) {
 	return (
 		<span className="inline-flex items-center gap-1.5">
 			<span
-				className="inline-block h-0.5 w-4"
-				style={
-					dashed
-						? {
-								backgroundImage: `repeating-linear-gradient(to right, ${color} 0 5px, transparent 5px 8px)`,
-							}
-						: { backgroundColor: color }
-				}
+				className="inline-block h-2.5 w-2.5 rounded-[2px]"
+				style={{
+					backgroundColor: color,
+					opacity,
+				}}
+			/>
+			{label}
+		</span>
+	);
+}
+
+function PeriodLegendItem({
+	label,
+	opacity = 1,
+}: {
+	label: string;
+	opacity?: number;
+}) {
+	return (
+		<span className="inline-flex items-center gap-1.5">
+			<span
+				className="inline-block h-2.5 w-4 rounded-[2px]"
+				style={{
+					background: `linear-gradient(90deg, ${COLORS.input} 0 33%, ${COLORS.output} 33% 66%, ${COLORS.cached} 66%)`,
+					opacity,
+				}}
 			/>
 			{label}
 		</span>
@@ -329,9 +347,14 @@ export function Overview({
 						<LegendItem color={COLORS.output} label="Output" />
 						<LegendItem color={COLORS.cached} label="Cached input" />
 						{hasComparison && (
-							<LegendItem
-								color={COLORS.current}
+							<PeriodLegendItem
 								label={`Current · ${formatUsageDateRange(currentRange)}`}
+							/>
+						)}
+						{hasComparison && comparisonLabel && (
+							<PeriodLegendItem
+								label={`${comparisonName(comparisonMode)} · ${comparisonLabel}`}
+								opacity={0.38}
 							/>
 						)}
 					</>
@@ -341,13 +364,15 @@ export function Overview({
 						label={`Current · ${formatUsageDateRange(currentRange)}`}
 					/>
 				)}
-				{hasComparison && comparisonLabel && (
-					<LegendItem
-						color={COLORS.comparison}
-						label={`${comparisonName(comparisonMode)} · ${comparisonLabel}`}
-						dashed
-					/>
-				)}
+				{hasComparison &&
+					comparisonLabel &&
+					!(metric === "costs" && costView === "breakdown") && (
+						<LegendItem
+							color={COLORS.comparison}
+							label={`${comparisonName(comparisonMode)} · ${comparisonLabel}`}
+							opacity={0.55}
+						/>
+					)}
 				{isComparisonLoading && (
 					<span className="animate-pulse">Loading comparison…</span>
 				)}
@@ -358,32 +383,12 @@ export function Overview({
 				)}
 			</div>
 			<ResponsiveContainer width="100%" height={350}>
-				<AreaChart
+				<BarChart
 					data={chartData}
 					margin={{ top: 5, right: 10, left: 10, bottom: 0 }}
+					barCategoryGap="18%"
+					barGap={3}
 				>
-					<defs>
-						<linearGradient id="gradientCurrent" x1="0" y1="0" x2="0" y2="1">
-							<stop offset="5%" stopColor={COLORS.current} stopOpacity={0.45} />
-							<stop
-								offset="95%"
-								stopColor={COLORS.current}
-								stopOpacity={0.03}
-							/>
-						</linearGradient>
-						<linearGradient id="gradientInput" x1="0" y1="0" x2="0" y2="1">
-							<stop offset="5%" stopColor={COLORS.input} stopOpacity={0.45} />
-							<stop offset="95%" stopColor={COLORS.input} stopOpacity={0.03} />
-						</linearGradient>
-						<linearGradient id="gradientOutput" x1="0" y1="0" x2="0" y2="1">
-							<stop offset="5%" stopColor={COLORS.output} stopOpacity={0.45} />
-							<stop offset="95%" stopColor={COLORS.output} stopOpacity={0.03} />
-						</linearGradient>
-						<linearGradient id="gradientCached" x1="0" y1="0" x2="0" y2="1">
-							<stop offset="5%" stopColor={COLORS.cached} stopOpacity={0.45} />
-							<stop offset="95%" stopColor={COLORS.cached} stopOpacity={0.03} />
-						</linearGradient>
-					</defs>
 					<CartesianGrid
 						strokeDasharray="3 3"
 						vertical={false}
@@ -424,100 +429,86 @@ export function Overview({
 						cursor={{ stroke: "currentColor", strokeOpacity: 0.15 }}
 					/>
 					{metric === "costs" && costView === "breakdown" && (
-						<Area
-							type="linear"
+						<Bar
 							dataKey="currentInputCost"
-							stroke={COLORS.input}
-							strokeWidth={2}
-							fill="url(#gradientInput)"
-							dot={pointCount === 1}
+							stackId="current"
+							fill={COLORS.input}
+							maxBarSize={56}
 							isAnimationActive={false}
 						/>
 					)}
 					{metric === "costs" && costView === "breakdown" && (
-						<Area
-							type="linear"
+						<Bar
 							dataKey="currentOutputCost"
-							stroke={COLORS.output}
-							strokeWidth={2}
-							fill="url(#gradientOutput)"
-							dot={pointCount === 1}
+							stackId="current"
+							fill={COLORS.output}
+							maxBarSize={56}
 							isAnimationActive={false}
 						/>
 					)}
 					{metric === "costs" && costView === "breakdown" && (
-						<Area
-							type="linear"
+						<Bar
 							dataKey="currentCachedInputCost"
-							stroke={COLORS.cached}
-							strokeWidth={2}
-							fill="url(#gradientCached)"
-							dot={pointCount === 1}
+							stackId="current"
+							fill={COLORS.cached}
+							radius={[4, 4, 0, 0]}
+							maxBarSize={56}
 							isAnimationActive={false}
 						/>
 					)}
 					{metric === "costs" && costView === "breakdown" && hasComparison && (
-						<Area
-							type="linear"
+						<Bar
 							dataKey="comparisonInputCost"
-							stroke={COLORS.input}
-							strokeWidth={1.5}
-							strokeDasharray="5 4"
-							fill="none"
-							dot={pointCount === 1}
+							stackId="comparison"
+							fill={COLORS.input}
+							fillOpacity={0.38}
+							maxBarSize={56}
 							isAnimationActive={false}
 						/>
 					)}
 					{metric === "costs" && costView === "breakdown" && hasComparison && (
-						<Area
-							type="linear"
+						<Bar
 							dataKey="comparisonOutputCost"
-							stroke={COLORS.output}
-							strokeWidth={1.5}
-							strokeDasharray="5 4"
-							fill="none"
-							dot={pointCount === 1}
+							stackId="comparison"
+							fill={COLORS.output}
+							fillOpacity={0.38}
+							maxBarSize={56}
 							isAnimationActive={false}
 						/>
 					)}
 					{metric === "costs" && costView === "breakdown" && hasComparison && (
-						<Area
-							type="linear"
+						<Bar
 							dataKey="comparisonCachedInputCost"
-							stroke={COLORS.cached}
-							strokeWidth={1.5}
-							strokeDasharray="5 4"
-							fill="none"
-							dot={pointCount === 1}
+							stackId="comparison"
+							fill={COLORS.cached}
+							fillOpacity={0.38}
+							radius={[4, 4, 0, 0]}
+							maxBarSize={56}
 							isAnimationActive={false}
 						/>
 					)}
 					{(metric !== "costs" || costView === "total") && (
-						<Area
-							type="linear"
+						<Bar
 							dataKey={metric === "costs" ? "currentCost" : "currentRequests"}
-							stroke={COLORS.current}
-							strokeWidth={2.25}
-							fill="url(#gradientCurrent)"
-							dot={pointCount === 1}
+							fill={COLORS.current}
+							radius={[4, 4, 0, 0]}
+							maxBarSize={56}
 							isAnimationActive={false}
 						/>
 					)}
 					{(metric !== "costs" || costView === "total") && hasComparison && (
-						<Area
-							type="linear"
+						<Bar
 							dataKey={
 								metric === "costs" ? "comparisonCost" : "comparisonRequests"
 							}
-							stroke={COLORS.comparison}
-							strokeWidth={2}
-							strokeDasharray="6 5"
-							fill="none"
-							dot={pointCount === 1}
+							fill={COLORS.comparison}
+							fillOpacity={0.55}
+							radius={[4, 4, 0, 0]}
+							maxBarSize={56}
 							isAnimationActive={false}
 						/>
 					)}
-				</AreaChart>
+				</BarChart>
 			</ResponsiveContainer>
 		</div>
 	);

--- a/apps/ui/src/components/rankings/rankings-content.tsx
+++ b/apps/ui/src/components/rankings/rankings-content.tsx
@@ -1,15 +1,24 @@
 "use client";
 
 import { format } from "date-fns";
-import { ChevronDown, Server, TrendingDown, TrendingUp } from "lucide-react";
+import {
+	ArrowRight,
+	ChevronDown,
+	Server,
+	TrendingDown,
+	TrendingUp,
+} from "lucide-react";
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 
+import { AppLogo } from "@/components/apps/app-logo";
+import { getAppMetadata } from "@/components/apps/app-metadata";
 import { Badge } from "@/lib/components/badge";
 import { Button } from "@/lib/components/button";
 import {
 	Card,
+	CardAction,
 	CardContent,
 	CardDescription,
 	CardHeader,
@@ -33,9 +42,17 @@ export interface RankingsModelMeta {
 	providerId: string;
 }
 
+export interface RankingsAppStat {
+	source: string;
+	totalTokens: number;
+	totalRequests: number;
+	lastUsedAt: string | null;
+}
+
 interface RankingsContentProps {
 	modelMeta: Record<string, RankingsModelMeta>;
 	providerNames: Record<string, string>;
+	topApps: RankingsAppStat[];
 }
 
 type StatsWindow = "24h" | "7d" | "30d";
@@ -66,12 +83,6 @@ const CHART_SERIES_LIMIT = SERIES_PALETTE.length;
 
 const LEADERBOARD_PREVIEW_COUNT = 20;
 const PROVIDER_SHARE_COUNT = 12;
-
-// Model ids contain dots (e.g. "gpt-5.2"), which recharts would interpret as
-// nested data paths, so chart keys are sanitized before use.
-function chartKey(modelId: string): string {
-	return modelId.replace(/[^a-zA-Z0-9_-]/g, "_");
-}
 
 function TrendBadge({ trendPercent }: { trendPercent: number | null }) {
 	if (trendPercent === null) {
@@ -119,13 +130,77 @@ function ProviderIconBadge({
 	return <Icon className={className} aria-hidden />;
 }
 
+function TopAppRow({
+	app,
+	rank,
+	leaderTokens,
+}: {
+	app: RankingsAppStat;
+	rank: number;
+	leaderTokens: number;
+}) {
+	const metadata = getAppMetadata(app.source);
+	const share = leaderTokens > 0 ? (app.totalTokens / leaderTokens) * 100 : 0;
+	const content = (
+		<>
+			<span className="w-4 shrink-0 text-right font-mono text-xs tabular-nums text-muted-foreground">
+				{rank}
+			</span>
+			<AppLogo Icon={metadata.Icon} name={metadata.displayName} size="sm" />
+			<span className="min-w-0 flex-1">
+				<span className="flex items-center justify-between gap-3 text-sm">
+					<span className="truncate font-medium group-hover:underline group-hover:underline-offset-4">
+						{metadata.displayName}
+					</span>
+					<span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+						{formatCompact(app.totalTokens)}
+					</span>
+				</span>
+				<span className="mt-1.5 block h-1 overflow-hidden rounded-full bg-muted">
+					<span
+						className={cn(
+							"block h-full rounded-full transition-[width]",
+							rank === 1 ? "bg-blue-500 dark:bg-blue-400" : "bg-foreground/70",
+						)}
+						style={{ width: share > 0 ? `${Math.max(share, 1)}%` : "0%" }}
+					/>
+				</span>
+			</span>
+		</>
+	);
+	const rowClassName = "flex items-center gap-3 rounded-lg px-2 py-2";
+
+	return (
+		<li>
+			{metadata.url ? (
+				<a
+					href={metadata.url}
+					target="_blank"
+					rel="noopener noreferrer"
+					className={cn(
+						rowClassName,
+						"group outline-none transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring/50",
+					)}
+				>
+					{content}
+				</a>
+			) : (
+				<div className={rowClassName}>{content}</div>
+			)}
+		</li>
+	);
+}
+
 export function RankingsContent({
 	modelMeta,
 	providerNames,
+	topApps,
 }: RankingsContentProps) {
 	const api = useApi();
 	const [statsWindow, setStatsWindow] = useState<StatsWindow>("7d");
 	const [showAllModels, setShowAllModels] = useState(false);
+	const [hoveredModelId, setHoveredModelId] = useState<string | null>(null);
+	const [focusedModelId, setFocusedModelId] = useState<string | null>(null);
 
 	const { data, isLoading } = api.useQuery(
 		"get",
@@ -143,34 +218,71 @@ export function RankingsContent({
 		() => (data?.series ?? []).slice(0, CHART_SERIES_LIMIT),
 		[data],
 	);
+	const chartKeyByModelId = useMemo(
+		() =>
+			new Map(series.map((entry, index) => [entry.modelId, `series_${index}`])),
+		[series],
+	);
 
 	const chartConfig = useMemo(() => {
 		const config: ChartConfig = {};
 		series.forEach((entry, index) => {
 			const palette = SERIES_PALETTE[index];
-			config[chartKey(entry.modelId)] = {
+			const key = chartKeyByModelId.get(entry.modelId);
+			if (!key) {
+				return;
+			}
+			config[key] = {
 				label: modelMeta[entry.modelId]?.name ?? entry.modelId,
 				theme: { light: palette.light, dark: palette.dark },
 			};
 		});
 		return config;
-	}, [series, modelMeta]);
+	}, [series, chartKeyByModelId, modelMeta]);
 
-	const chartedKeys = useMemo(
-		() => new Set(series.map((entry) => chartKey(entry.modelId))),
+	const chartedModelIds = useMemo(
+		() => new Set(series.map((entry) => entry.modelId)),
 		[series],
 	);
+	const modelTokensById = useMemo(
+		() => new Map(models.map((model) => [model.modelId, model.totalTokens])),
+		[models],
+	);
+	const requestedActiveModelId = hoveredModelId ?? focusedModelId;
+	const activeModelId = series.some(
+		(entry) => entry.modelId === requestedActiveModelId,
+	)
+		? requestedActiveModelId
+		: null;
+	const displayedSeries = useMemo(() => {
+		if (!activeModelId) {
+			return series;
+		}
+		const activeSeries = series.find(
+			(entry) => entry.modelId === activeModelId,
+		);
+		return activeSeries
+			? [
+					activeSeries,
+					...series.filter((entry) => entry.modelId !== activeModelId),
+				]
+			: series;
+	}, [activeModelId, series]);
 
 	const chartData = useMemo(() => {
 		const rows = new Map<string, Record<string, number | string>>();
 		for (const entry of series) {
+			const key = chartKeyByModelId.get(entry.modelId);
+			if (!key) {
+				continue;
+			}
 			for (const point of entry.points) {
 				const row = rows.get(point.timestamp) ?? { timestamp: point.timestamp };
-				row[chartKey(entry.modelId)] = point.totalTokens;
+				row[key] = point.totalTokens;
 				rows.set(point.timestamp, row);
 			}
 		}
-		const keys = series.map((entry) => chartKey(entry.modelId));
+		const keys = Array.from(chartKeyByModelId.values());
 		return Array.from(rows.values())
 			.map((row) => {
 				for (const key of keys) {
@@ -179,7 +291,7 @@ export function RankingsContent({
 				return row;
 			})
 			.sort((a, b) => String(a.timestamp).localeCompare(String(b.timestamp)));
-	}, [series]);
+	}, [series, chartKeyByModelId]);
 
 	// Hourly buckets in the 7d window are too dense for per-bucket ticks, so
 	// the axis marks the first bucket of each local calendar day — robust to
@@ -213,6 +325,16 @@ export function RankingsContent({
 	const otherProviderTokens = providers
 		.slice(PROVIDER_SHARE_COUNT)
 		.reduce((sum, p) => sum + p.totalTokens, 0);
+	const topAppLeaderTokens = topApps[0]?.totalTokens ?? 0;
+
+	const selectStatsWindow = (window: StatsWindow) => {
+		setHoveredModelId(null);
+		setFocusedModelId(null);
+		setStatsWindow(window);
+	};
+	const clearHoveredModel = (modelId: string) => {
+		setHoveredModelId((current) => (current === modelId ? null : current));
+	};
 
 	const tickFormatter = (value: string) =>
 		statsWindow === "24h"
@@ -237,7 +359,7 @@ export function RankingsContent({
 							type="button"
 							role="tab"
 							aria-selected={statsWindow === option.value}
-							onClick={() => setStatsWindow(option.value)}
+							onClick={() => selectStatsWindow(option.value)}
 							className={cn(
 								"rounded-md px-3 py-1.5 text-sm transition-colors",
 								statsWindow === option.value
@@ -295,7 +417,7 @@ export function RankingsContent({
 					<CardTitle>Token volume by model</CardTitle>
 					<CardDescription>
 						Tokens processed through LLM Gateway for the top models over the
-						selected window.
+						selected window. Hover or focus a model to isolate its usage.
 					</CardDescription>
 				</CardHeader>
 				<CardContent>
@@ -306,11 +428,11 @@ export function RankingsContent({
 							Not enough traffic in this window yet.
 						</div>
 					) : (
-						<>
+						<div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(15rem,18rem)] lg:items-center">
 							<ChartContainer
 								id="rankings"
 								config={chartConfig}
-								className="h-72 w-full"
+								className="h-72 w-full [&_.recharts-bar-rectangle]:transition-[fill] [&_.recharts-bar-rectangle]:duration-200"
 							>
 								<BarChart
 									data={chartData}
@@ -361,12 +483,14 @@ export function RankingsContent({
 														</div>
 													);
 												}}
-												formatter={(value, name, item) => (
+												formatter={(value, name) => (
 													<div className="flex w-full items-center justify-between gap-4">
 														<div className="flex items-center gap-1.5">
 															<span
 																className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
-																style={{ background: item.color }}
+																style={{
+																	background: `var(--color-${String(name)})`,
+																}}
 															/>
 															<span className="text-muted-foreground">
 																{chartConfig[name as string]?.label ?? name}
@@ -380,38 +504,81 @@ export function RankingsContent({
 											/>
 										}
 									/>
-									{series.map((entry) => {
-										const key = chartKey(entry.modelId);
+									{displayedSeries.map((entry) => {
+										const key = chartKeyByModelId.get(entry.modelId);
+										if (!key) {
+											return null;
+										}
 										return (
 											<Bar
-												key={key}
+												key={entry.modelId}
 												dataKey={key}
 												stackId="models"
-												fill={`var(--color-${key})`}
+												fill={
+													activeModelId && activeModelId !== entry.modelId
+														? "var(--muted)"
+														: `var(--color-${key})`
+												}
+												isAnimationActive={false}
 											/>
 										);
 									})}
 								</BarChart>
 							</ChartContainer>
-							<div className="mt-4 flex flex-wrap gap-x-4 gap-y-2">
-								{series.map((entry, index) => (
-									<Link
-										key={entry.modelId}
-										href={`/models/${encodeURIComponent(entry.modelId)}`}
-										className="inline-flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
-									>
-										<span
-											className="h-2.5 w-2.5 rounded-[2px]"
-											style={{
-												background: `var(--color-${chartKey(entry.modelId)})`,
-											}}
-										/>
-										{modelMeta[entry.modelId]?.name ?? entry.modelId}
-										<span className="sr-only">{`ranked #${index + 1}`}</span>
-									</Link>
-								))}
-							</div>
-						</>
+							<ol
+								className="grid gap-1 sm:grid-cols-2 lg:grid-cols-1"
+								aria-label="Models shown in the token volume chart"
+							>
+								{series.map((entry, index) => {
+									const key = chartKeyByModelId.get(entry.modelId);
+									if (!key) {
+										return null;
+									}
+									const modelName =
+										modelMeta[entry.modelId]?.name ?? entry.modelId;
+									const share = data?.totals.totalTokens
+										? ((modelTokensById.get(entry.modelId) ?? 0) /
+												data.totals.totalTokens) *
+											100
+										: 0;
+									const isActive = activeModelId === entry.modelId;
+									return (
+										<li key={entry.modelId}>
+											<Link
+												href={`/models/${encodeURIComponent(entry.modelId)}`}
+												onPointerEnter={() => setHoveredModelId(entry.modelId)}
+												onPointerLeave={() => clearHoveredModel(entry.modelId)}
+												onPointerCancel={() => clearHoveredModel(entry.modelId)}
+												onFocus={() => setFocusedModelId(entry.modelId)}
+												onBlur={() =>
+													setFocusedModelId((current) =>
+														current === entry.modelId ? null : current,
+													)
+												}
+												className={cn(
+													"grid h-8 grid-cols-[1.25rem_auto_minmax(0,1fr)_auto] items-center gap-2 rounded-md px-2 text-xs outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring/50",
+													isActive
+														? "bg-muted font-medium text-foreground"
+														: "text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+												)}
+											>
+												<span className="font-mono tabular-nums text-muted-foreground">
+													{index + 1}
+												</span>
+												<span
+													className="h-2.5 w-2.5 rounded-full"
+													style={{ background: `var(--color-${key})` }}
+												/>
+												<span className="truncate">{modelName}</span>
+												<span className="font-mono tabular-nums text-foreground">
+													{share.toFixed(1)}%
+												</span>
+											</Link>
+										</li>
+									);
+								})}
+							</ol>
+						</div>
 					)}
 				</CardContent>
 			</Card>
@@ -449,7 +616,8 @@ export function RankingsContent({
 											leaderTokens > 0
 												? (model.totalTokens / leaderTokens) * 100
 												: 0;
-										const isCharted = chartedKeys.has(chartKey(model.modelId));
+										const chartedKey = chartKeyByModelId.get(model.modelId);
+										const isCharted = chartedModelIds.has(model.modelId);
 										return (
 											<li key={model.modelId}>
 												<Link
@@ -483,9 +651,10 @@ export function RankingsContent({
 																className="block h-full rounded-full"
 																style={{
 																	width: `${Math.max(share, 1.5)}%`,
-																	background: isCharted
-																		? `var(--color-${chartKey(model.modelId)})`
-																		: "color-mix(in oklab, var(--muted-foreground) 50%, transparent)",
+																	background:
+																		isCharted && chartedKey
+																			? `var(--color-${chartedKey})`
+																			: "color-mix(in oklab, var(--muted-foreground) 50%, transparent)",
 																}}
 															/>
 														</span>
@@ -529,76 +698,113 @@ export function RankingsContent({
 					</CardContent>
 				</Card>
 
-				{/* Provider market share */}
-				<Card>
-					<CardHeader>
-						<CardTitle>Provider market share</CardTitle>
-						<CardDescription>
-							Share of token volume routed to each provider.
-						</CardDescription>
-					</CardHeader>
-					<CardContent>
-						{isLoading ? (
-							<div className="space-y-3">
-								{[1, 2, 3, 4, 5].map((i) => (
-									<div
-										key={i}
-										className="h-10 animate-pulse rounded bg-muted"
-									/>
-								))}
-							</div>
-						) : topProviders.length === 0 ? (
-							<p className="py-8 text-center text-sm text-muted-foreground">
-								Not enough traffic in this window yet.
-							</p>
-						) : (
-							<ul className="space-y-4">
-								{topProviders.map((provider) => {
-									const share =
-										providerTotalTokens > 0
-											? (provider.totalTokens / providerTotalTokens) * 100
-											: 0;
-									return (
-										<li key={provider.providerId}>
-											<Link
-												href={`/providers/${encodeURIComponent(provider.providerId)}`}
-												className="group block"
-											>
-												<span className="flex items-center justify-between gap-2 text-sm">
-													<span className="flex min-w-0 items-center gap-2">
-														<ProviderIconBadge
-															providerId={provider.providerId}
-															className="h-4 w-4 shrink-0"
-														/>
-														<span className="truncate group-hover:underline group-hover:underline-offset-4">
-															{providerNames[provider.providerId] ??
-																provider.providerId}
+				<div className="space-y-6">
+					{/* Provider market share */}
+					<Card>
+						<CardHeader>
+							<CardTitle>Provider market share</CardTitle>
+							<CardDescription>
+								Share of token volume routed to each provider.
+							</CardDescription>
+						</CardHeader>
+						<CardContent>
+							{isLoading ? (
+								<div className="space-y-3">
+									{[1, 2, 3, 4, 5].map((i) => (
+										<div
+											key={i}
+											className="h-10 animate-pulse rounded bg-muted"
+										/>
+									))}
+								</div>
+							) : topProviders.length === 0 ? (
+								<p className="py-8 text-center text-sm text-muted-foreground">
+									Not enough traffic in this window yet.
+								</p>
+							) : (
+								<ul className="space-y-4">
+									{topProviders.map((provider) => {
+										const share =
+											providerTotalTokens > 0
+												? (provider.totalTokens / providerTotalTokens) * 100
+												: 0;
+										return (
+											<li key={provider.providerId}>
+												<Link
+													href={`/providers/${encodeURIComponent(provider.providerId)}`}
+													className="group block"
+												>
+													<span className="flex items-center justify-between gap-2 text-sm">
+														<span className="flex min-w-0 items-center gap-2">
+															<ProviderIconBadge
+																providerId={provider.providerId}
+																className="h-4 w-4 shrink-0"
+															/>
+															<span className="truncate group-hover:underline group-hover:underline-offset-4">
+																{providerNames[provider.providerId] ??
+																	provider.providerId}
+															</span>
+														</span>
+														<span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
+															{share.toFixed(1)}%
 														</span>
 													</span>
-													<span className="shrink-0 font-mono text-xs tabular-nums text-muted-foreground">
-														{share.toFixed(1)}%
+													<span className="mt-1.5 block h-1.5 overflow-hidden rounded-full bg-muted">
+														<span
+															className="block h-full rounded-full bg-foreground/70 transition-[width]"
+															style={{ width: `${Math.max(share, 1)}%` }}
+														/>
 													</span>
-												</span>
-												<span className="mt-1.5 block h-1.5 overflow-hidden rounded-full bg-muted">
-													<span
-														className="block h-full rounded-full bg-foreground/70 transition-[width]"
-														style={{ width: `${Math.max(share, 1)}%` }}
-													/>
-												</span>
-											</Link>
+												</Link>
+											</li>
+										);
+									})}
+									{otherProviderTokens > 0 && (
+										<li className="text-xs text-muted-foreground">
+											+ {formatCompact(otherProviderTokens)} tokens across{" "}
+											{providers.length - PROVIDER_SHARE_COUNT} more providers
 										</li>
-									);
-								})}
-								{otherProviderTokens > 0 && (
-									<li className="text-xs text-muted-foreground">
-										+ {formatCompact(otherProviderTokens)} tokens across{" "}
-										{providers.length - PROVIDER_SHARE_COUNT} more providers
-									</li>
-								)}
-							</ul>
-						)}
-					</CardContent>
-				</Card>
+									)}
+								</ul>
+							)}
+						</CardContent>
+					</Card>
+
+					<Card>
+						<CardHeader>
+							<CardTitle>Top apps</CardTitle>
+							<CardDescription>
+								All-time token volume by app and source.
+							</CardDescription>
+							<CardAction>
+								<Button asChild variant="ghost" size="sm" className="-mr-2">
+									<Link href="/apps">
+										View all
+										<ArrowRight className="h-3.5 w-3.5" />
+									</Link>
+								</Button>
+							</CardAction>
+						</CardHeader>
+						<CardContent>
+							{topApps.length === 0 ? (
+								<p className="py-8 text-center text-sm text-muted-foreground">
+									No app traffic recorded yet.
+								</p>
+							) : (
+								<ol className="space-y-1">
+									{topApps.map((app, index) => (
+										<TopAppRow
+											key={app.source}
+											app={app}
+											rank={index + 1}
+											leaderTokens={topAppLeaderTokens}
+										/>
+									))}
+								</ol>
+							)}
+						</CardContent>
+					</Card>
+				</div>
 			</div>
 		</div>
 	);

--- a/ee/admin/src/app/global-stats/client.tsx
+++ b/ee/admin/src/app/global-stats/client.tsx
@@ -18,12 +18,18 @@ import {
 	CartesianGrid,
 	Cell,
 	Legend,
+	Line,
+	LineChart,
 	Pie,
 	PieChart,
 	XAxis,
 	YAxis,
 } from "recharts";
 
+import {
+	ChartTypeToggle,
+	type ChartType,
+} from "@/components/chart-type-toggle";
 import {
 	GlobalStatsRangePicker,
 	resolveGlobalStatsRange,
@@ -39,8 +45,6 @@ import {
 } from "@/components/ui/card";
 import {
 	ChartContainer,
-	ChartLegend,
-	ChartLegendContent,
 	ChartTooltip,
 	ChartTooltipContent,
 } from "@/components/ui/chart";
@@ -49,11 +53,13 @@ import {
 	useUsageMode,
 } from "@/components/usage-mode-selector";
 import { useApi } from "@/lib/fetch-client";
+import { buildGlobalStatsStackedChart } from "@/lib/global-stats-chart";
 import { orgKindDescription, orgKindLabel } from "@/lib/org-kind";
 import { usageModeDescription, usageModeLabel } from "@/lib/usage-mode";
 import { cn } from "@/lib/utils";
 
 import type { ChartConfig } from "@/components/ui/chart";
+import type { ReactNode } from "react";
 
 type GroupBy = "model" | "source" | "mode" | "kind";
 type ModelView = "mapping" | "canonical" | "provider";
@@ -143,7 +149,6 @@ const BREAKDOWN_PAGE_SIZE = 25;
 
 // Max distinct series in the stacked bar chart before the rest collapse into "Other".
 const TIMESERIES_STACK_LIMIT = 8;
-const OTHER_KEY = "__other__";
 const OTHER_COLOR = "hsl(215 16% 47%)";
 
 function parseGroupBy(value: string | null): GroupBy {
@@ -215,6 +220,29 @@ function StatCard({
 	);
 }
 
+function ToolbarGroup({
+	label,
+	children,
+	className,
+}: {
+	label: string;
+	children: ReactNode;
+	className?: string;
+}) {
+	return (
+		<div
+			className={cn("flex min-w-0 flex-col gap-1.5", className)}
+			role="group"
+			aria-label={label}
+		>
+			<span className="font-mono text-[9px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+				{label}
+			</span>
+			{children}
+		</div>
+	);
+}
+
 /**
  * "PAYG: $12.30 · DevPass: $4.10" from a composition slice, skipping empty
  * buckets. Null when there is nothing to compare against, so the caller can
@@ -266,6 +294,8 @@ export function GlobalStatsClient() {
 	const chartMetric = parseMetric(searchParams.get("metric"));
 	const modelView = parseModelView(searchParams.get("modelView"));
 	const showTimeseriesBreakdown = parseBreakdown(searchParams.get("breakdown"));
+	const [chartType, setChartType] = useState<ChartType>("bar");
+	const TimeseriesChart = chartType === "bar" ? BarChart : LineChart;
 
 	const updateParam = useCallback(
 		(key: string, value: string) => {
@@ -398,17 +428,23 @@ export function GlobalStatsClient() {
 	// Pie data: top 10 by the selected metric, the rest collapsed into "Other".
 	const pieData = useMemo(() => {
 		if (breakdown.length === 0) {
-			return [] as { name: string; value: number; key: string }[];
+			return [] as {
+				name: string;
+				value: number;
+				key: string;
+				chartKey: string;
+			}[];
 		}
 		const sorted = [...breakdown].sort(
 			(a, b) => b[chartMetric] - a[chartMetric],
 		);
 		const top = sorted.slice(0, 10);
 		const rest = sorted.slice(10);
-		const items = top.map((b) => ({
+		const items = top.map((b, index) => ({
 			name: b.label,
 			value: b[chartMetric],
 			key: b.key,
+			chartKey: `slice_${index}`,
 		}));
 		if (rest.length > 0) {
 			const otherValue = rest.reduce((sum, b) => sum + b[chartMetric], 0);
@@ -417,6 +453,7 @@ export function GlobalStatsClient() {
 					name: `Other (${rest.length})`,
 					value: otherValue,
 					key: "__other__",
+					chartKey: "slice_other",
 				});
 			}
 		}
@@ -426,7 +463,7 @@ export function GlobalStatsClient() {
 	const pieChartConfig = useMemo<ChartConfig>(() => {
 		const config: ChartConfig = {};
 		pieData.forEach((slice, idx) => {
-			config[slice.key] = {
+			config[slice.chartKey] = {
 				label: slice.name,
 				color: PIE_COLORS[idx % PIE_COLORS.length],
 			};
@@ -441,51 +478,31 @@ export function GlobalStatsClient() {
 		[breakdown, chartMetric],
 	);
 
-	// Top dimensions (by the selected metric) shown as their own stacked series;
-	// everything else collapses into a single "Other" bucket.
-	const stackSeries = useMemo(() => {
-		const top = sortedBreakdown.slice(0, TIMESERIES_STACK_LIMIT);
-		const restCount = Math.max(0, sortedBreakdown.length - top.length);
-		const keys = top.map((b) => b.key);
-		if (restCount > 0) {
-			keys.push(OTHER_KEY);
-		}
-		return { top, topKeys: new Set(top.map((b) => b.key)), restCount, keys };
-	}, [sortedBreakdown]);
+	const stackedChart = useMemo(
+		() =>
+			buildGlobalStatsStackedChart({
+				rankedBreakdown: sortedBreakdown,
+				timeseries,
+				timeseriesBreakdown,
+				metric: chartMetric,
+				limit: TIMESERIES_STACK_LIMIT,
+			}),
+		[sortedBreakdown, timeseries, timeseriesBreakdown, chartMetric],
+	);
 
 	const stackChartConfig = useMemo<ChartConfig>(() => {
 		const config: ChartConfig = {};
-		stackSeries.top.forEach((b, idx) => {
-			config[b.key] = {
-				label: b.label,
-				color: PIE_COLORS[idx % PIE_COLORS.length],
+		stackedChart.series.forEach((entry, index) => {
+			config[entry.chartKey] = {
+				label: entry.label,
+				color:
+					entry.sourceKey === null
+						? OTHER_COLOR
+						: PIE_COLORS[index % PIE_COLORS.length],
 			};
 		});
-		if (stackSeries.restCount > 0) {
-			config[OTHER_KEY] = {
-				label: `Other (${stackSeries.restCount})`,
-				color: OTHER_COLOR,
-			};
-		}
 		return config;
-	}, [stackSeries]);
-
-	const stackedTimeseries = useMemo(() => {
-		const byDate = new Map<string, Record<string, number | string>>();
-		for (const point of timeseries) {
-			byDate.set(point.date, { date: point.date });
-		}
-		for (const row of timeseriesBreakdown) {
-			const entry = byDate.get(row.date);
-			if (!entry) {
-				continue;
-			}
-			const seriesKey = stackSeries.topKeys.has(row.key) ? row.key : OTHER_KEY;
-			entry[seriesKey] =
-				((entry[seriesKey] as number | undefined) ?? 0) + row[chartMetric];
-		}
-		return Array.from(byDate.values());
-	}, [timeseries, timeseriesBreakdown, stackSeries, chartMetric]);
+	}, [stackedChart.series]);
 
 	const breakdownNoun =
 		groupBy === "model"
@@ -532,8 +549,8 @@ export function GlobalStatsClient() {
 
 	return (
 		<div className="mx-auto flex w-full max-w-[1920px] flex-col gap-6 px-4 py-8 md:px-8">
-			<header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-				<div>
+			<header className="space-y-5">
+				<div className="max-w-4xl">
 					<h1 className="text-3xl font-semibold tracking-tight">
 						Global Stats
 					</h1>
@@ -548,27 +565,45 @@ export function GlobalStatsClient() {
 						</p>
 					) : null}
 				</div>
-				<div className="flex flex-wrap items-center gap-3">
-					<UsageModeSelector compact />
-					<OrgKindSelector compact />
-					<div className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-1">
-						{GROUP_OPTIONS.map((opt) => {
-							const Icon = opt.icon;
-							return (
-								<Button
-									key={opt.value}
-									variant={groupBy === opt.value ? "default" : "ghost"}
-									size="sm"
-									className="h-7 gap-1.5 px-3 text-xs"
-									onClick={() => setGroupBy(opt.value)}
-								>
-									<Icon className="h-3.5 w-3.5" />
-									{opt.label}
-								</Button>
-							);
-						})}
+				<div className="rounded-xl border border-border/60 bg-card/70 p-3 shadow-sm">
+					<div className="grid gap-3 md:grid-cols-2 xl:grid-cols-[auto_auto_minmax(0,1fr)_auto] xl:items-end">
+						<ToolbarGroup label="Traffic">
+							<UsageModeSelector
+								compact
+								className="w-fit max-w-full flex-wrap"
+							/>
+						</ToolbarGroup>
+						<ToolbarGroup label="Organization">
+							<OrgKindSelector compact className="w-fit max-w-full flex-wrap" />
+						</ToolbarGroup>
+						<ToolbarGroup label="Break down by">
+							<div
+								className="flex w-fit max-w-full flex-wrap items-center gap-1 rounded-md border border-border/60 bg-background p-1"
+								role="group"
+								aria-label="Break down by"
+							>
+								{GROUP_OPTIONS.map((opt) => {
+									const Icon = opt.icon;
+									return (
+										<Button
+											key={opt.value}
+											variant={groupBy === opt.value ? "default" : "ghost"}
+											size="sm"
+											className="h-7 gap-1.5 px-3 text-xs"
+											aria-pressed={groupBy === opt.value}
+											onClick={() => setGroupBy(opt.value)}
+										>
+											<Icon className="h-3.5 w-3.5" aria-hidden />
+											{opt.label}
+										</Button>
+									);
+								})}
+							</div>
+						</ToolbarGroup>
+						<ToolbarGroup label="Range">
+							<GlobalStatsRangePicker />
+						</ToolbarGroup>
 					</div>
-					<GlobalStatsRangePicker />
 				</div>
 			</header>
 
@@ -645,8 +680,8 @@ export function GlobalStatsClient() {
 			</section>
 
 			<Card>
-				<CardHeader className="flex flex-col items-stretch space-y-2 border-b p-4 sm:flex-row sm:items-center sm:justify-between sm:space-y-0 sm:p-6">
-					<div>
+				<CardHeader className="gap-0 space-y-0 border-b p-0">
+					<div className="p-4 sm:p-6">
 						<CardTitle>Daily timeseries</CardTitle>
 						<CardDescription>
 							Aggregate{" "}
@@ -670,58 +705,80 @@ export function GlobalStatsClient() {
 							.{scopeParts.length > 0 ? ` ${scopeLabel} traffic only.` : ""}
 						</CardDescription>
 					</div>
-					<div className="flex flex-wrap items-center gap-2">
-						<Button
-							variant={showTimeseriesBreakdown ? "default" : "outline"}
-							size="sm"
-							className="h-7 gap-1.5 px-3 text-xs"
-							onClick={toggleTimeseriesBreakdown}
-						>
-							{groupBy === "model" ? (
-								<Cpu className="h-3.5 w-3.5" />
-							) : groupBy === "mode" ? (
-								<Wallet className="h-3.5 w-3.5" />
-							) : groupBy === "kind" ? (
-								<Building2 className="h-3.5 w-3.5" />
-							) : (
-								<Layers className="h-3.5 w-3.5" />
-							)}
-							Breakdown
-						</Button>
+					<div className="flex flex-wrap items-end gap-3 border-t border-border/60 bg-muted/20 px-4 py-3 sm:px-6">
+						<ToolbarGroup label="Display">
+							<Button
+								variant={showTimeseriesBreakdown ? "secondary" : "outline"}
+								size="sm"
+								className="h-8 gap-1.5 px-3 text-xs"
+								aria-pressed={showTimeseriesBreakdown}
+								onClick={toggleTimeseriesBreakdown}
+							>
+								{groupBy === "model" ? (
+									<Cpu className="h-3.5 w-3.5" aria-hidden />
+								) : groupBy === "mode" ? (
+									<Wallet className="h-3.5 w-3.5" aria-hidden />
+								) : groupBy === "kind" ? (
+									<Building2 className="h-3.5 w-3.5" aria-hidden />
+								) : (
+									<Layers className="h-3.5 w-3.5" aria-hidden />
+								)}
+								Breakdown
+							</Button>
+						</ToolbarGroup>
 						{showTimeseriesBreakdown && groupBy === "model" ? (
-							<div className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-1">
-								{MODEL_VIEW_OPTIONS.map((opt) => {
-									const Icon = opt.icon;
-									return (
-										<Button
-											key={opt.value}
-											variant={modelView === opt.value ? "default" : "ghost"}
-											size="sm"
-											className="h-7 gap-1.5 px-3 text-xs"
-											onClick={() => setModelView(opt.value)}
-										>
-											<Icon className="h-3.5 w-3.5" />
-											{opt.label}
-										</Button>
-									);
-								})}
-							</div>
+							<ToolbarGroup label="Model view">
+								<div
+									className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-0.5"
+									role="group"
+									aria-label="Model view"
+								>
+									{MODEL_VIEW_OPTIONS.map((opt) => {
+										const Icon = opt.icon;
+										return (
+											<Button
+												key={opt.value}
+												variant={
+													modelView === opt.value ? "secondary" : "ghost"
+												}
+												size="sm"
+												className="h-7 gap-1.5 px-3 text-xs shadow-none"
+												aria-pressed={modelView === opt.value}
+												onClick={() => setModelView(opt.value)}
+											>
+												<Icon className="h-3.5 w-3.5" aria-hidden />
+												{opt.label}
+											</Button>
+										);
+									})}
+								</div>
+							</ToolbarGroup>
 						) : null}
-						<div className="flex items-center gap-1">
-							{(Object.keys(timeseriesChartConfig) as TimeseriesMetric[]).map(
-								(m) => (
-									<Button
-										key={m}
-										variant={chartMetric === m ? "default" : "outline"}
-										size="sm"
-										className="h-7 px-3 text-xs"
-										onClick={() => setChartMetric(m)}
-									>
-										{timeseriesChartConfig[m].label as string}
-									</Button>
-								),
-							)}
-						</div>
+						<ToolbarGroup label="Measure">
+							<div
+								className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-0.5"
+								role="group"
+								aria-label="Measure"
+							>
+								{(Object.keys(timeseriesChartConfig) as TimeseriesMetric[]).map(
+									(m) => (
+										<Button
+											key={m}
+											variant={chartMetric === m ? "secondary" : "ghost"}
+											size="sm"
+											className="h-7 px-3 text-xs shadow-none"
+											aria-pressed={chartMetric === m}
+											onClick={() => setChartMetric(m)}
+										>
+											{timeseriesChartConfig[m].label as string}
+										</Button>
+									),
+								)}
+							</div>
+						</ToolbarGroup>
+						<ToolbarGroup label="Chart">
+							<ChartTypeToggle value={chartType} onValueChange={setChartType} />
+						</ToolbarGroup>
 					</div>
 				</CardHeader>
 				<CardContent className="px-2 pb-4 sm:p-6">
@@ -730,114 +787,163 @@ export function GlobalStatsClient() {
 							No data for this range.
 						</div>
 					) : (
-						<ChartContainer
-							config={
-								showTimeseriesBreakdown
-									? stackChartConfig
-									: timeseriesChartConfig
-							}
-							className="aspect-auto h-[320px] w-full"
-						>
-							<BarChart
-								data={showTimeseriesBreakdown ? stackedTimeseries : timeseries}
-								margin={{ left: 12, right: 12 }}
+						<>
+							<ChartContainer
+								config={
+									showTimeseriesBreakdown
+										? stackChartConfig
+										: timeseriesChartConfig
+								}
+								className="aspect-auto h-[320px] w-full"
 							>
-								<CartesianGrid vertical={false} strokeDasharray="3 3" />
-								<XAxis
-									dataKey="date"
-									tickLine={false}
-									axisLine={false}
-									tickMargin={8}
-									minTickGap={32}
-									tickFormatter={(value) => {
-										if (typeof value !== "string" || !value) {
-											return "";
-										}
-										const date = parseISO(value);
-										if (Number.isNaN(date.getTime())) {
-											return value;
-										}
-										return format(date, "MMM d");
-									}}
-								/>
-								<YAxis
-									tickLine={false}
-									axisLine={false}
-									width={56}
-									tickFormatter={compactMetricFormatter(chartMetric)}
-								/>
-								<ChartTooltip
-									content={
-										<ChartTooltipContent
-											className="w-[220px]"
-											sortByValue={showTimeseriesBreakdown}
-											labelFormatter={(value) => {
-												if (typeof value !== "string" || !value) {
-													return "";
-												}
-												const date = parseISO(value);
-												if (Number.isNaN(date.getTime())) {
-													return value;
-												}
-												return format(date, "MMM d, yyyy");
-											}}
-											formatter={(value, name, item) =>
-												showTimeseriesBreakdown ? (
-													<div className="flex w-full items-center gap-2">
-														<span
-															className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
-															style={{
-																backgroundColor:
-																	(item as { fill?: string })?.fill ??
-																	item?.color,
-															}}
-														/>
-														<span className="flex-1 text-muted-foreground">
-															{(stackChartConfig[name as string]
-																?.label as string) ?? String(name)}
-														</span>
-														<span className="font-mono font-medium tabular-nums text-foreground">
-															{metricFormatter(chartMetric)(Number(value))}
-														</span>
-													</div>
-												) : (
-													metricFormatter(chartMetric)(Number(value))
-												)
-											}
-										/>
+								<TimeseriesChart
+									data={
+										showTimeseriesBreakdown ? stackedChart.data : timeseries
 									}
-								/>
-								{showTimeseriesBreakdown ? (
-									stackSeries.keys.map((key) => (
+									accessibilityLayer
+									margin={{ left: 12, right: 12, top: 8 }}
+								>
+									<CartesianGrid vertical={false} strokeDasharray="3 3" />
+									<XAxis
+										dataKey="date"
+										tickLine={false}
+										axisLine={false}
+										tickMargin={8}
+										minTickGap={32}
+										tickFormatter={(value) => {
+											if (typeof value !== "string" || !value) {
+												return "";
+											}
+											const date = parseISO(value);
+											if (Number.isNaN(date.getTime())) {
+												return value;
+											}
+											return format(date, "MMM d");
+										}}
+									/>
+									<YAxis
+										tickLine={false}
+										axisLine={false}
+										width={56}
+										tickFormatter={compactMetricFormatter(chartMetric)}
+									/>
+									<ChartTooltip
+										content={
+											<ChartTooltipContent
+												className="w-[220px]"
+												sortByValue={showTimeseriesBreakdown}
+												labelFormatter={(value) => {
+													if (typeof value !== "string" || !value) {
+														return "";
+													}
+													const date = parseISO(value);
+													if (Number.isNaN(date.getTime())) {
+														return value;
+													}
+													return format(date, "MMM d, yyyy");
+												}}
+												formatter={(value, name, item) =>
+													showTimeseriesBreakdown ? (
+														<div className="flex w-full items-center gap-2">
+															<span
+																className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
+																style={{
+																	backgroundColor:
+																		stackChartConfig[name as string]?.color ??
+																		item?.color,
+																}}
+															/>
+															<span className="flex-1 text-muted-foreground">
+																{(stackChartConfig[name as string]
+																	?.label as string) ?? String(name)}
+															</span>
+															<span className="font-mono font-medium tabular-nums text-foreground">
+																{metricFormatter(chartMetric)(Number(value))}
+															</span>
+														</div>
+													) : (
+														metricFormatter(chartMetric)(Number(value))
+													)
+												}
+											/>
+										}
+									/>
+									{showTimeseriesBreakdown ? (
+										stackedChart.series.map((entry) =>
+											chartType === "bar" ? (
+												<Bar
+													key={entry.chartKey}
+													dataKey={entry.chartKey}
+													stackId="timeseries"
+													fill={`var(--color-${entry.chartKey})`}
+													maxBarSize={88}
+												/>
+											) : (
+												<Line
+													key={entry.chartKey}
+													dataKey={entry.chartKey}
+													type="monotone"
+													stroke={`var(--color-${entry.chartKey})`}
+													strokeWidth={2}
+													dot={false}
+													connectNulls
+												/>
+											),
+										)
+									) : chartType === "bar" ? (
 										<Bar
-											key={key}
-											dataKey={key}
-											stackId="timeseries"
-											fill={`var(--color-${key})`}
+											dataKey={chartMetric}
+											fill={`var(--color-${chartMetric})`}
+											maxBarSize={88}
+											radius={[4, 4, 0, 0]}
 										/>
-									))
-								) : (
-									<Bar
-										dataKey={chartMetric}
-										fill={`var(--color-${chartMetric})`}
-										radius={[4, 4, 0, 0]}
-									/>
-								)}
-								{showTimeseriesBreakdown ? (
-									<ChartLegend
-										verticalAlign="bottom"
-										content={<ChartLegendContent />}
-									/>
-								) : null}
-							</BarChart>
-						</ChartContainer>
+									) : (
+										<Line
+											dataKey={chartMetric}
+											type="monotone"
+											stroke={`var(--color-${chartMetric})`}
+											strokeWidth={2.5}
+											dot={false}
+											connectNulls
+										/>
+									)}
+								</TimeseriesChart>
+							</ChartContainer>
+							{showTimeseriesBreakdown ? (
+								<div
+									className="mt-4 flex flex-wrap gap-x-4 gap-y-2 px-3 sm:px-0"
+									role="list"
+									aria-label="Chart legend"
+								>
+									{stackedChart.series.map((entry, index) => (
+										<div
+											key={entry.chartKey}
+											className="flex min-w-0 max-w-full items-center gap-1.5 text-xs text-muted-foreground"
+											role="listitem"
+											title={entry.label}
+										>
+											<span
+												className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
+												style={{
+													backgroundColor:
+														entry.sourceKey === null
+															? OTHER_COLOR
+															: PIE_COLORS[index % PIE_COLORS.length],
+												}}
+											/>
+											<span className="max-w-72 truncate">{entry.label}</span>
+										</div>
+									))}
+								</div>
+							) : null}
+						</>
 					)}
 				</CardContent>
 			</Card>
 
 			<Card>
-				<CardHeader className="flex flex-col items-stretch space-y-2 border-b p-4 sm:flex-row sm:items-center sm:justify-between sm:space-y-0 sm:p-6">
-					<div>
+				<CardHeader className="gap-0 space-y-0 border-b p-0">
+					<div className="p-4 sm:p-6">
 						<CardTitle>
 							{timeseriesChartConfig[chartMetric].label as string} share —{" "}
 							{breakdownNoun}
@@ -850,41 +956,57 @@ export function GlobalStatsClient() {
 							{scopeParts.length > 0 ? ` ${scopeLabel} traffic only.` : ""}
 						</CardDescription>
 					</div>
-					<div className="flex flex-wrap items-center gap-3">
+					<div className="flex flex-wrap items-end gap-3 border-t border-border/60 bg-muted/20 px-4 py-3 sm:px-6">
 						{groupBy === "model" ? (
-							<div className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-1">
-								{MODEL_VIEW_OPTIONS.map((opt) => {
-									const Icon = opt.icon;
-									return (
-										<Button
-											key={opt.value}
-											variant={modelView === opt.value ? "default" : "ghost"}
-											size="sm"
-											className="h-7 gap-1.5 px-3 text-xs"
-											onClick={() => setModelView(opt.value)}
-										>
-											<Icon className="h-3.5 w-3.5" />
-											{opt.label}
-										</Button>
-									);
-								})}
-							</div>
+							<ToolbarGroup label="Model view">
+								<div
+									className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-0.5"
+									role="group"
+									aria-label="Model view"
+								>
+									{MODEL_VIEW_OPTIONS.map((opt) => {
+										const Icon = opt.icon;
+										return (
+											<Button
+												key={opt.value}
+												variant={
+													modelView === opt.value ? "secondary" : "ghost"
+												}
+												size="sm"
+												className="h-7 gap-1.5 px-3 text-xs shadow-none"
+												aria-pressed={modelView === opt.value}
+												onClick={() => setModelView(opt.value)}
+											>
+												<Icon className="h-3.5 w-3.5" aria-hidden />
+												{opt.label}
+											</Button>
+										);
+									})}
+								</div>
+							</ToolbarGroup>
 						) : null}
-						<div className="flex items-center gap-1">
-							{(Object.keys(timeseriesChartConfig) as TimeseriesMetric[]).map(
-								(m) => (
-									<Button
-										key={m}
-										variant={chartMetric === m ? "default" : "outline"}
-										size="sm"
-										className="h-7 px-3 text-xs"
-										onClick={() => setChartMetric(m)}
-									>
-										{timeseriesChartConfig[m].label as string}
-									</Button>
-								),
-							)}
-						</div>
+						<ToolbarGroup label="Measure">
+							<div
+								className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-0.5"
+								role="group"
+								aria-label="Measure"
+							>
+								{(Object.keys(timeseriesChartConfig) as TimeseriesMetric[]).map(
+									(m) => (
+										<Button
+											key={m}
+											variant={chartMetric === m ? "secondary" : "ghost"}
+											size="sm"
+											className="h-7 px-3 text-xs shadow-none"
+											aria-pressed={chartMetric === m}
+											onClick={() => setChartMetric(m)}
+										>
+											{timeseriesChartConfig[m].label as string}
+										</Button>
+									),
+								)}
+							</div>
+						</ToolbarGroup>
 					</div>
 				</CardHeader>
 				<CardContent className="grid gap-6 p-4 sm:p-6 lg:grid-cols-2">
@@ -928,7 +1050,7 @@ export function GlobalStatsClient() {
 									>
 										{pieData.map((slice, idx) => (
 											<Cell
-												key={slice.key}
+												key={slice.chartKey}
 												fill={PIE_COLORS[idx % PIE_COLORS.length]}
 											/>
 										))}

--- a/ee/admin/src/app/organizations/[orgId]/manage-org-dialog.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/manage-org-dialog.tsx
@@ -64,6 +64,7 @@ interface ManageOrgDialogProps {
 		trialStartDate: string | null;
 		trialEndDate: string | null;
 	}) => Promise<{ success: boolean; error?: string }>;
+	primaryTrigger?: boolean;
 }
 
 const PLAN_DEFAULT_SEATS: Record<Plan, number> = {
@@ -126,6 +127,7 @@ export function ManageOrgDialog({
 	trialStartDate,
 	trialEndDate,
 	onSave,
+	primaryTrigger = false,
 }: ManageOrgDialogProps) {
 	const router = useRouter();
 	const [open, setOpen] = useState(false);
@@ -329,7 +331,7 @@ export function ManageOrgDialog({
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>
 			<DialogTrigger asChild>
-				<Button variant="outline" size="sm">
+				<Button variant={primaryTrigger ? "default" : "outline"} size="sm">
 					<Settings2 className="mr-1.5 h-4 w-4" />
 					Manage org
 				</Button>

--- a/ee/admin/src/app/organizations/[orgId]/org-metrics.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/org-metrics.tsx
@@ -9,10 +9,10 @@ import {
 	Server,
 	TrendingDown,
 } from "lucide-react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
-import { Button } from "@/components/ui/button";
+import { TokenTimeRangeToggle } from "@/components/token-time-range-toggle";
 import {
 	UsageModeSelector,
 	useUsageMode,
@@ -114,8 +114,6 @@ function MetricCard({
 
 export function OrgMetricsSection({ orgId }: { orgId: string }) {
 	const searchParams = useSearchParams();
-	const router = useRouter();
-	const pathname = usePathname();
 
 	const window = parseWindow(searchParams.get("window"));
 	const usageMode = useUsageMode();
@@ -136,20 +134,6 @@ export function OrgMetricsSection({ orgId }: { orgId: string }) {
 	useEffect(() => {
 		void loadMetrics(window);
 	}, [loadMetrics, window]);
-
-	const handleWindowChange = useCallback(
-		(w: TokenWindow) => {
-			const params = new URLSearchParams(searchParams.toString());
-			if (w === "1d") {
-				params.delete("window");
-			} else {
-				params.set("window", w);
-			}
-			const query = params.toString();
-			router.push(query ? `${pathname}?${query}` : pathname);
-		},
-		[searchParams, router, pathname],
-	);
 
 	if (loading) {
 		return (
@@ -188,73 +172,27 @@ export function OrgMetricsSection({ orgId }: { orgId: string }) {
 
 	return (
 		<section className="space-y-4">
-			<div className="flex items-center justify-between">
+			<div className="flex flex-col gap-4 rounded-xl border border-border/60 bg-card/50 p-4 lg:flex-row lg:items-center lg:justify-between">
 				<div>
 					<h2 className="text-lg font-semibold">Usage Metrics</h2>
-					<p className="text-xs text-muted-foreground">
+					<p className="mt-1 text-xs text-muted-foreground">
 						{windowLabel} ({new Date(metrics.startDate).toLocaleDateString()} –{" "}
 						{new Date(metrics.endDate).toLocaleDateString()})
 					</p>
 				</div>
-				<div className="flex items-center gap-1">
-					<UsageModeSelector />
-					<div className="mx-1 h-5 w-px bg-border" />
-					<Button
-						variant={window === "1h" ? "default" : "outline"}
-						size="sm"
-						onClick={() => handleWindowChange("1h")}
-					>
-						1h
-					</Button>
-					<Button
-						variant={window === "4h" ? "default" : "outline"}
-						size="sm"
-						onClick={() => handleWindowChange("4h")}
-					>
-						4h
-					</Button>
-					<Button
-						variant={window === "12h" ? "default" : "outline"}
-						size="sm"
-						onClick={() => handleWindowChange("12h")}
-					>
-						12h
-					</Button>
-					<Button
-						variant={window === "1d" ? "default" : "outline"}
-						size="sm"
-						onClick={() => handleWindowChange("1d")}
-					>
-						24h
-					</Button>
-					<Button
-						variant={window === "7d" ? "default" : "outline"}
-						size="sm"
-						onClick={() => handleWindowChange("7d")}
-					>
-						7d
-					</Button>
-					<Button
-						variant={window === "30d" ? "default" : "outline"}
-						size="sm"
-						onClick={() => handleWindowChange("30d")}
-					>
-						30d
-					</Button>
-					<Button
-						variant={window === "90d" ? "default" : "outline"}
-						size="sm"
-						onClick={() => handleWindowChange("90d")}
-					>
-						90d
-					</Button>
-					<Button
-						variant={window === "365d" ? "default" : "outline"}
-						size="sm"
-						onClick={() => handleWindowChange("365d")}
-					>
-						365d
-					</Button>
+				<div className="grid gap-3 sm:grid-cols-2 sm:items-end">
+					<div className="space-y-1.5">
+						<span className="block text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+							Traffic
+						</span>
+						<UsageModeSelector compact />
+					</div>
+					<div className="space-y-1.5">
+						<span className="block text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+							Window
+						</span>
+						<TokenTimeRangeToggle initial={window} />
+					</div>
 				</div>
 			</div>
 			<div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">

--- a/ee/admin/src/app/organizations/[orgId]/page.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/page.tsx
@@ -1,6 +1,7 @@
 import {
 	ArrowLeft,
 	Building2,
+	ChevronDown,
 	ChevronLeft,
 	ChevronRight,
 	ExternalLink,
@@ -24,6 +25,11 @@ import { ManualCreditsDialog } from "@/components/manual-credits-dialog";
 import { PlanTermBadge } from "@/components/plan-term-badge";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import {
 	Table,
 	TableBody,
@@ -328,176 +334,271 @@ export default async function OrganizationPage({
 				</Button>
 			</div>
 
-			<header className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-start">
-				<div className="space-y-2">
-					<div className="flex items-center gap-3">
-						<div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
-							<Building2 className="h-5 w-5" />
+			<header className="rounded-2xl border border-border/60 bg-card/50 p-5 shadow-sm">
+				<Collapsible>
+					<div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+						<div className="min-w-0">
+							<div className="flex items-center gap-3">
+								<div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-primary/20 bg-primary/10 text-primary">
+									<Building2 className="h-5 w-5" />
+								</div>
+								<div className="min-w-0">
+									<h1 className="truncate text-2xl font-semibold tracking-tight">
+										{org.name}
+									</h1>
+									<p className="truncate font-mono text-xs text-muted-foreground">
+										{org.id}
+									</p>
+								</div>
+							</div>
+							<div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+								<span>{org.billingEmail}</span>
+								<a
+									href={stripeSearchUrl(org.billingEmail)}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="inline-flex items-center gap-1 text-blue-600 hover:underline"
+									title={`Search Stripe for ${org.billingEmail}`}
+								>
+									<ExternalLink className="h-3 w-3" />
+									Stripe
+								</a>
+								<span>Created {formatDate(org.createdAt)}</span>
+							</div>
 						</div>
-						<div>
-							<h1 className="text-2xl font-semibold tracking-tight">
-								{org.name}
-							</h1>
-							<p className="text-sm text-muted-foreground">{org.id}</p>
+						<div className="flex shrink-0 items-center gap-2">
+							<ManageOrgDialog
+								orgName={org.name}
+								plan={org.plan}
+								seats={org.seats ?? null}
+								apiKeyLimit={org.apiKeyLimit ?? null}
+								projectLimit={org.projectLimit ?? null}
+								trustTierOverride={
+									trustTier?.overridden ? trustTier.tier : null
+								}
+								planExpiresAt={org.planExpiresAt ?? null}
+								planStartedAt={org.planStartedAt ?? null}
+								isTrialActive={org.isTrialActive ?? false}
+								trialStartDate={org.trialStartDate ?? null}
+								trialEndDate={org.trialEndDate ?? null}
+								primaryTrigger
+								onSave={async (data) => {
+									"use server";
+									return await manageOrganization(orgId, data);
+								}}
+							/>
+							<CollapsibleTrigger asChild>
+								<Button variant="outline" size="sm" className="group gap-2">
+									More actions
+									<ChevronDown className="h-3.5 w-3.5 transition-transform group-data-[state=open]:rotate-180" />
+								</Button>
+							</CollapsibleTrigger>
 						</div>
 					</div>
-					<div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-						<span>{org.billingEmail}</span>
-						<span>•</span>
-						<a
-							href={stripeSearchUrl(org.billingEmail)}
-							target="_blank"
-							rel="noopener noreferrer"
-							className="inline-flex items-center gap-1 text-blue-600 hover:underline"
-							title={`Search Stripe for ${org.billingEmail}`}
-						>
-							<ExternalLink className="h-3 w-3" />
-							Stripe
-						</a>
-						<span>•</span>
-						<span>Created {formatDate(org.createdAt)}</span>
-					</div>
-					<div className="flex flex-wrap items-center gap-2">
-						<Badge variant={getPlanBadgeVariant(org.plan)}>{org.plan}</Badge>
-						{trustTier &&
-							(trustTier.exempt === "none" ? (
-								<Badge variant="default">
-									Trust Tier {trustTier.tier}
-									{trustTier.overridden ? " (manual)" : ""}
+
+					<div className="mt-5 grid overflow-hidden rounded-xl border border-border/60 bg-background/70 sm:grid-cols-2 xl:grid-cols-4">
+						<div className="border-b border-border/60 p-4 sm:border-r xl:border-b-0">
+							<p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+								Plan
+							</p>
+							<div className="mt-2 flex flex-wrap items-center gap-2">
+								<Badge variant={getPlanBadgeVariant(org.plan)}>
+									{org.plan}
 								</Badge>
-							) : (
-								<Badge variant="outline">
-									{trustTier.exempt === "enterprise"
-										? "No rate limits (enterprise)"
-										: trustTier.exempt === "dev"
-											? "Dev plan limits"
-											: "Chat plan limits"}
+								{org.devPlan !== "none" ? (
+									<Badge variant={getDevPlanBadgeVariant(org.devPlan)}>
+										Dev: {org.devPlan}
+									</Badge>
+								) : null}
+								<PlanTermBadge
+									planExpiresAt={org.planExpiresAt}
+									planStartedAt={org.planStartedAt}
+									isTrialActive={org.isTrialActive}
+									trialStartDate={org.trialStartDate}
+									trialEndDate={org.trialEndDate}
+								/>
+							</div>
+						</div>
+						<div className="border-b border-border/60 p-4 xl:border-b-0 xl:border-r">
+							<p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+								Account
+							</p>
+							<div className="mt-2 flex flex-wrap items-center gap-2">
+								<Badge
+									variant={org.status === "active" ? "secondary" : "outline"}
+								>
+									{org.status ?? "active"}
 								</Badge>
-							))}
-						<PlanTermBadge
-							planExpiresAt={org.planExpiresAt}
-							planStartedAt={org.planStartedAt}
-							isTrialActive={org.isTrialActive}
-							trialStartDate={org.trialStartDate}
-							trialEndDate={org.trialEndDate}
-						/>
-						{org.devPlan !== "none" && (
-							<Badge variant={getDevPlanBadgeVariant(org.devPlan)}>
-								Dev: {org.devPlan}
-							</Badge>
-						)}
-						<Badge variant={org.status === "active" ? "secondary" : "outline"}>
-							{org.status ?? "active"}
-						</Badge>
-						{org.riskFlagged && (
-							<Link href="/flagged-accounts">
-								<Badge variant="destructive">High risk — review</Badge>
-							</Link>
-						)}
-						{org.seats !== null && org.seats !== undefined && (
-							<Badge variant="outline">Seats: {org.seats}</Badge>
-						)}
-						{org.apiKeyLimit !== null && org.apiKeyLimit !== undefined && (
-							<Badge variant="outline">API keys: {org.apiKeyLimit}</Badge>
-						)}
-						{org.projectLimit !== null && org.projectLimit !== undefined && (
-							<Badge variant="outline">Projects: {org.projectLimit}</Badge>
-						)}
-						<span className="text-sm font-medium">
-							Credits: {creditsFormatter.format(parseFloat(org.credits))}
-						</span>
+								{org.riskFlagged ? (
+									<Link href="/flagged-accounts">
+										<Badge variant="destructive">High risk — review</Badge>
+									</Link>
+								) : null}
+							</div>
+						</div>
+						<div className="border-b border-border/60 p-4 sm:border-r sm:border-b-0">
+							<p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+								Credits
+							</p>
+							<p className="mt-1.5 text-xl font-semibold tabular-nums">
+								{creditsFormatter.format(parseFloat(org.credits))}
+							</p>
+						</div>
+						<div className="p-4">
+							<p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+								Trust policy
+							</p>
+							<p className="mt-1.5 text-sm font-medium">
+								{!trustTier
+									? "Default"
+									: trustTier.exempt === "none"
+										? `Tier ${trustTier.tier}${trustTier.overridden ? " · manual" : ""}`
+										: trustTier.exempt === "enterprise"
+											? "Enterprise exemption"
+											: trustTier.exempt === "dev"
+												? "Dev plan limits"
+												: "Chat plan limits"}
+							</p>
+						</div>
 					</div>
-					{trustTier && trustTier.exempt === "none" && (
-						<p className="text-sm text-muted-foreground">
-							Tier {trustTier.tier}: {trustTier.rpmMultiplier}× RPM ·{" "}
-							{creditsFormatter.format(trustTier.dailyCapUsd)}/day ·{" "}
-							{creditsFormatter.format(trustTier.monthlyCapUsd)}/month ·{" "}
-							{creditsFormatter.format(trustTier.topUpDailyCapUsd)}/24h top-ups
-							—{" "}
-							{trustTier.overridden
-								? "pinned by admin (override active)"
-								: `qualifies via ${trustTier.accountAgeDays}d age / ${creditsFormatter.format(trustTier.qualifyingSpendUsd)} net credits usage`}
-						</p>
-					)}
-				</div>
-				<div className="flex flex-wrap items-center gap-2">
-					{org.kind === "devpass" && (
-						<Button variant="outline" size="sm" asChild>
-							<Link href={`/devpass/${orgId}`}>Open in DevPass</Link>
-						</Button>
-					)}
-					<ManageOrgDialog
-						orgName={org.name}
-						plan={org.plan}
-						seats={org.seats ?? null}
-						apiKeyLimit={org.apiKeyLimit ?? null}
-						projectLimit={org.projectLimit ?? null}
-						trustTierOverride={trustTier?.overridden ? trustTier.tier : null}
-						planExpiresAt={org.planExpiresAt ?? null}
-						planStartedAt={org.planStartedAt ?? null}
-						isTrialActive={org.isTrialActive ?? false}
-						trialStartDate={org.trialStartDate ?? null}
-						trialEndDate={org.trialEndDate ?? null}
-						onSave={async (data) => {
-							"use server";
-							return await manageOrganization(orgId, data);
-						}}
-					/>
-					<GiftCreditsDialog
-						orgId={orgId}
-						orgName={org.name}
-						onGift={async (data) => {
-							"use server";
-							return await giftCreditsToOrganization(orgId, data);
-						}}
-					/>
-					<ManualCreditsDialog
-						orgName={org.name}
-						onCredit={async (data) => {
-							"use server";
-							return await addManualCreditsToOrganization(orgId, data);
-						}}
-					/>
-					<EnterpriseDealDialog
-						orgName={org.name}
-						onSave={async (data) => {
-							"use server";
-							return await addEnterpriseDealToOrganization(orgId, data);
-						}}
-					/>
-					<ReferralBonusDialog
-						orgName={org.name}
-						enabled={org.referralBonusEnabled ?? false}
-						percent={org.referralBonusPercent ?? 50}
-						onSave={async (data) => {
-							"use server";
-							return await updateReferralBonus(orgId, data);
-						}}
-					/>
-					<Button variant="outline" size="sm" asChild>
-						<Link href={`/organizations/${orgId}/discounts`}>
-							Manage Discounts
-						</Link>
-					</Button>
-					<Button variant="outline" size="sm" asChild>
-						<Link href={`/organizations/${orgId}/rate-limits`}>
-							Manage Rate Limits
-						</Link>
-					</Button>
-					<BlockOrgButton
-						orgId={orgId}
-						orgName={org.name}
-						variant="full"
-						disabled={getOrgDeletionBlockedReason(org.credits) !== null}
-						disabledReason={
-							getOrgDeletionBlockedReason(org.credits) ?? undefined
-						}
-						onBlock={async (id) => {
-							"use server";
-							return await blockOrganization(id);
-						}}
-					/>
-				</div>
+
+					<div className="mt-3 flex flex-wrap items-center gap-x-5 gap-y-2 rounded-lg bg-muted/35 px-3 py-2 text-xs text-muted-foreground">
+						{org.seats !== null && org.seats !== undefined ? (
+							<span>
+								Seats{" "}
+								<strong className="font-medium text-foreground">
+									{org.seats}
+								</strong>
+							</span>
+						) : null}
+						{org.apiKeyLimit !== null && org.apiKeyLimit !== undefined ? (
+							<span>
+								API keys{" "}
+								<strong className="font-medium text-foreground">
+									{org.apiKeyLimit}
+								</strong>
+							</span>
+						) : null}
+						{org.projectLimit !== null && org.projectLimit !== undefined ? (
+							<span>
+								Projects{" "}
+								<strong className="font-medium text-foreground">
+									{org.projectLimit}
+								</strong>
+							</span>
+						) : null}
+						{trustTier?.exempt === "none" ? (
+							<>
+								<span>{trustTier.rpmMultiplier}× RPM</span>
+								<span>
+									{creditsFormatter.format(trustTier.dailyCapUsd)}/day
+								</span>
+								<span>
+									{creditsFormatter.format(trustTier.monthlyCapUsd)}/month
+								</span>
+								<span>
+									{creditsFormatter.format(trustTier.topUpDailyCapUsd)}/24h
+									top-ups
+								</span>
+								<span>
+									{trustTier.overridden
+										? "Override active"
+										: `${trustTier.accountAgeDays}d age · ${creditsFormatter.format(trustTier.qualifyingSpendUsd)} net usage`}
+								</span>
+							</>
+						) : null}
+					</div>
+
+					<CollapsibleContent>
+						<div className="mt-4 grid gap-3 rounded-xl border border-border/60 bg-background p-4 md:grid-cols-2 xl:grid-cols-4">
+							<div>
+								<p className="mb-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+									Credits
+								</p>
+								<div className="flex flex-wrap gap-2">
+									<GiftCreditsDialog
+										orgId={orgId}
+										orgName={org.name}
+										onGift={async (data) => {
+											"use server";
+											return await giftCreditsToOrganization(orgId, data);
+										}}
+									/>
+									<ManualCreditsDialog
+										orgName={org.name}
+										onCredit={async (data) => {
+											"use server";
+											return await addManualCreditsToOrganization(orgId, data);
+										}}
+									/>
+								</div>
+							</div>
+							<div>
+								<p className="mb-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+									Commercial
+								</p>
+								<div className="flex flex-wrap gap-2">
+									<EnterpriseDealDialog
+										orgName={org.name}
+										onSave={async (data) => {
+											"use server";
+											return await addEnterpriseDealToOrganization(orgId, data);
+										}}
+									/>
+									<ReferralBonusDialog
+										orgName={org.name}
+										enabled={org.referralBonusEnabled ?? false}
+										percent={org.referralBonusPercent ?? 50}
+										onSave={async (data) => {
+											"use server";
+											return await updateReferralBonus(orgId, data);
+										}}
+									/>
+								</div>
+							</div>
+							<div>
+								<p className="mb-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+									Controls
+								</p>
+								<div className="flex flex-wrap gap-2">
+									<Button variant="outline" size="sm" asChild>
+										<Link href={`/organizations/${orgId}/discounts`}>
+											Discounts
+										</Link>
+									</Button>
+									<Button variant="outline" size="sm" asChild>
+										<Link href={`/organizations/${orgId}/rate-limits`}>
+											Rate limits
+										</Link>
+									</Button>
+									{org.kind === "devpass" ? (
+										<Button variant="outline" size="sm" asChild>
+											<Link href={`/devpass/${orgId}`}>Open in DevPass</Link>
+										</Button>
+									) : null}
+								</div>
+							</div>
+							<div>
+								<p className="mb-2 text-[11px] font-medium uppercase tracking-wide text-destructive">
+									Account safety
+								</p>
+								<BlockOrgButton
+									orgId={orgId}
+									orgName={org.name}
+									variant="full"
+									disabled={getOrgDeletionBlockedReason(org.credits) !== null}
+									disabledReason={
+										getOrgDeletionBlockedReason(org.credits) ?? undefined
+									}
+									onBlock={async (id) => {
+										"use server";
+										return await blockOrganization(id);
+									}}
+								/>
+							</div>
+						</div>
+					</CollapsibleContent>
+				</Collapsible>
 			</header>
 
 			<OrgMetricsSection orgId={orgId} />

--- a/ee/admin/src/app/organizations/[orgId]/page.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/page.tsx
@@ -309,6 +309,7 @@ export default async function OrganizationPage({
 	}
 
 	const org = transactionsData.organization;
+	const actionsContentId = `organization-actions-${orgId}`;
 	const transactions = transactionsData.transactions;
 	const txTotal = transactionsData.total;
 	const txTotalPages = Math.ceil(txTotal / txLimit);
@@ -387,7 +388,7 @@ export default async function OrganizationPage({
 									return await manageOrganization(orgId, data);
 								}}
 							/>
-							<CollapsibleTrigger asChild>
+							<CollapsibleTrigger asChild aria-controls={actionsContentId}>
 								<Button variant="outline" size="sm" className="group gap-2">
 									More actions
 									<ChevronDown className="h-3.5 w-3.5 transition-transform group-data-[state=open]:rotate-180" />
@@ -509,7 +510,7 @@ export default async function OrganizationPage({
 						) : null}
 					</div>
 
-					<CollapsibleContent>
+					<CollapsibleContent id={actionsContentId}>
 						<div className="mt-4 grid gap-3 rounded-xl border border-border/60 bg-background p-4 md:grid-cols-2 xl:grid-cols-4">
 							<div>
 								<p className="mb-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">

--- a/ee/admin/src/app/organizations/[orgId]/page.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/page.tsx
@@ -24,7 +24,7 @@ import { GiftCreditsDialog } from "@/components/gift-credits-dialog";
 import { ManualCreditsDialog } from "@/components/manual-credits-dialog";
 import { PlanTermBadge } from "@/components/plan-term-badge";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import {
 	Collapsible,
 	CollapsibleContent,
@@ -388,11 +388,16 @@ export default async function OrganizationPage({
 									return await manageOrganization(orgId, data);
 								}}
 							/>
-							<CollapsibleTrigger asChild aria-controls={actionsContentId}>
-								<Button variant="outline" size="sm" className="group gap-2">
-									More actions
-									<ChevronDown className="h-3.5 w-3.5 transition-transform group-data-[state=open]:rotate-180" />
-								</Button>
+							<CollapsibleTrigger
+								aria-controls={actionsContentId}
+								className={buttonVariants({
+									variant: "outline",
+									size: "sm",
+									className: "group gap-2",
+								})}
+							>
+								More actions
+								<ChevronDown className="h-3.5 w-3.5 transition-transform group-data-[state=open]:rotate-180" />
 							</CollapsibleTrigger>
 						</div>
 					</div>

--- a/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/project-metrics.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/project-metrics.tsx
@@ -9,10 +9,10 @@ import {
 	Server,
 	TrendingDown,
 } from "lucide-react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
-import { Button } from "@/components/ui/button";
+import { TokenTimeRangeToggle } from "@/components/token-time-range-toggle";
 import {
 	UsageModeSelector,
 	useUsageMode,
@@ -120,22 +120,23 @@ export function ProjectMetricsSection({
 	projectId: string;
 }) {
 	const searchParams = useSearchParams();
-	const router = useRouter();
-	const pathname = usePathname();
 
 	const selectedWindow = parseWindow(searchParams.get("window"));
 	const usageMode = useUsageMode();
 	const [metrics, setMetrics] = useState<ProjectMetrics | null>(null);
 	const [loading, setLoading] = useState(true);
+	const [loadError, setLoadError] = useState<string | null>(null);
 
 	const loadMetrics = useCallback(
 		async (w: TokenWindow) => {
 			setLoading(true);
+			setLoadError(null);
 			try {
 				const data = await loadProjectMetricsAction(orgId, projectId, w);
 				setMetrics(data);
-			} catch (error) {
-				console.error("Failed to load project metrics:", error);
+			} catch {
+				setMetrics(null);
+				setLoadError("Unable to load usage data. Try again shortly.");
 			} finally {
 				setLoading(false);
 			}
@@ -146,20 +147,6 @@ export function ProjectMetricsSection({
 	useEffect(() => {
 		void loadMetrics(selectedWindow);
 	}, [loadMetrics, selectedWindow]);
-
-	const handleWindowChange = useCallback(
-		(w: TokenWindow) => {
-			const params = new URLSearchParams(searchParams.toString());
-			if (w === "1d") {
-				params.delete("window");
-			} else {
-				params.set("window", w);
-			}
-			const query = params.toString();
-			router.push(query ? `${pathname}?${query}` : pathname);
-		},
-		[searchParams, router, pathname],
-	);
 
 	if (loading) {
 		return (
@@ -178,7 +165,7 @@ export function ProjectMetricsSection({
 			<section className="space-y-4">
 				<h2 className="text-lg font-semibold">Usage Metrics</h2>
 				<div className="rounded-lg border border-dashed border-border/60 p-8 text-center text-sm text-muted-foreground">
-					No usage data available.
+					{loadError ?? "No usage data available."}
 				</div>
 			</section>
 		);
@@ -198,29 +185,27 @@ export function ProjectMetricsSection({
 
 	return (
 		<section className="space-y-4">
-			<div className="flex items-center justify-between">
+			<div className="flex flex-col gap-4 rounded-xl border border-border/60 bg-card/50 p-4 lg:flex-row lg:items-center lg:justify-between">
 				<div>
 					<h2 className="text-lg font-semibold">Usage Metrics</h2>
-					<p className="text-xs text-muted-foreground">
+					<p className="mt-1 text-xs text-muted-foreground">
 						{windowLabel} ({new Date(metrics.startDate).toLocaleDateString()} –{" "}
 						{new Date(metrics.endDate).toLocaleDateString()})
 					</p>
 				</div>
-				<div className="flex items-center gap-1">
-					<UsageModeSelector />
-					<div className="mx-1 h-5 w-px bg-border" />
-					{(["1h", "4h", "12h", "1d", "7d", "30d", "90d", "365d"] as const).map(
-						(w) => (
-							<Button
-								key={w}
-								variant={selectedWindow === w ? "default" : "outline"}
-								size="sm"
-								onClick={() => handleWindowChange(w)}
-							>
-								{w === "1d" ? "24h" : w}
-							</Button>
-						),
-					)}
+				<div className="grid gap-3 sm:grid-cols-2 sm:items-end">
+					<div className="space-y-1.5">
+						<span className="block text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+							Traffic
+						</span>
+						<UsageModeSelector compact />
+					</div>
+					<div className="space-y-1.5">
+						<span className="block text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+							Window
+						</span>
+						<TokenTimeRangeToggle initial={selectedWindow} />
+					</div>
 				</div>
 			</div>
 			<div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">

--- a/ee/admin/src/app/routing-analytics/client.tsx
+++ b/ee/admin/src/app/routing-analytics/client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
 	Bar,
 	BarChart,
@@ -12,6 +12,10 @@ import {
 	YAxis,
 } from "recharts";
 
+import {
+	ChartTypeToggle,
+	type ChartType,
+} from "@/components/chart-type-toggle";
 import { StatCard } from "@/components/detail-stat-cards";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -316,6 +320,8 @@ export function RoutingAnalyticsClient() {
 	const selectedProviderId = searchParams.get("providerId");
 	const window = parseWindow(searchParams.get("window"));
 	const metric = parseMetric(searchParams.get("metric"));
+	const [chartType, setChartType] = useState<ChartType>("line");
+	const MetricChart = chartType === "line" ? LineChart : BarChart;
 
 	const updateParams = useCallback(
 		(values: Record<string, string | null>) => {
@@ -376,17 +382,39 @@ export function RoutingAnalyticsClient() {
 					?.requestCount ?? 0) > 0,
 		);
 	}, [data]);
+	const providerChartSeries = useMemo(
+		() =>
+			chartedProviders.map((mapping, index) => ({
+				...mapping,
+				chartKey: `series_${index}`,
+			})),
+		[chartedProviders],
+	);
+	const chartKeyByProvider = useMemo(
+		() =>
+			new Map(
+				providerChartSeries.map((mapping) => [
+					mapping.providerId,
+					mapping.chartKey,
+				]),
+			),
+		[providerChartSeries],
+	);
 
 	const chartConfig = useMemo(() => {
 		const config: ChartConfig = {};
-		chartedProviders.forEach((mapping, index) => {
-			config[mapping.providerId] = {
+		providerChartSeries.forEach((mapping, index) => {
+			config[mapping.chartKey] = {
 				label: mapping.providerName,
 				color: SERIES_COLORS[index % SERIES_COLORS.length],
 			};
 		});
 		return config;
-	}, [chartedProviders]);
+	}, [providerChartSeries]);
+	const providerSeriesColor = (providerId: string) => {
+		const chartKey = chartKeyByProvider.get(providerId);
+		return chartKey ? chartConfig[chartKey]?.color : undefined;
+	};
 
 	const metricChartData = useMemo(() => {
 		if (!data) {
@@ -395,11 +423,14 @@ export function RoutingAnalyticsClient() {
 		return data.hourly.map((hour) => {
 			const row: Record<string, string | number | null> = { hour: hour.hour };
 			for (const entry of hour.providers) {
-				row[entry.providerId] = entry[metric];
+				const chartKey = chartKeyByProvider.get(entry.providerId);
+				if (chartKey) {
+					row[chartKey] = entry[metric];
+				}
 			}
 			return row;
 		});
-	}, [data, metric]);
+	}, [data, metric, chartKeyByProvider]);
 
 	const trafficChartData = useMemo(() => {
 		if (!data) {
@@ -408,11 +439,14 @@ export function RoutingAnalyticsClient() {
 		return data.hourly.map((hour) => {
 			const row: Record<string, string | number> = { hour: hour.hour };
 			for (const entry of hour.providers) {
-				row[entry.providerId] = entry.requestCount;
+				const chartKey = chartKeyByProvider.get(entry.providerId);
+				if (chartKey) {
+					row[chartKey] = entry.requestCount;
+				}
 			}
 			return row;
 		});
-	}, [data]);
+	}, [data, chartKeyByProvider]);
 
 	const totalRequests = useMemo(
 		() => data?.summary.reduce((sum, s) => sum + s.requestCount, 0) ?? 0,
@@ -863,8 +897,9 @@ export function RoutingAnalyticsClient() {
 															<span
 																className="h-2.5 w-2.5 shrink-0 rounded-full"
 																style={{
-																	backgroundColor:
-																		chartConfig[summary.providerId]?.color,
+																	backgroundColor: providerSeriesColor(
+																		summary.providerId,
+																	),
 																}}
 															/>
 															<span className="font-medium">
@@ -1027,18 +1062,24 @@ export function RoutingAnalyticsClient() {
 									{metricOption.description}
 								</CardDescription>
 							</div>
-							<div className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-1">
-								{METRIC_OPTIONS.map((option) => (
-									<Button
-										key={option.value}
-										variant={metric === option.value ? "default" : "ghost"}
-										size="sm"
-										className="h-7 px-3 text-xs"
-										onClick={() => updateParams({ metric: option.value })}
-									>
-										{option.label}
-									</Button>
-								))}
+							<div className="flex flex-wrap items-center gap-2">
+								<div className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-1">
+									{METRIC_OPTIONS.map((option) => (
+										<Button
+											key={option.value}
+											variant={metric === option.value ? "default" : "ghost"}
+											size="sm"
+											className="h-7 px-3 text-xs"
+											onClick={() => updateParams({ metric: option.value })}
+										>
+											{option.label}
+										</Button>
+									))}
+								</div>
+								<ChartTypeToggle
+									value={chartType}
+									onValueChange={setChartType}
+								/>
 							</div>
 						</CardHeader>
 						<CardContent className="px-2 pb-4 sm:p-6">
@@ -1046,8 +1087,9 @@ export function RoutingAnalyticsClient() {
 								config={chartConfig}
 								className="aspect-auto h-[320px] w-full"
 							>
-								<LineChart
+								<MetricChart
 									data={metricChartData}
+									accessibilityLayer
 									margin={{ left: 12, right: 12 }}
 								>
 									<CartesianGrid vertical={false} strokeDasharray="3 3" />
@@ -1091,22 +1133,31 @@ export function RoutingAnalyticsClient() {
 										}
 									/>
 									<ChartLegend content={<ChartLegendContent />} />
-									{chartedProviders.map((mapping) => {
+									{providerChartSeries.map((mapping) => {
 										const emphasis = seriesEmphasis(mapping.providerId);
-										return (
+										return chartType === "line" ? (
 											<Line
 												key={mapping.providerId}
-												dataKey={mapping.providerId}
+												dataKey={mapping.chartKey}
 												type="monotone"
-												stroke={`var(--color-${mapping.providerId})`}
+												stroke={`var(--color-${mapping.chartKey})`}
 												strokeWidth={emphasis.strokeWidth}
 												strokeOpacity={emphasis.opacity}
 												dot={false}
 												connectNulls={false}
 											/>
+										) : (
+											<Bar
+												key={mapping.providerId}
+												dataKey={mapping.chartKey}
+												fill={`var(--color-${mapping.chartKey})`}
+												fillOpacity={emphasis.opacity}
+												maxBarSize={30}
+												radius={[2, 2, 0, 0]}
+											/>
 										);
 									})}
-								</LineChart>
+								</MetricChart>
 							</ChartContainer>
 							{metric === "score" ? (
 								<p className="mt-2 px-2 text-xs text-muted-foreground sm:px-0">
@@ -1156,12 +1207,12 @@ export function RoutingAnalyticsClient() {
 										}
 									/>
 									<ChartLegend content={<ChartLegendContent />} />
-									{chartedProviders.map((mapping) => (
+									{providerChartSeries.map((mapping) => (
 										<Bar
 											key={mapping.providerId}
-											dataKey={mapping.providerId}
+											dataKey={mapping.chartKey}
 											stackId="requests"
-											fill={`var(--color-${mapping.providerId})`}
+											fill={`var(--color-${mapping.chartKey})`}
 											fillOpacity={seriesEmphasis(mapping.providerId).opacity}
 										/>
 									))}
@@ -1310,8 +1361,9 @@ export function RoutingAnalyticsClient() {
 																<span
 																	className="h-2.5 w-2.5 shrink-0 rounded-full"
 																	style={{
-																		backgroundColor:
-																			chartConfig[summary.providerId]?.color,
+																		backgroundColor: providerSeriesColor(
+																			summary.providerId,
+																		),
 																	}}
 																/>
 																{mapping.providerName}

--- a/ee/admin/src/components/chart-type-toggle.tsx
+++ b/ee/admin/src/components/chart-type-toggle.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { ChartColumn, ChartLine } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export type ChartType = "line" | "bar";
+
+const chartTypes: {
+	value: ChartType;
+	label: string;
+	icon: typeof ChartLine;
+}[] = [
+	{ value: "line", label: "Line", icon: ChartLine },
+	{ value: "bar", label: "Bar", icon: ChartColumn },
+];
+
+export function ChartTypeToggle({
+	value,
+	onValueChange,
+	className,
+}: {
+	value: ChartType;
+	onValueChange: (value: ChartType) => void;
+	className?: string;
+}) {
+	return (
+		<div
+			className={cn(
+				"inline-flex items-center gap-0.5 rounded-md border border-border/60 bg-background p-0.5",
+				className,
+			)}
+			role="group"
+			aria-label="Chart type"
+		>
+			{chartTypes.map((option) => {
+				const Icon = option.icon;
+				return (
+					<Button
+						key={option.value}
+						type="button"
+						variant={value === option.value ? "secondary" : "ghost"}
+						size="sm"
+						className="h-7 gap-1.5 px-2.5 text-xs shadow-none"
+						aria-pressed={value === option.value}
+						onClick={() => onValueChange(option.value)}
+					>
+						<Icon className="h-3.5 w-3.5" aria-hidden />
+						{option.label}
+					</Button>
+				);
+			})}
+		</div>
+	);
+}

--- a/ee/admin/src/components/chat-plans-timeseries-chart.tsx
+++ b/ee/admin/src/components/chat-plans-timeseries-chart.tsx
@@ -2,8 +2,12 @@
 
 import { format, parseISO } from "date-fns";
 import { useState } from "react";
-import { CartesianGrid, Line, LineChart, XAxis } from "recharts";
+import { Bar, BarChart, CartesianGrid, Line, LineChart, XAxis } from "recharts";
 
+import {
+	ChartTypeToggle,
+	type ChartType,
+} from "@/components/chart-type-toggle";
 import {
 	Card,
 	CardContent,
@@ -60,6 +64,8 @@ export function ChatPlansTimeseriesChart({
 	to?: string;
 }) {
 	const [activeSeries, setActiveSeries] = useState<ActiveSeries>("revenue");
+	const [chartType, setChartType] = useState<ChartType>("line");
+	const ChartRoot = chartType === "line" ? LineChart : BarChart;
 	const $api = useApi();
 	const { data, isLoading, isError } = $api.useQuery(
 		"get",
@@ -76,7 +82,10 @@ export function ChatPlansTimeseriesChart({
 		<Card>
 			<CardHeader className="flex flex-col items-stretch space-y-0 border-b p-0 sm:flex-row">
 				<div className="flex flex-1 flex-col justify-center gap-1 px-6 py-5 sm:py-6">
-					<CardTitle>Lounge (chat) plans revenue & usage</CardTitle>
+					<div className="flex flex-wrap items-center justify-between gap-3">
+						<CardTitle>Lounge (chat) plans revenue & usage</CardTitle>
+						<ChartTypeToggle value={chartType} onValueChange={setChartType} />
+					</div>
 					<CardDescription>
 						Daily revenue from Lounge (chat) plan transactions, real provider
 						cost across current and former subscribers, and the resulting
@@ -135,7 +144,11 @@ export function ChatPlansTimeseriesChart({
 						config={chartConfig}
 						className="aspect-auto h-[250px] w-full"
 					>
-						<LineChart data={chartData} margin={{ left: 12, right: 12 }}>
+						<ChartRoot
+							data={chartData}
+							accessibilityLayer
+							margin={{ left: 12, right: 12 }}
+						>
 							<CartesianGrid vertical={false} />
 							<XAxis
 								dataKey="date"
@@ -161,14 +174,23 @@ export function ChatPlansTimeseriesChart({
 									/>
 								}
 							/>
-							<Line
-								dataKey={activeSeries}
-								type="monotone"
-								stroke={`var(--color-${activeSeries})`}
-								strokeWidth={2}
-								dot={false}
-							/>
-						</LineChart>
+							{chartType === "line" ? (
+								<Line
+									dataKey={activeSeries}
+									type="monotone"
+									stroke={`var(--color-${activeSeries})`}
+									strokeWidth={2}
+									dot={false}
+								/>
+							) : (
+								<Bar
+									dataKey={activeSeries}
+									fill={`var(--color-${activeSeries})`}
+									maxBarSize={40}
+									radius={[3, 3, 0, 0]}
+								/>
+							)}
+						</ChartRoot>
 					</ChartContainer>
 				)}
 			</CardContent>

--- a/ee/admin/src/components/devpass-timeseries-chart.tsx
+++ b/ee/admin/src/components/devpass-timeseries-chart.tsx
@@ -2,8 +2,12 @@
 
 import { format, parseISO } from "date-fns";
 import { useMemo, useState } from "react";
-import { CartesianGrid, Line, LineChart, XAxis } from "recharts";
+import { Bar, BarChart, CartesianGrid, Line, LineChart, XAxis } from "recharts";
 
+import {
+	ChartTypeToggle,
+	type ChartType,
+} from "@/components/chart-type-toggle";
 import {
 	Card,
 	CardContent,
@@ -82,6 +86,8 @@ export function DevpassTimeseriesChart({
 		"rawRevenue",
 	]);
 	const [cumulative, setCumulative] = useState(false);
+	const [chartType, setChartType] = useState<ChartType>("line");
+	const ChartRoot = chartType === "line" ? LineChart : BarChart;
 	const $api = useApi();
 	const { data, isLoading, isError } = $api.useQuery(
 		"get",
@@ -141,18 +147,21 @@ export function DevpassTimeseriesChart({
 						totals won&apos;t match the cycle-scoped KPI cards above.
 					</CardDescription>
 				</div>
-				<div className="flex shrink-0 items-center gap-2">
-					<Label
-						htmlFor="devpass-cumulative"
-						className="text-xs font-normal text-muted-foreground"
-					>
-						Cumulative
-					</Label>
-					<Switch
-						id="devpass-cumulative"
-						checked={cumulative}
-						onCheckedChange={setCumulative}
-					/>
+				<div className="flex shrink-0 flex-wrap items-center gap-3">
+					<div className="flex items-center gap-2">
+						<Label
+							htmlFor="devpass-cumulative"
+							className="text-xs font-normal text-muted-foreground"
+						>
+							Cumulative
+						</Label>
+						<Switch
+							id="devpass-cumulative"
+							checked={cumulative}
+							onCheckedChange={setCumulative}
+						/>
+					</div>
+					<ChartTypeToggle value={chartType} onValueChange={setChartType} />
 				</div>
 			</CardHeader>
 			<div className="grid grid-cols-2 border-y sm:grid-cols-5">
@@ -215,7 +224,11 @@ export function DevpassTimeseriesChart({
 						config={chartConfig}
 						className="aspect-auto h-[250px] w-full"
 					>
-						<LineChart data={chartData} margin={{ left: 12, right: 12 }}>
+						<ChartRoot
+							data={chartData}
+							accessibilityLayer
+							margin={{ left: 12, right: 12 }}
+						>
 							<CartesianGrid vertical={false} />
 							<XAxis
 								dataKey="date"
@@ -253,17 +266,27 @@ export function DevpassTimeseriesChart({
 									/>
 								}
 							/>
-							{activeSeries.map((key) => (
-								<Line
-									key={key}
-									dataKey={key}
-									type="monotone"
-									stroke={`var(--color-${key})`}
-									strokeWidth={2}
-									dot={false}
-								/>
-							))}
-						</LineChart>
+							{activeSeries.map((key) =>
+								chartType === "line" ? (
+									<Line
+										key={key}
+										dataKey={key}
+										type="monotone"
+										stroke={`var(--color-${key})`}
+										strokeWidth={2}
+										dot={false}
+									/>
+								) : (
+									<Bar
+										key={key}
+										dataKey={key}
+										fill={`var(--color-${key})`}
+										maxBarSize={32}
+										radius={[2, 2, 0, 0]}
+									/>
+								),
+							)}
+						</ChartRoot>
 					</ChartContainer>
 				)}
 			</CardContent>

--- a/ee/admin/src/components/history-chart.tsx
+++ b/ee/admin/src/components/history-chart.tsx
@@ -2,8 +2,20 @@
 
 import { format } from "date-fns";
 import { useCallback, useEffect, useState } from "react";
-import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import {
+	Area,
+	AreaChart,
+	Bar,
+	BarChart,
+	CartesianGrid,
+	XAxis,
+	YAxis,
+} from "recharts";
 
+import {
+	ChartTypeToggle,
+	type ChartType,
+} from "@/components/chart-type-toggle";
 import { TokenBreakdown } from "@/components/token-breakdown";
 import { Button } from "@/components/ui/button";
 import {
@@ -161,6 +173,8 @@ export function HistoryChart({
 	const [internalWindow, setInternalWindow] = useState<HistoryWindow>("4h");
 	const window = externalWindow ?? internalWindow;
 	const [activeMetric, setActiveMetric] = useState<ActiveMetric>("requests");
+	const [chartType, setChartType] = useState<ChartType>("line");
+	const ChartRoot = chartType === "line" ? AreaChart : BarChart;
 
 	const loadData = useCallback(
 		async (w: HistoryWindow) => {
@@ -170,7 +184,6 @@ export function HistoryChart({
 				const result = await fetchData(w);
 				setData(result ?? []);
 			} catch (err) {
-				console.error("Failed to load history:", err);
 				setData([]);
 				setError(
 					err instanceof Error ? err.message : "Failed to load history data",
@@ -375,21 +388,30 @@ export function HistoryChart({
 						</span>
 					)}
 				</div>
-				<div className="flex items-center gap-1 border-b pb-2">
-					{metricTabs.map((tab) => (
-						<button
-							key={tab.key}
-							className={cn(
-								"rounded-md px-3 py-1 text-xs font-medium transition-colors",
-								activeMetric === tab.key
-									? "bg-primary text-primary-foreground"
-									: "text-muted-foreground hover:text-foreground",
-							)}
-							onClick={() => setActiveMetric(tab.key)}
-						>
-							{tab.label}
-						</button>
-					))}
+				<div className="flex flex-wrap items-center justify-between gap-2 border-b pb-2">
+					<div
+						className="flex items-center gap-1"
+						role="group"
+						aria-label="Metric"
+					>
+						{metricTabs.map((tab) => (
+							<button
+								key={tab.key}
+								type="button"
+								aria-pressed={activeMetric === tab.key}
+								className={cn(
+									"rounded-md px-3 py-1 text-xs font-medium transition-colors",
+									activeMetric === tab.key
+										? "bg-primary text-primary-foreground"
+										: "text-muted-foreground hover:text-foreground",
+								)}
+								onClick={() => setActiveMetric(tab.key)}
+							>
+								{tab.label}
+							</button>
+						))}
+					</div>
+					<ChartTypeToggle value={chartType} onValueChange={setChartType} />
 				</div>
 			</CardHeader>
 			<CardContent className="px-2 pb-4 sm:px-6">
@@ -421,8 +443,9 @@ export function HistoryChart({
 						config={config}
 						className="aspect-auto h-[200px] w-full"
 					>
-						<AreaChart
+						<ChartRoot
 							data={data}
+							accessibilityLayer
 							margin={{ left: 0, right: 8, top: 4, bottom: 0 }}
 						>
 							<CartesianGrid vertical={false} strokeDasharray="3 3" />
@@ -490,23 +513,31 @@ export function HistoryChart({
 									/>
 								}
 							/>
-							{dataKeys.map((key, i) => (
-								<Area
-									key={key}
-									dataKey={key}
-									type="monotone"
-									// The three token series are disjoint slices of the total, so
-									// stacking them keeps the silhouette equal to total tokens.
-									stackId={activeMetric === "tokens" ? "tokens" : undefined}
-									stroke={`var(--color-${key})`}
-									fill={`var(--color-${key})`}
-									fillOpacity={
-										activeMetric === "tokens" ? 0.3 : i === 0 ? 0.1 : 0.05
-									}
-									strokeWidth={2}
-								/>
-							))}
-						</AreaChart>
+							{dataKeys.map((key, i) =>
+								chartType === "line" ? (
+									<Area
+										key={key}
+										dataKey={key}
+										type="monotone"
+										stackId={activeMetric === "tokens" ? "tokens" : undefined}
+										stroke={`var(--color-${key})`}
+										fill={`var(--color-${key})`}
+										fillOpacity={
+											activeMetric === "tokens" ? 0.3 : i === 0 ? 0.1 : 0.05
+										}
+										strokeWidth={2}
+									/>
+								) : (
+									<Bar
+										key={key}
+										dataKey={key}
+										stackId={activeMetric === "tokens" ? "tokens" : undefined}
+										fill={`var(--color-${key})`}
+										maxBarSize={34}
+									/>
+								),
+							)}
+						</ChartRoot>
 					</ChartContainer>
 				)}
 			</CardContent>

--- a/ee/admin/src/components/provider-credentials-spend-overview.tsx
+++ b/ee/admin/src/components/provider-credentials-spend-overview.tsx
@@ -2,8 +2,20 @@
 
 import { format } from "date-fns";
 import { useMemo, useState } from "react";
-import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import {
+	Area,
+	AreaChart,
+	Bar,
+	BarChart,
+	CartesianGrid,
+	XAxis,
+	YAxis,
+} from "recharts";
 
+import {
+	ChartTypeToggle,
+	type ChartType,
+} from "@/components/chart-type-toggle";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -264,13 +276,16 @@ function ProviderSpendChart({
 	providerName,
 	metric,
 	bucketIsHour,
+	chartType,
 }: {
 	series: ProviderSeries;
 	providerName: string;
 	metric: Metric;
 	bucketIsHour: boolean;
+	chartType: ChartType;
 }) {
 	const Icon = getProviderIcon(series.provider);
+	const ChartRoot = chartType === "line" ? AreaChart : BarChart;
 
 	return (
 		<div className="rounded-lg border border-border/60 p-4">
@@ -291,8 +306,9 @@ function ProviderSpendChart({
 				</div>
 			) : (
 				<ChartContainer config={series.config} className="h-56 w-full">
-					<AreaChart
+					<ChartRoot
 						data={series.data}
+						accessibilityLayer
 						margin={{ left: 0, right: 8, top: 4, bottom: 0 }}
 					>
 						<CartesianGrid vertical={false} strokeDasharray="3 3" />
@@ -353,20 +369,30 @@ function ProviderSpendChart({
 								);
 							}}
 						/>
-						{series.seriesKeys.map((sk) => (
-							<Area
-								key={sk}
-								dataKey={sk}
-								type="monotone"
-								stackId="1"
-								stroke={`var(--color-${sk})`}
-								fill={`var(--color-${sk})`}
-								fillOpacity={0.5}
-								strokeWidth={1}
-							/>
-						))}
+						{series.seriesKeys.map((sk) =>
+							chartType === "line" ? (
+								<Area
+									key={sk}
+									dataKey={sk}
+									type="monotone"
+									stackId="credential"
+									stroke={`var(--color-${sk})`}
+									fill={`var(--color-${sk})`}
+									fillOpacity={0.5}
+									strokeWidth={1}
+								/>
+							) : (
+								<Bar
+									key={sk}
+									dataKey={sk}
+									stackId="credential"
+									fill={`var(--color-${sk})`}
+									maxBarSize={42}
+								/>
+							),
+						)}
 						<ChartLegend content={<ChartLegendContent />} />
-					</AreaChart>
+					</ChartRoot>
 				</ChartContainer>
 			)}
 		</div>
@@ -389,6 +415,7 @@ export function ProviderCredentialsSpendOverview({
 }) {
 	const [window, setWindow] = useState<SpendWindow>("7d");
 	const [metric, setMetric] = useState<Metric>("cost");
+	const [chartType, setChartType] = useState<ChartType>("line");
 	const $api = useApi();
 
 	const { data, isLoading } = $api.useQuery(
@@ -422,6 +449,7 @@ export function ProviderCredentialsSpendOverview({
 						</CardDescription>
 					</div>
 					<div className="flex flex-wrap items-center gap-3">
+						<ChartTypeToggle value={chartType} onValueChange={setChartType} />
 						<div className="flex items-center gap-1">
 							{METRICS.map((entry) => (
 								<button
@@ -470,6 +498,7 @@ export function ProviderCredentialsSpendOverview({
 								providerName={providerNames[series.provider] ?? series.provider}
 								metric={metric}
 								bucketIsHour={bucketIsHour}
+								chartType={chartType}
 							/>
 						))}
 					</div>

--- a/ee/admin/src/components/provider-key-spend-dialog.tsx
+++ b/ee/admin/src/components/provider-key-spend-dialog.tsx
@@ -3,8 +3,20 @@
 import { format } from "date-fns";
 import { BarChart3 } from "lucide-react";
 import { useMemo, useState } from "react";
-import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
+import {
+	Area,
+	AreaChart,
+	Bar,
+	BarChart,
+	CartesianGrid,
+	XAxis,
+	YAxis,
+} from "recharts";
 
+import {
+	ChartTypeToggle,
+	type ChartType,
+} from "@/components/chart-type-toggle";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -67,6 +79,8 @@ export function ProviderKeySpendDialog({
 }) {
 	const [open, setOpen] = useState(false);
 	const [window, setWindow] = useState<SpendWindow>("7d");
+	const [chartType, setChartType] = useState<ChartType>("line");
+	const ChartRoot = chartType === "line" ? AreaChart : BarChart;
 	const $api = useApi();
 
 	const { data, isLoading } = $api.useQuery(
@@ -120,17 +134,25 @@ export function ProviderKeySpendDialog({
 					</DialogDescription>
 				</DialogHeader>
 
-				<div className="flex items-center gap-1">
-					{WINDOWS.map((entry) => (
-						<Button
-							key={entry.key}
-							variant={window === entry.key ? "secondary" : "ghost"}
-							size="sm"
-							onClick={() => setWindow(entry.key)}
-						>
-							{entry.label}
-						</Button>
-					))}
+				<div className="flex flex-wrap items-center justify-between gap-2">
+					<div
+						className="flex items-center gap-1"
+						role="group"
+						aria-label="Time range"
+					>
+						{WINDOWS.map((entry) => (
+							<Button
+								key={entry.key}
+								variant={window === entry.key ? "secondary" : "ghost"}
+								size="sm"
+								aria-pressed={window === entry.key}
+								onClick={() => setWindow(entry.key)}
+							>
+								{entry.label}
+							</Button>
+						))}
+					</div>
+					<ChartTypeToggle value={chartType} onValueChange={setChartType} />
 				</div>
 
 				{isLoading ? (
@@ -167,7 +189,7 @@ export function ProviderKeySpendDialog({
 							</p>
 						) : (
 							<ChartContainer config={chartConfig} className="h-64 w-full">
-								<AreaChart data={chartData}>
+								<ChartRoot data={chartData} accessibilityLayer>
 									<CartesianGrid vertical={false} />
 									<XAxis
 										dataKey="timestamp"
@@ -197,14 +219,23 @@ export function ProviderKeySpendDialog({
 											/>
 										}
 									/>
-									<Area
-										dataKey="cost"
-										type="monotone"
-										stroke="var(--color-cost)"
-										fill="var(--color-cost)"
-										fillOpacity={0.2}
-									/>
-								</AreaChart>
+									{chartType === "line" ? (
+										<Area
+											dataKey="cost"
+											type="monotone"
+											stroke="var(--color-cost)"
+											fill="var(--color-cost)"
+											fillOpacity={0.2}
+										/>
+									) : (
+										<Bar
+											dataKey="cost"
+											fill="var(--color-cost)"
+											maxBarSize={42}
+											radius={[3, 3, 0, 0]}
+										/>
+									)}
+								</ChartRoot>
 							</ChartContainer>
 						)}
 

--- a/ee/admin/src/components/revenue-chart.tsx
+++ b/ee/admin/src/components/revenue-chart.tsx
@@ -13,6 +13,10 @@ import {
 } from "recharts";
 
 import {
+	ChartTypeToggle,
+	type ChartType,
+} from "@/components/chart-type-toggle";
+import {
 	Card,
 	CardContent,
 	CardDescription,
@@ -100,6 +104,8 @@ export function RevenueChart({
 	totals: { credits: number; devpass: number; enterprise: number };
 }) {
 	const [activeView, setActiveView] = useState<ActiveView>("credits");
+	const [chartType, setChartType] = useState<ChartType>("line");
+	const MainChart = chartType === "line" ? LineChart : BarChart;
 
 	const dailyData = useMemo(
 		() =>
@@ -119,9 +125,12 @@ export function RevenueChart({
 		<Card>
 			<CardHeader className="flex flex-col items-stretch space-y-0 border-b p-0 sm:flex-row">
 				<div className="flex flex-1 flex-col justify-center gap-1.5 px-6 py-5 sm:py-6">
-					<CardTitle className="font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
-						Credits, DevPass & Enterprise Revenue
-					</CardTitle>
+					<div className="flex flex-wrap items-center justify-between gap-3">
+						<CardTitle className="font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+							Credits, DevPass & Enterprise Revenue
+						</CardTitle>
+						<ChartTypeToggle value={chartType} onValueChange={setChartType} />
+					</div>
 					<CardDescription className="text-xs">
 						{revenueViews[activeView].description}
 					</CardDescription>
@@ -149,7 +158,11 @@ export function RevenueChart({
 					config={chartConfig}
 					className="aspect-auto h-[250px] w-full"
 				>
-					<LineChart data={data} margin={{ left: 12, right: 12 }}>
+					<MainChart
+						data={data}
+						accessibilityLayer
+						margin={{ left: 12, right: 12 }}
+					>
 						<CartesianGrid vertical={false} />
 						<XAxis
 							dataKey="date"
@@ -184,17 +197,27 @@ export function RevenueChart({
 								/>
 							}
 						/>
-						{revenueViews[activeView].lines.map((key) => (
-							<Line
-								key={key}
-								dataKey={key}
-								type="monotone"
-								stroke={`var(--color-${key})`}
-								strokeWidth={2}
-								dot={false}
-							/>
-						))}
-					</LineChart>
+						{revenueViews[activeView].lines.map((key) =>
+							chartType === "line" ? (
+								<Line
+									key={key}
+									dataKey={key}
+									type="monotone"
+									stroke={`var(--color-${key})`}
+									strokeWidth={2}
+									dot={false}
+								/>
+							) : (
+								<Bar
+									key={key}
+									dataKey={key}
+									fill={`var(--color-${key})`}
+									maxBarSize={36}
+									radius={[2, 2, 0, 0]}
+								/>
+							),
+						)}
+					</MainChart>
 				</ChartContainer>
 				<div className="mt-2 px-2 sm:px-0">
 					<p className="mb-1 px-2 text-xs text-muted-foreground sm:px-3">

--- a/ee/admin/src/components/signups-chart.tsx
+++ b/ee/admin/src/components/signups-chart.tsx
@@ -5,6 +5,10 @@ import { useMemo, useState } from "react";
 import { Bar, BarChart, CartesianGrid, Line, LineChart, XAxis } from "recharts";
 
 import {
+	ChartTypeToggle,
+	type ChartType,
+} from "@/components/chart-type-toggle";
+import {
 	Card,
 	CardContent,
 	CardDescription,
@@ -47,6 +51,8 @@ export function SignupsChart({
 	totals: { signups: number; paidCustomers: number };
 }) {
 	const [activeChart, setActiveChart] = useState<ActiveChart>("signups");
+	const [chartType, setChartType] = useState<ChartType>("line");
+	const MainChart = chartType === "line" ? LineChart : BarChart;
 
 	const dailyData = useMemo(
 		() =>
@@ -64,9 +70,12 @@ export function SignupsChart({
 		<Card>
 			<CardHeader className="flex flex-col items-stretch space-y-0 border-b p-0 sm:flex-row">
 				<div className="flex flex-1 flex-col justify-center gap-1.5 px-6 py-5 sm:py-6">
-					<CardTitle className="font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
-						Signups & Paid Customers
-					</CardTitle>
+					<div className="flex flex-wrap items-center justify-between gap-3">
+						<CardTitle className="font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+							Signups & Paid Customers
+						</CardTitle>
+						<ChartTypeToggle value={chartType} onValueChange={setChartType} />
+					</div>
 					<CardDescription className="text-xs">
 						Cumulative signups and paid customers over time
 					</CardDescription>
@@ -94,7 +103,11 @@ export function SignupsChart({
 					config={chartConfig}
 					className="aspect-auto h-[250px] w-full"
 				>
-					<LineChart data={data} margin={{ left: 12, right: 12 }}>
+					<MainChart
+						data={data}
+						accessibilityLayer
+						margin={{ left: 12, right: 12 }}
+					>
 						<CartesianGrid vertical={false} />
 						<XAxis
 							dataKey="date"
@@ -119,14 +132,23 @@ export function SignupsChart({
 								/>
 							}
 						/>
-						<Line
-							dataKey={activeChart}
-							type="monotone"
-							stroke={`var(--color-${activeChart})`}
-							strokeWidth={2}
-							dot={false}
-						/>
-					</LineChart>
+						{chartType === "line" ? (
+							<Line
+								dataKey={activeChart}
+								type="monotone"
+								stroke={`var(--color-${activeChart})`}
+								strokeWidth={2}
+								dot={false}
+							/>
+						) : (
+							<Bar
+								dataKey={activeChart}
+								fill={`var(--color-${activeChart})`}
+								maxBarSize={40}
+								radius={[3, 3, 0, 0]}
+							/>
+						)}
+					</MainChart>
 				</ChartContainer>
 				<div className="mt-2 px-2 sm:px-0">
 					<p className="mb-1 px-2 text-xs text-muted-foreground sm:px-3">

--- a/ee/admin/src/components/token-time-range-toggle.tsx
+++ b/ee/admin/src/components/token-time-range-toggle.tsx
@@ -1,16 +1,15 @@
 "use client";
 
-import { ChevronDownIcon } from "lucide-react";
+import { Check, ChevronDownIcon, Clock3 } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useState } from "react";
 
-import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 import {
 	Popover,
 	PopoverContent,
 	PopoverTrigger,
 } from "@/components/ui/popover";
-import { cn } from "@/lib/utils";
 
 import type { TokenWindow } from "@/lib/types";
 
@@ -34,38 +33,12 @@ export function TokenTimeRangeToggle({ initial }: TimeRangeToggleProps) {
 	const router = useRouter();
 	const pathname = usePathname();
 	const [open, setOpen] = useState(false);
-	const [search, setSearch] = useState("");
-	const [current, setCurrent] = useState<TokenWindow>(initial);
-
-	useEffect(() => {
-		const param = searchParams.get("window");
-		if (
-			param === "1h" ||
-			param === "4h" ||
-			param === "12h" ||
-			param === "1d" ||
-			param === "7d" ||
-			param === "30d" ||
-			param === "90d" ||
-			param === "365d"
-		) {
-			setCurrent(param);
-		} else {
-			setCurrent("1d");
-		}
-	}, [searchParams]);
+	const param = searchParams.get("window");
+	const current = windowOptions.some((option) => option.value === param)
+		? (param as TokenWindow)
+		: initial;
 
 	const selected = windowOptions.find((o) => o.value === current);
-
-	const filteredOptions = useMemo(
-		() =>
-			search.trim()
-				? windowOptions.filter((o) =>
-						o.label.toLowerCase().includes(search.toLowerCase()),
-					)
-				: windowOptions,
-		[search],
-	);
 
 	function setWindow(value: TokenWindow) {
 		const params = new URLSearchParams(searchParams.toString());
@@ -74,52 +47,46 @@ export function TokenTimeRangeToggle({ initial }: TimeRangeToggleProps) {
 		} else {
 			params.set("window", value);
 		}
-		setCurrent(value);
 		const query = params.toString();
-		router.push(query ? `${pathname}?${query}` : pathname);
+		router.replace(query ? `${pathname}?${query}` : pathname, {
+			scroll: false,
+		});
 		setOpen(false);
 	}
 
 	return (
-		<Popover
-			open={open}
-			onOpenChange={(isOpen) => {
-				setOpen(isOpen);
-				if (!isOpen) {
-					setSearch("");
-				}
-			}}
-		>
+		<Popover open={open} onOpenChange={setOpen}>
 			<PopoverTrigger asChild>
-				<button
+				<Button
 					type="button"
-					className="border-input hover:bg-accent hover:text-accent-foreground flex h-9 items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors"
+					variant="outline"
+					size="sm"
+					className="min-w-36 justify-between gap-3 bg-background"
 				>
-					{selected?.label ?? "Select window"}
+					<span className="inline-flex items-center gap-2">
+						<Clock3 className="h-3.5 w-3.5 text-muted-foreground" />
+						{selected?.label ?? "Select window"}
+					</span>
 					<ChevronDownIcon className="h-4 w-4 opacity-50" />
-				</button>
+				</Button>
 			</PopoverTrigger>
 			<PopoverContent className="w-52 p-0" align="end">
-				<div className="px-3 pb-2 pt-3">
-					<Input
-						autoFocus
-						value={search}
-						onChange={(e) => setSearch(e.target.value)}
-						className="h-8 rounded-none border-0 border-b-2 border-primary bg-transparent px-0 shadow-none focus-visible:ring-0"
-					/>
+				<div className="border-b px-3 py-2.5">
+					<p className="text-sm font-medium">Usage window</p>
+					<p className="text-xs text-muted-foreground">
+						Choose the aggregation range
+					</p>
 				</div>
-				<div className="max-h-72 overflow-y-auto pb-1">
-					{filteredOptions.map((option) => (
+				<div className="p-1">
+					{windowOptions.map((option) => (
 						<button
 							key={option.value}
 							type="button"
 							onClick={() => setWindow(option.value)}
-							className={cn(
-								"w-full px-3 py-2 text-left text-sm transition-colors hover:bg-accent",
-								current === option.value && "bg-accent/50",
-							)}
+							className="flex w-full items-center justify-between rounded-sm px-2 py-2 text-left text-sm transition-colors hover:bg-accent"
 						>
 							{option.label}
+							{current === option.value ? <Check className="h-4 w-4" /> : null}
 						</button>
 					))}
 				</div>

--- a/ee/admin/src/lib/admin-organizations.ts
+++ b/ee/admin/src/lib/admin-organizations.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { apiErrorMessage } from "./api-error";
 import { createServerApiClient } from "./server-api";
 
 import type { TokenWindow } from "./types";
@@ -18,12 +19,17 @@ export async function loadProjectMetricsAction(
 	window: TokenWindow,
 ) {
 	const $api = await createServerApiClient();
-	const { data } = await $api.GET(
+	const { data, error, response } = await $api.GET(
 		"/admin/organizations/{orgId}/projects/{projectId}/metrics",
 		{
 			params: { path: { orgId, projectId }, query: { window } },
 		},
 	);
+	if (!response.ok) {
+		throw new Error(
+			apiErrorMessage(error, "Failed to load project metrics", response),
+		);
+	}
 	return data ?? null;
 }
 

--- a/ee/admin/src/lib/global-stats-chart.spec.ts
+++ b/ee/admin/src/lib/global-stats-chart.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "vitest";
+
+import { buildGlobalStatsStackedChart } from "./global-stats-chart";
+
+const metricValues = {
+	requestCount: 1,
+	cost: 1,
+	totalTokens: 1,
+};
+
+describe("buildGlobalStatsStackedChart", () => {
+	test("maps punctuation-heavy dimension ids to distinct safe keys", () => {
+		const breakdown = [
+			{ key: "openai/gpt-5.6", label: "Mapping", ...metricValues },
+			{ key: "openai.gpt-5/6", label: "Collision candidate", ...metricValues },
+			{ key: "model:preview", label: "Preview", ...metricValues },
+		];
+		const chart = buildGlobalStatsStackedChart({
+			rankedBreakdown: breakdown,
+			timeseries: [{ date: "2026-09-01" }],
+			timeseriesBreakdown: breakdown.map((item, index) => ({
+				date: "2026-09-01",
+				key: item.key,
+				requestCount: index + 1,
+				cost: index + 1,
+				totalTokens: index + 1,
+			})),
+			metric: "cost",
+			limit: 8,
+		});
+
+		expect(chart.series).toEqual([
+			{ chartKey: "series_0", label: "Mapping", sourceKey: breakdown[0].key },
+			{
+				chartKey: "series_1",
+				label: "Collision candidate",
+				sourceKey: breakdown[1].key,
+			},
+			{ chartKey: "series_2", label: "Preview", sourceKey: breakdown[2].key },
+		]);
+		expect(chart.data[0]).toMatchObject({
+			series_0: 1,
+			series_1: 2,
+			series_2: 3,
+		});
+		expect(
+			chart.series.every((entry) => /^[a-zA-Z0-9_-]+$/.test(entry.chartKey)),
+		).toBe(true);
+	});
+
+	test("zero-fills dates and folds series beyond the limit into Other", () => {
+		const breakdown = Array.from({ length: 4 }, (_, index) => ({
+			key: `model/${index}`,
+			label: `Model ${index}`,
+			requestCount: 4 - index,
+			cost: 4 - index,
+			totalTokens: 4 - index,
+		}));
+		const chart = buildGlobalStatsStackedChart({
+			rankedBreakdown: breakdown,
+			timeseries: [{ date: "2026-09-01" }, { date: "2026-09-02" }],
+			timeseriesBreakdown: [
+				{ date: "2026-09-01", key: "model/0", ...metricValues },
+				{ date: "2026-09-01", key: "model/2", ...metricValues },
+				{
+					date: "2026-09-01",
+					key: "model/3",
+					requestCount: 2,
+					cost: 2,
+					totalTokens: 2,
+				},
+			],
+			metric: "requestCount",
+			limit: 2,
+		});
+
+		expect(chart.restCount).toBe(2);
+		expect(chart.series.at(-1)).toEqual({
+			chartKey: "series_other",
+			label: "Other (2)",
+			sourceKey: null,
+		});
+		expect(chart.data).toEqual([
+			{
+				date: "2026-09-01",
+				series_0: 1,
+				series_1: 0,
+				series_other: 3,
+			},
+			{
+				date: "2026-09-02",
+				series_0: 0,
+				series_1: 0,
+				series_other: 0,
+			},
+		]);
+	});
+});

--- a/ee/admin/src/lib/global-stats-chart.ts
+++ b/ee/admin/src/lib/global-stats-chart.ts
@@ -1,0 +1,98 @@
+export type GlobalStatsChartMetric = "requestCount" | "cost" | "totalTokens";
+
+export interface GlobalStatsBreakdownItem {
+	key: string;
+	label: string;
+	requestCount: number;
+	cost: number;
+	totalTokens: number;
+}
+
+export interface GlobalStatsTimeseriesPoint {
+	date: string;
+}
+
+export interface GlobalStatsTimeseriesBreakdownPoint extends GlobalStatsTimeseriesPoint {
+	key: string;
+	requestCount: number;
+	cost: number;
+	totalTokens: number;
+}
+
+export interface GlobalStatsChartSeries {
+	chartKey: string;
+	label: string;
+	sourceKey: string | null;
+}
+
+export interface GlobalStatsStackedChart {
+	data: Record<string, number | string>[];
+	series: GlobalStatsChartSeries[];
+	restCount: number;
+}
+
+/**
+ * Pivots API dimension keys into chart-safe rank keys. Model identifiers can
+ * contain dots and slashes, which are unsafe as Recharts paths and CSS custom
+ * property suffixes. Positional keys are both collision-proof and stable for
+ * the ranked series shown in this render.
+ */
+export function buildGlobalStatsStackedChart({
+	rankedBreakdown,
+	timeseries,
+	timeseriesBreakdown,
+	metric,
+	limit,
+}: {
+	rankedBreakdown: GlobalStatsBreakdownItem[];
+	timeseries: GlobalStatsTimeseriesPoint[];
+	timeseriesBreakdown: GlobalStatsTimeseriesBreakdownPoint[];
+	metric: GlobalStatsChartMetric;
+	limit: number;
+}): GlobalStatsStackedChart {
+	const top = rankedBreakdown.slice(0, limit);
+	const restCount = Math.max(0, rankedBreakdown.length - top.length);
+	const series: GlobalStatsChartSeries[] = top.map((item, index) => ({
+		chartKey: `series_${index}`,
+		label: item.label,
+		sourceKey: item.key,
+	}));
+	if (restCount > 0) {
+		series.push({
+			chartKey: "series_other",
+			label: `Other (${restCount})`,
+			sourceKey: null,
+		});
+	}
+
+	const chartKeyBySource = new Map(
+		series
+			.filter(
+				(entry): entry is GlobalStatsChartSeries & { sourceKey: string } =>
+					entry.sourceKey !== null,
+			)
+			.map((entry) => [entry.sourceKey, entry.chartKey]),
+	);
+	const rows = new Map<string, Record<string, number | string>>();
+	for (const point of timeseries) {
+		const row: Record<string, number | string> = { date: point.date };
+		for (const entry of series) {
+			row[entry.chartKey] = 0;
+		}
+		rows.set(point.date, row);
+	}
+
+	for (const point of timeseriesBreakdown) {
+		const row = rows.get(point.date);
+		if (!row) {
+			continue;
+		}
+		const chartKey = chartKeyBySource.get(point.key) ?? "series_other";
+		if (!(chartKey in row)) {
+			continue;
+		}
+		row[chartKey] = Number(row[chartKey]) + point[metric];
+	}
+
+	return { data: Array.from(rows.values()), series, restCount };
+}


### PR DESCRIPTION
## Summary

- replace the main usage area chart with grouped and stacked bars plus an explicit legend
- add reusable line/bar controls across admin time-series charts and reorganize global and organization controls
- add a hover-isolating rankings legend and an all-time top-apps panel
- broaden support-assistant knowledge across the gateway, dashboard, DevPass, Lounge, Airside, and documentation

## Testing

- `pnpm format`
- `pnpm build`
- `pnpm exec vitest run apps/api/src/utils/chat-support-knowledge.spec.ts --no-file-parallelism`
- `pnpm exec vitest run ee/admin/src/lib/global-stats-chart.spec.ts --no-file-parallelism`
- browser-verified dashboard bars, rankings hover isolation, Global Stats line/bar switching, and organization-action hydration

## Screenshots

Seeded local data. Each image compares before on the left with after on the right.

<details open>
<summary>Main dashboard usage chart</summary>

Light

![Main dashboard usage chart in light mode](https://raw.githubusercontent.com/theopenco/llmgateway/f2f84f7e7ca3c7cc59716f977c44257f165b0446/dashboard-light.png)

Dark

![Main dashboard usage chart in dark mode](https://raw.githubusercontent.com/theopenco/llmgateway/f2f84f7e7ca3c7cc59716f977c44257f165b0446/dashboard-dark.png)

</details>

<details open>
<summary>Rankings legend and top apps</summary>

Light

![Rankings in light mode](https://raw.githubusercontent.com/theopenco/llmgateway/f2f84f7e7ca3c7cc59716f977c44257f165b0446/rankings-light.png)

Dark

![Rankings in dark mode](https://raw.githubusercontent.com/theopenco/llmgateway/f2f84f7e7ca3c7cc59716f977c44257f165b0446/rankings-dark.png)

</details>

<details>
<summary>Admin dashboard chart controls</summary>

Light

![Admin dashboard chart controls in light mode](https://raw.githubusercontent.com/theopenco/llmgateway/f2f84f7e7ca3c7cc59716f977c44257f165b0446/admin-home-light.png)

Dark

![Admin dashboard chart controls in dark mode](https://raw.githubusercontent.com/theopenco/llmgateway/f2f84f7e7ca3c7cc59716f977c44257f165b0446/admin-home-dark.png)

</details>

<details>
<summary>Global Stats controls</summary>

Light

![Global Stats controls in light mode](https://raw.githubusercontent.com/theopenco/llmgateway/f2f84f7e7ca3c7cc59716f977c44257f165b0446/admin-global-light.png)

Dark

![Global Stats controls in dark mode](https://raw.githubusercontent.com/theopenco/llmgateway/f2f84f7e7ca3c7cc59716f977c44257f165b0446/admin-global-dark.png)

</details>

<details>
<summary>Organization detail controls</summary>

Light

![Organization detail controls in light mode](https://raw.githubusercontent.com/theopenco/llmgateway/f2f84f7e7ca3c7cc59716f977c44257f165b0446/admin-org-light.png)

Dark

![Organization detail controls in dark mode](https://raw.githubusercontent.com/theopenco/llmgateway/f2f84f7e7ca3c7cc59716f977c44257f165b0446/admin-org-dark.png)

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rankings now include a Top Apps section with usage statistics, logos, and links.
  * Admin charts support switching between line and bar views across analytics, revenue, signups, spend, and usage pages.
  * Public chat support knowledge now covers the expanded product suite, including Airside.

* **Improvements**
  * Dashboard and global statistics charts provide clearer comparisons, legends, and stacked breakdowns.
  * Organization and project metrics offer improved time-range controls and layouts.
  * Organization administration actions are grouped in a collapsible interface.
  * Invalid, restricted, preview, and internal knowledge pages are filtered from support results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->