### PR TITLE
fix(seo): improve product search visibility

### DIFF
--- a/apps/airside/public/llms.txt
+++ b/apps/airside/public/llms.txt
@@ -1,6 +1,6 @@
 # Airside by LLM Gateway
 
-> Airside is the self-serve carrier console for LLM providers on LLM Gateway. Providers claim their carrier by verifying an email on their API endpoint's domain, register their model fleet, file fares (pricing) for review, watch their routed traffic, and tune the discount and gateway margin that feed the smart routing election.
+> Airside is the self-service provider portal for LLM Gateway. LLM API providers can verify their domain, submit models and pricing for approval, and track routed traffic. Providers control their routing discount and the gateway margin they accept.
 
 ## How it works
 

--- a/apps/airside/src/app/layout.tsx
+++ b/apps/airside/src/app/layout.tsx
@@ -29,11 +29,11 @@ export const dynamic = "force-dynamic";
 export const metadata: Metadata = {
 	metadataBase: new URL("https://airside.llmgateway.io"),
 	title: {
-		default: "Airside by LLM Gateway — the carrier console",
+		default: "Airside — List Your LLM API on LLM Gateway",
 		template: "%s | Airside by LLM Gateway",
 	},
 	description:
-		"The self-serve console for LLM providers. Claim your carrier, register your fleet, file your fares, and watch dispatch route traffic to your models.",
+		"List your LLM API on LLM Gateway. Verify your provider domain, publish models and pricing, and track routed traffic through Airside's self-serve console.",
 	applicationName: "Airside",
 	alternates: { canonical: "./" },
 	robots: {
@@ -48,9 +48,9 @@ export const metadata: Metadata = {
 		},
 	},
 	openGraph: {
-		title: "Airside by LLM Gateway",
+		title: "Airside — List Your LLM API on LLM Gateway",
 		description:
-			"The self-serve console for LLM providers. Claim your carrier, register your fleet, file your fares, and win traffic.",
+			"List your LLM API on LLM Gateway, publish models and pricing, and track routed traffic through Airside's self-serve provider console.",
 		siteName: "Airside by LLM Gateway",
 		url: "https://airside.llmgateway.io",
 		locale: "en_US",
@@ -58,9 +58,9 @@ export const metadata: Metadata = {
 	},
 	twitter: {
 		card: "summary_large_image",
-		title: "Airside by LLM Gateway",
+		title: "Airside — List Your LLM API on LLM Gateway",
 		description:
-			"The self-serve console for LLM providers. Claim your carrier, register your fleet, file your fares, and win traffic.",
+			"List your LLM API on LLM Gateway, publish models and pricing, and track routed traffic through Airside's self-serve provider console.",
 	},
 };
 

--- a/apps/airside/src/app/page.tsx
+++ b/apps/airside/src/app/page.tsx
@@ -107,7 +107,7 @@ const JSON_LD = [
 		name: "Airside by LLM Gateway",
 		url: SITE_URL,
 		description:
-			"The self-serve console for LLM providers. Claim your carrier, register your fleet, file your fares, and win traffic on LLM Gateway.",
+			"Airside is the self-service provider portal for LLM Gateway. Verify your domain, submit models and pricing for approval, and track routed traffic.",
 		inLanguage: "en",
 		publisher: { "@id": "https://llmgateway.io#organization" },
 	},
@@ -168,9 +168,9 @@ export default function LandingPage() {
 								Put your models on the departure board.
 							</h1>
 							<p className="text-muted-foreground mt-6 max-w-xl text-lg text-pretty">
-								LLM Gateway routes developer traffic across model providers.
-								Airside is where providers run the airline: claim your carrier,
-								register your fleet, file your fares — and win routes.
+								Airside is the self-service provider portal for LLM Gateway.
+								List your LLM API, submit models and pricing for approval, and
+								track the developer traffic routed to your service.
 							</p>
 							<div className="mt-8 flex flex-wrap items-center gap-3">
 								<Button asChild size="lg" className="font-semibold">

--- a/apps/airside/src/app/sitemap.ts
+++ b/apps/airside/src/app/sitemap.ts
@@ -3,24 +3,19 @@ import type { MetadataRoute } from "next";
 const baseUrl = "https://airside.llmgateway.io";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-	const lastModified = new Date();
-
 	return [
 		{
 			url: baseUrl,
-			lastModified,
 			changeFrequency: "weekly",
 			priority: 1,
 		},
 		{
 			url: `${baseUrl}/legal/terms`,
-			lastModified,
 			changeFrequency: "yearly",
 			priority: 0.3,
 		},
 		{
 			url: `${baseUrl}/legal/privacy`,
-			lastModified,
 			changeFrequency: "yearly",
 			priority: 0.3,
 		},

--- a/apps/code/public/llms.txt
+++ b/apps/code/public/llms.txt
@@ -1,13 +1,13 @@
 # DevPass by LLM Gateway
 
-> DevPass is a flat-price subscription for AI coding tools. One API key unlocks 200+ models across 40+ providers in any OpenAI-compatible coding agent — DevPass Code, Claude Code, opencode, GitHub Copilot, Cursor, Continue, and more — with a fixed monthly usage allowance instead of surprise token bills. Once the allowance is used, requests pause by default; users can optionally enable pay-as-you-go overflow and top up a credits balance to keep going at provider rates.
+> DevPass is a flat-price subscription for AI coding tools. One API key connects the models in the live [DevPass catalogue](https://devpass.llmgateway.io/models) in any OpenAI-compatible coding agent — DevPass Code, Claude Code, opencode, GitHub Copilot, Cursor, Continue, and more — with a fixed monthly usage allowance instead of surprise token bills. Once the allowance is used, requests pause by default; users can optionally enable pay-as-you-go overflow and top up a credits balance to keep going at provider rates.
 
 ## Plans
 
 - Lite: $29/month — includes $87 of model usage at standard provider rates.
 - Pro: $79/month — includes $237 of model usage.
 - Max: $179/month — includes $537 of model usage.
-- Every plan includes the newest frontier models as they are released and full cost tracking.
+- Every plan includes model access and cost tracking; check the live catalogue for availability.
 - First-month guarantee: refund yourself from the dashboard within 14 days if you've used less than 20% of your monthly allowance.
 
 ## Key pages
@@ -29,4 +29,4 @@
 
 - DevPass works with any tool that speaks the OpenAI API format — point it at the gateway base URL.
 - Usage allowances are metered at provider list rates; there is no markup on tokens.
-- DevPass always smart-routes each request to the best provider; pinning a specific provider (provider-prefixed model ids like openai/gpt-4o) is not available on DevPass — use LLM Gateway's pay-as-you-go API for provider pinning.
+- DevPass always smart-routes each request to the best provider; pinning a specific provider (provider-prefixed model IDs) is not available on DevPass — use LLM Gateway's pay-as-you-go API for provider pinning.

--- a/apps/code/public/pricing.md
+++ b/apps/code/public/pricing.md
@@ -2,7 +2,7 @@
 
 Last updated: 2026-09-01
 
-> DevPass is a flat-price monthly subscription for AI coding tools. One API key unlocks 200+ models across 40+ providers in any OpenAI- or Anthropic-compatible coding agent (DevPass Code, Claude Code, OpenCode, Cursor, Cline, and more). Usage is metered at provider list rates with no token markup.
+> DevPass is a flat-price monthly subscription for AI coding tools. One API key connects the models in the live [DevPass catalogue](https://devpass.llmgateway.io/models) in any OpenAI- or Anthropic-compatible coding agent (DevPass Code, Claude Code, OpenCode, Cursor, Cline, and more). Usage is metered at provider list rates with no token markup.
 
 ## Lite
 
@@ -32,7 +32,7 @@ Last updated: 2026-09-01
 
 ## Every plan includes
 
-- All 200+ models, with new flagships available on release day (Claude, GPT, Gemini, GLM, Qwen, Kimi, and more)
+- Model access as listed in the live [DevPass catalogue](https://devpass.llmgateway.io/models)
 - Works with DevPass Code, Claude Code, OpenCode, Empryo, SoulForge, and any OpenAI/Anthropic-compatible tool
 - Real-time dashboard with per-request cost and latency
 - Switch tiers or cancel anytime — no lock-in, no cancellation fee

--- a/apps/code/src/app/dashboard/layout.tsx
+++ b/apps/code/src/app/dashboard/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+	title: "Dashboard",
+	robots: { index: false, follow: false },
+};
+
+export default function Layout({ children }: { children: ReactNode }) {
+	return <>{children}</>;
+}

--- a/apps/code/src/app/forgot-password/layout.tsx
+++ b/apps/code/src/app/forgot-password/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+	title: "Reset your password",
+	robots: { index: false, follow: false },
+};
+
+export default function Layout({ children }: { children: ReactNode }) {
+	return <>{children}</>;
+}

--- a/apps/code/src/app/login/layout.tsx
+++ b/apps/code/src/app/login/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+	title: "Sign in",
+	robots: { index: false, follow: false },
+};
+
+export default function Layout({ children }: { children: ReactNode }) {
+	return <>{children}</>;
+}

--- a/apps/code/src/app/reset-password/layout.tsx
+++ b/apps/code/src/app/reset-password/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+	title: "Set a new password",
+	robots: { index: false, follow: false },
+};
+
+export default function Layout({ children }: { children: ReactNode }) {
+	return <>{children}</>;
+}

--- a/apps/code/src/app/robots.ts
+++ b/apps/code/src/app/robots.ts
@@ -6,7 +6,7 @@ export default function robots(): MetadataRoute.Robots {
 			{
 				userAgent: "*",
 				allow: "/",
-				disallow: ["/dashboard/", "/login", "/signup", "/api/"],
+				disallow: ["/dashboard", "/api/"],
 			},
 		],
 		sitemap: "https://devpass.llmgateway.io/sitemap.xml",

--- a/apps/code/src/app/signup/layout.tsx
+++ b/apps/code/src/app/signup/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+	title: "Create an account",
+	robots: { index: false, follow: false },
+};
+
+export default function Layout({ children }: { children: ReactNode }) {
+	return <>{children}</>;
+}

--- a/apps/code/src/app/sitemap.ts
+++ b/apps/code/src/app/sitemap.ts
@@ -8,67 +8,56 @@ export default function sitemap(): MetadataRoute.Sitemap {
 	const staticPages: MetadataRoute.Sitemap = [
 		{
 			url: baseUrl,
-			lastModified: new Date(),
 			changeFrequency: "weekly",
 			priority: 1,
 		},
 		{
 			url: `${baseUrl}/coding-models`,
-			lastModified: new Date(),
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/models`,
-			lastModified: new Date(),
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/pricing`,
-			lastModified: new Date(),
 			changeFrequency: "weekly",
 			priority: 0.9,
 		},
 		{
 			url: `${baseUrl}/claude-code-alternative`,
-			lastModified: new Date(),
 			changeFrequency: "weekly",
 			priority: 0.9,
 		},
 		{
 			url: `${baseUrl}/guides`,
-			lastModified: new Date(),
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/compare`,
-			lastModified: new Date(),
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/leaderboard`,
-			lastModified: new Date(),
 			changeFrequency: "daily",
 			priority: 0.7,
 		},
 		{
 			url: `${baseUrl}/data/${new Date().getUTCFullYear()}`,
-			lastModified: new Date(),
 			changeFrequency: "daily",
 			priority: 0.7,
 		},
 		{
 			url: `${baseUrl}/legal/privacy`,
-			lastModified: new Date(),
 			changeFrequency: "yearly",
 			priority: 0.3,
 		},
 		{
 			url: `${baseUrl}/legal/terms`,
-			lastModified: new Date(),
 			changeFrequency: "yearly",
 			priority: 0.3,
 		},

--- a/apps/docs/app/llms-full.txt/route.ts
+++ b/apps/docs/app/llms-full.txt/route.ts
@@ -1,14 +1,14 @@
+import { docsBaseUrl } from "@/lib/base-url";
 import { getLLMText } from "@/lib/get-llm-text";
 import { source } from "@/lib/source";
 
-// cached forever
-export const revalidate = false;
+export const dynamic = "force-dynamic";
 
 const HEADER = `# LLM Gateway — Full Documentation
 
-> LLM Gateway is an open-source, OpenAI-compatible API gateway that routes, manages, and analyzes LLM requests across 40+ providers (OpenAI, Anthropic, Google, and more) through a single unified API. Switch providers without changing code, manage API keys centrally, track usage and cost, add caching and guardrails, and self-host or use the managed cloud.
+> LLM Gateway is an open-source, OpenAI-compatible API gateway for routing, managing, and analyzing requests across LLM providers. Use one API key, track usage and cost, configure caching and guardrails, and self-host or use the managed cloud. Current models and pricing: https://llmgateway.io/models
 
-API base URL: https://api.llmgateway.io/v1 · Docs: https://docs.llmgateway.io · Site: https://llmgateway.io
+API base URL: https://api.llmgateway.io/v1 · Docs: ${docsBaseUrl} · Site: https://llmgateway.io
 
 This file concatenates the full text of every documentation page below.`;
 

--- a/apps/docs/app/llms.mdx/[[...slug]]/route.ts
+++ b/apps/docs/app/llms.mdx/[[...slug]]/route.ts
@@ -1,8 +1,10 @@
 import { notFound } from "next/navigation";
 
+import { docsBaseUrl } from "@/lib/base-url";
+import { marketingGuideCanonical } from "@/lib/guide-canonical";
 import { getLLMText, source } from "@/lib/source";
 
-export const revalidate = false;
+export const dynamic = "force-dynamic";
 
 export async function GET(
 	_req: Request,
@@ -20,6 +22,7 @@ export async function GET(
 			// Keep the raw-markdown mirrors fetchable for AI crawlers but out
 			// of search indexes (they duplicate the HTML docs pages).
 			"X-Robots-Tag": "noindex",
+			Link: `<${marketingGuideCanonical(page.url) ?? `${docsBaseUrl}${page.url}`}>; rel="canonical"`,
 		},
 	});
 }

--- a/apps/docs/app/llms.txt/route.ts
+++ b/apps/docs/app/llms.txt/route.ts
@@ -1,12 +1,13 @@
+import { docsBaseUrl } from "@/lib/base-url";
+import { marketingGuideCanonical } from "@/lib/guide-canonical";
 import { source } from "@/lib/source";
 
 import type { InferPageType } from "fumadocs-core/source";
 
-// cached forever
-export const revalidate = false;
+export const dynamic = "force-dynamic";
 
 const SITE_URL = "https://llmgateway.io";
-const DOCS_URL = "https://docs.llmgateway.io";
+const DOCS_URL = docsBaseUrl;
 
 type Page = InferPageType<typeof source>;
 
@@ -38,7 +39,7 @@ export async function GET() {
 	const grouped = new Map<string, string[]>();
 	for (const page of pages) {
 		const key = sectionKey(page);
-		const line = `- [${page.data.title}](${DOCS_URL}${page.url})${page.data.description ? `: ${page.data.description}` : ""}`;
+		const line = `- [${page.data.title}](${marketingGuideCanonical(page.url) ?? `${DOCS_URL}${page.url}`})${page.data.description ? `: ${page.data.description}` : ""}`;
 		const existing = grouped.get(key);
 		if (existing) {
 			existing.push(line);
@@ -53,11 +54,11 @@ export async function GET() {
 
 	const content = `# LLM Gateway
 
-> LLM Gateway is an open-source, OpenAI-compatible API gateway that routes, manages, and analyzes LLM requests across 40+ providers (OpenAI, Anthropic, Google, and more) through a single unified API. Switch providers without changing code, manage API keys centrally, track usage and cost, add caching and guardrails, and self-host or use the managed cloud.
+> LLM Gateway is an open-source, OpenAI-compatible API gateway for routing, managing, and analyzing requests across LLM providers. Use one API key, track usage and cost, configure caching and guardrails, and self-host or use the managed cloud.
 
 ## Key facts
 
-- One OpenAI-compatible API for 40+ providers and 200+ models.
+- One OpenAI-compatible API; see the live [model catalogue](${SITE_URL}/models) for availability, pricing, and capabilities.
 - Migrate by changing only the base URL (\`https://api.llmgateway.io/v1\`) and your API key — no code rewrites.
 - Open source (AGPLv3 core) with a managed cloud option; self-hosting supported via Docker.
 - Built-in usage analytics, per-model/provider cost breakdowns, automatic routing, fallbacks, caching, and guardrails.
@@ -66,7 +67,7 @@ export async function GET() {
 ## Product pages
 
 - [Home](${SITE_URL}): Unified API for multiple LLM providers.
-- [Models](${SITE_URL}/models): Browse 200+ supported models with pricing and capabilities.
+- [Models](${SITE_URL}/models): Browse supported models with pricing and capabilities.
 - [Providers](${SITE_URL}/providers): All supported LLM providers.
 - [Pricing](${SITE_URL}/pricing): Plans and pricing.
 - [Enterprise](${SITE_URL}/enterprise): Self-hosting, SSO, and team features.

--- a/apps/docs/content/developers/devpass-usage.mdx
+++ b/apps/docs/content/developers/devpass-usage.mdx
@@ -6,8 +6,6 @@ icon: Gauge
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# DevPass Usage API
-
 Use `GET /v1/key` to show DevPass allowance meters in a coding tool or other
 trusted application. The endpoint uses the application's existing gateway API
 key, so it does not require a dashboard session.

--- a/apps/docs/content/features/airside.mdx
+++ b/apps/docs/content/features/airside.mdx
@@ -6,8 +6,6 @@ icon: PlaneTakeoff
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Airside for Providers
-
 [Airside](https://airside.llmgateway.io) is the self-serve console for the companies behind the models — the [providers](https://llmgateway.io/providers) LLM Gateway routes to. It runs on an airport metaphor: LLM Gateway is the airport, developers are passengers, and providers are **carriers**. As a carrier you claim your provider, register your fleet of models, file your fares, and watch traffic arrive.
 
 ## Claiming your carrier

--- a/apps/docs/content/features/anthropic-endpoint.mdx
+++ b/apps/docs/content/features/anthropic-endpoint.mdx
@@ -6,8 +6,6 @@ icon: MessageCircle
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Anthropic API Compatibility
-
 LLMGateway provides a native Anthropic-compatible endpoint at `/v1/messages` that allows you to use any model in our catalog while maintaining the familiar Anthropic API format
 This is especially useful for applications designed for Claude that you want to extend to use other models.
 

--- a/apps/docs/content/features/api-keys.mdx
+++ b/apps/docs/content/features/api-keys.mdx
@@ -6,8 +6,6 @@ icon: Key
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# API Keys & IAM Rules
-
 API keys are the primary method for authenticating with the LLM Gateway. This guide covers creating API keys, managing them, and configuring IAM rules for fine-grained access control.
 
 ## Overview

--- a/apps/docs/content/features/audit-logs.mdx
+++ b/apps/docs/content/features/audit-logs.mdx
@@ -6,8 +6,6 @@ icon: ClipboardList
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Audit Logs
-
 Audit logs provide complete visibility into all actions within your organization. Track who did what, when, and to which resource.
 
 <Callout type="info">

--- a/apps/docs/content/features/caching/gateway-caching.mdx
+++ b/apps/docs/content/features/caching/gateway-caching.mdx
@@ -6,8 +6,6 @@ icon: Zap
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Gateway Caching
-
 Gateway caching serves a previously-seen, byte-identical request entirely from LLM Gateway without forwarding it to the upstream provider. Repeated identical calls cost **$0** — there is no inference and no provider charge. It is most useful for API workloads with deterministic inputs (classification, batch jobs, FAQ lookups, retries) rather than free-form chat.
 
 <Callout type="info">

--- a/apps/docs/content/features/caching/index.mdx
+++ b/apps/docs/content/features/caching/index.mdx
@@ -6,8 +6,6 @@ icon: Zap
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Caching
-
 LLM Gateway supports **two distinct kinds of caching**, and they solve different problems. Pick the one that matches your workload — they can also be used together.
 
 ## Provider / Model Caching

--- a/apps/docs/content/features/caching/provider-cache-control.mdx
+++ b/apps/docs/content/features/caching/provider-cache-control.mdx
@@ -6,8 +6,6 @@ icon: Database
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Provider Cache Control
-
 Most modern LLM providers offer **prompt caching**: when a request reuses a long prefix from a previous request (for example, a multi-thousand-token system prompt or a growing conversation history), the provider stores that prefix and serves it back at a steep discount on subsequent calls. Only the cached portion is discounted — new input tokens and all output tokens are still billed at the normal rate.
 
 This is the behavior you see surfaced as `cached_tokens` in your usage payloads, and it is what makes chat apps, assistants, and coding tools (Cursor, Cline, Claude Code, etc.) economically viable on long contexts.

--- a/apps/docs/content/features/compliance.mdx
+++ b/apps/docs/content/features/compliance.mdx
@@ -6,8 +6,6 @@ icon: BadgeCheck
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Provider Compliance Policies
-
 Provider compliance policies let you guarantee that requests are only ever routed to providers that meet your organization's regulatory requirements. When a request would be routed to a provider that doesn't meet the policy, the gateway blocks it **before any data leaves the gateway**.
 
 <Callout type="info">

--- a/apps/docs/content/features/cost-breakdown.mdx
+++ b/apps/docs/content/features/cost-breakdown.mdx
@@ -6,8 +6,6 @@ icon: DollarSign
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Cost Breakdown
-
 LLM Gateway provides real-time cost information for each API request directly in the response's `usage` object. This allows you to track costs programmatically without needing to query the dashboard.
 
 <Callout type="info">

--- a/apps/docs/content/features/custom-providers.mdx
+++ b/apps/docs/content/features/custom-providers.mdx
@@ -6,8 +6,6 @@ icon: Columns3Cog
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Custom Providers
-
 LLMGateway supports integrating custom OpenAI-compatible providers, allowing you to use any API that follows the OpenAI chat completions format. This feature is perfect for:
 
 - Private or self-hosted LLM deployments

--- a/apps/docs/content/features/data-retention.mdx
+++ b/apps/docs/content/features/data-retention.mdx
@@ -6,8 +6,6 @@ icon: Database
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Data Retention
-
 LLM Gateway offers configurable data retention policies that allow you to store full request and response payloads. This enables powerful debugging capabilities, detailed analytics, and compliance with data governance requirements.
 
 ## Retention Levels

--- a/apps/docs/content/features/documents.mdx
+++ b/apps/docs/content/features/documents.mdx
@@ -6,8 +6,6 @@ icon: FileText
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Document Reading
-
 LLMGateway supports sending documents (PDFs and other file types) to document-capable models using OpenAI's `file` content block format. The gateway forwards the document to the underlying provider so the model can read and reason over its contents.
 
 ## Document-Capable Models

--- a/apps/docs/content/features/dynamic-routes.mdx
+++ b/apps/docs/content/features/dynamic-routes.mdx
@@ -6,8 +6,6 @@ icon: Workflow
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Dynamic Routes
-
 Dynamic routes let you move routing logic out of your application code and into the gateway. Instead of hardcoding a model, you define a named decision graph — conditions on the request, percentage-based traffic splits, and model targets — and invoke it by putting `dynamic/<name>` in the `model` field of any OpenAI-compatible request:
 
 ```bash

--- a/apps/docs/content/features/embeddable-payments.mdx
+++ b/apps/docs/content/features/embeddable-payments.mdx
@@ -6,8 +6,6 @@ icon: Wallet
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Embeddable Payments (Payments SDK)
-
 The **Payments SDK** lets you drop **end-user payments + in-app credit purchases** into your product the same way Stripe Elements lets you drop in payments. Your end-users get their **own wallet**, buy credits **inside your app**, and pay per request for any model the gateway supports. LLM Gateway is the merchant of record; you set a markup and keep the margin.
 
 <Callout type="warn">

--- a/apps/docs/content/features/embeddings.mdx
+++ b/apps/docs/content/features/embeddings.mdx
@@ -6,8 +6,6 @@ icon: Database
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Embeddings
-
 LLMGateway exposes an OpenAI-compatible `/v1/embeddings` endpoint for generating vector representations of text — useful for semantic search, clustering, recommendations, and RAG.
 
 Browse available embedding models on the [models page](https://llmgateway.io/models?filters=1&embedding=true).

--- a/apps/docs/content/features/guardrails.mdx
+++ b/apps/docs/content/features/guardrails.mdx
@@ -6,8 +6,6 @@ icon: Shield
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Guardrails
-
 Guardrails protect your organization by automatically detecting and blocking harmful content in LLM requests before they reach the model.
 
 <Callout type="info">

--- a/apps/docs/content/features/image-generation.mdx
+++ b/apps/docs/content/features/image-generation.mdx
@@ -6,8 +6,6 @@ icon: Image
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Image Generation
-
 LLMGateway supports image generation through two APIs:
 
 1. **`/v1/images/generations`** — OpenAI-compatible images endpoint (recommended for simple image generation)

--- a/apps/docs/content/features/master-keys.mdx
+++ b/apps/docs/content/features/master-keys.mdx
@@ -6,8 +6,6 @@ icon: KeyRound
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Master Keys
-
 Master keys are org-scoped bearer tokens that let you create projects, gateway API keys, IAM rules (both per key and per organization member), and your organization's custom providers and custom models programmatically — without going through the dashboard. They are intended for server-to-server provisioning (e.g. multi-tenant onboarding from your own backend).
 
 They also expose [usage and cost reporting](#usage-and-cost-reporting), so you can pull per-member and per-model spend into your own dashboards, data warehouse, or chargeback process.

--- a/apps/docs/content/features/metadata.mdx
+++ b/apps/docs/content/features/metadata.mdx
@@ -4,8 +4,6 @@ description: Send additional context and metadata to LLM Gateway using custom he
 icon: Braces
 ---
 
-# Metadata
-
 LLM Gateway supports sending additional metadata with your requests using custom headers. This allows you to include information like user sessions, application versions, tenant IDs, or other contextual data that can be useful for analytics and monitoring.
 
 Later, you can filter by specific values to return, such as for a specific user or session. Additionally, in the future, you will be able to segment your analytics and monitoring based on this metadata. For example, you could show cost and latency breakdowns per user, application, country, feature, or any other dimension you want to track.

--- a/apps/docs/content/features/models-directory.mdx
+++ b/apps/docs/content/features/models-directory.mdx
@@ -6,8 +6,6 @@ icon: BotMessageSquare
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Org Models Directory
-
 The **Models** page in the dashboard (`Organization → Models`) lists every model your organization can route to in a single directory: the full LLM Gateway catalogue plus the models defined for your own [custom providers](/features/custom-providers). It answers two questions for your whole team:
 
 - **What can we call?** — every catalogue and custom model, searchable and filterable by capability, provider, price, and context size, exactly like the public [models page](https://llmgateway.io/models).

--- a/apps/docs/content/features/moderations.mdx
+++ b/apps/docs/content/features/moderations.mdx
@@ -4,8 +4,6 @@ description: Classify unsafe text and image inputs with the OpenAI-compatible mo
 icon: ShieldCheck
 ---
 
-# Moderations
-
 LLMGateway supports the OpenAI-compatible `/v1/moderations` endpoint for text
 and multimodal safety classification.
 

--- a/apps/docs/content/features/ocr.mdx
+++ b/apps/docs/content/features/ocr.mdx
@@ -4,8 +4,6 @@ description: Extract text and structure from documents and images as markdown wi
 icon: ScanText
 ---
 
-# OCR
-
 LLMGateway exposes a dedicated `/v1/ocr` endpoint for optical character
 recognition. It extracts text, tables, and layout from PDFs and images and
 returns them as clean markdown, one entry per page.

--- a/apps/docs/content/features/realtime.mdx
+++ b/apps/docs/content/features/realtime.mdx
@@ -6,8 +6,6 @@ icon: AudioLines
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Realtime API
-
 LLMGateway supports low-latency, speech-to-speech conversations through the
 OpenAI-compatible **`/v1/realtime`** WebSocket endpoint. Sessions support text
 and audio input/output, server-side voice activity detection (VAD), input

--- a/apps/docs/content/features/reasoning.mdx
+++ b/apps/docs/content/features/reasoning.mdx
@@ -6,8 +6,6 @@ icon: Brain
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Reasoning
-
 LLMGateway supports reasoning-capable models that can show their step-by-step thought process before providing a final answer. This feature is particularly useful for complex problem-solving tasks, mathematical calculations, and logical reasoning.
 
 ## Reasoning-Enabled Models

--- a/apps/docs/content/features/rerank.mdx
+++ b/apps/docs/content/features/rerank.mdx
@@ -6,8 +6,6 @@ icon: ListOrdered
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Rerank
-
 LLMGateway exposes a Cohere-compatible `/v1/rerank` endpoint that scores a list
 of candidate documents against a query and returns them ordered by relevance.
 

--- a/apps/docs/content/features/response-healing.mdx
+++ b/apps/docs/content/features/response-healing.mdx
@@ -6,8 +6,6 @@ icon: Bandage
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Response Healing
-
 Response Healing is a plugin that automatically validates and repairs malformed JSON responses from AI models. When enabled, LLM Gateway ensures that API responses conform to your specified schemas even when the model's formatting is imperfect.
 
 ## Why Response Healing?

--- a/apps/docs/content/features/routing.mdx
+++ b/apps/docs/content/features/routing.mdx
@@ -6,8 +6,6 @@ icon: Route
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Routing
-
 LLMGateway provides flexible and intelligent routing options to help you get the best performance and cost efficiency from your AI applications. Whether you want to use specific models, providers, or let our system automatically optimize your requests, we've got you covered.
 
 LLMGateway also includes **automatic retry and fallback** — if a provider fails, your request is seamlessly retried on the next best provider, all within the same API call.

--- a/apps/docs/content/features/service-tiers.mdx
+++ b/apps/docs/content/features/service-tiers.mdx
@@ -6,8 +6,6 @@ icon: Gauge
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Service Tiers
-
 Some OpenAI, Google, and Fireworks models support selectable **processing tiers** that trade
 latency and availability against price. You pick one per request with the
 OpenAI-compatible `service_tier` parameter, and LLM Gateway forwards it only

--- a/apps/docs/content/features/sessions.mdx
+++ b/apps/docs/content/features/sessions.mdx
@@ -6,8 +6,6 @@ icon: Fingerprint
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Sessions
-
 A **session** ties together the requests that belong to the same conversation or workflow. By attaching a stable session identifier to your requests, LLMGateway can treat them as a unit — keeping provider routing consistent across turns and letting you trace and filter the whole conversation in the dashboard.
 
 Sessions are the foundation for several features. Today they power **sticky provider routing** and **session-level observability**; more session-scoped capabilities will build on the same identifier over time.

--- a/apps/docs/content/features/source.mdx
+++ b/apps/docs/content/features/source.mdx
@@ -4,8 +4,6 @@ description: Use the X-Source header to identify your domain for public usage st
 icon: Link
 ---
 
-# Source Attribution
-
 The `X-Source` header allows you to identify your domain when making requests to LLM Gateway. This information is used to generate public usage statistics showing how LLM Gateway is being used across different websites and applications.
 
 ## X-Source Header

--- a/apps/docs/content/features/speech-generation.mdx
+++ b/apps/docs/content/features/speech-generation.mdx
@@ -6,8 +6,6 @@ icon: Volume2
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Speech Generation
-
 LLMGateway supports text-to-speech (TTS) through the OpenAI-compatible
 **`/v1/audio/speech`** endpoint, powered by ElevenLabs, Google Gemini, OpenAI,
 and Alibaba Qwen speech models.

--- a/apps/docs/content/features/sso/entra.mdx
+++ b/apps/docs/content/features/sso/entra.mdx
@@ -7,8 +7,6 @@ icon: Microsoft
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Microsoft Entra ID
-
 This guide walks an organization admin through connecting **Microsoft Entra ID** (formerly Azure Active Directory) to LLM Gateway for SAML single sign-on and SCIM provisioning.
 
 <Callout type="info">

--- a/apps/docs/content/features/sso/google.mdx
+++ b/apps/docs/content/features/sso/google.mdx
@@ -7,8 +7,6 @@ icon: Google
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Google Workspace
-
 Google Workspace works differently from the SAML providers: employees already sign in to LLM Gateway with the standard **Sign in with Google** button using their Workspace-managed Google account. Instead of registering a SAML application, you configure an **auto-join email domain** — anyone who signs in with a Google account on that domain is added to your organization automatically.
 
 <Callout type="info">

--- a/apps/docs/content/features/sso/index.mdx
+++ b/apps/docs/content/features/sso/index.mdx
@@ -6,8 +6,6 @@ icon: ShieldCheck
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# SSO
-
 LLM Gateway supports per-organization **SAML 2.0 single sign-on (SSO)** and **SCIM 2.0 directory provisioning**, so an enterprise team can let members sign in with their corporate identity provider and keep membership in sync automatically.
 
 <Callout type="info">

--- a/apps/docs/content/features/sso/okta.mdx
+++ b/apps/docs/content/features/sso/okta.mdx
@@ -7,8 +7,6 @@ icon: Okta
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Okta
-
 This guide walks an organization admin through connecting **Okta** to LLM Gateway for SAML single sign-on and SCIM provisioning.
 
 <Callout type="info">

--- a/apps/docs/content/features/timeouts.mdx
+++ b/apps/docs/content/features/timeouts.mdx
@@ -6,8 +6,6 @@ icon: Timer
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Request Timeouts
-
 The gateway enforces hard time limits on every request. These protect the
 platform from stuck upstream connections, but they matter to you directly if
 you run long generations or agentic pipelines: a single completion that runs

--- a/apps/docs/content/features/transcription.mdx
+++ b/apps/docs/content/features/transcription.mdx
@@ -4,8 +4,6 @@ description: Transcribe audio into text (speech-to-text) with word-level timesta
 icon: Mic
 ---
 
-# Transcription
-
 LLMGateway exposes a dedicated `/v1/audio/transcriptions` endpoint for
 speech-to-text. It transcribes audio files into text with word-level
 timestamps, optional speaker diarization, and inverse text normalization

--- a/apps/docs/content/features/video-generation.mdx
+++ b/apps/docs/content/features/video-generation.mdx
@@ -6,8 +6,6 @@ icon: Video
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Video Generation
-
 LLMGateway supports asynchronous video generation through an OpenAI-compatible `POST /v1/videos` flow.
 
 Currently available models:

--- a/apps/docs/content/features/vision.mdx
+++ b/apps/docs/content/features/vision.mdx
@@ -6,8 +6,6 @@ icon: Eye
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Vision Support
-
 LLMGateway supports vision-enabled models that can analyze and describe images. You can provide images via HTTPS URLs or inline base64-encoded data.
 
 ## Vision-Enabled Models

--- a/apps/docs/content/features/web-search.mdx
+++ b/apps/docs/content/features/web-search.mdx
@@ -6,8 +6,6 @@ icon: Globe
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Native Web Search
-
 LLM Gateway supports native web search capabilities that allow models to access real-time information from the internet. This feature is useful for answering questions about current events, recent news, live data, and other time-sensitive information that may not be in the model's training data.
 
 ## How It Works

--- a/apps/docs/content/resources/error-handling.mdx
+++ b/apps/docs/content/resources/error-handling.mdx
@@ -6,8 +6,6 @@ icon: TriangleAlert
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Error Handling
-
 On the OpenAI-compatible endpoints, LLMGateway returns errors in the same format as the OpenAI API, so existing OpenAI SDKs and tooling can parse gateway errors without changes. This applies to errors forwarded from upstream providers as well as errors raised by the gateway itself (authentication failures, usage limits, validation problems, timeouts, and so on). The Anthropic-compatible Messages endpoint (`/v1/messages`) instead returns Anthropic-native errors — see [Anthropic Endpoint](#anthropic-endpoint) below.
 
 ## Error Format

--- a/apps/docs/content/resources/rate-limits.mdx
+++ b/apps/docs/content/resources/rate-limits.mdx
@@ -6,8 +6,6 @@ icon: Timer
 
 import { Callout } from "fumadocs-ui/components/callout";
 
-# Rate Limits
-
 LLMGateway applies rate limits to ensure fair usage and protect platform stability. Limits are evaluated in a few independent layers:
 
 - **Per-organization endpoint limits** — a requests-per-minute cap on every API endpoint, scoped to your organization.

--- a/apps/docs/lib/get-llm-text.ts
+++ b/apps/docs/lib/get-llm-text.ts
@@ -1,7 +1,10 @@
+import { docsBaseUrl } from "@/lib/base-url";
+import { marketingGuideCanonical } from "@/lib/guide-canonical";
+
 import type { source } from "@/lib/source";
 import type { InferPageType } from "fumadocs-core/source";
 
-const DOCS_URL = "https://docs.llmgateway.io";
+const DOCS_URL = docsBaseUrl;
 
 // Navigation-card components whose target pages are already concatenated in
 // full elsewhere in llms-full.txt; interactive embeds have no text value and
@@ -38,6 +41,6 @@ export async function getLLMText(page: InferPageType<typeof source>) {
 	// absolute docs URLs.
 	const absolute = processed.replace(/\]\((\/[^)\s]*)\)/g, `](${DOCS_URL}$1)`);
 	return `# ${page.data.title}
-URL: ${DOCS_URL}${page.url}
+URL: ${marketingGuideCanonical(page.url) ?? `${DOCS_URL}${page.url}`}
 ${replaceMdxComponents(absolute)}`;
 }

--- a/apps/docs/lib/source.ts
+++ b/apps/docs/lib/source.ts
@@ -42,13 +42,7 @@ export function getPageImage(page: InferPageType<typeof source>) {
 	};
 }
 
-export async function getLLMText(page: InferPageType<typeof source>) {
-	const processed = await page.data.getText("processed");
-
-	return `# ${page.data.title} (${page.url})
-	
-${processed}`;
-}
+export { getLLMText } from "./get-llm-text";
 
 export const openapi = createOpenAPI({
 	input: ["./openapi.json"],

--- a/apps/playground/public/llms.txt
+++ b/apps/playground/public/llms.txt
@@ -1,6 +1,6 @@
 # Lounge by LLM Gateway
 
-> Lounge (lounge.llmgateway.io) is the members' lounge for AI: chat with 200+ models from OpenAI, Anthropic, Google, xAI, DeepSeek, Meta, Mistral, and other providers in one place. It supports text chat, image and video generation, side-by-side multi-model group chats, and projects with knowledge files — every frontier model, one membership.
+> Lounge is an AI chat app by LLM Gateway. Use models from multiple providers in one interface; the live [catalogue](https://llmgateway.io/models) lists current availability. It supports text chat, image and video generation, side-by-side multi-model group chats, and projects with knowledge files with one membership.
 
 ## Memberships
 
@@ -16,9 +16,9 @@
 - [Pricing](https://lounge.llmgateway.io/pricing): Starter, Plus, and Pro memberships with included usage.
 - [Pricing (machine-readable)](https://lounge.llmgateway.io/pricing.md): Plain-markdown Lounge pricing for AI agents.
 - [Compare](https://lounge.llmgateway.io/compare): Lounge vs ChatGPT, Claude, Gemini, Poe, T3 Chat, Perplexity, and OpenRouter.
-- [Image studio](https://lounge.llmgateway.io/image): DALL·E, Flux, Stable Diffusion, and Seedream side by side.
-- [Video studio](https://lounge.llmgateway.io/video): Veo, Wan, and other text-to-video models.
-- [Audio studio](https://lounge.llmgateway.io/audio): ElevenLabs, OpenAI, and Gemini text to speech.
+- [Image studio](https://lounge.llmgateway.io/image): Generate and compare images across supported models.
+- [Video studio](https://lounge.llmgateway.io/video): Generate short videos from text prompts.
+- [Audio studio](https://lounge.llmgateway.io/audio): Turn text into speech with supported voices and models.
 - [Voice calls](https://lounge.llmgateway.io/realtime): Realtime speech-to-speech conversations.
 - [Group chat](https://lounge.llmgateway.io/group): One prompt to many models, compared side by side.
 - [Canvas](https://lounge.llmgateway.io/canvas): Build UIs from JSON specs with live preview.

--- a/apps/playground/public/pricing.md
+++ b/apps/playground/public/pricing.md
@@ -2,20 +2,20 @@
 
 Last updated: 2026-09-01
 
-> Lounge is a monthly AI chat membership: one subscription for 200+ models from OpenAI, Anthropic, Google, xAI, DeepSeek, Meta, Mistral, and more, plus image, video, and audio studios and multi-model group chat. Each tier includes a monthly credit allowance metered at provider list rates.
+> Lounge is a monthly AI chat membership: one subscription for models from multiple providers, plus image, video, and audio studios and multi-model group chat. Each tier includes a monthly credit allowance metered at provider list rates.
 
 ## Starter
 
 - Price: $9/month
 - Included usage: $18 of model usage per month (2× what you pay)
-- Models: Claude Sonnet plus fast models such as Claude Haiku and Gemini Flash
+- Models: standard model access; premium models require Plus or Pro. See the [current catalogue](https://llmgateway.io/models).
 - Chat, image, video, and audio studios; real-time usage and per-message cost
 
 ## Plus
 
 - Price: $19/month
 - Included usage: $47.50 of model usage per month (2.5× what you pay)
-- Models: every frontier model — Claude Opus, GPT-5, Gemini Pro, Grok, and more
+- Models: standard and premium model access. See the [current catalogue](https://llmgateway.io/models).
 - Replaces ChatGPT Plus, Claude Pro, and Gemini Advanced with one bill
 
 ## Pro

--- a/apps/playground/src/app/audio/page.tsx
+++ b/apps/playground/src/app/audio/page.tsx
@@ -15,14 +15,14 @@ import type { Project, Organization } from "@/lib/types";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-	title: "AI Text to Speech — ElevenLabs, OpenAI & Gemini",
+	title: "AI Text to Speech — Compare Voices and Models",
 	description:
-		"Generate speech from text with ElevenLabs, OpenAI, and Gemini TTS models. Pick voices, compare providers, and download the audio in one playground.",
+		"Turn text into speech in Lounge. Choose a supported model and voice, compare outputs, and download generated audio.",
 	alternates: { canonical: "/audio" },
 	openGraph: {
-		title: "AI Text to Speech — ElevenLabs, OpenAI & Gemini | Lounge",
+		title: "AI Text to Speech — Compare Voices and Models | Lounge",
 		description:
-			"Generate speech from text with ElevenLabs, OpenAI, and Gemini TTS models. Pick voices, compare providers, and download the audio.",
+			"Turn text into speech in Lounge. Choose a supported model and voice, compare outputs, and download generated audio.",
 		type: "website",
 		url: "https://lounge.llmgateway.io/audio",
 	},
@@ -103,6 +103,10 @@ export default async function AudioPage({
 		initialProjectsData = null;
 	}
 
+	if (!selectedOrganization) {
+		return <PlaygroundSeoSection variant="audio" />;
+	}
+
 	if (!initialProjectsData && selectedOrganization?.id) {
 		try {
 			initialProjectsData = (await fetchServerData(
@@ -150,7 +154,6 @@ export default async function AudioPage({
 					projectId={selectedProject.id}
 				/>
 			) : null}
-			<PlaygroundSeoSection variant="audio" />
 			<AudioPageClient
 				models={models}
 				providers={providers}

--- a/apps/playground/src/app/canvas/page.tsx
+++ b/apps/playground/src/app/canvas/page.tsx
@@ -83,6 +83,10 @@ export default async function CanvasPage({
 		organizations[0] ??
 		null;
 
+	if (!selectedOrganization) {
+		return <PlaygroundSeoSection variant="canvas" />;
+	}
+
 	if (!initialProjectsData && selectedOrganization?.id) {
 		try {
 			initialProjectsData = (await fetchServerData(
@@ -130,7 +134,6 @@ export default async function CanvasPage({
 					projectId={selectedProject.id}
 				/>
 			) : null}
-			<PlaygroundSeoSection variant="canvas" />
 			<CanvasPageClient
 				models={models}
 				providers={providers}

--- a/apps/playground/src/app/group/page.tsx
+++ b/apps/playground/src/app/group/page.tsx
@@ -13,12 +13,12 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
 	title: "Group Chat — Compare AI Models Side by Side",
 	description:
-		"Send one prompt to multiple AI models simultaneously. Compare responses from GPT-5, Claude, Gemini, and more in real time.",
+		"Send one prompt to multiple AI models and compare streamed responses, latency, and cost side by side in Lounge.",
 	alternates: { canonical: "/group" },
 	openGraph: {
 		title: "Group Chat — Compare AI Models Side by Side | Lounge",
 		description:
-			"Send one prompt to multiple AI models simultaneously. Compare responses from GPT-5, Claude, Gemini, and more in real time.",
+			"Send one prompt to multiple AI models and compare streamed responses, latency, and cost side by side in Lounge.",
 		type: "website",
 		url: "https://lounge.llmgateway.io/group",
 	},
@@ -98,6 +98,10 @@ export default async function GroupPage({
 		null;
 
 	// Ensure we have projects for the selected organization (when orgId not provided)
+	if (!selectedOrganization) {
+		return <PlaygroundSeoSection variant="group" />;
+	}
+
 	if (!initialProjectsData && selectedOrganization?.id) {
 		try {
 			initialProjectsData = (await fetchServerData(
@@ -147,7 +151,6 @@ export default async function GroupPage({
 					projectId={selectedProject.id}
 				/>
 			) : null}
-			<PlaygroundSeoSection variant="group" />
 			<GroupChatClient
 				models={models.filter(
 					(m) =>

--- a/apps/playground/src/app/image/page.tsx
+++ b/apps/playground/src/app/image/page.tsx
@@ -15,14 +15,14 @@ import type { Project, Organization } from "@/lib/types";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-	title: "AI Image Generator — DALL·E, Flux, Stable Diffusion",
+	title: "AI Image Generator — Compare Models",
 	description:
-		"Generate images with DALL-E, Stable Diffusion, Flux, and other AI models. Compare outputs across providers in one playground.",
+		"Generate images from text prompts, compare supported image models, and save results in Lounge. One account for image generation and AI chat.",
 	alternates: { canonical: "/image" },
 	openGraph: {
-		title: "AI Image Generator — DALL·E, Flux, Stable Diffusion | Lounge",
+		title: "AI Image Generator — Compare Models | Lounge",
 		description:
-			"Generate images with DALL-E, Stable Diffusion, Flux, and other AI models. Compare outputs across providers in one playground.",
+			"Generate images from text prompts, compare supported image models, and save results in Lounge. One account for image generation and AI chat.",
 		type: "website",
 		url: "https://lounge.llmgateway.io/image",
 	},
@@ -97,6 +97,10 @@ export default async function ImagePage({
 		organizations[0] ??
 		null;
 
+	if (!selectedOrganization) {
+		return <PlaygroundSeoSection variant="image" />;
+	}
+
 	if (!initialProjectsData && selectedOrganization?.id) {
 		try {
 			initialProjectsData = (await fetchServerData(
@@ -144,7 +148,6 @@ export default async function ImagePage({
 					projectId={selectedProject.id}
 				/>
 			) : null}
-			<PlaygroundSeoSection variant="image" />
 			<ImagePageClient
 				models={models}
 				providers={providers}

--- a/apps/playground/src/app/realtime/page.tsx
+++ b/apps/playground/src/app/realtime/page.tsx
@@ -78,6 +78,10 @@ export default async function RealtimePage({
 		selectedOrganization?.id === orgId && orgIdProjectsData
 			? (orgIdProjectsData as { projects: Project[] })
 			: null;
+	if (!selectedOrganization) {
+		return <PlaygroundSeoSection variant="realtime" />;
+	}
+
 	if (!initialProjectsData && selectedOrganization?.id) {
 		try {
 			initialProjectsData = (await fetchServerData(
@@ -125,7 +129,6 @@ export default async function RealtimePage({
 					projectId={selectedProject.id}
 				/>
 			) : null}
-			<PlaygroundSeoSection variant="realtime" />
 			<RealtimePageClient
 				models={models}
 				providers={providers}

--- a/apps/playground/src/app/robots.ts
+++ b/apps/playground/src/app/robots.ts
@@ -6,7 +6,7 @@ export default function robots(): MetadataRoute.Robots {
 			{
 				userAgent: "*",
 				allow: "/",
-				disallow: ["/login", "/signup", "/api/"],
+				disallow: ["/api/"],
 			},
 		],
 		sitemap: "https://lounge.llmgateway.io/sitemap.xml",

--- a/apps/playground/src/app/sitemap.ts
+++ b/apps/playground/src/app/sitemap.ts
@@ -1,3 +1,4 @@
+import { connection } from "next/server";
 import createFetchClient from "openapi-fetch";
 
 import { comparisons } from "@/lib/comparisons";
@@ -29,6 +30,8 @@ async function fetchPublicShares(): Promise<ShareListItem[]> {
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+	await connection();
+
 	const baseUrl = "https://lounge.llmgateway.io";
 
 	const staticEntries: MetadataRoute.Sitemap = [

--- a/apps/playground/src/app/sitemap.ts
+++ b/apps/playground/src/app/sitemap.ts
@@ -18,91 +18,77 @@ async function fetchPublicShares(): Promise<ShareListItem[]> {
 	const client = createFetchClient<paths>({
 		baseUrl: config.apiBackendUrl,
 	});
-	try {
-		const { data } = await client.GET("/public/chats/share", {
-			params: { query: { limit: 5000 } },
-			next: { revalidate: 3600 },
-		});
-		return data?.shares ?? [];
-	} catch {
-		return [];
+	const { data, error } = await client.GET("/public/chats/share", {
+		params: { query: { limit: 5000 } },
+		next: { revalidate: 3600 },
+	});
+	if (error || !data) {
+		throw new Error("Unable to load public chat shares for the sitemap");
 	}
+	return data.shares;
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 	const baseUrl = "https://lounge.llmgateway.io";
-	const now = new Date();
 
 	const staticEntries: MetadataRoute.Sitemap = [
 		{
 			url: baseUrl,
-			lastModified: now,
 			changeFrequency: "daily",
 			priority: 1,
 		},
 		{
 			url: `${baseUrl}/image`,
-			lastModified: now,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/video`,
-			lastModified: now,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/audio`,
-			lastModified: now,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/group`,
-			lastModified: now,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/canvas`,
-			lastModified: now,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/pricing`,
-			lastModified: now,
 			changeFrequency: "weekly",
 			priority: 0.7,
 		},
 		{
 			url: `${baseUrl}/realtime`,
-			lastModified: now,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/escape`,
-			lastModified: now,
 			changeFrequency: "weekly",
 			priority: 0.7,
 		},
 		{
 			url: `${baseUrl}/leaderboard`,
-			lastModified: now,
 			changeFrequency: "daily",
 			priority: 0.6,
 		},
 		{
 			url: `${baseUrl}/compare`,
-			lastModified: now,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		...comparisons.map((comparison) => ({
 			url: `${baseUrl}/compare/${comparison.slug}`,
-			lastModified: now,
 			changeFrequency: "weekly" as const,
 			priority: 0.7,
 		})),

--- a/apps/playground/src/app/video/page.tsx
+++ b/apps/playground/src/app/video/page.tsx
@@ -15,14 +15,14 @@ import type { Project, Organization } from "@/lib/types";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-	title: "AI Video Generator — Veo, Wan & More",
+	title: "AI Video Generator — Create Short Videos",
 	description:
-		"Generate videos with Veo, Wan, and other AI video models. Preview results and compare providers in Lounge.",
+		"Generate short videos from text prompts. Explore supported video models, preview results, and download your creations in Lounge.",
 	alternates: { canonical: "/video" },
 	openGraph: {
-		title: "AI Video Generator — Veo, Wan & More | Lounge",
+		title: "AI Video Generator — Create Short Videos | Lounge",
 		description:
-			"Generate videos with Veo, Wan, and other AI video models. Preview results and compare providers in Lounge.",
+			"Generate short videos from text prompts. Explore supported video models, preview results, and download your creations in Lounge.",
 		type: "website",
 		url: "https://lounge.llmgateway.io/video",
 	},
@@ -97,6 +97,10 @@ export default async function VideoPage({
 		organizations[0] ??
 		null;
 
+	if (!selectedOrganization) {
+		return <PlaygroundSeoSection variant="video" />;
+	}
+
 	if (!initialProjectsData && selectedOrganization?.id) {
 		try {
 			initialProjectsData = (await fetchServerData(
@@ -144,7 +148,6 @@ export default async function VideoPage({
 					projectId={selectedProject.id}
 				/>
 			) : null}
-			<PlaygroundSeoSection variant="video" />
 			<VideoPageClient
 				models={models}
 				providers={providers}

--- a/apps/playground/src/components/playground/auth-dialog.tsx
+++ b/apps/playground/src/components/playground/auth-dialog.tsx
@@ -109,12 +109,12 @@ export function AuthDialog({
 						<Wordmark size="sm" />
 					</div>
 
-					<h1
+					<h2
 						id="auth-dialog-title"
 						className="mt-5 text-xl font-semibold leading-tight tracking-tight sm:text-2xl"
 					>
 						{title}
-					</h1>
+					</h2>
 					<p className="mt-2.5 text-sm text-muted-foreground">{description}</p>
 
 					<div className="mt-5 flex items-center gap-3">

--- a/apps/playground/src/components/seo/playground-seo-section.tsx
+++ b/apps/playground/src/components/seo/playground-seo-section.tsx
@@ -1,5 +1,8 @@
 import Link from "next/link";
 
+import { Button } from "@/components/ui/button";
+import { Wordmark } from "@/components/ui/wordmark";
+
 export type SeoVariant =
 	"chat" | "image" | "video" | "audio" | "group" | "canvas" | "realtime";
 
@@ -12,11 +15,11 @@ interface VariantContent {
 
 const variants: Record<SeoVariant, VariantContent> = {
 	chat: {
-		h1: "Lounge — AI chat with 200+ models in one place",
+		h1: "Lounge — AI chat with multiple models in one place",
 		intro:
-			"Lounge is the members' AI chat by LLM Gateway. Chat with GPT, Claude, Gemini, Grok, DeepSeek, Llama, Mistral, and more from a single interface. Switch models mid-conversation, attach files and images, and stream responses in real time — one credit balance, no per-provider billing setup.",
+			"Lounge is the members' AI chat by LLM Gateway. Chat with models from multiple providers in a single interface. Switch models mid-conversation, attach files and images, and stream responses in real time — one credit balance, no per-provider billing setup.",
 		bullets: [
-			"Supports 200+ models across OpenAI, Anthropic, Google, xAI, DeepSeek, Meta, Mistral, and other providers.",
+			"Find supported models, capabilities, and pricing in the live model catalogue.",
 			"Stream responses, fork past conversations, and share read-only chat snapshots via public links.",
 			"One credit balance covers every provider — top up once, route requests anywhere, get unified usage and cost analytics through LLM Gateway.",
 		],
@@ -30,11 +33,11 @@ const variants: Record<SeoVariant, VariantContent> = {
 		],
 	},
 	image: {
-		h1: "AI image generation — DALL·E, Flux, Stable Diffusion side by side",
+		h1: "AI image generation — compare models in one place",
 		intro:
 			"Generate images from text prompts using the latest AI image models. Compare outputs across providers, request multiple variants per prompt, and save or share the results.",
 		bullets: [
-			"Models include DALL·E 3, Flux Pro, Flux Schnell, Stable Diffusion 3, Seedream, and more.",
+			"Choose an image model from the current catalogue and explore its supported settings.",
 			"Request 1, 2, or 4 images per prompt and compare them in a grid.",
 			"All requests route through LLM Gateway for unified billing and usage tracking.",
 		],
@@ -47,11 +50,11 @@ const variants: Record<SeoVariant, VariantContent> = {
 		],
 	},
 	video: {
-		h1: "AI video generation — compare Veo, Wan, and more in one place",
+		h1: "AI video generation — create and compare short videos",
 		intro:
 			"Generate short videos from text prompts using the newest AI video models. Preview results inline, compare providers, and download the output.",
 		bullets: [
-			"Models include Google Veo, Alibaba Wan, and other text-to-video providers.",
+			"Choose a supported video model and review its available durations and resolutions.",
 			"Preview generated videos in the browser without leaving the Lounge.",
 			"Routes through LLM Gateway for cost tracking across providers.",
 		],
@@ -64,11 +67,11 @@ const variants: Record<SeoVariant, VariantContent> = {
 		],
 	},
 	audio: {
-		h1: "AI audio generation — text to speech with ElevenLabs, OpenAI, and Gemini",
+		h1: "AI audio generation — compare text-to-speech models",
 		intro:
 			"Turn text into natural-sounding speech using the latest text-to-speech models. Pick a voice, compare providers side by side, and download the audio.",
 		bullets: [
-			"Models include ElevenLabs Multilingual v2, Eleven v3, OpenAI TTS and GPT-4o Mini TTS, and Gemini TTS.",
+			"Browse supported speech models and voices in the audio studio.",
 			"Choose from dozens of prebuilt voices and control format and speed.",
 			"All requests route through LLM Gateway for unified billing and usage tracking.",
 		],
@@ -82,9 +85,9 @@ const variants: Record<SeoVariant, VariantContent> = {
 	group: {
 		h1: "Group chat — compare AI models side by side on the same prompt",
 		intro:
-			"Send one prompt to multiple AI models simultaneously and compare their responses. Useful for evaluating quality, speed, and cost across GPT, Claude, Gemini, Grok, and other models.",
+			"Send one prompt to multiple AI models simultaneously and compare their responses. Evaluate response quality, speed, and cost before choosing a model for your workflow.",
 		bullets: [
-			"Run the same prompt against any combination of 200+ supported models.",
+			"Run the same prompt against multiple supported chat models.",
 			"See streamed responses side by side in real time.",
 			"Compare latency, token counts, and cost per response in a single view.",
 		],
@@ -102,7 +105,7 @@ const variants: Record<SeoVariant, VariantContent> = {
 			"Generate, edit, and export interactive UI specs as JSON with live preview. Export the result as a PDF or image. Powered by LLM Gateway.",
 		bullets: [
 			"Iterate on UI layouts by editing a JSON spec with live preview.",
-			"Use any of 200+ supported models to generate or modify canvas specs.",
+			"Choose a supported model to generate or modify canvas specs.",
 			"Export the canvas to PDF or PNG for sharing.",
 		],
 		related: [
@@ -114,7 +117,7 @@ const variants: Record<SeoVariant, VariantContent> = {
 		],
 	},
 	realtime: {
-		h1: "AI voice calls — realtime speech to speech with any model",
+		h1: "AI voice calls — realtime speech to speech",
 		intro:
 			"Have a live voice conversation with realtime speech-to-speech models. Pick a model and a voice, talk naturally, interrupt mid-sentence, and read both sides of the transcript afterwards.",
 		bullets: [
@@ -133,17 +136,70 @@ const variants: Record<SeoVariant, VariantContent> = {
 
 export function PlaygroundSeoSection({ variant }: { variant: SeoVariant }) {
 	const content = variants[variant];
+	const Container = variant === "chat" ? "section" : "main";
 	return (
-		<section className="sr-only">
-			<h1>{content.h1}</h1>
-			<p>{content.intro}</p>
-			<ul>
+		<Container
+			className={
+				variant === "chat"
+					? "sr-only"
+					: "mx-auto flex max-w-4xl flex-col gap-5 px-6 py-16"
+			}
+		>
+			{variant !== "chat" && (
+				<nav
+					aria-label="Lounge"
+					className="mb-8 flex items-center justify-between gap-4"
+				>
+					<Link href="/">
+						<Wordmark size="sm" />
+					</Link>
+					<Link
+						href="/pricing"
+						className="text-sm text-muted-foreground underline underline-offset-4"
+					>
+						Membership pricing
+					</Link>
+				</nav>
+			)}
+			<h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">
+				{content.h1}
+			</h1>
+			<p className="text-muted-foreground leading-relaxed">{content.intro}</p>
+			{variant !== "chat" && (
+				<div className="flex flex-wrap gap-3">
+					<Button asChild>
+						<Link
+							href={`/signup?returnUrl=${encodeURIComponent(`/${variant}`)}`}
+						>
+							Get started
+						</Link>
+					</Button>
+					<Button variant="outline" asChild>
+						<Link
+							href={`/login?returnUrl=${encodeURIComponent(`/${variant}`)}`}
+						>
+							Sign in
+						</Link>
+					</Button>
+				</div>
+			)}
+			<ul className="flex list-disc flex-col gap-2 pl-5 text-muted-foreground">
 				{content.bullets.map((bullet) => (
 					<li key={bullet}>{bullet}</li>
 				))}
 			</ul>
+			<p className="text-sm text-muted-foreground">
+				See the{" "}
+				<Link
+					href="https://llmgateway.io/models"
+					className="underline underline-offset-4"
+				>
+					live model catalogue
+				</Link>{" "}
+				for current availability and pricing.
+			</p>
 			<nav aria-label="Related tools">
-				<ul>
+				<ul className="flex flex-wrap gap-x-5 gap-y-2 text-sm underline underline-offset-4">
 					{content.related.map((link) => (
 						<li key={link.href}>
 							<Link href={link.href}>{link.label}</Link>
@@ -151,6 +207,6 @@ export function PlaygroundSeoSection({ variant }: { variant: SeoVariant }) {
 					))}
 				</ul>
 			</nav>
-		</section>
+		</Container>
 	);
 }

--- a/apps/ui/public/llms.txt
+++ b/apps/ui/public/llms.txt
@@ -1,12 +1,12 @@
 # LLM Gateway
 
-> LLM Gateway is a unified API for routing requests across 40+ LLM providers, including OpenAI, Anthropic, Google, Meta, Mistral, and DeepSeek. Use one OpenAI-compatible API and one key to access 200+ models, with usage analytics, cost tracking, caching, and automatic failover. Open source (AGPLv3) and self-hostable.
+> LLM Gateway is an open-source AI gateway. Route requests through one OpenAI-compatible API and key, with usage analytics, cost tracking, caching, and automatic failover. The live models and providers directories list current availability. Open source (AGPLv3) and self-hostable.
 
 ## Key pages
 
 - [Models](https://llmgateway.io/models): Full catalog of supported LLMs with pricing, context windows, and capabilities.
 - [LLM Rankings](https://llmgateway.io/rankings): Which models developers actually run in production — live token volume, trends, and provider market share over 24h/7d/30d windows.
-- [Model release timeline](https://llmgateway.io/timeline): When each LLM was released by its provider and when it was added to LLM Gateway — a reference for AI model release dates (GPT, Claude, Gemini, Llama, Mistral, DeepSeek).
+- [Model release timeline](https://llmgateway.io/timeline): When each LLM was released by its provider and when it was added to LLM Gateway — a reference for AI model release dates.
 - [Pricing](https://llmgateway.io/pricing): Per-token at provider rates. Pay-as-you-go credits carry a flat 5% platform fee; Bring-Your-Own-Keys is free; enterprise plans available.
 - [Pricing (machine-readable)](https://llmgateway.io/pricing.md): Plain-markdown pricing summary for AI agents.
 - [Providers](https://llmgateway.io/providers): Every supported provider and the models each offers.
@@ -27,7 +27,7 @@
 - [Best models for math](https://llmgateway.io/models/math): Reasoning models for competition math and quantitative work.
 - [Long context models](https://llmgateway.io/models/long-context): Models with 200K to 2M token context windows.
 - [Cheapest models](https://llmgateway.io/models/cheapest): Models at or under $0.20 per million input tokens.
-- [Open source models](https://llmgateway.io/models/open-source): Open-weight LLMs (Llama, DeepSeek, Qwen, GLM, Kimi, GPT-OSS) served via API.
+- [Open source models](https://llmgateway.io/models/open-source): Open-weight LLMs served via API, with current pricing and capabilities.
 
 ## Developer resources
 
@@ -41,6 +41,6 @@
 
 ## Notes
 
-- New models are typically available within 48 hours of their provider release.
+- See the live [catalogue](https://llmgateway.io/models) for current model availability.
 - The API is OpenAI-compatible; point your existing SDK at the gateway base URL.
 - Pages with a markdown representation honor `Accept: text/markdown` (currently / and /pricing).

--- a/apps/ui/public/pricing.md
+++ b/apps/ui/public/pricing.md
@@ -2,14 +2,14 @@
 
 Last updated: 2026-08-15
 
-> One OpenAI-compatible API for 200+ models across 40+ providers. Per-token prices match each provider's published rates; LLM Gateway charges a flat 5% platform fee when you buy credits. Bringing your own provider keys is free, and self-hosting is free under AGPLv3.
+> One OpenAI-compatible API for the models and providers in the live catalogue. Per-token prices match each provider's published rates; LLM Gateway charges a flat 5% platform fee when you buy credits. Bringing your own provider keys is free, and self-hosting is free under AGPLv3.
 
 ## Managed cloud — pay-as-you-go credits
 
 - Price: $0 subscription. Prepaid credits, $10 minimum / $5,000 maximum per top-up.
 - Platform fee: flat 5% added at credit purchase (plus 1.5% for international cards).
 - Token pricing: provider list rates per token — no markup on tokens. Live per-model prices: https://llmgateway.io/models
-- Includes: 200+ models, 40+ providers, automatic failover, response caching, usage analytics, and cost tracking.
+- Includes: access to the live model catalogue, automatic failover, response caching, usage analytics, and cost tracking.
 
 ## Bring Your Own Keys (BYOK)
 

--- a/apps/ui/src/app/products/devpass/page.tsx
+++ b/apps/ui/src/app/products/devpass/page.tsx
@@ -23,7 +23,7 @@ const DEVPASS_URL = "https://devpass.llmgateway.io";
 
 const title = "DevPass — Flat-Price Dev Plans for AI Coding";
 const description =
-	"DevPass turns every dollar into $3 of model usage at provider rates. Fixed-price monthly plans for Claude Code, Cursor, Cline, and any OpenAI-compatible coding tool — 200+ models, one API key.";
+	"DevPass offers flat-price AI coding subscriptions with included model usage. Connect your coding tools with one API key and track usage in one dashboard.";
 
 export const metadata: Metadata = {
 	title,

--- a/apps/ui/src/app/sitemap.ts
+++ b/apps/ui/src/app/sitemap.ts
@@ -12,11 +12,6 @@ import { isMappingDeactivated } from "@llmgateway/shared/components";
 
 import type { MetadataRoute } from "next";
 
-// Stable per-deploy timestamp. Using a single build-time date (instead of a
-// fresh `new Date()` per URL/request) keeps `lastModified` from reporting
-// "changed just now" on every crawl, which trains search engines to ignore it.
-const buildDate = new Date();
-
 // Most recent provider release date across the catalog. Used as the timeline
 // page's `lastModified` so it reflects real content freshness (a new model)
 // rather than the deploy time.
@@ -30,7 +25,7 @@ const latestModelReleaseDate = (() => {
 			}
 		}
 	}
-	return latest.getTime() === 0 ? buildDate : latest;
+	return latest.getTime() === 0 ? undefined : latest;
 })();
 
 // Distinct release years across the catalog plus the latest release date within
@@ -73,115 +68,96 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 	const staticPages: MetadataRoute.Sitemap = [
 		{
 			url: baseUrl,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 1,
 		},
 		{
 			url: `${baseUrl}/models`,
-			lastModified: buildDate,
 			changeFrequency: "daily",
 			priority: 0.9,
 		},
 		{
 			url: `${baseUrl}/pricing`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.9,
 		},
 		{
 			url: `${baseUrl}/about`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.6,
 		},
 		{
 			url: `${baseUrl}/contact`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.6,
 		},
 		{
 			url: `${baseUrl}/blog`,
-			lastModified: buildDate,
 			changeFrequency: "daily",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/guides`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/changelog`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.7,
 		},
 		{
 			url: `${baseUrl}/providers`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/rankings`,
-			lastModified: buildDate,
 			changeFrequency: "daily",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/partners`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/enterprise`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/products/ai-gateway`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/products/lounge`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/products/devpass`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/products/observability`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/open-source`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/integrations`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.7,
 		},
 		{
 			url: `${baseUrl}/referrals`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.6,
 		},
@@ -193,247 +169,206 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		},
 		{
 			url: `${baseUrl}/brand`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.4,
 		},
 		{
 			url: `${baseUrl}/migration`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.7,
 		},
 		{
 			url: `${baseUrl}/reliability`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/ship`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.7,
 		},
 		{
 			url: `${baseUrl}/token-cost-calculator`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.9,
 		},
 		{
 			url: `${baseUrl}/copilot-cost-calculator`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.9,
 		},
 		{
 			url: `${baseUrl}/nano-banana-simulator/20`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.6,
 		},
 		{
 			url: `${baseUrl}/blog/category`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.5,
 		},
 		{
 			url: `${baseUrl}/models/compare`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.7,
 		},
 		{
 			url: `${baseUrl}/models/text`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/models/vision`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/models/reasoning`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/models/web-search`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/models/image-to-image`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/models/text-to-image`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/models/video`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/models/embeddings`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/models/tools`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/models/discounted`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.7,
 		},
 		{
 			url: `${baseUrl}/models/roleplay`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/models/coding`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/models/creative-writing`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/models/translation`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/models/math`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/models/long-context`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/models/cheapest`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/models/open-source`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/models/premium`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/mcp`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.7,
 		},
 		{
 			url: `${baseUrl}/agents`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.7,
 		},
 		{
 			url: `${baseUrl}/templates`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.7,
 		},
 		{
 			url: `${baseUrl}/apps`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/compare`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.8,
 		},
 		{
 			url: `${baseUrl}/compare/aws-bedrock`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.7,
 		},
 		{
 			url: `${baseUrl}/compare/azure-ai-foundry`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.7,
 		},
 		{
 			url: `${baseUrl}/compare/github-copilot`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.7,
 		},
 		{
 			url: `${baseUrl}/compare/litellm`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.7,
 		},
 		{
 			url: `${baseUrl}/compare/open-router`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.7,
 		},
 		{
 			url: `${baseUrl}/compare/portkey`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.7,
 		},
 		{
 			url: `${baseUrl}/compare/vercel-ai-gateway`,
-			lastModified: buildDate,
 			changeFrequency: "monthly",
 			priority: 0.7,
 		},
 		{
 			url: `${baseUrl}/use-cases`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		},
@@ -455,7 +390,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		// Main model page
 		modelPages.push({
 			url: `${baseUrl}/models/${encodeURIComponent(model.id)}`,
-			lastModified: "releasedAt" in model ? model.releasedAt : buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		});
@@ -489,7 +423,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		}
 		modelPages.push({
 			url: `${baseUrl}/models/${encodeURIComponent(model.id)}`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		});
@@ -501,7 +434,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		.filter((provider) => provider.name !== "LLM Gateway")
 		.map((provider) => ({
 			url: `${baseUrl}/providers/${provider.id}`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		}));
@@ -519,7 +451,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		}
 		providerPages.push({
 			url: `${baseUrl}/providers/${provider.id}`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.8,
 		});
@@ -529,7 +460,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 	const providerCountryPages: MetadataRoute.Sitemap =
 		getProviderCountries().map((country) => ({
 			url: `${baseUrl}/providers/country/${country.code.toLowerCase()}`,
-			lastModified: buildDate,
 			changeFrequency: "weekly",
 			priority: 0.7,
 		}));
@@ -537,7 +467,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 	// Feature pages
 	const featurePages: MetadataRoute.Sitemap = features.map((feature) => ({
 		url: `${baseUrl}/features/${feature.slug}`,
-		lastModified: buildDate,
 		changeFrequency: "monthly",
 		priority: 0.7,
 	}));
@@ -546,7 +475,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 	const enterpriseFeaturePages: MetadataRoute.Sitemap = enterpriseFeatures.map(
 		(feature) => ({
 			url: `${baseUrl}/enterprise/${feature.slug}`,
-			lastModified: buildDate,
 			changeFrequency: "monthly" as const,
 			priority: 0.8,
 		}),
@@ -576,7 +504,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		blogCategorySlugs,
 	).map((category) => ({
 		url: `${baseUrl}/blog/category/${encodeURIComponent(category)}`,
-		lastModified: buildDate,
 		changeFrequency: "weekly" as const,
 		priority: 0.5,
 	}));
@@ -628,7 +555,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		}));
 
 	// Per-year timeline hub children (/timeline/{year})
-	const currentYear = buildDate.getFullYear();
+	const currentYear = new Date().getUTCFullYear();
 	const timelineYearPages: MetadataRoute.Sitemap = timelineYears.map(
 		({ year, lastModified }) => ({
 			url: `${baseUrl}/timeline/${year}`,

--- a/apps/ui/src/components/landing/hero.tsx
+++ b/apps/ui/src/components/landing/hero.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { ArrowRight, ChevronRight } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
@@ -136,7 +134,7 @@ export function Hero({
 
 								{/* Centered hero content - optimized for conversion */}
 								<div className="text-center max-w-4xl mx-auto">
-									<div className="animate-hero-enter">
+									<div>
 										<h1 className="text-balance text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight text-foreground">
 											LLM Gateway — One API for {MARKETING_STATS.providers}{" "}
 											providers, including OpenAI, Anthropic, and Google

--- a/reports/seo-audit-2026-09-05.md
+++ b/reports/seo-audit-2026-09-05.md
@@ -1,0 +1,42 @@
+# Product SEO and AI search audit — September 5, 2026
+
+The audit covered LLM Gateway's marketing site, DevPass, Lounge, Airside, documentation, and the admin application's indexing policy. The goal was to help developers find the products, understand their differences, and reach setup or pricing information.
+
+## Evidence and fixes
+
+A Chromium crawl checked 40 live pages across the five public sites: rendered titles, descriptions, canonical URLs, robots directives, headings, JSON-LD, and broken images. All 40 returned HTTP 200; no broken images were observed. Source review covered shared layouts, sitemaps, account routes, and markdown exports.
+
+| Priority | Product             | Finding                                                                                                                           | Change                                                                                                                                        |
+| -------- | ------------------- | --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| High     | DevPass             | Login and signup inherited indexable metadata while robots.txt prevented crawlers from reading the pages.                         | Add noindex to account and dashboard layouts; allow crawling of account pages so the directive can be read.                                   |
+| High     | Lounge              | Studio introductions were visually hidden and a login overlay covered guest pages. Five sampled studios also had duplicate H1s.   | Give guests visible, server-rendered studio introductions with signup, login, pricing, and related-tool links. Keep signed-in studios intact. |
+| Medium   | Docs                | The layout's title duplicated a body H1 on 43 pages.                                                                              | Remove redundant body titles, retaining headings in code examples.                                                                            |
+| Medium   | All public products | Static sitemap entries advertised deployment time as their modification date.                                                     | Omit unsupported modification dates; retain content dates and public-share update times.                                                      |
+| Medium   | Docs                | Markdown exports used different serializers, hardcoded the production host, and did not consistently identify the HTML canonical. | Share the serializer, honor the configured docs host, and align canonical URLs and headers.                                                   |
+| Medium   | AI context files    | Static catalogue lists and release-availability promises could drift from actual availability.                                    | Replace lists and promises with live catalogue links in product context and pricing summaries.                                                |
+| Medium   | Airside             | The product's purpose depended heavily on the airport metaphor.                                                                   | State the provider portal's purpose directly in the introduction, metadata, structured data, and llms.txt.                                    |
+| Low      | Gateway             | The DevPass product description was unnecessarily long.                                                                           | Shorten it around the subscription, included usage, and coding-tool integration.                                                              |
+
+Lounge's sitemap now propagates an upstream failure instead of publishing an apparently successful sitemap with missing public shares.
+
+## AI search readiness
+
+The existing public sites already provide crawlable pages, product/pricing information, comparison pages, and machine-readable context files. Rendered structured data included appropriate organization, website, product/application, FAQ, collection, and article types; there was no evidence supporting a blanket schema rewrite. Admin already declares noindex.
+
+The fixes make product definitions and studio capabilities readable without a login overlay and keep markdown mirrors consistent with their canonical pages. Google recommends crawlability, visible useful content, and ordinary SEO foundations for AI search; it does not require a special AI file or schema. [Google AI search guidance](https://developers.google.com/search/docs/fundamentals/ai-optimization-guide).
+
+Public crawling was already allowed. Training and search crawlers have different purposes, so no new training policy was inferred from this task. [OpenAI crawler documentation](https://developers.openai.com/api/docs/bots).
+
+## Validation
+
+Repository formatting, the full 19-task build, and 22 isolated API tests passed. Browser checks covered 86 rendered pages, all product robots/sitemaps/context files, and the docs markdown exports. Studio guest pages remained readable at desktop and mobile widths. The new skills dashboard passed creation, import, binary download, editing, immediate reopening, publishing controls, deletion, and developer access checks in light and dark themes.
+
+## Validation boundaries
+
+The final local mobile Lighthouse run reported SEO 100, CLS 0, simulated LCP 12.3 s, and TBT 580 ms. The local baseline reported LCP 4.1 s but selected the small navigation label; the final run selected the actual headline, so those LCP values do not establish a speedup. The headline now renders as server content without an entrance animation. Broader performance changes need a stable baseline with representative field data.
+
+A live mobile Lighthouse sample identified the homepage heading as the LCP element, with render delay as the dominant phase. These are lab observations, not real-user Core Web Vitals. The PageSpeed API returned a quota error, so field performance could not be established. [LCP measurement guidance](https://web.dev/articles/optimize-lcp).
+
+Search spot checks found product and documentation results, but search results are not a measurement of AI citations. No Search Console, analytics, ChatGPT, or Perplexity account data was available. No ranking, traffic, or AI citation improvement is claimed.
+
+After deployment, use Search Console to verify account-page exclusion and refreshed canonical pages. Establish a repeatable citation baseline across category, comparison, pricing, and setup queries for each product before measuring changes in AI visibility.


### PR DESCRIPTION
A rendered audit of the public products found indexable account pages, studio copy covered by a login overlay, duplicate documentation titles, and sitemap timestamps tied to deployments.

- Add DevPass account/dashboard noindex metadata and let crawlers read account-page directives on DevPass and Lounge.
- Show guests readable Lounge studio pages with signup, login, pricing, catalogue, and related-tool links; keep signed-in studios available.
- Remove duplicate body H1s from 43 docs pages and align markdown exports with the configured host and HTML canonicals.
- Remove unsupported sitemap modification dates. Resolve Lounge public shares at request time and propagate failures instead of publishing incomplete results.
- Replace stale catalogue enumerations and release promises in machine-readable product summaries with live links. Clarify Airside's purpose and shorten the DevPass product description.
- Keep the Gateway hero on the server and render its heading without an entrance animation.

The audit used the seo-audit and ai-seo workflows, rendered HTML/JSON-LD, and live search spot checks. Existing crawler access and useful structured data were retained. Search Console and AI citation account data were unavailable, so no ranking or citation gains are claimed. Google's [AI search guidance](https://developers.google.com/search/docs/fundamentals/ai-optimization-guide) informed the content and crawlability changes.

Validation: `pnpm format` and a fresh full `pnpm build` with an unreachable API passed. Production sitemap checks covered upstream failure, recovery, shared-chat entries, and cached responses. Checked 86 rendered pages, robots/sitemaps/context and pricing files across all public products, and markdown canonical headers and runtime host handling. Studio guest pages passed desktop/mobile checks; admin remains noindex.

Performance validation: the final local mobile Lighthouse run reported SEO 100, CLS 0, simulated LCP 12.3 s, and TBT 580 ms. Its LCP candidate changed from the navigation label to the headline, so no speedup is claimed. PageSpeed field data was unavailable due to a quota response.

[Full audit report](https://github.com/theopenco/llmgateway/blob/fix/product-seo/reports/seo-audit-2026-09-05.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Content & Messaging**
  - Updated Airside, DevPass, Playground, and Gateway descriptions to use current catalogue-focused, provider-neutral language.
  - Refreshed product, pricing, and SEO copy across marketing pages.

- **Documentation**
  - Improved generated documentation links and canonical URLs.
  - Removed duplicate page headings for cleaner documentation presentation.
  - Added an SEO and AI-search audit report.

- **SEO & Navigation**
  - Added page-specific titles for authentication and dashboard screens.
  - Updated sitemap and crawler settings for more accurate indexing behavior.

- **Playground**
  - Improved SEO fallback pages and refreshed visible catalogue, pricing, and authentication content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->