### PR TITLE
feat(ui): manage enterprise organization skills

### DIFF
--- a/apps/docs/content/features/organization-skills.mdx
+++ b/apps/docs/content/features/organization-skills.mdx
@@ -1,0 +1,52 @@
+---
+title: Organization skills
+description: Publish shared skills and custom instructions for developers in your enterprise organization.
+---
+
+Organization skills are reusable instructions and supporting files that enterprise teams share through the CLI. Owners and admins publish skills in the dashboard; developers can discover and download them using a project API key from the same organization.
+
+## Publish a skill
+
+1. Open **Organization → Skills** in the dashboard.
+2. Choose **Import SKILL.md** for a single skill, **Import folder** for a skill with references, scripts, or assets, or **New custom skill** to write instructions.
+3. Review the content and save. New skills are enabled immediately.
+
+A skill folder must contain `SKILL.md` at its root. Its YAML header needs a unique lowercase, hyphenated `name` of up to 64 characters and a `description` of up to 1,024 characters. Write the instructions below the header:
+
+```md
+---
+name: code-review
+description: Review code changes against the team's standards.
+---
+
+# Code review
+
+- Check correctness and error handling.
+- Explain the impact of each finding.
+- Suggest tests for important edge cases.
+```
+
+Bundles support up to 100 additional files and 1 MB of total content. `SKILL.md` supports up to 200,000 characters within that limit. Supporting paths must be relative to the skill folder; duplicate paths and parent-directory traversal are rejected. Existing YAML fields, such as `license` or `allowed-tools`, are preserved.
+
+## Manage access
+
+All active organization members can view skills. Owners and admins can edit, disable, or delete them. Keep a published skill's name unchanged; create a new skill to use a different name.
+
+Disabling a skill removes it from CLI discovery and prevents new downloads. Deleting it also removes its stored content. These actions cannot remove copies already downloaded to a developer's machine. Publishing and management actions appear in the organization's audit log without recording the skill content.
+
+## CLI API contract
+
+These endpoints belong to the [platform API](https://internal.llmgateway.io/docs). Authenticate with `Authorization: Bearer <project-api-key>`, using a regular project API key issued to an active member with access to that project.
+
+| Method | Path                | Response                                         |
+| ------ | ------------------- | ------------------------------------------------ |
+| GET    | `/v1/skills`        | `{ skills: [...] }` with enabled skill summaries |
+| GET    | `/v1/skills/{name}` | `{ skill: { ...summary, content, files } }`      |
+
+A summary contains `id`, `name`, `description`, `enabled`, `createdAt`, and `updatedAt`. Timestamps use ISO 8601. `content` is the complete `SKILL.md`, including its YAML header. Each supporting file contains a relative `path`, `content`, and optional `encoding` (`utf-8` by default, or `base64` for binary files).
+
+Clients should discover skills at the start of a session, download selected skills by name, and write each bundle into its own directory. Revalidate authorization before reusing organization content and remove cached availability when access is denied. Treat supporting scripts as code to review before running.
+
+The server derives the organization from the API key. Expired or revoked keys return `401`; removed project access or missing enterprise access returns `403`; missing or disabled skills return `404`. Responses use `Cache-Control: private, no-store`.
+
+Dashboard management uses session authentication at `/orgs/{organizationId}/skills`: `GET` lists summaries and `POST` creates a bundle. At `/orgs/{organizationId}/skills/{id}`, `GET` reads a bundle, `PUT` replaces `{ content, files }`, `PATCH` sets `{ enabled }`, and `DELETE` removes it. Duplicate names return `409`.

--- a/apps/ui/src/app/dashboard/[orgId]/org/skills/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/skills/page.tsx
@@ -1,0 +1,10 @@
+import { OrganizationSkills } from "@/components/skills/organization-skills";
+
+export default async function OrganizationSkillsPage({
+	params,
+}: {
+	params: Promise<{ orgId: string }>;
+}) {
+	const { orgId } = await params;
+	return <OrganizationSkills organizationId={orgId} />;
+}

--- a/apps/ui/src/components/dashboard/dashboard-sidebar.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-sidebar.tsx
@@ -223,6 +223,12 @@ const ORGANIZATION_NAVIGATION: readonly {
 		enterpriseGated: true,
 	},
 	{
+		href: "org/skills",
+		label: "Skills",
+		icon: AnimatedTerminal,
+		enterpriseGated: true,
+	},
+	{
 		href: "org/guardrails",
 		label: "Guardrails",
 		icon: AnimatedShield,
@@ -764,9 +770,7 @@ function OrganizationSection({
 	);
 }
 
-// Org-level entries visible to project-scoped "developer" members: the custom
-// models catalog is readable by every active member, so developers get a
-// read-only view of the providers and models their org makes available.
+// Organization resources available to project-scoped developers.
 function DeveloperOrgSection({
 	isActive,
 	isMobile,
@@ -795,6 +799,16 @@ function DeveloperOrgSection({
 						isMobile={isMobile}
 						toggleSidebar={toggleSidebar}
 					/>
+					{isEnterprise && (
+						<OrgNavItem
+							href={buildOrgUrl("org/skills")}
+							label="Skills"
+							icon={AnimatedTerminal}
+							isActive={isActive("org/skills")}
+							isMobile={isMobile}
+							toggleSidebar={toggleSidebar}
+						/>
+					)}
 				</SidebarMenu>
 			</SidebarGroupContent>
 		</SidebarGroup>
@@ -1270,6 +1284,16 @@ export function DashboardSidebar({
 					section: "Organization",
 					icon: AnimatedBotMessageSquare,
 				},
+				...(selectedOrganization?.enterpriseAccess === true
+					? [
+							{
+								href: buildOrgUrl("org/skills"),
+								label: "Skills",
+								section: "Organization",
+								icon: AnimatedTerminal,
+							},
+						]
+					: []),
 			];
 		}
 
@@ -1314,7 +1338,14 @@ export function DashboardSidebar({
 				external: !item.internal,
 			})),
 		];
-	}, [isDeveloper, buildUrl, buildOrgUrl, searchParams, toolsResources]);
+	}, [
+		isDeveloper,
+		selectedOrganization?.enterpriseAccess,
+		buildUrl,
+		buildOrgUrl,
+		searchParams,
+		toolsResources,
+	]);
 
 	const searchMatches = useMemo(
 		() => filterSearchableLinks(searchableLinks, searchQuery),

--- a/apps/ui/src/components/skills/organization-skills.tsx
+++ b/apps/ui/src/components/skills/organization-skills.tsx
@@ -1,0 +1,694 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import {
+	FileCode2,
+	FolderUp,
+	Loader2,
+	Plus,
+	Trash2,
+	Upload,
+} from "lucide-react";
+import Link from "next/link";
+import { useRef, useState } from "react";
+
+import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
+import { Alert, AlertDescription, AlertTitle } from "@/lib/components/alert";
+import { Badge } from "@/lib/components/badge";
+import { Button } from "@/lib/components/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardFooter,
+	CardHeader,
+	CardTitle,
+} from "@/lib/components/card";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/lib/components/dialog";
+import {
+	Empty,
+	EmptyDescription,
+	EmptyHeader,
+	EmptyMedia,
+	EmptyTitle,
+} from "@/lib/components/empty";
+import {
+	Field,
+	FieldDescription,
+	FieldGroup,
+	FieldLabel,
+} from "@/lib/components/field";
+import { Skeleton } from "@/lib/components/skeleton";
+import { Switch } from "@/lib/components/switch";
+import { Textarea } from "@/lib/components/textarea";
+import { toast } from "@/lib/components/use-toast";
+import { useApi } from "@/lib/fetch-client";
+
+import type { paths } from "@/lib/api/v1";
+
+type Skill =
+	paths["/orgs/{organizationId}/skills/{id}"]["get"]["responses"][200]["content"]["application/json"]["skill"];
+type Bundle = Pick<Skill, "content" | "files">;
+
+const template = `---
+name: code-review
+description: Review code changes against our team's standards.
+---
+
+# Code review
+
+- Check correctness and error handling.
+- Explain the impact of each finding.
+- Suggest tests for important edge cases.
+`;
+
+function errorMessage(error: unknown) {
+	return error &&
+		typeof error === "object" &&
+		"message" in error &&
+		typeof error.message === "string"
+		? error.message
+		: "Unable to save this change. Check the skill format and try again.";
+}
+
+async function readBundle(upload: FileList): Promise<Bundle> {
+	const files = Array.from(upload);
+	if (
+		files.length > 101 ||
+		files.reduce((sum, file) => sum + file.size, 0) > 1024 * 1024
+	) {
+		throw new Error(
+			"Upload up to 100 supporting files, with a total size of 1 MB or less.",
+		);
+	}
+	const main = files.find(
+		(file) =>
+			file.name === "SKILL.md" &&
+			(!file.webkitRelativePath ||
+				file.webkitRelativePath.split("/").length === 2),
+	);
+	if (!main) {
+		throw new Error(
+			"Choose a SKILL.md file or a skill folder with SKILL.md at its root.",
+		);
+	}
+	const prefix = main.webkitRelativePath
+		? main.webkitRelativePath.slice(0, -"SKILL.md".length)
+		: "";
+	const supportingFiles: Bundle["files"] = [];
+	for (const file of files) {
+		if (file === main) {
+			continue;
+		}
+		const path = file.webkitRelativePath.slice(prefix.length);
+		if (!prefix || !file.webkitRelativePath.startsWith(prefix)) {
+			throw new Error(
+				"All supporting files must be inside the selected skill folder.",
+			);
+		}
+		const bytes = new Uint8Array(await file.arrayBuffer());
+		let content: string;
+		let encoding: "utf-8" | "base64" = "utf-8";
+		try {
+			content = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+			if (content.includes("\0")) {
+				throw new Error("Binary file");
+			}
+		} catch {
+			content = btoa(
+				Array.from(bytes, (byte) => String.fromCharCode(byte)).join(""),
+			);
+			encoding = "base64";
+		}
+		supportingFiles.push({ path, content, encoding });
+	}
+	return { content: await main.text(), files: supportingFiles };
+}
+
+function SkillForm({
+	organizationId,
+	initial,
+	skillId,
+	readOnly,
+	onSaved,
+}: {
+	organizationId: string;
+	initial: Bundle;
+	skillId?: string;
+	readOnly: boolean;
+	onSaved: () => void;
+}) {
+	const api = useApi();
+	const queryClient = useQueryClient();
+	const [content, setContent] = useState(initial.content);
+	const [files, setFiles] = useState(initial.files);
+	const [importing, setImporting] = useState(false);
+	const folderInput = useRef<HTMLInputElement>(null);
+	const [error, setError] = useState<string | null>(null);
+	const create = api.useMutation("post", "/orgs/{organizationId}/skills");
+	const update = api.useMutation("put", "/orgs/{organizationId}/skills/{id}");
+	const pending = create.isPending || update.isPending || importing;
+
+	async function replaceBundle(upload: FileList | null) {
+		if (!upload?.length) {
+			return;
+		}
+		setError(null);
+		setImporting(true);
+		try {
+			const bundle = await readBundle(upload);
+			setContent(bundle.content);
+			setFiles(bundle.files);
+		} catch (cause) {
+			setError(errorMessage(cause));
+		} finally {
+			setImporting(false);
+		}
+	}
+
+	async function save() {
+		setError(null);
+		try {
+			if (skillId) {
+				const updated = await update.mutateAsync({
+					params: { path: { organizationId, id: skillId } },
+					body: { content, files },
+				});
+				queryClient.setQueryData(
+					api.queryOptions("get", "/orgs/{organizationId}/skills/{id}", {
+						params: { path: { organizationId, id: skillId } },
+					}).queryKey,
+					updated,
+				);
+			} else {
+				await create.mutateAsync({
+					params: { path: { organizationId } },
+					body: { content, files },
+				});
+			}
+			onSaved();
+			toast({ title: "Skill saved" });
+		} catch (cause) {
+			setError(errorMessage(cause));
+		}
+	}
+
+	return (
+		<form
+			onSubmit={(event) => {
+				event.preventDefault();
+				void save();
+			}}
+			className="flex min-h-0 flex-col gap-5"
+		>
+			{!readOnly && (
+				<div>
+					<Button
+						type="button"
+						variant="outline"
+						disabled={pending}
+						onClick={() => folderInput.current?.click()}
+					>
+						<FolderUp data-icon="inline-start" />
+						Replace from folder
+					</Button>
+					<input
+						ref={folderInput}
+						type="file"
+						className="hidden"
+						aria-label="Replace skill folder"
+						{...{ webkitdirectory: "" }}
+						onChange={(event) => {
+							void replaceBundle(event.target.files);
+							event.target.value = "";
+						}}
+					/>
+				</div>
+			)}
+			<FieldGroup>
+				<Field>
+					<FieldLabel htmlFor="skill-content">SKILL.md</FieldLabel>
+					<FieldDescription>
+						Use a lowercase, hyphenated name and a description in the YAML
+						header, followed by your instructions.
+					</FieldDescription>
+					<Textarea
+						id="skill-content"
+						className="min-h-72 max-h-[45vh] overflow-y-auto font-mono"
+						value={content}
+						onChange={(event) => setContent(event.target.value)}
+						readOnly={readOnly}
+						disabled={pending}
+						required
+						maxLength={200_000}
+					/>
+				</Field>
+			</FieldGroup>
+			{files.length > 0 && (
+				<div
+					className="flex max-h-36 flex-col gap-1 overflow-y-auto"
+					aria-label="Supporting files"
+				>
+					<p className="text-sm font-medium">
+						Supporting files ({files.length})
+					</p>
+					{files.map((file) => (
+						<div
+							key={file.path}
+							className="flex items-center justify-between gap-2 text-sm"
+						>
+							<span className="truncate">{file.path}</span>
+							{!readOnly && (
+								<Button
+									type="button"
+									variant="ghost"
+									size="icon"
+									disabled={pending}
+									aria-label={`Remove ${file.path}`}
+									onClick={() =>
+										setFiles(files.filter((item) => item.path !== file.path))
+									}
+								>
+									<Trash2 />
+								</Button>
+							)}
+						</div>
+					))}
+				</div>
+			)}
+			{error && (
+				<Alert variant="destructive">
+					<AlertDescription>{error}</AlertDescription>
+				</Alert>
+			)}
+			{!readOnly && (
+				<DialogFooter>
+					<Button type="submit" disabled={pending}>
+						{pending && (
+							<Loader2 className="animate-spin" data-icon="inline-start" />
+						)}
+						Save skill
+					</Button>
+				</DialogFooter>
+			)}
+		</form>
+	);
+}
+
+function ExistingSkill({
+	organizationId,
+	id,
+	readOnly,
+	onSaved,
+}: {
+	organizationId: string;
+	id: string;
+	readOnly: boolean;
+	onSaved: () => void;
+}) {
+	const api = useApi();
+	const query = api.useQuery("get", "/orgs/{organizationId}/skills/{id}", {
+		params: { path: { organizationId, id } },
+	});
+	if (query.isPending) {
+		return <Skeleton className="h-72" />;
+	}
+	if (query.isError) {
+		return (
+			<Alert variant="destructive">
+				<AlertDescription>
+					Unable to load this skill.{" "}
+					<Button variant="link" onClick={() => void query.refetch()}>
+						Try again
+					</Button>
+				</AlertDescription>
+			</Alert>
+		);
+	}
+	return (
+		<SkillForm
+			key={query.data.skill.updatedAt}
+			organizationId={organizationId}
+			skillId={id}
+			initial={query.data.skill}
+			readOnly={readOnly}
+			onSaved={onSaved}
+		/>
+	);
+}
+
+export function OrganizationSkills({
+	organizationId,
+}: {
+	organizationId: string;
+}) {
+	const api = useApi();
+	const queryClient = useQueryClient();
+	const { selectedOrganization } = useDashboardNavigation();
+	const enterprise = selectedOrganization?.enterpriseAccess === true;
+	const manage =
+		selectedOrganization?.role === "owner" ||
+		selectedOrganization?.role === "admin";
+	const queryOptions = { params: { path: { organizationId } } };
+	const query = api.useQuery(
+		"get",
+		"/orgs/{organizationId}/skills",
+		queryOptions,
+		{ enabled: enterprise },
+	);
+	const toggle = api.useMutation("patch", "/orgs/{organizationId}/skills/{id}");
+	const remove = api.useMutation(
+		"delete",
+		"/orgs/{organizationId}/skills/{id}",
+	);
+	const [editor, setEditor] = useState<{ id: string } | Bundle | null>(null);
+	const [deleteSkill, setDeleteSkill] = useState<{
+		id: string;
+		name: string;
+	} | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [importing, setImporting] = useState(false);
+	const fileInput = useRef<HTMLInputElement>(null);
+	const folderInput = useRef<HTMLInputElement>(null);
+	const refresh = () =>
+		queryClient.invalidateQueries({
+			queryKey: api.queryOptions(
+				"get",
+				"/orgs/{organizationId}/skills",
+				queryOptions,
+			).queryKey,
+		});
+	const saved = () => {
+		setEditor(null);
+		void refresh();
+	};
+
+	async function upload(files: FileList | null) {
+		if (!files?.length) {
+			return;
+		}
+		setError(null);
+		setImporting(true);
+		try {
+			setEditor(await readBundle(files));
+		} catch (cause) {
+			setError(errorMessage(cause));
+		} finally {
+			setImporting(false);
+		}
+	}
+
+	return (
+		<div className="flex flex-col gap-6 p-4 pt-6 md:p-8">
+			<div className="flex flex-wrap items-start justify-between gap-4">
+				<div className="flex flex-col gap-1">
+					<h1 className="text-2xl font-bold tracking-tight md:text-3xl">
+						Skills
+					</h1>
+					<p className="text-muted-foreground">
+						Share your organization&apos;s workflows and expertise with
+						developers in the CLI.
+					</p>
+				</div>
+				{enterprise && manage && (
+					<div className="flex flex-wrap gap-2">
+						<Button
+							variant="outline"
+							disabled={importing}
+							onClick={() => fileInput.current?.click()}
+						>
+							<Upload data-icon="inline-start" />
+							Import SKILL.md
+						</Button>
+						<Button
+							variant="outline"
+							disabled={importing}
+							onClick={() => folderInput.current?.click()}
+						>
+							<FolderUp data-icon="inline-start" />
+							Import folder
+						</Button>
+						<Button onClick={() => setEditor({ content: template, files: [] })}>
+							<Plus data-icon="inline-start" />
+							New custom skill
+						</Button>
+						<input
+							ref={fileInput}
+							type="file"
+							accept=".md"
+							className="hidden"
+							aria-label="Import SKILL.md"
+							onChange={(event) => {
+								void upload(event.target.files);
+								event.target.value = "";
+							}}
+						/>
+						<input
+							ref={folderInput}
+							type="file"
+							className="hidden"
+							aria-label="Import skill folder"
+							{...{ webkitdirectory: "" }}
+							onChange={(event) => {
+								void upload(event.target.files);
+								event.target.value = "";
+							}}
+						/>
+					</div>
+				)}
+			</div>
+			{!enterprise ? (
+				<Card>
+					<CardHeader>
+						<CardTitle>Organization skills are an Enterprise feature</CardTitle>
+						<CardDescription>
+							Publish shared skills once so your developers can use the same
+							instructions and supporting files in the CLI.
+						</CardDescription>
+					</CardHeader>
+					<CardFooter>
+						<Button asChild>
+							<Link href="/enterprise">Explore Enterprise</Link>
+						</Button>
+					</CardFooter>
+				</Card>
+			) : (
+				<>
+					<Alert>
+						<FileCode2 />
+						<AlertTitle>Available across your organization</AlertTitle>
+						<AlertDescription>
+							Developers use a project API key from this organization to access
+							enabled skills in the CLI. Owners and admins manage publishing.{" "}
+							<Link
+								href="https://docs.llmgateway.io/features/organization-skills"
+								className="underline"
+							>
+								Read the guide
+							</Link>
+						</AlertDescription>
+					</Alert>
+					{error && (
+						<Alert variant="destructive">
+							<AlertDescription>{error}</AlertDescription>
+						</Alert>
+					)}
+					{query.isPending ? (
+						<Skeleton className="h-56" />
+					) : query.isError ? (
+						<Alert variant="destructive">
+							<AlertDescription>
+								Unable to load skills.{" "}
+								<Button variant="link" onClick={() => void query.refetch()}>
+									Try again
+								</Button>
+							</AlertDescription>
+						</Alert>
+					) : query.data?.skills.length ? (
+						<div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
+							{query.data.skills.map((skill) => (
+								<Card key={skill.id}>
+									<CardHeader>
+										<div className="flex items-center justify-between gap-3">
+											<CardTitle className="min-w-0 break-all">
+												{skill.name}
+											</CardTitle>
+											<Badge
+												className="shrink-0"
+												variant={skill.enabled ? "default" : "secondary"}
+											>
+												{skill.enabled ? "Enabled" : "Disabled"}
+											</Badge>
+										</div>
+										<CardDescription className="[overflow-wrap:anywhere]">
+											{skill.description}
+										</CardDescription>
+									</CardHeader>
+									<CardContent>
+										<p className="text-sm text-muted-foreground">
+											{skill.enabled
+												? "Available to developers in the CLI"
+												: "Hidden from CLI discovery and downloads"}
+										</p>
+									</CardContent>
+									<CardFooter className="mt-auto flex flex-wrap justify-between gap-3">
+										<Button
+											variant="outline"
+											onClick={() => setEditor({ id: skill.id })}
+										>
+											{manage ? "Edit skill" : "View skill"}
+										</Button>
+										{manage && (
+											<div className="flex items-center gap-3">
+												<Switch
+													aria-label={`Enable ${skill.name}`}
+													checked={skill.enabled}
+													disabled={toggle.isPending}
+													onCheckedChange={(enabled) => {
+														setError(null);
+														toggle.mutate(
+															{
+																params: {
+																	path: { organizationId, id: skill.id },
+																},
+																body: { enabled },
+															},
+															{
+																onSuccess: () => {
+																	void refresh();
+																},
+																onError: (cause) =>
+																	setError(errorMessage(cause)),
+															},
+														);
+													}}
+												/>
+												<Button
+													variant="ghost"
+													size="icon"
+													aria-label={`Delete ${skill.name}`}
+													onClick={() => setDeleteSkill(skill)}
+												>
+													<Trash2 />
+												</Button>
+											</div>
+										)}
+									</CardFooter>
+								</Card>
+							))}
+						</div>
+					) : (
+						<Empty className="border">
+							<EmptyHeader>
+								<EmptyMedia variant="icon">
+									<FileCode2 />
+								</EmptyMedia>
+								<EmptyTitle>No organization skills yet</EmptyTitle>
+								<EmptyDescription>
+									{manage
+										? "Import an existing skill or create custom instructions for your team. Skill folders can include references, scripts, and assets."
+										: "Your organization’s owners and admins can publish skills for you to use in the CLI."}
+								</EmptyDescription>
+							</EmptyHeader>
+						</Empty>
+					)}
+				</>
+			)}
+			<Dialog
+				open={editor !== null}
+				onOpenChange={(open) => {
+					if (!open) {
+						setEditor(null);
+					}
+				}}
+			>
+				<DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-3xl">
+					<DialogHeader>
+						<DialogTitle>
+							{editor && "id" in editor
+								? manage
+									? "Edit skill"
+									: "View skill"
+								: "Add organization skill"}
+						</DialogTitle>
+						<DialogDescription>
+							Keep the skill name stable so developers can continue finding it.
+							Changes apply to future CLI downloads.
+						</DialogDescription>
+					</DialogHeader>
+					{editor &&
+						("id" in editor ? (
+							<ExistingSkill
+								organizationId={organizationId}
+								id={editor.id}
+								readOnly={!manage}
+								onSaved={saved}
+							/>
+						) : (
+							<SkillForm
+								organizationId={organizationId}
+								initial={editor}
+								readOnly={!manage}
+								onSaved={saved}
+							/>
+						))}
+				</DialogContent>
+			</Dialog>
+			<Dialog
+				open={deleteSkill !== null}
+				onOpenChange={(open) => {
+					if (!open) {
+						setDeleteSkill(null);
+					}
+				}}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Delete {deleteSkill?.name}?</DialogTitle>
+						<DialogDescription>
+							This removes the skill from the organization. Developers will no
+							longer be able to download it.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<Button variant="outline" onClick={() => setDeleteSkill(null)}>
+							Cancel
+						</Button>
+						<Button
+							variant="destructive"
+							disabled={remove.isPending}
+							onClick={() => {
+								if (deleteSkill) {
+									remove.mutate(
+										{
+											params: { path: { organizationId, id: deleteSkill.id } },
+										},
+										{
+											onSuccess: () => {
+												setDeleteSkill(null);
+												void refresh();
+											},
+											onError: (cause) => {
+												setDeleteSkill(null);
+												setError(errorMessage(cause));
+											},
+										},
+									);
+								}
+							}}
+						>
+							Delete skill
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</div>
+	);
+}

