### PR TITLE
fix(models): set Novita GLM-5.3 Flash list price

### DIFF
--- a/packages/models/src/models/zai.ts
+++ b/packages/models/src/models/zai.ts
@@ -31,9 +31,9 @@ export const zaiModels = [
 			{
 				providerId: "novita",
 				externalId: "zai-org/glm-5.3-flash",
-				inputPrice: "0.075e-6",
-				cachedInputPrice: "0.015e-6",
-				outputPrice: "0.25e-6",
+				inputPrice: "0.15e-6",
+				cachedInputPrice: "0.03e-6",
+				outputPrice: "0.5e-6",
 				requestPrice: "0",
 				contextSize: 1048576,
 				maxOutput: 131072,


### PR DESCRIPTION
`novita/glm-5.3-flash` was added in #3926 at the rates Novita currently charges, but those are a temporary 50% promotion, not the list price. Carrying the promotional rate in the catalogue means the discount is baked into every cost calculation and cannot be turned off, tracked, or applied selectively.

This sets the mapping to Novita's list price so the promotion can be applied as an admin `discount` row instead, which keeps the catalogue stable when the promotion ends.

| Price | Before (promo) | After (list) |
| --- | --- | --- |
| `inputPrice` | 0.075 | **0.15** |
| `cachedInputPrice` | 0.015 | **0.03** |
| `outputPrice` | 0.25 | **0.5** |

USD per million tokens. No tiers (`is_tiered_billing: false`).

Verified against Novita's [metadata API](https://api.novita.ai/openai/v1/models) for `zai-org/glm-5.3-flash`: `pricing.prompt.origin_price_per_m_decimal` is `0.15`, `pricing.completion` is `0.5`, and `pricing.input_cache_read` is `0.03`, each with the current `price_per_m_decimal` at exactly half. The list rates match Z.ai's first-party pricing already in the `zai` mapping.

Token semantics are unchanged from #3926 (completion tokens include reasoning, cached tokens are inside prompt tokens), so only the coefficients move. Scoped e2e was not rerun: it asserts response shape, not cost, and no metadata or request shaping changed.

Follow-up outside this PR: add the 50% admin discount for `novita` / `glm-5.3-flash` once this deploys, so effective pricing stays the same.

Validation: `pnpm format`, `pnpm build`, and `model-metadata.spec.ts`, `providers.spec.ts`, `costs.spec.ts` pass.

https://claude.ai/code/session_01XjfQEaWb8PULn7odqLnEWR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated pricing for the Novita GLM-5.3-Flash model across input, cached input, and output usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->