### PR TITLE
fix: retire inactive stealth providers

### DIFF
--- a/apps/api/src/routes/admin-routing-analytics.ts
+++ b/apps/api/src/routes/admin-routing-analytics.ts
@@ -27,7 +27,7 @@ import {
 } from "@llmgateway/db";
 import {
 	getProviderDefinition,
-	models,
+	allModels as models,
 	type ProviderModelMapping,
 } from "@llmgateway/models";
 import { deriveStabilityMetrics } from "@llmgateway/shared";

--- a/apps/api/src/routes/internal-models.spec.ts
+++ b/apps/api/src/routes/internal-models.spec.ts
@@ -1,0 +1,68 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { internalModels } from "@/routes/internal-models.js";
+
+import { db, eq, tables } from "@llmgateway/db";
+
+const modelId = "retirement-catalogue-test";
+const carrierId = "retirement-test-carrier";
+
+describe("retired provider catalogue visibility", () => {
+	beforeAll(async () => {
+		for (const id of ["iceberg", "granite", "glacier", carrierId]) {
+			await db
+				.insert(tables.provider)
+				.values({
+					id,
+					name: id,
+					description: "Catalogue test provider",
+					status: "active",
+				})
+				.onConflictDoUpdate({
+					target: tables.provider.id,
+					set: { status: "active" },
+				});
+		}
+		await db.insert(tables.model).values({ id: modelId, family: "test" });
+		await db.insert(tables.modelProviderMapping).values(
+			["iceberg", "granite", "glacier", carrierId].map((providerId) => ({
+				modelId,
+				providerId,
+				externalId: modelId,
+				status: "active" as const,
+			})),
+		);
+	});
+
+	afterAll(async () => {
+		await db.delete(tables.model).where(eq(tables.model.id, modelId));
+		await db.delete(tables.provider).where(eq(tables.provider.id, carrierId));
+	});
+
+	it("hides retired providers even before catalogue sync updates their database status", async () => {
+		const response = await internalModels.request("/providers");
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as { providers: { id: string }[] };
+		const ids = body.providers.map((provider) => provider.id);
+		expect(ids).not.toContain("iceberg");
+		expect(ids).not.toContain("granite");
+		expect(ids).toContain("glacier");
+		expect(ids).toContain(carrierId);
+	});
+
+	it("hides retired mappings while retaining database rows and DB-only carriers", async () => {
+		const response = await internalModels.request("/models");
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as {
+			models: { id: string; mappings: { providerId: string }[] }[];
+		};
+		const model = body.models.find((entry) => entry.id === modelId);
+		expect(model?.mappings.map((mapping) => mapping.providerId).sort()).toEqual(
+			["glacier", carrierId].sort(),
+		);
+		const retained = await db.query.modelProviderMapping.findMany({
+			where: { modelId: { eq: modelId } },
+		});
+		expect(retained).toHaveLength(4);
+	});
+});

