### PR TITLE
fix(api): hide internal organization fields

### DIFF
--- a/apps/api/src/routes/organization.spec.ts
+++ b/apps/api/src/routes/organization.spec.ts
@@ -6,6 +6,7 @@ import {
 	createTestUser,
 	deleteAll,
 } from "@/testing.js";
+import { serializeOrganization } from "@/utils/serialize-organization.js";
 
 import {
 	redisClient,
@@ -22,6 +23,56 @@ import {
 } from "@llmgateway/db";
 import { hashApiKeyForStorage } from "@llmgateway/shared/api-key-hash";
 import { randomInt } from "@llmgateway/shared/random";
+
+const internalOrganizationFields = [
+	"stripeCustomerId",
+	"stripeSubscriptionId",
+	"subscriptionCancelled",
+	"paymentFailureCount",
+	"lastPaymentFailureAt",
+	"paymentFailureStartedAt",
+	"trustTierOverride",
+	"devPlanStripeSubscriptionId",
+	"devPlanCancelled",
+	"devPlanPendingTier",
+	"devPlanCardFingerprint",
+	"devPlanCreditsFrozen",
+	"devPlanCreditsLimitBeforeFreeze",
+	"devPlanTierChangeClaimedAt",
+	"chatPlanStripeSubscriptionId",
+	"chatPlanCancelled",
+	"chatPlanCardFingerprint",
+	"lastTopUpAmount",
+	"endUserMarginBalance",
+	"stripeConnectAccountId",
+	"stripeConnectOnboarded",
+	"safetyIdentifier",
+	"riskFlagged",
+];
+
+async function expectPublicOrganization(
+	organization: { id: string },
+	listed = false,
+) {
+	const stored = await db.query.organization.findFirst({
+		where: { id: { eq: organization.id } },
+	});
+	expect(stored).toBeDefined();
+	const publicFields = Object.fromEntries(
+		Object.entries(stored!).filter(
+			([field]) => !internalOrganizationFields.includes(field),
+		),
+	);
+	const expected = JSON.parse(JSON.stringify(publicFields)) as Record<
+		string,
+		unknown
+	>;
+	if (listed) {
+		expected.role = "owner";
+		expected.enterpriseAccess = false;
+	}
+	expect(organization).toEqual(expected);
+}
 
 describe("organization route", () => {
 	let token: string;
@@ -47,6 +98,72 @@ describe("organization route", () => {
 
 	afterEach(async () => {
 		await deleteAll();
+	});
+
+	test.each([
+		{ method: "GET", path: "/orgs", body: undefined },
+		{ method: "POST", path: "/orgs", body: { name: "New Organization" } },
+		{
+			method: "PATCH",
+			path: "/orgs/test-org-id",
+			body: { name: "Updated Organization" },
+		},
+		{ method: "PATCH", path: "/orgs/test-org-id", body: {} },
+	])(
+		"$method $path returns only public organization fields ($body)",
+		async ({ method, path, body }) => {
+			const date = new Date("2026-01-01T00:00:00Z");
+			await db
+				.update(tables.organization)
+				.set({
+					riskFlagged: true,
+					trustTierOverride: 2,
+					stripeConnectAccountId: "test-connect-account",
+					stripeConnectOnboarded: true,
+					devPlanCardFingerprint: "test-card-fingerprint",
+					planStartedAt: date,
+					planExpiresAt: date,
+					trialStartDate: date,
+					trialEndDate: date,
+					devPlanPremiumWeekStart: date,
+					devPlanBillingCycleStart: date,
+					devPlanExpiresAt: date,
+					chatPlanBillingCycleStart: date,
+					chatPlanExpiresAt: date,
+				})
+				.where(eq(tables.organization.id, "test-org-id"));
+
+			const response = await app.request(path, {
+				method,
+				headers: { "Content-Type": "application/json", Cookie: token },
+				body: body === undefined ? undefined : JSON.stringify(body),
+			});
+			expect(response.status).toBe(200);
+			const result = (await response.json()) as {
+				organizations: Array<{ id: string }>;
+				organization: { id: string };
+			};
+			if (method === "GET") {
+				expect(result.organizations.map((org) => org.id)).toContain(
+					"test-org-id",
+				);
+				for (const org of result.organizations) {
+					await expectPublicOrganization(org, true);
+				}
+			} else {
+				await expectPublicOrganization(result.organization);
+			}
+		},
+	);
+
+	test("organization serialization ignores unknown row fields", async () => {
+		const stored = await db.query.organization.findFirst({
+			where: { id: { eq: "test-org-id" } },
+		});
+		const extended = { ...stored!, futureInternalField: "internal" };
+		expect(serializeOrganization(extended)).not.toHaveProperty(
+			"futureInternalField",
+		);
 	});
 
 	test("PATCH /orgs/{id} logs enabling auto top-up in audit log", async () => {
@@ -150,6 +267,7 @@ describe("organization route", () => {
 
 		const body = (await response.json()) as {
 			organizations: Array<{
+				id: string;
 				name: string;
 				kind: "default" | "chat" | "devpass";
 			}>;
@@ -158,6 +276,7 @@ describe("organization route", () => {
 		expect(body.organizations).toHaveLength(1);
 		expect(body.organizations[0]?.name).toBe("Default Organization");
 		expect(body.organizations[0]?.kind).toBe("default");
+		await expectPublicOrganization(body.organizations[0]!, true);
 
 		const afterOrganizations = await db.query.userOrganization.findMany({
 			with: {

--- a/apps/api/src/routes/organization.ts
+++ b/apps/api/src/routes/organization.ts
@@ -21,6 +21,7 @@ import {
 	isRefundTransaction,
 } from "@/utils/invoice.js";
 import { providerCacheControlModeSchema } from "@/utils/provider-cache-control.js";
+import { serializeOrganization } from "@/utils/serialize-organization.js";
 import { isConfigurableDomain, normalizeDomain } from "@/utils/sso-domain.js";
 import {
 	isZeroDataRetentionEnabled,
@@ -399,7 +400,7 @@ organization.openapi(getOrganizations, async (c) => {
 
 	let organizations = userOrganizations
 		.map((uo) => ({
-			...uo.organization!,
+			...serializeOrganization(uo.organization!),
 			role: uo.role,
 			enterpriseAccess: hasOrganizationEnterpriseAccess(
 				uo.organization?.id,
@@ -425,7 +426,7 @@ organization.openapi(getOrganizations, async (c) => {
 		) {
 			organizations = [
 				{
-					...defaultOrganization,
+					...serializeOrganization(defaultOrganization),
 					role: "owner" as const,
 					enterpriseAccess: hasOrganizationEnterpriseAccess(
 						defaultOrganization.id,
@@ -594,7 +595,7 @@ organization.openapi(createOrganization, async (c) => {
 	});
 
 	return c.json({
-		organization: newOrganization,
+		organization: serializeOrganization(newOrganization),
 	});
 });
 
@@ -1083,7 +1084,7 @@ organization.openapi(updateOrganization, async (c) => {
 
 	return c.json({
 		message: "Organization updated successfully",
-		organization: updatedOrganization,
+		organization: serializeOrganization(updatedOrganization),
 	});
 });
 

--- a/apps/api/src/utils/serialize-organization.ts
+++ b/apps/api/src/utils/serialize-organization.ts
@@ -1,0 +1,71 @@
+import type { Organization, SerializedOrganization } from "@llmgateway/db";
+
+export function serializeOrganization(
+	organization: Organization,
+): SerializedOrganization {
+	return {
+		id: organization.id,
+		createdAt: organization.createdAt.toISOString(),
+		updatedAt: organization.updatedAt.toISOString(),
+		name: organization.name,
+		logo: organization.logo,
+		billingEmail: organization.billingEmail,
+		billingCompany: organization.billingCompany,
+		billingAddress: organization.billingAddress,
+		billingTaxId: organization.billingTaxId,
+		billingNotes: organization.billingNotes,
+		credits: organization.credits,
+		plan: organization.plan,
+		planExpiresAt: organization.planExpiresAt?.toISOString() ?? null,
+		planStartedAt: organization.planStartedAt?.toISOString() ?? null,
+		isTrialActive: organization.isTrialActive,
+		trialStartDate: organization.trialStartDate?.toISOString() ?? null,
+		trialEndDate: organization.trialEndDate?.toISOString() ?? null,
+		seats: organization.seats,
+		apiKeyLimit: organization.apiKeyLimit,
+		projectLimit: organization.projectLimit,
+		retentionLevel: organization.retentionLevel,
+		providerCompliancePolicy: organization.providerCompliancePolicy,
+		ssoAutoJoinDomain: organization.ssoAutoJoinDomain,
+		status: organization.status,
+		autoTopUpEnabled: organization.autoTopUpEnabled,
+		autoTopUpThreshold: organization.autoTopUpThreshold,
+		autoTopUpAmount: organization.autoTopUpAmount,
+		referralEarnings: organization.referralEarnings,
+		referralBonusEnabled: organization.referralBonusEnabled,
+		referralBonusPercent: organization.referralBonusPercent,
+		kind: organization.kind,
+		devPlan: organization.devPlan,
+		devPlanCycle: organization.devPlanCycle,
+		devPlanCreditsUsed: organization.devPlanCreditsUsed,
+		devPlanCreditsLimit: organization.devPlanCreditsLimit,
+		devPlanPremiumCreditsUsed: organization.devPlanPremiumCreditsUsed,
+		devPlanPremiumWeekStart:
+			organization.devPlanPremiumWeekStart?.toISOString() ?? null,
+		devPlanResetPassesLite: organization.devPlanResetPassesLite,
+		devPlanResetPassesPro: organization.devPlanResetPassesPro,
+		devPlanResetPassesMax: organization.devPlanResetPassesMax,
+		devPlanIncludedResetPassesUsed: organization.devPlanIncludedResetPassesUsed,
+		devPlanBillingCycleStart:
+			organization.devPlanBillingCycleStart?.toISOString() ?? null,
+		devPlanExpiresAt: organization.devPlanExpiresAt?.toISOString() ?? null,
+		devPlanServiceTier: organization.devPlanServiceTier,
+		devPlanPaygEnabled: organization.devPlanPaygEnabled,
+		devPlanBillingOverride: organization.devPlanBillingOverride,
+		chatPlan: organization.chatPlan,
+		chatPlanCycle: organization.chatPlanCycle,
+		chatPlanCreditsUsed: organization.chatPlanCreditsUsed,
+		chatPlanCreditsLimit: organization.chatPlanCreditsLimit,
+		chatPlanBillingCycleStart:
+			organization.chatPlanBillingCycleStart?.toISOString() ?? null,
+		chatPlanExpiresAt: organization.chatPlanExpiresAt?.toISOString() ?? null,
+		defaultDeveloperMaxApiKeys: organization.defaultDeveloperMaxApiKeys,
+		defaultDeveloperUsageLimit: organization.defaultDeveloperUsageLimit,
+		defaultDeveloperPeriodUsageLimit:
+			organization.defaultDeveloperPeriodUsageLimit,
+		defaultDeveloperPeriodUsageDurationValue:
+			organization.defaultDeveloperPeriodUsageDurationValue,
+		defaultDeveloperPeriodUsageDurationUnit:
+			organization.defaultDeveloperPeriodUsageDurationUnit,
+	};
+}


### PR DESCRIPTION
Organization list, create, and update responses serialized full database rows, exposing internal fields omitted from the public response type. Add an explicit `serializeOrganization()` field picker across those paths, including automatic default-organization creation and empty PATCH requests.

Regression tests check the complete JSON response, preserved public fields and dates, and exclusion of unknown future columns.

Validation: `pnpm format`, `pnpm build`, and `pnpm test:unit apps/api/src/routes/organization.spec.ts` with an isolated database and Redis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Organization data returned by list, create, and update API requests is now consistently limited to public fields.
  - Date values are returned in a standardized ISO format, with empty dates represented consistently.
  - Unexpected or internal organization fields are no longer included in API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->