--- a/apps/ui/src/lib/components/empty.tsx
+++ b/apps/ui/src/lib/components/empty.tsx
@@ -1,0 +1,104 @@
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+function Empty({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="empty"
+			className={cn(
+				"flex min-w-0 flex-1 flex-col items-center justify-center gap-6 text-balance rounded-lg border-dashed p-6 text-center md:p-12",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="empty-header"
+			className={cn(
+				"flex max-w-sm flex-col items-center gap-2 text-center",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+const emptyMediaVariants = cva(
+	"mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+	{
+		variants: {
+			variant: {
+				default: "bg-transparent",
+				icon: "bg-muted text-foreground flex size-10 shrink-0 items-center justify-center rounded-lg [&_svg:not([class*='size-'])]:size-6",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+		},
+	},
+);
+
+function EmptyMedia({
+	className,
+	variant = "default",
+	...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyMediaVariants>) {
+	return (
+		<div
+			data-slot="empty-icon"
+			data-variant={variant}
+			className={cn(emptyMediaVariants({ variant, className }))}
+			{...props}
+		/>
+	);
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="empty-title"
+			className={cn("text-lg font-medium tracking-tight", className)}
+			{...props}
+		/>
+	);
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+	return (
+		<div
+			data-slot="empty-description"
+			className={cn(
+				"text-muted-foreground [&>a:hover]:text-primary text-sm/relaxed [&>a]:underline [&>a]:underline-offset-4",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="empty-content"
+			className={cn(
+				"flex w-full min-w-0 max-w-sm flex-col items-center gap-4 text-balance text-sm",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	Empty,
+	EmptyHeader,
+	EmptyTitle,
+	EmptyDescription,
+	EmptyContent,
+	EmptyMedia,
+};

--- a/apps/ui/src/lib/components/field.tsx
+++ b/apps/ui/src/lib/components/field.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { cva, type VariantProps } from "class-variance-authority";
+import { useMemo } from "react";
+
+import { Label } from "@/lib/components/label";
+import { Separator } from "@/lib/components/separator";
+import { cn } from "@/lib/utils";
+
+function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
+	return (
+		<fieldset
+			data-slot="field-set"
+			className={cn(
+				"flex flex-col gap-6",
+				"has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function FieldLegend({
+	className,
+	variant = "legend",
+	...props
+}: React.ComponentProps<"legend"> & { variant?: "legend" | "label" }) {
+	return (
+		<legend
+			data-slot="field-legend"
+			data-variant={variant}
+			className={cn(
+				"mb-3 font-medium",
+				"data-[variant=legend]:text-base",
+				"data-[variant=label]:text-sm",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="field-group"
+			className={cn(
+				"group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 [&>[data-slot=field-group]]:gap-4",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+const fieldVariants = cva(
+	"group/field data-[invalid=true]:text-destructive flex w-full gap-3",
+	{
+		variants: {
+			orientation: {
+				vertical: ["flex-col [&>*]:w-full [&>.sr-only]:w-auto"],
+				horizontal: [
+					"flex-row items-center",
+					"[&>[data-slot=field-label]]:flex-auto",
+					"has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px has-[>[data-slot=field-content]]:items-start",
+				],
+				responsive: [
+					"@md/field-group:flex-row @md/field-group:items-center @md/field-group:[&>*]:w-auto flex-col [&>*]:w-full [&>.sr-only]:w-auto",
+					"@md/field-group:[&>[data-slot=field-label]]:flex-auto",
+					"@md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+				],
+			},
+		},
+		defaultVariants: {
+			orientation: "vertical",
+		},
+	},
+);
+
+function Field({
+	className,
+	orientation = "vertical",
+	...props
+}: React.ComponentProps<"div"> & VariantProps<typeof fieldVariants>) {
+	return (
+		<div
+			role="group"
+			data-slot="field"
+			data-orientation={orientation}
+			className={cn(fieldVariants({ orientation }), className)}
+			{...props}
+		/>
+	);
+}
+
+function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="field-content"
+			className={cn(
+				"group/field-content flex flex-1 flex-col gap-1.5 leading-snug",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function FieldLabel({
+	className,
+	...props
+}: React.ComponentProps<typeof Label>) {
+	return (
+		<Label
+			data-slot="field-label"
+			className={cn(
+				"group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50",
+				"has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border [&>[data-slot=field]]:p-4",
+				"has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="field-label"
+			className={cn(
+				"flex w-fit items-center gap-2 text-sm font-medium leading-snug group-data-[disabled=true]/field:opacity-50",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
+	return (
+		<p
+			data-slot="field-description"
+			className={cn(
+				"text-muted-foreground text-sm font-normal leading-normal group-has-[[data-orientation=horizontal]]/field:text-balance",
+				"nth-last-2:-mt-1 last:mt-0 [[data-variant=legend]+&]:-mt-1.5",
+				"[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function FieldSeparator({
+	children,
+	className,
+	...props
+}: React.ComponentProps<"div"> & {
+	children?: React.ReactNode;
+}) {
+	return (
+		<div
+			data-slot="field-separator"
+			data-content={!!children}
+			className={cn(
+				"relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2",
+				className,
+			)}
+			{...props}
+		>
+			<Separator className="absolute inset-0 top-1/2" />
+			{children && (
+				<span
+					className="bg-background text-muted-foreground relative mx-auto block w-fit px-2"
+					data-slot="field-separator-content"
+				>
+					{children}
+				</span>
+			)}
+		</div>
+	);
+}
+
+function FieldError({
+	className,
+	children,
+	errors,
+	...props
+}: React.ComponentProps<"div"> & {
+	errors?: Array<{ message?: string } | undefined>;
+}) {
+	const content = useMemo(() => {
+		if (children) {
+			return children;
+		}
+
+		if (!errors) {
+			return null;
+		}
+
+		if (errors?.length === 1 && errors[0]?.message) {
+			return errors[0].message;
+		}
+
+		return (
+			<ul className="ml-4 flex list-disc flex-col gap-1">
+				{errors.map(
+					(error, index) =>
+						error?.message && <li key={index}>{error.message}</li>,
+				)}
+			</ul>
+		);
+	}, [children, errors]);
+
+	if (!content) {
+		return null;
+	}
+
+	return (
+		<div
+			role="alert"
+			data-slot="field-error"
+			className={cn("text-destructive text-sm font-normal", className)}
+			{...props}
+		>
+			{content}
+		</div>
+	);
+}
+
+export {
+	Field,
+	FieldLabel,
+	FieldDescription,
+	FieldError,
+	FieldGroup,
+	FieldLegend,
+	FieldSeparator,
+	FieldSet,
+	FieldContent,
+	FieldTitle,
+};


### PR DESCRIPTION
Add an Organization → Skills screen so enterprise owners and admins can import a SKILL.md file or complete folder, write a custom skill, edit its bundle, and control whether developers can discover it through the CLI. Developers get a read-only view. Non-enterprise organizations see the enterprise entry point.

The screen uses the generated API client and TanStack Query. The guide documents publishing, access, bundle limits, and the CLI endpoint contract.

Validation: exercised custom creation, single-file and folder imports, binary-file download through the CLI API, editing, enable/disable, deletion, and developer read-only access in the isolated stack. Checked mobile layout and both themes; no browser errors. Repository formatting and the full build passed.

Light theme

<img width="1440" alt="Organization skills in light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/78684078c3bc9e6d716f6e848cc56799c140e071/skills-light.png" />

Dark theme

<img width="1440" alt="Organization skills in dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/78684078c3bc9e6d716f6e848cc56799c140e071/skills-dark.png" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization Skills management for eligible enterprise organizations.
  * Users can create, import, edit, enable, disable, and delete reusable skills and supporting files.
  * Added Skills navigation and search access in the organization dashboard.
  * Added validation and feedback for skill uploads, including file limits and required structure.

* **Documentation**
  * Added documentation covering skill creation, access management, publishing, CLI usage, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->