--- a/apps/api/src/routes/internal-models.ts
+++ b/apps/api/src/routes/internal-models.ts
@@ -21,6 +21,7 @@ import {
 import {
 	models as modelDefinitions,
 	providers as providerDefinitions,
+	isRetiredProvider,
 	type ProviderModelMapping,
 } from "@llmgateway/models";
 import { deriveStabilityMetrics } from "@llmgateway/shared";
@@ -222,6 +223,9 @@ internalModels.openapi(getModelsRoute, async (c) => {
 
 	const mappingsByModelId = new Map<string, typeof activeMappings>();
 	for (const mapping of activeMappings) {
+		if (isRetiredProvider(mapping.providerId)) {
+			continue;
+		}
 		const existing = mappingsByModelId.get(mapping.modelId);
 		if (existing) {
 			existing.push(mapping);
@@ -493,14 +497,16 @@ internalModels.openapi(getProvidersRoute, async (c) => {
 
 	// modelCardBadge only exists in the catalogue, not the provider table
 	return c.json({
-		providers: providers.map((provider) => ({
-			...provider,
-			modelCardBadge:
-				providerDefinitions.find((p) => p.id === provider.id)?.modelCardBadge ??
-				null,
-			airsideLogoUrl: brandingByProvider.get(provider.id)?.logoUrl ?? null,
-			airsideIconUrl: brandingByProvider.get(provider.id)?.iconUrl ?? null,
-		})),
+		providers: providers
+			.filter((provider) => !isRetiredProvider(provider.id))
+			.map((provider) => ({
+				...provider,
+				modelCardBadge:
+					providerDefinitions.find((p) => p.id === provider.id)
+						?.modelCardBadge ?? null,
+				airsideLogoUrl: brandingByProvider.get(provider.id)?.logoUrl ?? null,
+				airsideIconUrl: brandingByProvider.get(provider.id)?.iconUrl ?? null,
+			})),
 	});
 });
 
@@ -680,7 +686,11 @@ internalModels.openapi(modelBenchmarksRoute, async (c) => {
 		fetchedAt: arenaBenchmarks.fetchedAt,
 	};
 
-	return c.json({ modelId, providers, arena });
+	return c.json({
+		modelId,
+		providers: providers.filter((p) => !isRetiredProvider(p.providerId)),
+		arena,
+	});
 });
 
 // --- Public per-provider uptime/history (last 4h) ---
@@ -875,6 +885,9 @@ internalModels.openapi(modelUptimeRoute, async (c) => {
 
 	// Seed with active providers so idle ones still render
 	for (const p of activeProviders) {
+		if (isRetiredProvider(p.providerId)) {
+			continue;
+		}
 		if (!byProvider.has(p.providerId)) {
 			byProvider.set(p.providerId, {
 				providerId: p.providerId,
@@ -885,6 +898,9 @@ internalModels.openapi(modelUptimeRoute, async (c) => {
 	}
 
 	for (const r of rows) {
+		if (isRetiredProvider(r.providerId)) {
+			continue;
+		}
 		const key = r.providerId;
 		const entry = byProvider.get(key) ?? {
 			providerId: r.providerId,

--- a/apps/api/src/routes/public-providers-stats.ts
+++ b/apps/api/src/routes/public-providers-stats.ts
@@ -14,6 +14,7 @@ import {
 	gte,
 	sql,
 } from "@llmgateway/db";
+import { isRetiredProvider } from "@llmgateway/models";
 import { deriveStabilityMetrics } from "@llmgateway/shared";
 
 import type { ServerTypes } from "@/vars.js";
@@ -187,5 +188,8 @@ publicProvidersStats.openapi(listRoute, async (c) => {
 		};
 	});
 
-	return c.json({ providers, window });
+	return c.json({
+		providers: providers.filter((p) => !isRetiredProvider(p.providerId)),
+		window,
+	});
 });

--- a/apps/gateway/src/lib/costs.spec.ts
+++ b/apps/gateway/src/lib/costs.spec.ts
@@ -39,6 +39,20 @@ describe("calculateCosts", () => {
 		expect(result.estimatedCost).toBe(false); // Not estimated
 	});
 
+	it("retains pricing for historical requests to retired providers", async () => {
+		const result = await calculateCosts(
+			"glm-5.2",
+			"granite",
+			null,
+			100,
+			50,
+			null,
+		);
+		expect(result.inputCost).toBeCloseTo(100 * 1.4e-6, 10);
+		expect(result.outputCost).toBeCloseTo(50 * 4.4e-6, 10);
+		expect(result.totalCost).toBeCloseTo(0.00036, 10);
+	});
+
 	it("should calculate costs with null token counts but provided text", async () => {
 		const result = await calculateCosts(
 			"gpt-4",

--- a/apps/gateway/src/lib/costs.ts
+++ b/apps/gateway/src/lib/costs.ts
@@ -9,7 +9,7 @@ import { logger } from "@llmgateway/logger";
 import {
 	type ModelDefinition,
 	type ProviderModelMapping,
-	models,
+	allModels as models,
 	type PricingTier,
 	type ToolCall,
 	expandAllProviderRegions,

--- a/apps/gateway/src/models/models.spec.ts
+++ b/apps/gateway/src/models/models.spec.ts
@@ -34,6 +34,24 @@ describe("Models API", () => {
 		}
 	});
 
+	test.each([
+		"",
+		"?include_deactivated=true",
+		"?mapped=true&include_deactivated=true",
+	])("omits retired providers from the catalogue%s", async (query) => {
+		const response = await app.request(`/v1/models${query}`);
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as {
+			data: { id: string; providers?: { providerId: string }[] }[];
+		};
+		for (const model of body.data) {
+			expect(model.id).not.toMatch(/^(iceberg|granite)\//);
+			for (const mapping of model.providers ?? []) {
+				expect(["iceberg", "granite"]).not.toContain(mapping.providerId);
+			}
+		}
+	});
+
 	test("GET /v1/models should return a list of models", async () => {
 		const res = await app.request("/v1/models");
 

--- a/apps/worker/src/services/sync-models.spec.ts
+++ b/apps/worker/src/services/sync-models.spec.ts
@@ -62,6 +62,38 @@ describe("sync-models", () => {
 		expect(gptModel?.status).toBe("active");
 	});
 
+	it("archives providers without deleting their existing mappings", async () => {
+		await syncProvidersAndModels();
+		const original = await db.query.modelProviderMapping.findFirst({
+			where: { providerId: { eq: "iceberg" } },
+		});
+		expect(original).toBeDefined();
+		await db
+			.update(provider)
+			.set({ status: "active" })
+			.where(eq(provider.id, "iceberg"));
+		await db
+			.update(modelProviderMapping)
+			.set({ status: "active", logsCount: 42 })
+			.where(eq(modelProviderMapping.id, original!.id));
+
+		await syncProvidersAndModels();
+
+		const archivedProvider = await db.query.provider.findFirst({
+			where: { id: { eq: "iceberg" } },
+		});
+		const archivedMapping = await db.query.modelProviderMapping.findFirst({
+			where: { id: { eq: original!.id } },
+		});
+		expect(archivedProvider?.status).toBe("inactive");
+		expect(archivedMapping).toMatchObject({
+			id: original!.id,
+			status: "inactive",
+			logsCount: 42,
+		});
+		expect(archivedMapping?.deactivatedAt).toEqual(original!.deactivatedAt);
+	});
+
 	it("should sync model-provider mappings", async () => {
 		await syncProvidersAndModels();
 

--- a/apps/worker/src/services/sync-models.ts
+++ b/apps/worker/src/services/sync-models.ts
@@ -12,8 +12,9 @@ import {
 } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
 import {
-	providers,
-	models,
+	allProviders as providers,
+	allModels as models,
+	isRetiredProvider,
 	expandAllProviderRegions,
 } from "@llmgateway/models";
 
@@ -35,7 +36,7 @@ export async function syncProvidersAndModels() {
 					color: providerDef.color,
 					website: providerDef.website,
 					announcement: providerDef.announcement,
-					status: "active",
+					status: providerDef.retiredAt ? "inactive" : "active",
 				})
 				.onConflictDoUpdate({
 					target: provider.id,
@@ -47,6 +48,7 @@ export async function syncProvidersAndModels() {
 						color: providerDef.color,
 						website: providerDef.website,
 						announcement: providerDef.announcement,
+						...(providerDef.retiredAt ? { status: "inactive" as const } : {}),
 						updatedAt: new Date(),
 					},
 				});
@@ -203,7 +205,9 @@ export async function syncProvidersAndModels() {
 									"test" in mapping
 										? (mapping.test as "skip" | "only" | null)
 										: null,
-								status: "active",
+								status: isRetiredProvider(mapping.providerId)
+									? "inactive"
+									: "active",
 								deprecatedAt:
 									"deprecatedAt" in mapping
 										? (mapping.deprecatedAt ?? null)
@@ -294,7 +298,9 @@ export async function syncProvidersAndModels() {
 								"test" in mapping
 									? (mapping.test as "skip" | "only" | undefined)
 									: undefined,
-							status: "active",
+							status: isRetiredProvider(mapping.providerId)
+								? "inactive"
+								: "active",
 						});
 					}
 				}

--- a/packages/actions/src/prepare-request-body.spec.ts
+++ b/packages/actions/src/prepare-request-body.spec.ts
@@ -7785,15 +7785,6 @@ describe("prepareRequestBody - developer role normalization", () => {
 		)) as any;
 	}
 
-	test("rewrites developer to system for a mapping with supportsDeveloperRole: false (granite/glm-5.2)", async () => {
-		const requestBody = await prepare("granite", "glm-5.2");
-		expect(requestBody.messages[0].role).toBe("system");
-		expect(requestBody.messages[0].content).toBe(
-			"You are a helpful assistant.",
-		);
-		expect(requestBody.messages[1].role).toBe("user");
-	});
-
 	test("rewrites developer to system for alibaba/glm-5.2 (supportsDeveloperRole: false)", async () => {
 		const requestBody = await prepare("alibaba", "glm-5.2");
 		expect(requestBody.messages[0].role).toBe("system");

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -6,10 +6,7 @@ import {
 } from "crypto";
 
 import { redisClient, storageRedisClient } from "@llmgateway/cache";
-import {
-	models as allModels,
-	providers as allProviders,
-} from "@llmgateway/models";
+import { allModels, allProviders, isRetiredProvider } from "@llmgateway/models";
 import { DEV_PLAN_PRICES, getDevPlanCreditsLimit } from "@llmgateway/shared";
 import { hashApiKeyForStorage } from "@llmgateway/shared/api-key-hash";
 
@@ -1148,7 +1145,7 @@ function generateSeedProviders() {
 		cancellation: p.cancellation ?? null,
 		color: p.color ?? null,
 		website: p.website ?? null,
-		status: "active" as const,
+		status: p.retiredAt ? ("inactive" as const) : ("active" as const),
 		logsCount: randomInt(500, 50000),
 		errorsCount: randomInt(10, 2000),
 		clientErrorsCount: randomInt(5, 500),
@@ -1244,7 +1241,7 @@ function generateSeedModelProviderMappings() {
 				stability: p.stability ?? "stable",
 				supportedParameters: p.supportedParameters ?? null,
 				test: p.test ?? null,
-				status: "active" as const,
+				status: isRetiredProvider(p.providerId) ? "inactive" : "active",
 				logsCount: randomInt(50, 15000),
 				errorsCount: randomInt(2, 800),
 				clientErrorsCount: randomInt(1, 200),

--- a/packages/models/src/model-metadata.spec.ts
+++ b/packages/models/src/model-metadata.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { models } from "./models.js";
+import { allModels as models } from "./models.js";
 
 import type { ModelDefinition, ProviderModelMapping } from "./models.js";
 

--- a/packages/models/src/models.ts
+++ b/packages/models/src/models.ts
@@ -25,12 +25,11 @@ import { tencentModels } from "./models/tencent.js";
 import { xaiModels } from "./models/xai.js";
 import { xiaomiModels } from "./models/xiaomi.js";
 import { zaiModels } from "./models/zai.js";
+import { isRetiredProvider, type ProviderId } from "./providers.js";
 
-import type { providers } from "./providers.js";
+export type Provider = ProviderId;
 
-export type Provider = (typeof providers)[number]["id"];
-
-export type Model = (typeof models)[number]["id"];
+export type Model = (typeof allModels)[number]["id"];
 
 /**
  * Decimal-safe price representation. Always a string so values are preserved
@@ -179,7 +178,7 @@ export interface ProviderRegion {
 export type ToolChoiceMode = "auto" | "none" | "required" | "function";
 
 export interface ProviderModelMapping {
-	providerId: (typeof providers)[number]["id"];
+	providerId: ProviderId;
 	/**
 	 * Provider-specific upstream model id used when calling the upstream
 	 * provider. Distinct from the canonical `ModelDefinition.id` and from any
@@ -862,7 +861,8 @@ export interface ModelDefinition {
 	releasedAt?: Date;
 }
 
-export const models = [
+/** Complete definitions, including retired providers, for history and billing. */
+export const allModels = [
 	...llmgatewayModels,
 	...openaiModels,
 	...anthropicModels,
@@ -891,3 +891,12 @@ export const models = [
 	...zaiModels,
 	...elevenlabsModels,
 ] as const satisfies ModelDefinition[];
+
+export const models: (ModelDefinition & { id: Model })[] = allModels.map(
+	(model) => ({
+		...model,
+		providers: model.providers.filter(
+			(mapping) => !isRetiredProvider(mapping.providerId),
+		),
+	}),
+);

--- a/packages/models/src/providers.spec.ts
+++ b/packages/models/src/providers.spec.ts
@@ -3,9 +3,12 @@ import { describe, expect, it } from "vitest";
 import { getSupportedServiceTiers, supportsServiceTier } from "./helpers.js";
 import { anthropicModels } from "./models/anthropic.js";
 import { xaiModels } from "./models/xai.js";
-import { models } from "./models.js";
+import { allModels, models } from "./models.js";
 import {
 	formatServiceTierMultiplier,
+	allProviders,
+	getProviderDefinition,
+	isRetiredProvider,
 	getServiceTier,
 	isStealthProvider,
 	providers,
@@ -44,6 +47,56 @@ describe("provider legal metadata", () => {
 
 		expect(incompleteProviders).toEqual([]);
 	});
+});
+
+describe("retired providers", () => {
+	it("only archives providers whose mappings have all deactivated", () => {
+		for (const provider of allProviders.filter((p) => p.retiredAt)) {
+			const mappings = allModels.flatMap((model) =>
+				model.providers.filter((mapping) => mapping.providerId === provider.id),
+			);
+			expect(mappings.length).toBeGreaterThan(0);
+			for (const mapping of mappings as ProviderModelMapping[]) {
+				expect(mapping.deactivatedAt).toBeInstanceOf(Date);
+				expect(mapping.deactivatedAt!.getTime()).toBeLessThanOrEqual(
+					provider.retiredAt!.getTime(),
+				);
+			}
+		}
+	});
+
+	it.each(["iceberg", "granite"])(
+		"hides %s while retaining its history and redaction metadata",
+		(id) => {
+			expect(isRetiredProvider(id)).toBe(true);
+			expect(providers.some((provider) => provider.id === id)).toBe(false);
+			expect(
+				models.some((model) =>
+					model.providers.some((mapping) => mapping.providerId === id),
+				),
+			).toBe(false);
+			expect(
+				allModels.some((model) =>
+					model.providers.some((mapping) => mapping.providerId === id),
+				),
+			).toBe(true);
+			expect(getProviderDefinition(id)?.name).toBeTruthy();
+			expect(isStealthProvider(id)).toBe(true);
+		},
+	);
+
+	it.each(["glacier", "quartz"])(
+		"keeps operational stealth provider %s listed",
+		(id) => {
+			expect(isRetiredProvider(id)).toBe(false);
+			expect(providers.some((provider) => provider.id === id)).toBe(true);
+			expect(
+				models.some((model) =>
+					model.providers.some((mapping) => mapping.providerId === id),
+				),
+			).toBe(true);
+		},
+	);
 });
 
 describe("getServiceTier", () => {

--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -252,9 +252,11 @@ export interface ProviderDefinition {
 	dataPolicy?: ProviderDataPolicy | null;
 	/** Additional provider policy links shown in the Data & Privacy card */
 	additionalLinks?: ProviderAdditionalLink[];
+	/** Archived from the catalogue; retained for historical lookups. */
+	retiredAt?: Date;
 }
 
-export const providers: ProviderDefinition[] = [
+export const allProviders: ProviderDefinition[] = [
 	{
 		id: "llmgateway",
 		name: "LLM Gateway",
@@ -451,6 +453,7 @@ export const providers: ProviderDefinition[] = [
 	},
 	{
 		id: "iceberg",
+		retiredAt: new Date("2026-09-02"),
 		name: "Iceberg",
 		forwardsSafetyIdentifier: false,
 		description:
@@ -476,6 +479,7 @@ export const providers: ProviderDefinition[] = [
 	},
 	{
 		id: "granite",
+		retiredAt: new Date("2026-08-21"),
 		name: "Granite",
 		forwardsSafetyIdentifier: false,
 		description:
@@ -2106,12 +2110,18 @@ export const providers: ProviderDefinition[] = [
 	},
 ] as const satisfies ProviderDefinition[];
 
-export type ProviderId = (typeof providers)[number]["id"];
+export const providers = allProviders.filter((provider) => !provider.retiredAt);
+
+export type ProviderId = (typeof allProviders)[number]["id"];
+
+export function isRetiredProvider(providerId: string): boolean {
+	return Boolean(getProviderDefinition(providerId)?.retiredAt);
+}
 
 export function getProviderDefinition(
 	providerId: ProviderId | string,
 ): ProviderDefinition | undefined {
-	return providers.find((p) => p.id === providerId);
+	return allProviders.find((p) => p.id === providerId);
 }
 
 /**
@@ -2201,9 +2211,7 @@ export function isStealthProvider(
 	provider: ProviderId | ProviderDefinition,
 ): boolean {
 	const def =
-		typeof provider === "string"
-			? providers.find((p) => p.id === provider)
-			: provider;
+		typeof provider === "string" ? getProviderDefinition(provider) : provider;
 	return Boolean(def?.env.required.baseUrl);
 }
 


### PR DESCRIPTION
Iceberg and Granite have no active mappings but still appear in catalogue-backed pages. Retire both providers and omit their eight mappings from the listed catalogue, public statistics, and generated pages.

Keep complete definitions for historical pricing, routing analytics, and stealth-error redaction. Catalogue sync marks the existing provider and mapping rows inactive, preserving their IDs and usage history. API filtering also handles rows whose status has not been synced yet and preserves DB-only carriers.

Validation: 623 tests passed across 12 suites, covering catalogue responses (including deactivated views), stale database rows, sync preservation, historical pricing, request shaping, and error redaction. No upstream e2e calls are needed for already-deactivated mappings.

Local HTTP checks confirm both retired provider pages return 404 and an old Granite model URL permanently redirects to the canonical model page.

`pnpm format` and the full `pnpm build --env-mode=loose --concurrency=2` passed. The build flags forward the isolated API URL and limit local resource use.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Retired providers are now archived and excluded from active provider, model, benchmark, uptime, and statistics listings.
  - Historical model and provider records remain available for billing and historical data.
  - Synchronization archives retired provider mappings without deleting existing records.

- **Bug Fixes**
  - Preserved historical pricing and cost calculations for retired provider models.
  - Retained branding and catalogue indicators for active providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->