### PR TITLE
feat(devpass): redesign model census page

### DIFF
--- a/apps/code/e2e/census.pw.ts
+++ b/apps/code/e2e/census.pw.ts
@@ -89,3 +89,29 @@ test("public census page lists methodology and CTA", async ({ page }) => {
 		page.getByRole("link", { name: /File your entry/ }),
 	).toBeVisible();
 });
+
+test("public census registry sorts and filters from the URL", async ({
+	page,
+}) => {
+	const year = new Date().getUTCFullYear();
+	await page.goto(`/data/${year}`);
+
+	await expect(page.getByRole("table")).toBeVisible();
+	await page.getByRole("button", { name: "Quality" }).click();
+	await expect(page).toHaveURL(/sort=quality/);
+	await expect(
+		page.getByRole("columnheader", { name: /Quality/ }),
+	).toHaveAttribute("aria-sort", "descending");
+
+	await page
+		.getByRole("group", { name: "Vendor" })
+		.getByRole("button")
+		.first()
+		.click();
+	await expect(page).toHaveURL(/vendor=/);
+	await expect(page.getByText(/filters applied/)).toBeVisible();
+
+	await page.getByRole("button", { name: "Reset filters" }).click();
+	await expect(page).not.toHaveURL(/vendor=/);
+	await expect(page.getByText(/filters applied/)).toHaveCount(0);
+});

--- a/apps/code/src/app/data/[year]/CensusRegistry.tsx
+++ b/apps/code/src/app/data/[year]/CensusRegistry.tsx
@@ -1,0 +1,719 @@
+"use client";
+
+import {
+	ArrowDownWideNarrow,
+	ArrowUpNarrowWide,
+	Search,
+	X,
+} from "lucide-react";
+import { usePathname } from "next/navigation";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+import {
+	applyCensusQuery,
+	DEFAULT_QUERY,
+	defaultDir,
+	formatScore,
+	isFiltered,
+	MIN_ENTRY_OPTIONS,
+	recommendStatus,
+	serializeCensusQuery,
+	SORT_KEYS,
+	SORT_LABELS,
+	USE_CASE_LABELS,
+	labelForUseCase,
+} from "./census-shared";
+
+import type { CensusModel, CensusQuery, SortKey } from "./census-shared";
+import type { ReactNode } from "react";
+
+interface CensusRegistryProps {
+	year: number;
+	models: CensusModel[];
+	vendors: { id: string; name: string }[];
+	vendorMarks: Record<string, ReactNode>;
+	initialQuery: CensusQuery;
+	minResponses: number;
+	modelHrefBase: string;
+}
+
+const STATUS_TONES = {
+	emerald: "border-emerald-400/60 text-emerald-300",
+	amber: "border-amber-400/60 text-amber-300",
+	stone: "border-stone-400/50 text-stone-300",
+} as const;
+
+const SEGMENTS = [0, 1, 2, 3, 4];
+
+function ScoreMeter({ value }: { value: number }) {
+	return (
+		<div aria-hidden="true" className="flex gap-0.5">
+			{SEGMENTS.map((segment) => {
+				const fill = Math.max(0, Math.min(1, value - segment));
+				return (
+					<span
+						key={segment}
+						className="relative h-1.5 w-3 overflow-hidden rounded-[2px] bg-white/10"
+					>
+						<span
+							className="absolute inset-y-0 left-0 bg-emerald-400"
+							style={{ width: `${fill * 100}%` }}
+						/>
+					</span>
+				);
+			})}
+		</div>
+	);
+}
+
+function ScoreCell({
+	value,
+	label,
+	active,
+}: {
+	value: number;
+	label: string;
+	active: boolean;
+}) {
+	return (
+		<td
+			className={cn(
+				"px-3 py-4 align-middle",
+				active && "bg-emerald-400/[0.06]",
+			)}
+		>
+			<div className="flex flex-col items-end gap-1.5">
+				<span className="font-mono text-lg font-semibold tabular-nums leading-none">
+					{formatScore(value)}
+					<span className="sr-only"> out of 5 {label}</span>
+				</span>
+				<ScoreMeter value={value} />
+			</div>
+		</td>
+	);
+}
+
+function StatusBadge({ percent }: { percent: number }) {
+	const status = recommendStatus(percent);
+	return (
+		<span
+			title={status.description}
+			className={cn(
+				"inline-flex items-center gap-1.5 rounded-sm border px-2 py-1 font-mono text-[11px] font-semibold uppercase tracking-[0.2em]",
+				STATUS_TONES[status.tone],
+			)}
+		>
+			<span
+				aria-hidden="true"
+				className={cn(
+					"h-1.5 w-1.5 rounded-full",
+					status.tone === "emerald" && "bg-emerald-400",
+					status.tone === "amber" && "bg-amber-400",
+					status.tone === "stone" && "bg-stone-400",
+				)}
+			/>
+			{status.label}
+			<span className="sr-only">: {status.description}</span>
+		</span>
+	);
+}
+
+function Chip({
+	pressed,
+	onClick,
+	children,
+	className,
+}: {
+	pressed: boolean;
+	onClick: () => void;
+	children: ReactNode;
+	className?: string;
+}) {
+	return (
+		<button
+			type="button"
+			aria-pressed={pressed}
+			onClick={onClick}
+			className={cn(
+				"inline-flex h-8 touch-manipulation items-center gap-1.5 rounded-full border px-3 text-xs font-medium transition-colors outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50",
+				pressed
+					? "border-emerald-700 bg-emerald-700 text-white dark:border-emerald-400 dark:bg-emerald-400 dark:text-emerald-950"
+					: "border-stone-300 bg-background text-foreground hover:border-stone-500 dark:border-stone-700 dark:hover:border-stone-500",
+				className,
+			)}
+		>
+			{children}
+		</button>
+	);
+}
+
+export function CensusRegistry({
+	year,
+	models,
+	vendors,
+	vendorMarks,
+	initialQuery,
+	minResponses,
+	modelHrefBase,
+}: CensusRegistryProps) {
+	const pathname = usePathname();
+	const modelHref = (modelId: string) =>
+		`${modelHrefBase}/models/${encodeURIComponent(modelId)}`;
+	const [query, setQuery] = useState<CensusQuery>(initialQuery);
+	const firstRender = useRef(true);
+
+	useEffect(() => {
+		if (firstRender.current) {
+			firstRender.current = false;
+			return;
+		}
+		window.history.replaceState(
+			window.history.state,
+			"",
+			`${pathname}${serializeCensusQuery(query)}`,
+		);
+	}, [query, pathname]);
+
+	const visible = useMemo(
+		() => applyCensusQuery(models, query),
+		[models, query],
+	);
+	const filtered = isFiltered(query);
+	// Remount the rows (replaying the entrance stagger) on sort and filter
+	// clicks, but not on every search keystroke.
+	const headerKey = `${query.sort}-${query.dir}-${query.vendors.join()}-${query.useCase}-${query.minEntries}`;
+
+	const update = (patch: Partial<CensusQuery>) =>
+		setQuery((prev) => ({ ...prev, ...patch }));
+
+	const setSort = (sort: SortKey) =>
+		setQuery((prev) =>
+			prev.sort === sort
+				? { ...prev, dir: prev.dir === "asc" ? "desc" : "asc" }
+				: { ...prev, sort, dir: defaultDir(sort) },
+		);
+
+	const toggleVendor = (vendorId: string) =>
+		setQuery((prev) => ({
+			...prev,
+			vendors: prev.vendors.includes(vendorId)
+				? prev.vendors.filter((v) => v !== vendorId)
+				: [...prev.vendors, vendorId],
+		}));
+
+	const columns: {
+		key: SortKey;
+		label: string;
+		align: "left" | "right";
+		hint: string;
+	}[] = [
+		{ key: "value", label: "Value", align: "right", hint: "Value for money" },
+		{
+			key: "quality",
+			label: "Quality",
+			align: "right",
+			hint: "Output quality",
+		},
+		{ key: "speed", label: "Speed", align: "right", hint: "Speed" },
+		{
+			key: "recommend",
+			label: "Recommend",
+			align: "right",
+			hint: "Would recommend",
+		},
+		{
+			key: "entries",
+			label: "Ratings",
+			align: "right",
+			hint: "Verified ratings",
+		},
+	];
+
+	const ariaSort = (key: SortKey) =>
+		query.sort === key
+			? query.dir === "asc"
+				? "ascending"
+				: "descending"
+			: "none";
+
+	const DirIcon = query.dir === "asc" ? ArrowUpNarrowWide : ArrowDownWideNarrow;
+
+	return (
+		<div>
+			{/* Toolbar */}
+			<form
+				role="search"
+				aria-label="Filter and sort the registry"
+				onSubmit={(event) => event.preventDefault()}
+				className="rounded-2xl border border-stone-300/90 bg-stone-50/80 p-4 dark:border-stone-700 dark:bg-stone-900/40"
+			>
+				<div className="flex flex-wrap items-end gap-3">
+					<div className="min-w-[14rem] flex-1">
+						<label
+							htmlFor="census-search"
+							className="mb-1.5 block font-mono text-[11px] uppercase tracking-[0.18em] text-stone-600 dark:text-stone-400"
+						>
+							Search
+						</label>
+						<div className="relative">
+							<Search
+								aria-hidden="true"
+								className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-stone-500"
+							/>
+							<Input
+								id="census-search"
+								name="q"
+								type="search"
+								spellCheck={false}
+								value={query.q}
+								onChange={(event) => update({ q: event.target.value })}
+								placeholder="Model or vendor…"
+								autoComplete="off"
+								className="h-9 bg-background pl-9"
+							/>
+						</div>
+					</div>
+
+					<div>
+						<label
+							htmlFor="census-use-case"
+							className="mb-1.5 block font-mono text-[11px] uppercase tracking-[0.18em] text-stone-600 dark:text-stone-400"
+						>
+							Use case
+						</label>
+						<Select
+							value={query.useCase ?? "any"}
+							onValueChange={(value) =>
+								update({ useCase: value === "any" ? null : value })
+							}
+						>
+							<SelectTrigger
+								id="census-use-case"
+								className="h-9 min-w-[11rem] bg-background"
+							>
+								<SelectValue placeholder="Any use case" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="any">Any use case</SelectItem>
+								{Object.entries(USE_CASE_LABELS).map(([value, label]) => (
+									<SelectItem key={value} value={value}>
+										{label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+
+					<fieldset>
+						<legend className="mb-1.5 block font-mono text-[11px] uppercase tracking-[0.18em] text-stone-600 dark:text-stone-400">
+							Ratings
+						</legend>
+						<div className="flex gap-1">
+							{MIN_ENTRY_OPTIONS.map((option) => (
+								<Chip
+									key={option}
+									pressed={query.minEntries === option}
+									onClick={() => update({ minEntries: option })}
+									className="h-9 rounded-md px-2.5 font-mono"
+								>
+									{option === 0 ? `${minResponses}+` : `${option}+`}
+								</Chip>
+							))}
+						</div>
+					</fieldset>
+
+					<div className="flex items-end gap-1 md:hidden">
+						<div>
+							<label
+								htmlFor="census-sort"
+								className="mb-1.5 block font-mono text-[11px] uppercase tracking-[0.18em] text-stone-600 dark:text-stone-400"
+							>
+								Sort by
+							</label>
+							<Select
+								value={query.sort}
+								onValueChange={(value) => {
+									const sort = value as SortKey;
+									update({ sort, dir: defaultDir(sort) });
+								}}
+							>
+								<SelectTrigger
+									id="census-sort"
+									className="h-9 min-w-[9rem] bg-background"
+								>
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{SORT_KEYS.map((key) => (
+										<SelectItem key={key} value={key}>
+											{SORT_LABELS[key]}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+						<Button
+							type="button"
+							variant="outline"
+							size="icon"
+							aria-label={
+								query.dir === "asc"
+									? "Sorted ascending. Switch to descending"
+									: "Sorted descending. Switch to ascending"
+							}
+							onClick={() =>
+								update({ dir: query.dir === "asc" ? "desc" : "asc" })
+							}
+						>
+							<DirIcon aria-hidden="true" />
+						</Button>
+					</div>
+
+					{filtered && (
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							className="h-9"
+							onClick={() =>
+								setQuery({ ...DEFAULT_QUERY, sort: query.sort, dir: query.dir })
+							}
+						>
+							<X aria-hidden="true" />
+							Reset filters
+						</Button>
+					)}
+				</div>
+
+				<fieldset className="mt-4">
+					<legend className="mb-1.5 block font-mono text-[11px] uppercase tracking-[0.18em] text-stone-600 dark:text-stone-400">
+						Vendor
+					</legend>
+					<div className="flex flex-wrap gap-1.5">
+						{vendors.map((vendor) => (
+							<Chip
+								key={vendor.id}
+								pressed={query.vendors.includes(vendor.id)}
+								onClick={() => toggleVendor(vendor.id)}
+							>
+								<span className="inline-flex h-4 w-4 items-center justify-center [&>*]:h-4 [&>*]:w-4">
+									{vendorMarks[vendor.id]}
+								</span>
+								{vendor.name}
+							</Chip>
+						))}
+					</div>
+				</fieldset>
+			</form>
+
+			<p
+				aria-live="polite"
+				className="mt-4 mb-3 flex flex-wrap items-baseline justify-between gap-2 font-mono text-xs text-stone-600 dark:text-stone-400"
+			>
+				<span>
+					Showing {visible.length} of {models.length} models
+					{filtered ? " · filters applied" : ""} · sorted by{" "}
+					{SORT_LABELS[query.sort].toLowerCase()}{" "}
+					{query.dir === "asc" ? "ascending" : "descending"}
+				</span>
+				<span className="tracking-[0.2em]">DOC. CS-{year}</span>
+			</p>
+
+			{/* Departures board */}
+			<div className="census-board overflow-hidden rounded-2xl border border-white/10 shadow-[0_40px_80px_-40px_rgba(0,0,0,0.7)]">
+				<div className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 px-4 py-3 sm:px-5">
+					<p className="flex items-center gap-2.5 font-mono text-[11px] font-semibold uppercase tracking-[0.3em] text-[#ece7d9]">
+						<span
+							aria-hidden="true"
+							className="h-2 w-2 rounded-full bg-emerald-400 motion-safe:animate-pulse"
+						/>
+						Departures · Coding models
+					</p>
+					<p className="font-mono text-[11px] uppercase tracking-[0.2em] text-[#b3bcb6]">
+						Rank = registry position by value · refreshed every 5 min
+					</p>
+				</div>
+
+				{visible.length === 0 ? (
+					<div className="px-6 py-16 text-center">
+						<p className="font-mono text-sm uppercase tracking-[0.3em] text-[#ece7d9]">
+							No models match
+						</p>
+						<p className="mt-2 text-sm text-[#b3bcb6]">
+							Loosen a filter or clear the search to bring the board back.
+						</p>
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							className="mt-5 border-white/20 bg-transparent text-[#ece7d9] hover:bg-white/10 hover:text-white"
+							onClick={() =>
+								setQuery({ ...DEFAULT_QUERY, sort: query.sort, dir: query.dir })
+							}
+						>
+							Reset filters
+						</Button>
+					</div>
+				) : (
+					<>
+						{/* Desktop table */}
+						<div className="hidden overflow-x-auto md:block">
+							<table className="w-full min-w-[56rem] border-collapse text-[#ece7d9]">
+								<caption className="sr-only">
+									The {year} DevPass Model Census registry. Scores are 1–5
+									averages from verified DevPass developers.
+								</caption>
+								<thead>
+									<tr className="border-b border-white/10 font-mono text-[11px] uppercase tracking-[0.2em] text-[#cfd6d1]">
+										<th scope="col" className="px-3 py-3 text-left sm:pl-5">
+											<span className="sr-only">Registry rank</span>
+											<span aria-hidden="true">#</span>
+										</th>
+										<th
+											scope="col"
+											aria-sort={ariaSort("name")}
+											className="px-3 py-3 text-left"
+										>
+											<button
+												type="button"
+												onClick={() => setSort("name")}
+												className={cn(
+													"-mx-1 inline-flex min-h-6 items-center gap-1.5 rounded-sm px-1 uppercase tracking-[0.2em] outline-none hover:text-white focus-visible:ring-2 focus-visible:ring-emerald-400",
+													query.sort === "name" && "text-white",
+												)}
+											>
+												Model
+												{query.sort === "name" && (
+													<DirIcon aria-hidden="true" className="h-3.5 w-3.5" />
+												)}
+											</button>
+										</th>
+										{columns.map((column) => (
+											<th
+												key={column.key}
+												scope="col"
+												aria-sort={ariaSort(column.key)}
+												className={cn(
+													"px-3 py-3 text-right",
+													query.sort === column.key && "bg-emerald-400/[0.06]",
+												)}
+											>
+												<button
+													type="button"
+													onClick={() => setSort(column.key)}
+													title={`Sort by ${column.hint.toLowerCase()}`}
+													className={cn(
+														"-mx-1 inline-flex min-h-6 items-center gap-1.5 rounded-sm px-1 uppercase tracking-[0.2em] outline-none hover:text-white focus-visible:ring-2 focus-visible:ring-emerald-400",
+														query.sort === column.key && "text-white",
+													)}
+												>
+													{column.label}
+													{query.sort === column.key && (
+														<DirIcon
+															aria-hidden="true"
+															className="h-3.5 w-3.5"
+														/>
+													)}
+												</button>
+											</th>
+										))}
+										<th scope="col" className="px-3 py-3 text-right sm:pr-5">
+											Status
+										</th>
+									</tr>
+								</thead>
+								<tbody key={headerKey}>
+									{visible.map((model, index) => (
+										<tr
+											key={model.modelId}
+											className={cn(
+												"border-b border-white/[0.07] transition-colors last:border-b-0 hover:bg-white/[0.04]",
+												index < 12 &&
+													"motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-top-1 motion-safe:fill-mode-both",
+											)}
+											style={
+												index < 12
+													? { animationDelay: `${index * 45}ms` }
+													: undefined
+											}
+										>
+											<td className="px-3 py-4 align-middle sm:pl-5">
+												<span
+													className={cn(
+														"inline-flex h-9 w-9 items-center justify-center rounded-full font-mono text-sm font-bold tabular-nums",
+														model.rank === 1
+															? "border-[3px] border-double border-emerald-400/80 text-emerald-300"
+															: model.rank <= 3
+																? "border border-emerald-400/50 text-emerald-200"
+																: "border border-dashed border-white/20 text-[#cfd6d1]",
+													)}
+												>
+													{model.rank}
+												</span>
+											</td>
+											<th
+												scope="row"
+												className="px-3 py-4 text-left align-middle font-normal"
+											>
+												<div className="flex items-center gap-3">
+													<span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-white/[0.06] text-[#ece7d9] [&>*]:h-5 [&>*]:w-5">
+														{vendorMarks[model.vendorId]}
+													</span>
+													<div className="min-w-0">
+														<a
+															href={modelHref(model.modelId)}
+															className="font-display block truncate rounded-sm text-base font-semibold leading-tight outline-none hover:underline focus-visible:ring-2 focus-visible:ring-emerald-400"
+														>
+															{model.name}
+														</a>
+														<div className="mt-0.5 truncate font-mono text-[11px] text-[#b3bcb6]">
+															{model.vendorName} · {model.modelId}
+															{model.topUseCase
+																? ` · mostly ${labelForUseCase(model.topUseCase).toLowerCase()}`
+																: ""}
+														</div>
+													</div>
+												</div>
+											</th>
+											<ScoreCell
+												value={model.avgValueScore}
+												label="value"
+												active={query.sort === "value"}
+											/>
+											<ScoreCell
+												value={model.avgQualityScore}
+												label="quality"
+												active={query.sort === "quality"}
+											/>
+											<ScoreCell
+												value={model.avgSpeedScore}
+												label="speed"
+												active={query.sort === "speed"}
+											/>
+											<td
+												className={cn(
+													"px-3 py-4 text-right align-middle font-mono text-lg font-semibold tabular-nums",
+													query.sort === "recommend" && "bg-emerald-400/[0.06]",
+												)}
+											>
+												{model.recommendPercent}%
+											</td>
+											<td
+												className={cn(
+													"px-3 py-4 text-right align-middle font-mono text-base tabular-nums text-[#cfd6d1]",
+													query.sort === "entries" && "bg-emerald-400/[0.06]",
+												)}
+											>
+												{model.responseCount}
+											</td>
+											<td className="px-3 py-4 text-right align-middle sm:pr-5">
+												<StatusBadge percent={model.recommendPercent} />
+											</td>
+										</tr>
+									))}
+								</tbody>
+							</table>
+						</div>
+
+						{/* Mobile cards */}
+						<ul
+							key={`m-${headerKey}`}
+							className="divide-y divide-white/[0.07] md:hidden"
+						>
+							{visible.map((model, index) => (
+								<li
+									key={model.modelId}
+									className={cn(
+										"px-4 py-4 text-[#ece7d9]",
+										index < 8 &&
+											"motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-top-1 motion-safe:fill-mode-both",
+									)}
+									style={
+										index < 8
+											? { animationDelay: `${index * 45}ms` }
+											: undefined
+									}
+								>
+									<div className="flex items-center gap-3">
+										<span
+											className={cn(
+												"inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full font-mono text-sm font-bold tabular-nums",
+												model.rank === 1
+													? "border-[3px] border-double border-emerald-400/80 text-emerald-300"
+													: "border border-dashed border-white/20 text-[#cfd6d1]",
+											)}
+										>
+											{model.rank}
+										</span>
+										<div className="min-w-0 flex-1">
+											<h3 className="font-display truncate text-base font-semibold leading-tight">
+												<a
+													href={modelHref(model.modelId)}
+													className="rounded-sm outline-none hover:underline focus-visible:ring-2 focus-visible:ring-emerald-400"
+												>
+													{model.name}
+												</a>
+											</h3>
+											<p className="mt-0.5 truncate font-mono text-[11px] text-[#b3bcb6]">
+												{model.vendorName} · {model.responseCount} ratings
+											</p>
+										</div>
+										<div className="text-right">
+											<p className="font-mono text-xl font-bold tabular-nums leading-none">
+												{model.recommendPercent}%
+											</p>
+											<p className="mt-1 font-mono text-[10px] uppercase tracking-[0.18em] text-[#b3bcb6]">
+												recommend
+											</p>
+										</div>
+									</div>
+									<dl className="mt-3 grid grid-cols-3 gap-2">
+										{[
+											{ label: "Value", value: model.avgValueScore },
+											{ label: "Quality", value: model.avgQualityScore },
+											{ label: "Speed", value: model.avgSpeedScore },
+										].map((score) => (
+											<div
+												key={score.label}
+												className="rounded-md bg-white/[0.05] px-2.5 py-2"
+											>
+												<dt className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#b3bcb6]">
+													{score.label}
+												</dt>
+												<dd className="mt-1 flex items-center justify-between gap-2">
+													<span className="font-mono text-base font-semibold tabular-nums">
+														{formatScore(score.value)}
+													</span>
+													<ScoreMeter value={score.value} />
+												</dd>
+											</div>
+										))}
+									</dl>
+									<div className="mt-3 flex items-center justify-between gap-2">
+										<span className="truncate font-mono text-[11px] text-[#b3bcb6]">
+											{model.topUseCase
+												? `Mostly ${labelForUseCase(model.topUseCase).toLowerCase()}`
+												: "Use case n/a"}
+										</span>
+										<StatusBadge percent={model.recommendPercent} />
+									</div>
+								</li>
+							))}
+						</ul>
+					</>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/code/src/app/data/[year]/census-components.tsx
+++ b/apps/code/src/app/data/[year]/census-components.tsx
@@ -1,0 +1,339 @@
+import { Stamp } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+import {
+	ProviderIcons,
+	type ProviderIconKey,
+} from "@llmgateway/shared/components";
+
+import { formatScore, labelForUseCase } from "./census-shared";
+
+import type { CensusModel } from "./census-shared";
+import type { ModelSurveyResults } from "@/lib/model-survey";
+import type { ReactNode } from "react";
+
+// Catalogue families that share another provider's mark.
+const ICON_ALIASES: Record<string, ProviderIconKey> = {
+	google: "google-ai-studio",
+};
+
+export function VendorMark({
+	vendorId,
+	vendorName,
+	className,
+}: {
+	vendorId: string;
+	vendorName: string;
+	className?: string;
+}) {
+	const key = ICON_ALIASES[vendorId] ?? vendorId;
+	const Icon =
+		key in ProviderIcons ? ProviderIcons[key as ProviderIconKey] : null;
+	if (Icon) {
+		return <Icon className={cn("shrink-0", className)} aria-hidden="true" />;
+	}
+	return (
+		<span
+			aria-hidden="true"
+			className={cn(
+				"inline-flex shrink-0 items-center justify-center rounded-full border border-current font-mono text-[10px] font-bold uppercase leading-none",
+				className,
+			)}
+		>
+			{vendorName.slice(0, 2)}
+		</span>
+	);
+}
+
+const STAMP_TONES = {
+	emerald:
+		"border-emerald-700/80 text-emerald-800 dark:border-emerald-400/80 dark:text-emerald-300",
+	amber:
+		"border-amber-700/80 text-amber-800 dark:border-amber-400/80 dark:text-amber-300",
+	indigo:
+		"border-indigo-700/80 text-indigo-800 dark:border-indigo-400/80 dark:text-indigo-300",
+	stone:
+		"border-stone-600/80 text-stone-700 dark:border-stone-400/80 dark:text-stone-300",
+} as const;
+
+export function VisaStamp({
+	children,
+	sub,
+	tone = "emerald",
+	rotate = -6,
+	className,
+}: {
+	children: ReactNode;
+	sub?: ReactNode;
+	tone?: keyof typeof STAMP_TONES;
+	rotate?: number;
+	className?: string;
+}) {
+	return (
+		<div
+			className={cn(
+				"inline-flex flex-col items-center rounded-md border-4 border-double px-4 py-2 text-center font-mono uppercase mix-blend-multiply dark:mix-blend-screen",
+				STAMP_TONES[tone],
+				className,
+			)}
+			style={{ transform: `rotate(${rotate}deg)` }}
+		>
+			<span className="text-xs font-bold tracking-[0.3em] sm:text-sm">
+				{children}
+			</span>
+			{sub ? (
+				<span className="mt-0.5 text-[10px] tracking-[0.2em]">{sub}</span>
+			) : null}
+		</div>
+	);
+}
+
+/** Machine-readable-zone line: uppercase, non-alphanumerics become fillers, padded to `length`. */
+export function mrz(parts: (string | number)[], length = 44): string {
+	const text = parts
+		.map((part) =>
+			String(part)
+				.toUpperCase()
+				.replace(/[^A-Z0-9]+/g, "<"),
+		)
+		.join("<<");
+	return text.slice(0, length).padEnd(length, "<");
+}
+
+export function MrzLines({ lines }: { lines: string[] }) {
+	return (
+		<div
+			aria-hidden="true"
+			className="select-none overflow-hidden font-mono text-[11px] leading-5 tracking-[0.22em] text-stone-600 dark:text-stone-400"
+		>
+			{lines.map((line) => (
+				<div key={line} className="whitespace-nowrap">
+					{line}
+				</div>
+			))}
+		</div>
+	);
+}
+
+export function Barcode({ className }: { className?: string }) {
+	return (
+		<div
+			aria-hidden="true"
+			className={cn("h-9 w-full", className)}
+			style={{
+				backgroundImage:
+					"repeating-linear-gradient(90deg, currentColor 0 2px, transparent 2px 4px, currentColor 4px 5px, transparent 5px 8px, currentColor 8px 11px, transparent 11px 13px, currentColor 13px 14px, transparent 14px 18px)",
+			}}
+		/>
+	);
+}
+
+export function PassportDataPage({
+	year,
+	results,
+	isCurrentYear,
+	quarter,
+}: {
+	year: number;
+	results: ModelSurveyResults;
+	isCurrentYear: boolean;
+	quarter: number;
+}) {
+	const fields = [
+		{ label: "Entries filed", value: results.totalResponses },
+		{ label: "Developers reporting", value: results.totalRespondents },
+		{ label: "Models on registry", value: results.totalModelsRated },
+	];
+	return (
+		<section
+			aria-labelledby="census-doc-title"
+			className="census-paper relative overflow-hidden rounded-2xl border border-stone-300/90 shadow-[0_30px_70px_-40px_rgba(6,78,59,0.45)] dark:border-stone-700"
+		>
+			<Stamp
+				aria-hidden="true"
+				className="pointer-events-none absolute -right-8 -bottom-8 h-44 w-44 text-emerald-900/[0.07] dark:text-emerald-300/[0.06]"
+			/>
+			<div className="flex items-start justify-between gap-4 border-b border-dashed border-stone-400/70 px-5 py-4 dark:border-stone-600/70">
+				<div className="min-w-0">
+					<p className="font-mono text-[11px] font-semibold uppercase tracking-[0.3em] text-emerald-800 dark:text-emerald-300">
+						DevPass · Model Census
+					</p>
+					<h2
+						id="census-doc-title"
+						className="font-display mt-1 text-xl font-bold leading-tight text-balance"
+					>
+						Registry of coding models
+					</h2>
+				</div>
+				<VisaStamp
+					rotate={6}
+					className="mt-1 shrink-0"
+					sub={isCurrentYear ? "Filing now" : "Registry closed"}
+				>
+					{isCurrentYear ? `Open · Q${quarter}` : `Final ${year}`}
+				</VisaStamp>
+			</div>
+
+			<dl className="grid grid-cols-3 gap-x-3 gap-y-4 px-5 pt-5 pb-4">
+				{fields.map((field) => (
+					<div key={field.label} className="min-w-0">
+						<dt className="font-mono text-[10px] uppercase tracking-[0.18em] text-stone-600 dark:text-stone-400">
+							{field.label}
+						</dt>
+						<dd className="mt-1 font-mono text-2xl font-bold tabular-nums sm:text-3xl">
+							{field.value.toLocaleString("en-US")}
+						</dd>
+					</div>
+				))}
+				<div className="min-w-0">
+					<dt className="font-mono text-[10px] uppercase tracking-[0.18em] text-stone-600 dark:text-stone-400">
+						Wave
+					</dt>
+					<dd className="mt-1 font-mono text-sm font-semibold">
+						{isCurrentYear ? `Q${quarter} · filing now` : "All four filed"}
+					</dd>
+				</div>
+				<div className="min-w-0">
+					<dt className="font-mono text-[10px] uppercase tracking-[0.18em] text-stone-600 dark:text-stone-400">
+						Listing rule
+					</dt>
+					<dd className="mt-1 font-mono text-sm font-semibold">
+						{results.minResponses}+ verified ratings
+					</dd>
+				</div>
+				<div className="min-w-0">
+					<dt className="font-mono text-[10px] uppercase tracking-[0.18em] text-stone-600 dark:text-stone-400">
+						Scale
+					</dt>
+					<dd className="mt-1 font-mono text-sm font-semibold">1–5 averages</dd>
+				</div>
+			</dl>
+
+			<div className="border-t border-dashed border-stone-400/70 px-5 pt-3 pb-4 dark:border-stone-600/70">
+				<p className="mb-1.5 font-mono text-[10px] uppercase tracking-[0.25em] text-stone-600 dark:text-stone-400">
+					Doc. CS-{year} · issued by LLM Gateway
+				</p>
+				<MrzLines
+					lines={[
+						mrz(["P", "DEVPASS", "MODEL", "CENSUS", year]),
+						mrz([
+							`CS${year}`,
+							results.totalResponses,
+							results.totalRespondents,
+							results.totalModelsRated,
+							"LLMGATEWAY",
+						]),
+					]}
+				/>
+			</div>
+		</section>
+	);
+}
+
+export function BoardingPass({
+	title,
+	code,
+	model,
+	score,
+	scoreLabel,
+	year,
+	delayMs,
+}: {
+	title: string;
+	code: string;
+	model: CensusModel;
+	score: number;
+	scoreLabel: string;
+	year: number;
+	delayMs: number;
+}) {
+	const topUseCase = model.topUseCase ? labelForUseCase(model.topUseCase) : "—";
+	return (
+		<article
+			aria-label={`${title}: ${model.name}`}
+			className="census-paper relative grid grid-cols-[minmax(0,1fr)_6.5rem] overflow-hidden rounded-2xl border border-stone-300/90 shadow-[0_24px_50px_-32px_rgba(28,25,23,0.5)] transition-transform duration-300 motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-4 motion-safe:fill-mode-both motion-safe:hover:-translate-y-1 dark:border-stone-700"
+			style={{ animationDelay: `${delayMs}ms` }}
+		>
+			<div className="min-w-0 p-5">
+				<div className="flex items-start justify-between gap-3">
+					<p className="font-mono text-[11px] font-semibold uppercase tracking-[0.28em] text-emerald-800 dark:text-emerald-300">
+						Boarding pass · {title}
+					</p>
+					<VendorMark
+						vendorId={model.vendorId}
+						vendorName={model.vendorName}
+						className="h-6 w-6 text-stone-700 dark:text-stone-200"
+					/>
+				</div>
+				<h3 className="font-display mt-3 truncate text-2xl font-bold leading-tight tracking-tight">
+					{model.name}
+				</h3>
+				<p className="mt-1 truncate font-mono text-xs text-stone-600 dark:text-stone-400">
+					{model.modelId} · {model.vendorName}
+				</p>
+				<dl className="mt-4 grid grid-cols-[minmax(0,1.4fr)_auto_auto] gap-x-4 gap-y-3 text-sm">
+					<div className="min-w-0">
+						<dt className="font-mono text-[10px] uppercase tracking-[0.18em] text-stone-600 dark:text-stone-400">
+							Gate
+						</dt>
+						<dd className="mt-0.5 font-medium leading-snug">{topUseCase}</dd>
+					</div>
+					<div>
+						<dt className="font-mono text-[10px] uppercase tracking-[0.18em] text-stone-600 dark:text-stone-400">
+							Ratings
+						</dt>
+						<dd className="mt-0.5 font-mono font-semibold tabular-nums">
+							{model.responseCount}
+						</dd>
+					</div>
+					<div>
+						<dt className="font-mono text-[10px] uppercase tracking-[0.18em] text-stone-600 dark:text-stone-400">
+							Recommend
+						</dt>
+						<dd className="mt-0.5 font-mono font-semibold tabular-nums">
+							{model.recommendPercent}%
+						</dd>
+					</div>
+					<div className="col-span-3">
+						<dt className="font-mono text-[10px] uppercase tracking-[0.18em] text-stone-600 dark:text-stone-400">
+							Value · Quality · Speed
+						</dt>
+						<dd className="mt-0.5 font-mono font-semibold tabular-nums">
+							{formatScore(model.avgValueScore)} ·{" "}
+							{formatScore(model.avgQualityScore)} ·{" "}
+							{formatScore(model.avgSpeedScore)}
+						</dd>
+					</div>
+				</dl>
+			</div>
+
+			<div
+				aria-hidden="true"
+				className="absolute top-0 bottom-0 right-[6.5rem] w-0 border-l-2 border-dashed border-stone-400/70 dark:border-stone-600"
+			>
+				<span className="absolute -top-3 -left-3 h-6 w-6 rounded-full bg-background" />
+				<span className="absolute -bottom-3 -left-3 h-6 w-6 rounded-full bg-background" />
+			</div>
+
+			<div className="flex flex-col items-center justify-between bg-emerald-800 px-3 py-4 text-emerald-50 dark:bg-emerald-700">
+				<p className="font-mono text-[10px] uppercase tracking-[0.25em] text-emerald-100">
+					{code}
+				</p>
+				<div className="text-center">
+					<p className="font-mono text-4xl font-bold leading-none tabular-nums">
+						{formatScore(score)}
+					</p>
+					<p className="mt-1 font-mono text-[10px] uppercase tracking-[0.2em] text-emerald-100">
+						out of 5
+						<span className="sr-only"> for {scoreLabel.toLowerCase()}</span>
+					</p>
+				</div>
+				<Barcode className="text-emerald-200/80" />
+				<p className="font-mono text-[9px] tracking-[0.2em] text-emerald-100">
+					CS-{year}-{String(model.rank).padStart(2, "0")}
+				</p>
+			</div>
+		</article>
+	);
+}

--- a/apps/code/src/app/data/[year]/census-shared.ts
+++ b/apps/code/src/app/data/[year]/census-shared.ts
@@ -1,0 +1,229 @@
+import type { ModelSurveyModel } from "@/lib/model-survey";
+
+export const USE_CASE_LABELS: Record<string, string> = {
+	agentic_coding: "Agentic coding",
+	code_completion: "Autocomplete",
+	code_review: "Code review",
+	debugging: "Debugging",
+	writing_tests: "Writing tests",
+	docs_and_explanations: "Docs & explanations",
+	other: "Other",
+};
+
+export function labelForUseCase(useCase: string): string {
+	return USE_CASE_LABELS[useCase] ?? useCase;
+}
+
+export interface CensusModel extends ModelSurveyModel {
+	/** Position in the canonical registry order (value score, then entries). */
+	rank: number;
+	name: string;
+	vendorId: string;
+	vendorName: string;
+	topUseCase: string | null;
+}
+
+export const SORT_KEYS = [
+	"value",
+	"quality",
+	"speed",
+	"recommend",
+	"entries",
+	"name",
+] as const;
+export type SortKey = (typeof SORT_KEYS)[number];
+export type SortDir = "asc" | "desc";
+
+export const SORT_LABELS: Record<SortKey, string> = {
+	value: "Value",
+	quality: "Quality",
+	speed: "Speed",
+	recommend: "Recommend",
+	entries: "Ratings",
+	name: "Name",
+};
+
+export const MIN_ENTRY_OPTIONS = [0, 10, 25, 50] as const;
+
+export interface CensusQuery {
+	sort: SortKey;
+	dir: SortDir;
+	vendors: string[];
+	useCase: string | null;
+	minEntries: number;
+	q: string;
+}
+
+export const DEFAULT_QUERY: CensusQuery = {
+	sort: "value",
+	dir: "desc",
+	vendors: [],
+	useCase: null,
+	minEntries: 0,
+	q: "",
+};
+
+export function defaultDir(sort: SortKey): SortDir {
+	return sort === "name" ? "asc" : "desc";
+}
+
+function isSortKey(value: string): value is SortKey {
+	return (SORT_KEYS as readonly string[]).includes(value);
+}
+
+function first(value: string | string[] | undefined): string | undefined {
+	return Array.isArray(value) ? value[0] : value;
+}
+
+export function parseCensusQuery(
+	params: Record<string, string | string[] | undefined>,
+): CensusQuery {
+	const rawSort = first(params.sort) ?? "";
+	const sort = isSortKey(rawSort) ? rawSort : DEFAULT_QUERY.sort;
+	const rawDir = first(params.dir);
+	const dir = rawDir === "asc" || rawDir === "desc" ? rawDir : defaultDir(sort);
+	const vendors = (first(params.vendor) ?? "")
+		.split(",")
+		.map((v) => v.trim().toLowerCase())
+		.filter(Boolean);
+	const useCase = first(params.use) ?? null;
+	const rawMin = Number(first(params.min) ?? 0);
+	const minEntries = (MIN_ENTRY_OPTIONS as readonly number[]).includes(rawMin)
+		? rawMin
+		: 0;
+	const q = (first(params.q) ?? "").slice(0, 80);
+	return {
+		sort,
+		dir,
+		vendors,
+		useCase: useCase && USE_CASE_LABELS[useCase] ? useCase : null,
+		minEntries,
+		q,
+	};
+}
+
+export function serializeCensusQuery(query: CensusQuery): string {
+	const params = new URLSearchParams();
+	if (query.sort !== DEFAULT_QUERY.sort) {
+		params.set("sort", query.sort);
+	}
+	if (query.dir !== defaultDir(query.sort)) {
+		params.set("dir", query.dir);
+	}
+	if (query.vendors.length > 0) {
+		params.set("vendor", query.vendors.join(","));
+	}
+	if (query.useCase) {
+		params.set("use", query.useCase);
+	}
+	if (query.minEntries > 0) {
+		params.set("min", String(query.minEntries));
+	}
+	if (query.q.trim()) {
+		params.set("q", query.q.trim());
+	}
+	const encoded = params.toString();
+	return encoded ? `?${encoded}` : "";
+}
+
+export function isFiltered(query: CensusQuery): boolean {
+	return (
+		query.vendors.length > 0 ||
+		query.useCase !== null ||
+		query.minEntries > 0 ||
+		query.q.trim() !== ""
+	);
+}
+
+function sortValue(model: CensusModel, sort: SortKey): number | string {
+	switch (sort) {
+		case "value":
+			return model.avgValueScore;
+		case "quality":
+			return model.avgQualityScore;
+		case "speed":
+			return model.avgSpeedScore;
+		case "recommend":
+			return model.recommendPercent;
+		case "entries":
+			return model.responseCount;
+		case "name":
+			return model.name.toLowerCase();
+	}
+}
+
+export function applyCensusQuery(
+	models: CensusModel[],
+	query: CensusQuery,
+): CensusModel[] {
+	const needle = query.q.trim().toLowerCase();
+	const filtered = models.filter((model) => {
+		if (query.vendors.length > 0 && !query.vendors.includes(model.vendorId)) {
+			return false;
+		}
+		if (
+			query.useCase &&
+			!model.useCases.some((bucket) => bucket.useCase === query.useCase)
+		) {
+			return false;
+		}
+		if (model.responseCount < query.minEntries) {
+			return false;
+		}
+		if (
+			needle &&
+			!model.name.toLowerCase().includes(needle) &&
+			!model.modelId.toLowerCase().includes(needle) &&
+			!model.vendorName.toLowerCase().includes(needle)
+		) {
+			return false;
+		}
+		return true;
+	});
+
+	const direction = query.dir === "asc" ? 1 : -1;
+	return filtered.sort((a, b) => {
+		const av = sortValue(a, query.sort);
+		const bv = sortValue(b, query.sort);
+		if (av !== bv) {
+			return (av < bv ? -1 : 1) * direction;
+		}
+		if (a.responseCount !== b.responseCount) {
+			return b.responseCount - a.responseCount;
+		}
+		return a.rank - b.rank;
+	});
+}
+
+export interface RecommendStatus {
+	label: "Cleared" | "Boarding" | "Standby";
+	tone: "emerald" | "amber" | "stone";
+	description: string;
+}
+
+/** Departure-board status derived from the share of developers who would recommend a model. */
+export function recommendStatus(percent: number): RecommendStatus {
+	if (percent >= 90) {
+		return {
+			label: "Cleared",
+			tone: "emerald",
+			description: "90% or more of raters would recommend this model",
+		};
+	}
+	if (percent >= 75) {
+		return {
+			label: "Boarding",
+			tone: "amber",
+			description: "75–89% of raters would recommend this model",
+		};
+	}
+	return {
+		label: "Standby",
+		tone: "stone",
+		description: "Fewer than 75% of raters would recommend this model",
+	};
+}
+
+export function formatScore(value: number): string {
+	return value.toFixed(1);
+}

--- a/apps/code/src/app/data/[year]/page.tsx
+++ b/apps/code/src/app/data/[year]/page.tsx
@@ -406,13 +406,17 @@ export default async function CensusPage({
 		],
 	};
 
+	// Model names and ids flow into the schema; escape "<" so no value can
+	// close the script element.
+	const jsonLdJson = JSON.stringify(jsonLd).replace(/</g, "\\u003c");
+
 	return (
 		<div className="min-h-screen bg-background">
 			<Header />
 			<script
 				type="application/ld+json"
 				// eslint-disable-next-line @eslint-react/dom/no-dangerously-set-innerhtml
-				dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+				dangerouslySetInnerHTML={{ __html: jsonLdJson }}
 			/>
 
 			<main id="main">

--- a/apps/code/src/app/data/[year]/page.tsx
+++ b/apps/code/src/app/data/[year]/page.tsx
@@ -1,4 +1,4 @@
-import { ClipboardCheck, Stamp } from "lucide-react";
+import { ShieldCheck, Stamp } from "lucide-react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
@@ -6,24 +6,110 @@ import { Footer } from "@/components/Footer";
 import { GetDevPassButton } from "@/components/GetDevPassButton";
 import { Header } from "@/components/Header";
 import { Button } from "@/components/ui/button";
+import { getConfig } from "@/lib/config-server";
 import { FIRST_SURVEY_YEAR, fetchModelSurveyResults } from "@/lib/model-survey";
 
+import { models as catalogueModels, providers } from "@llmgateway/models";
+
+import {
+	BoardingPass,
+	PassportDataPage,
+	VendorMark,
+	VisaStamp,
+} from "./census-components";
+import { formatScore, parseCensusQuery } from "./census-shared";
+import { CensusRegistry } from "./CensusRegistry";
+
+import type { CensusModel } from "./census-shared";
 import type { ModelSurveyModel } from "@/lib/model-survey";
 import type { Metadata } from "next";
+import type { ReactNode } from "react";
 
 const BASE_URL = "https://devpass.llmgateway.io";
 
 export const revalidate = 300;
 
-const USE_CASE_LABELS: Record<string, string> = {
-	agentic_coding: "Agentic coding",
-	code_completion: "Autocomplete",
-	code_review: "Code review",
-	debugging: "Debugging",
-	writing_tests: "Writing tests",
-	docs_and_explanations: "Docs",
+// Display names for catalogue families whose provider name reads awkwardly
+// in a vendor chip, plus families that have no provider entry at all.
+const FAMILY_LABELS: Record<string, string> = {
+	google: "Google",
+	zai: "Z.ai",
+	alibaba: "Alibaba",
+	moonshot: "Moonshot",
+	mistral: "Mistral",
+	nvidia: "NVIDIA",
+	tencent: "Tencent",
+	inclusionai: "inclusionAI",
+	nousresearch: "Nous Research",
+	openbmb: "OpenBMB",
+	baai: "BAAI",
 	other: "Other",
 };
+
+const ID_FAMILY_HINTS: [RegExp, string][] = [
+	[/^(gpt|o\d|codex)/, "openai"],
+	[/^claude/, "anthropic"],
+	[/^gemini|^gemma/, "google"],
+	[/^deepseek/, "deepseek"],
+	[/^glm/, "zai"],
+	[/^qwen|^qwq/, "alibaba"],
+	[/^kimi|^moonshot/, "moonshot"],
+	[/^grok/, "xai"],
+	[/^(mistral|codestral|devstral|magistral)/, "mistral"],
+	[/^minimax/, "minimax"],
+	[/^llama/, "meta"],
+];
+
+type CatalogueModel = (typeof catalogueModels)[number];
+
+const catalogueById = new Map<string, CatalogueModel>(
+	catalogueModels.map((model): [string, CatalogueModel] => [model.id, model]),
+);
+
+function inferFamily(modelId: string): string {
+	const hit = ID_FAMILY_HINTS.find(([pattern]) => pattern.test(modelId));
+	return hit ? hit[1] : "other";
+}
+
+function vendorLabel(family: string): string {
+	return (
+		FAMILY_LABELS[family] ??
+		providers.find((provider) => provider.id === family)?.name ??
+		family.charAt(0).toUpperCase() + family.slice(1)
+	);
+}
+
+function enrichModels(models: ModelSurveyModel[]): CensusModel[] {
+	return models.map((model, index) => {
+		const definition = catalogueById.get(model.modelId);
+		const vendorId = definition?.family ?? inferFamily(model.modelId);
+		return {
+			...model,
+			rank: index + 1,
+			name: definition?.name ?? model.modelId,
+			vendorId,
+			vendorName: vendorLabel(vendorId),
+			topUseCase: model.useCases[0]?.useCase ?? null,
+		};
+	});
+}
+
+function leader(
+	models: CensusModel[],
+	score: (model: CensusModel) => number,
+): CensusModel | null {
+	let best: CensusModel | null = null;
+	for (const model of models) {
+		if (
+			!best ||
+			score(model) > score(best) ||
+			(score(model) === score(best) && model.responseCount > best.responseCount)
+		) {
+			best = model;
+		}
+	}
+	return best;
+}
 
 function parseYear(raw: string): number | null {
 	if (!/^\d{4}$/.test(raw)) {
@@ -47,8 +133,8 @@ export async function generateMetadata({
 	if (!year) {
 		return {};
 	}
-	const title = `The ${year} DevPass Model Census — Coding Models Rated by Developers`;
-	const description = `Value, quality, and speed scores for coding models, rated only by DevPass developers with verified real-world usage. No benchmarks — shipped-code verdicts.`;
+	const title = `${year} DevPass Model Census: Coding Models Rated by Developers`;
+	const description = `Coding models rated on value, quality, and speed by DevPass developers with verified usage. Sort and filter the ${year} registry by vendor, use case, and ratings.`;
 	return {
 		title: { absolute: title },
 		description,
@@ -67,123 +153,256 @@ export async function generateMetadata({
 	};
 }
 
-function ScoreMeter({ label, value }: { label: string; value: number }) {
-	return (
-		<div className="flex items-center gap-2">
-			<span className="w-14 shrink-0 font-mono text-[9px] uppercase tracking-[0.15em] text-muted-foreground">
-				{label}
-			</span>
-			<div className="h-1.5 flex-1 overflow-hidden rounded-full bg-stone-200 dark:bg-stone-800 sm:w-24 sm:flex-none">
-				<div
-					className="h-full rounded-full bg-emerald-600 dark:bg-emerald-400"
-					style={{ width: `${(value / 5) * 100}%` }}
-				/>
-			</div>
-			<span className="w-8 shrink-0 text-right font-mono text-xs tabular-nums">
-				{value.toFixed(1)}
-			</span>
-		</div>
-	);
+const RULES = [
+	{
+		title: "Usage-verified, or it doesn't count",
+		body: "You can only rate a model your DevPass workspace has hit with 50+ requests in the past 30 days. Nobody rates a model they read a thread about.",
+	},
+	{
+		title: "Members only",
+		body: "Every respondent has an active, paid DevPass plan. These are verdicts from people spending their own credits.",
+	},
+	{
+		title: "No small-sample noise",
+		body: "A model is published only after 5 or more developers rate it, and only aggregates ever leave the building.",
+	},
+	{
+		title: "One reward per member per quarter",
+		body: "The census runs in quarterly waves. Your first entry of each wave earns a free Reset Pass — rate as many models as you use, but nobody can farm passes.",
+	},
+];
+
+function buildFaq(year: number, minResponses: number) {
+	return [
+		{
+			question: "How are models scored in the DevPass Model Census?",
+			answer: `Each entry rates one model from 1 to 5 on value for money, output quality, and speed, plus a yes-or-no “would you recommend it”. The registry shows the per-model averages and the share of raters who would recommend the model.`,
+		},
+		{
+			question: "Who can rate a model?",
+			answer:
+				"Only paid DevPass members, and only for models their workspace has sent at least 50 requests to in the past 30 days. Ratings are tied to verified usage, not opinions from a thread.",
+		},
+		{
+			question: "How is the registry ranked?",
+			answer:
+				"Registry rank is the model's position by average value score, with ties broken by number of ratings. The sort and filter controls change what you see on the board but never the underlying rank.",
+		},
+		{
+			question: "Why is a model missing from the registry?",
+			answer: `A model appears once ${minResponses} or more developers have filed a verified rating on it in ${year}. Per-use-case breakdowns are additionally hidden below two entries so no single respondent can be identified.`,
+		},
+		{
+			question: "How often does the census update?",
+			answer:
+				"Members file entries in quarterly waves and the yearly registry aggregates every wave. The published totals refresh every five minutes.",
+		},
+	];
 }
 
-function ModelRow({ model, rank }: { model: ModelSurveyModel; rank: number }) {
-	const topUseCase = model.useCases[0];
-	// Only the rows near the fold stagger in; deep rows render instantly so a
-	// long registry never feels like it's loading.
-	const staggered = rank <= 10;
-	const staggerStep = (rank - 1) * 70;
-	const delayMs = 140 + staggerStep;
+function SectionHeading({
+	id,
+	eyebrow,
+	title,
+	aside,
+}: {
+	id: string;
+	eyebrow: string;
+	title: string;
+	aside?: ReactNode;
+}) {
 	return (
-		<div
-			className={`border-b border-dashed border-stone-300/80 px-4 py-5 last:border-b-0 dark:border-stone-700/80 sm:flex sm:flex-wrap sm:items-center sm:gap-x-6 sm:gap-y-4 sm:px-6 ${
-				staggered
-					? "motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-3 motion-safe:fill-mode-both"
-					: ""
-			}`}
-			style={staggered ? { animationDelay: `${delayMs}ms` } : undefined}
-		>
-			<div className="flex min-w-0 items-center gap-4 sm:flex-1">
-				<div
-					className={
-						rank === 1
-							? "flex h-10 w-10 shrink-0 rotate-[-6deg] items-center justify-center rounded-full border-[3px] border-double border-emerald-700/70 font-mono text-sm font-bold text-emerald-800 mix-blend-multiply dark:border-emerald-400/60 dark:text-emerald-300 dark:mix-blend-screen"
-							: "flex h-10 w-10 shrink-0 items-center justify-center rounded-full border-2 border-dashed border-stone-300 font-mono text-sm text-stone-500 dark:border-stone-700 dark:text-stone-400"
-					}
+		<div className="mb-8 flex flex-wrap items-end justify-between gap-x-6 gap-y-3">
+			<div>
+				<p className="font-mono text-[11px] font-semibold uppercase tracking-[0.3em] text-emerald-700 dark:text-emerald-400">
+					{eyebrow}
+				</p>
+				<h2
+					id={id}
+					className="font-display mt-2 text-3xl font-bold tracking-tight text-balance sm:text-4xl"
 				>
-					{rank}
-				</div>
-				<div className="min-w-0 flex-1">
-					<div className="truncate font-mono text-sm font-semibold">
-						{model.modelId}
-					</div>
-					<div className="mt-0.5 font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground">
-						{model.responseCount} verified ratings
-						{topUseCase
-							? ` · mostly ${USE_CASE_LABELS[topUseCase.useCase] ?? topUseCase.useCase}`
-							: ""}
-					</div>
-				</div>
-				<div className="shrink-0 text-right sm:hidden">
-					<div className="font-mono text-xl font-bold tabular-nums">
-						{model.recommendPercent}%
-					</div>
-					<div className="font-mono text-[9px] uppercase tracking-[0.15em] text-muted-foreground">
-						recommend
-					</div>
-				</div>
+					{title}
+				</h2>
 			</div>
-			<div className="mt-4 space-y-1.5 sm:mt-0">
-				<ScoreMeter label="Value" value={model.avgValueScore} />
-				<ScoreMeter label="Quality" value={model.avgQualityScore} />
-				<ScoreMeter label="Speed" value={model.avgSpeedScore} />
-			</div>
-			<div className="hidden w-24 text-right sm:block">
-				<div className="font-mono text-xl font-bold tabular-nums">
-					{model.recommendPercent}%
-				</div>
-				<div className="font-mono text-[9px] uppercase tracking-[0.15em] text-muted-foreground">
-					recommend
-				</div>
-			</div>
+			{aside ? (
+				<p className="max-w-md text-sm text-muted-foreground">{aside}</p>
+			) : null}
 		</div>
 	);
 }
 
 export default async function CensusPage({
 	params,
+	searchParams,
 }: {
 	params: Promise<{ year: string }>;
+	searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
-	const { year: rawYear } = await params;
+	const [{ year: rawYear }, rawSearchParams] = await Promise.all([
+		params,
+		searchParams,
+	]);
 	const year = parseYear(rawYear);
 	if (!year) {
 		notFound();
 	}
 
 	const results = await fetchModelSurveyResults(year);
-	const models = results?.models ?? [];
-	const isCurrentYear = year === new Date().getUTCFullYear();
+	const models = enrichModels(results?.models ?? []);
+	const minResponses = results?.minResponses ?? 5;
+	const now = new Date();
+	const isCurrentYear = year === now.getUTCFullYear();
+	const quarter = Math.floor(now.getUTCMonth() / 3) + 1;
+	const initialQuery = parseCensusQuery(rawSearchParams);
+	const modelHrefBase = getConfig().uiUrl;
 
+	const vendorCounts = new Map<string, { name: string; count: number }>();
+	for (const model of models) {
+		const entry = vendorCounts.get(model.vendorId);
+		if (entry) {
+			entry.count += 1;
+		} else {
+			vendorCounts.set(model.vendorId, { name: model.vendorName, count: 1 });
+		}
+	}
+	const vendors = Array.from(vendorCounts, ([id, entry]) => ({
+		id,
+		name: entry.name,
+		count: entry.count,
+	})).sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+	const vendorMarks = Object.fromEntries(
+		vendors.map((vendor) => [
+			vendor.id,
+			<VendorMark
+				key={vendor.id}
+				vendorId={vendor.id}
+				vendorName={vendor.name}
+			/>,
+		]),
+	);
+
+	const bestValue = leader(models, (m) => m.avgValueScore);
+	const bestQuality = leader(models, (m) => m.avgQualityScore);
+	const fastest = leader(models, (m) => m.avgSpeedScore);
+	const mostRated = leader(models, (m) => m.responseCount);
+	const champions =
+		bestValue && bestQuality && fastest
+			? [
+					{
+						title: "Best value",
+						code: "Value",
+						model: bestValue,
+						score: bestValue.avgValueScore,
+						scoreLabel: "Value",
+					},
+					{
+						title: "Best quality",
+						code: "Quality",
+						model: bestQuality,
+						score: bestQuality.avgQualityScore,
+						scoreLabel: "Quality",
+					},
+					{
+						title: "Fastest",
+						code: "Speed",
+						model: fastest,
+						score: fastest.avgSpeedScore,
+						scoreLabel: "Speed",
+					},
+				]
+			: [];
+
+	const asOf = now.toLocaleDateString("en-US", {
+		month: "long",
+		day: "numeric",
+		year: "numeric",
+		timeZone: "UTC",
+	});
+	const summary =
+		results && bestValue && bestQuality && fastest && mostRated
+			? `As of ${asOf}, ${bestValue.name} leads the ${year} DevPass Model Census on value for money (${formatScore(bestValue.avgValueScore)}/5 across ${bestValue.responseCount} verified ratings), ${bestQuality.name} leads on output quality (${formatScore(bestQuality.avgQualityScore)}/5), and ${fastest.name} leads on speed (${formatScore(fastest.avgSpeedScore)}/5). ${results.totalRespondents.toLocaleString("en-US")} DevPass developers have filed ${results.totalResponses.toLocaleString("en-US")} verified ratings across ${results.totalModelsRated} models. The most-rated model is ${mostRated.name} with ${mostRated.responseCount} ratings and a ${mostRated.recommendPercent}% recommend rate.`
+			: null;
+
+	const faq = buildFaq(year, minResponses);
+	const pageUrl = `${BASE_URL}/data/${year}`;
 	const jsonLd = {
 		"@context": "https://schema.org",
-		"@type": "Dataset",
-		name: `The ${year} DevPass Model Census`,
-		description:
-			"Coding LLMs rated on value for money, output quality, and speed by DevPass developers with verified usage.",
-		url: `${BASE_URL}/data/${year}`,
-		creator: {
-			"@type": "Organization",
-			name: "LLM Gateway",
-			url: "https://llmgateway.io",
-		},
-		license: "https://llmgateway.io/legal/terms",
-		isAccessibleForFree: true,
-		temporalCoverage: `${year}`,
-		variableMeasured: [
-			"value for money (1-5)",
-			"output quality (1-5)",
-			"speed (1-5)",
-			"would recommend (%)",
+		"@graph": [
+			{
+				"@type": "Dataset",
+				"@id": `${pageUrl}#dataset`,
+				name: `The ${year} DevPass Model Census`,
+				description:
+					"Coding LLMs rated on value for money, output quality, and speed by DevPass developers with verified usage.",
+				url: pageUrl,
+				creator: {
+					"@type": "Organization",
+					name: "LLM Gateway",
+					url: "https://llmgateway.io",
+				},
+				license: "https://llmgateway.io/legal/terms",
+				isAccessibleForFree: true,
+				temporalCoverage: `${year}`,
+				dateModified: now.toISOString().slice(0, 10),
+				keywords: [
+					"coding models",
+					"LLM ratings",
+					"developer survey",
+					"AI coding assistants",
+					"DevPass",
+				],
+				measurementTechnique:
+					"Self-reported 1–5 ratings from paid DevPass members with at least 50 requests on the rated model in the prior 30 days; models published at 5+ ratings.",
+				variableMeasured: [
+					"value for money (1-5)",
+					"output quality (1-5)",
+					"speed (1-5)",
+					"would recommend (%)",
+				],
+			},
+			...(models.length > 0
+				? [
+						{
+							"@type": "ItemList",
+							"@id": `${pageUrl}#registry`,
+							name: `${year} DevPass Model Census registry, ranked by value score`,
+							itemListOrder: "https://schema.org/ItemListOrderDescending",
+							numberOfItems: models.length,
+							itemListElement: models.map((model) => ({
+								"@type": "ListItem",
+								position: model.rank,
+								name: model.name,
+								description: `${model.vendorName} · value ${formatScore(model.avgValueScore)}/5, quality ${formatScore(model.avgQualityScore)}/5, speed ${formatScore(model.avgSpeedScore)}/5, ${model.recommendPercent}% would recommend, ${model.responseCount} verified ratings`,
+							})),
+						},
+					]
+				: []),
+			{
+				"@type": "FAQPage",
+				"@id": `${pageUrl}#faq`,
+				mainEntity: faq.map((item) => ({
+					"@type": "Question",
+					name: item.question,
+					acceptedAnswer: { "@type": "Answer", text: item.answer },
+				})),
+			},
+			{
+				"@type": "BreadcrumbList",
+				itemListElement: [
+					{
+						"@type": "ListItem",
+						position: 1,
+						name: "DevPass",
+						item: BASE_URL,
+					},
+					{
+						"@type": "ListItem",
+						position: 2,
+						name: `${year} Model Census`,
+						item: pageUrl,
+					},
+				],
+			},
 		],
 	};
 
@@ -196,161 +415,238 @@ export default async function CensusPage({
 				dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
 			/>
 
-			<main>
+			<main id="main">
 				{/* Hero */}
-				<section className="relative overflow-hidden border-b">
-					<div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_55%_55%_at_50%_-5%,_var(--tw-gradient-stops))] from-emerald-500/10 via-transparent to-transparent" />
-					<div className="container relative mx-auto max-w-3xl px-4 pt-16 pb-12 text-center motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-3 motion-safe:fill-mode-both sm:pt-20">
-						<div className="mb-4 inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3.5 py-1.5 font-mono text-xs font-medium uppercase tracking-[0.15em] text-emerald-600 dark:text-emerald-400">
-							<ClipboardCheck className="h-3.5 w-3.5" />
-							{isCurrentYear
-								? `Census open · Q${Math.floor(new Date().getUTCMonth() / 3) + 1} wave filing now`
-								: `Final ${year} registry`}
+				<section
+					aria-labelledby="census-title"
+					className="census-guilloche relative overflow-hidden border-b"
+				>
+					<div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_60%_55%_at_20%_-10%,_var(--tw-gradient-stops))] from-emerald-500/15 via-transparent to-transparent" />
+					<div className="container relative mx-auto grid max-w-6xl gap-10 px-4 pt-14 pb-14 lg:grid-cols-12 lg:items-center lg:pt-20 lg:pb-20">
+						<div className="motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-3 motion-safe:fill-mode-both lg:col-span-7">
+							<p className="inline-flex items-center gap-2 font-mono text-[11px] font-semibold uppercase tracking-[0.3em] text-emerald-700 dark:text-emerald-400">
+								<ShieldCheck aria-hidden="true" className="h-4 w-4" />
+								The {year} DevPass Model Census
+							</p>
+							<h1
+								id="census-title"
+								className="font-display mt-4 text-4xl font-bold tracking-tight text-balance sm:text-5xl lg:text-6xl"
+							>
+								Which coding models are actually worth the money?
+							</h1>
+							<p className="mt-5 max-w-xl text-lg leading-relaxed text-pretty text-muted-foreground">
+								The {year} DevPass Model Census rates coding models on value,
+								quality, and speed — using only developers who shipped with
+								them. Every rating is backed by at least 50 real requests
+								through LLM Gateway in the past 30 days. No benchmarks, no
+								vibes.
+							</p>
+							<div className="mt-8 flex flex-col items-start gap-3 sm:flex-row sm:items-center">
+								<Button size="lg" asChild>
+									<Link href="/dashboard/survey">
+										<Stamp aria-hidden="true" className="mr-1.5 h-4 w-4" />
+										File your entry · claim a free Reset Pass
+									</Link>
+								</Button>
+								<GetDevPassButton
+									cta="get_started"
+									location="census_hero"
+									signupHref="/signup?plan=pro"
+								/>
+							</div>
+							<ul className="mt-8 flex flex-wrap gap-x-6 gap-y-2 font-mono text-xs text-stone-600 dark:text-stone-400">
+								<li>✓ 50+ requests per rating</li>
+								<li>✓ Paid members only</li>
+								<li>✓ Aggregates, never individuals</li>
+							</ul>
 						</div>
-						<h1 className="text-4xl font-bold tracking-tight text-balance sm:text-5xl">
-							Which coding models are actually worth the money?
-						</h1>
-						<p className="mx-auto mt-5 max-w-2xl text-lg leading-relaxed text-pretty text-muted-foreground">
-							The {year} DevPass Model Census: value, quality, and speed — rated
-							only by developers who shipped with these models. Every rating is
-							backed by at least 50 real requests through LLM Gateway in the
-							past 30 days. No benchmarks, no vibes.
-						</p>
-						<div className="mt-8 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
-							<Button size="lg" asChild>
-								<Link href="/dashboard/survey">
-									<Stamp className="mr-1.5 h-4 w-4" />
-									File your entry · claim a free Reset Pass
-								</Link>
-							</Button>
-							<GetDevPassButton
-								cta="get_started"
-								location="census_hero"
-								signupHref="/signup?plan=pro"
-							/>
+						<div className="motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-4 motion-safe:fill-mode-both motion-safe:delay-150 lg:col-span-5">
+							{results ? (
+								<PassportDataPage
+									year={year}
+									results={results}
+									isCurrentYear={isCurrentYear}
+									quarter={quarter}
+								/>
+							) : (
+								<div className="census-paper rounded-2xl border border-stone-300/90 p-8 text-center dark:border-stone-700">
+									<VisaStamp tone="stone" rotate={-4} sub="Entries are safe">
+										Registry offline
+									</VisaStamp>
+									<p className="mx-auto mt-5 max-w-sm text-sm text-muted-foreground">
+										The registry couldn&apos;t be reached just now. Check back
+										in a few minutes.
+									</p>
+								</div>
+							)}
 						</div>
 					</div>
 				</section>
 
-				{/* Stats */}
-				{results && results.totalResponses > 0 && (
-					<section className="border-b bg-muted/20 px-4 py-8">
-						<div className="container mx-auto grid max-w-3xl grid-cols-3 gap-4 text-center">
-							{[
-								{ label: "Entries filed", value: results.totalResponses },
-								{
-									label: "Developers reporting",
-									value: results.totalRespondents,
-								},
-								{
-									label: "Models on the registry",
-									value: results.totalModelsRated,
-								},
-							].map((stat, index) => (
-								<div
-									key={stat.label}
-									className="motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-3 motion-safe:fill-mode-both"
-									style={{ animationDelay: `${index * 70}ms` }}
+				{/* Category leaders */}
+				{champions.length > 0 && (
+					<section aria-labelledby="leaders-title" className="px-4 py-14">
+						<div className="container mx-auto max-w-6xl">
+							<SectionHeading
+								id="leaders-title"
+								eyebrow="Now boarding · category leaders"
+								title="Top of the registry"
+								aside={`Highest average in each score across every model with ${minResponses}+ verified ratings. Ties go to the model with more ratings.`}
+							/>
+							<div className="grid gap-5 md:grid-cols-3">
+								{champions.map((champion, index) => {
+									const stagger = index * 90;
+									return (
+										<BoardingPass
+											key={champion.title}
+											title={champion.title}
+											code={champion.code}
+											model={champion.model}
+											score={champion.score}
+											scoreLabel={champion.scoreLabel}
+											year={year}
+											delayMs={120 + stagger}
+										/>
+									);
+								})}
+							</div>
+							{summary && (
+								<p
+									id="census-summary"
+									className="mt-8 max-w-4xl text-sm leading-relaxed text-muted-foreground"
 								>
-									<div className="font-mono text-2xl font-bold tabular-nums sm:text-3xl">
-										{stat.value.toLocaleString()}
-									</div>
-									<div className="mt-1 font-mono text-[10px] uppercase tracking-[0.15em] text-muted-foreground sm:tracking-[0.2em]">
-										{stat.label}
-									</div>
-								</div>
-							))}
+									{summary}
+								</p>
+							)}
 						</div>
 					</section>
 				)}
 
 				{/* Registry */}
-				<section className="px-4 py-12">
-					<div className="container mx-auto max-w-3xl">
-						<div className="mb-4 flex items-baseline justify-between gap-4">
-							<h2 className="font-mono text-[10px] uppercase tracking-[0.25em] text-stone-500 sm:tracking-[0.35em] dark:text-stone-400">
-								The registry · ranked by value score
-							</h2>
-							<span className="shrink-0 font-mono text-[9px] tracking-[0.25em] whitespace-nowrap text-stone-400 dark:text-stone-500">
-								Doc. CS-{year}
-							</span>
-						</div>
+				<section
+					aria-labelledby="registry-title"
+					className="border-t bg-muted/20 px-4 py-14"
+				>
+					<div className="container mx-auto max-w-6xl">
+						<SectionHeading
+							id="registry-title"
+							eyebrow="Departures · full registry"
+							title="Every model on the registry"
+							aside="Click a column to sort, or narrow the board by vendor, use case, and rating count. Filters live in the URL, so a view can be shared."
+						/>
 						{models.length > 0 ? (
-							<div className="overflow-hidden rounded-lg border border-dashed border-stone-400/70 bg-stone-50/70 dark:border-stone-600/70 dark:bg-stone-900/30">
-								{models.map((model, index) => (
-									<ModelRow
-										key={model.modelId}
-										model={model}
-										rank={index + 1}
-									/>
-								))}
-							</div>
+							<CensusRegistry
+								year={year}
+								models={models}
+								vendors={vendors.map(({ id, name }) => ({ id, name }))}
+								vendorMarks={vendorMarks}
+								initialQuery={initialQuery}
+								minResponses={minResponses}
+								modelHrefBase={modelHrefBase}
+							/>
 						) : (
-							<div className="rounded-lg border border-dashed border-stone-400/70 bg-stone-50/70 p-10 text-center dark:border-stone-600/70 dark:bg-stone-900/30">
-								<div className="mx-auto inline-block rounded-md border-4 border-double border-stone-400/70 px-6 py-2 font-mono uppercase text-stone-500 dark:border-stone-600 dark:text-stone-400">
-									<div className="text-sm font-bold tracking-[0.3em]">
-										{results ? "Registry open" : "Registry offline"}
-									</div>
-								</div>
-								<p className="mx-auto mt-4 max-w-md text-sm text-muted-foreground">
+							<div className="census-paper rounded-2xl border border-stone-300/90 p-10 text-center dark:border-stone-700">
+								<VisaStamp tone={results ? "emerald" : "stone"} rotate={-4}>
+									{results ? "Registry open" : "Registry offline"}
+								</VisaStamp>
+								<p className="mx-auto mt-5 max-w-md text-sm text-muted-foreground">
 									{results
-										? `Models appear here once ${results.minResponses} developers have filed verified entries on them. DevPass members: your census entry gets the registry moving — and earns you a free Reset Pass.`
+										? `Models appear here once ${minResponses} developers have filed verified entries on them. DevPass members: your census entry gets the registry moving — and earns you a free Reset Pass.`
 										: "The registry couldn't be reached just now — the entries are safe. Check back in a few minutes."}
 								</p>
 							</div>
 						)}
 						<p className="mt-4 text-center text-xs text-muted-foreground">
-							Scores are 1–5 averages. Models need {results?.minResponses ?? 5}+
-							verified ratings to be listed; totals refresh every few minutes.
+							Scores are 1–5 averages. Models need {minResponses}+ verified
+							ratings to be listed; totals refresh every few minutes. Last
+							updated {asOf} (UTC).
 						</p>
 					</div>
 				</section>
 
-				{/* Methodology */}
-				<section className="border-t bg-muted/20 px-4 py-16">
-					<div className="container mx-auto max-w-2xl">
-						<h2 className="mb-6 text-center text-2xl font-bold tracking-tight sm:text-3xl">
-							The rules of the registry
-						</h2>
-						<div className="space-y-4">
-							{[
-								{
-									title: "Usage-verified, or it doesn't count",
-									body: "You can only rate a model your DevPass workspace has hit with 50+ requests in the past 30 days. Nobody rates a model they read a thread about.",
-								},
-								{
-									title: "Members only",
-									body: "Every respondent has an active, paid DevPass plan. These are verdicts from people spending their own credits.",
-								},
-								{
-									title: "No small-sample noise",
-									body: "A model is published only after 5 or more developers rate it, and only aggregates ever leave the building.",
-								},
-								{
-									title: "One reward per member per quarter",
-									body: "The census runs in quarterly waves. Your first entry of each wave earns a free Reset Pass — rate as many models as you use, but nobody can farm passes.",
-								},
-							].map((rule, index) => (
-								<div
-									key={rule.title}
-									className="flex gap-4 rounded-lg border border-dashed p-4"
-								>
-									<div className="font-mono text-sm font-bold text-emerald-700 dark:text-emerald-400">
-										{String(index + 1).padStart(2, "0")}
-									</div>
-									<div>
-										<div className="text-sm font-semibold">{rule.title}</div>
-										<p className="mt-1 text-sm text-muted-foreground">
-											{rule.body}
-										</p>
-									</div>
-								</div>
-							))}
+				{/* Rules + FAQ */}
+				<section aria-labelledby="rules-title" className="border-t px-4 py-16">
+					<div className="container mx-auto grid max-w-6xl gap-12 lg:grid-cols-2 lg:gap-16">
+						<div>
+							<p className="font-mono text-[11px] font-semibold uppercase tracking-[0.3em] text-emerald-700 dark:text-emerald-400">
+								Conditions of entry
+							</p>
+							<h2
+								id="rules-title"
+								className="font-display mt-2 text-3xl font-bold tracking-tight text-balance sm:text-4xl"
+							>
+								The rules of the registry
+							</h2>
+							<ol className="mt-8 space-y-4">
+								{RULES.map((rule, index) => (
+									<li
+										key={rule.title}
+										className="census-paper flex gap-4 rounded-xl border border-stone-300/90 p-5 dark:border-stone-700"
+									>
+										<span
+											aria-hidden="true"
+											className="flex h-10 w-10 shrink-0 -rotate-6 items-center justify-center rounded-full border-[3px] border-double border-emerald-700/70 font-mono text-sm font-bold text-emerald-800 mix-blend-multiply dark:border-emerald-400/60 dark:text-emerald-300 dark:mix-blend-screen"
+										>
+											{String(index + 1).padStart(2, "0")}
+										</span>
+										<div>
+											<h3 className="text-base font-semibold">{rule.title}</h3>
+											<p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+												{rule.body}
+											</p>
+										</div>
+									</li>
+								))}
+							</ol>
 						</div>
-						<div className="mt-10 text-center">
+						<div>
+							<p className="font-mono text-[11px] font-semibold uppercase tracking-[0.3em] text-emerald-700 dark:text-emerald-400">
+								Reading the census
+							</p>
+							<h2
+								id="faq-title"
+								className="font-display mt-2 text-3xl font-bold tracking-tight text-balance sm:text-4xl"
+							>
+								Model Census FAQ
+							</h2>
+							<dl className="mt-8 divide-y divide-dashed divide-stone-300 dark:divide-stone-700">
+								{faq.map((item) => (
+									<div key={item.question} className="py-5 first:pt-0">
+										<dt className="text-base font-semibold">{item.question}</dt>
+										<dd className="mt-2 text-sm leading-relaxed text-muted-foreground">
+											{item.answer}
+										</dd>
+									</div>
+								))}
+							</dl>
+						</div>
+					</div>
+				</section>
+
+				{/* CTA */}
+				<section
+					aria-labelledby="cta-title"
+					className="census-paper border-t px-4 py-16"
+				>
+					<div className="container mx-auto max-w-3xl text-center">
+						<VisaStamp rotate={-5} sub={`Wave Q${quarter} · ${year}`}>
+							Your entry
+						</VisaStamp>
+						<h2
+							id="cta-title"
+							className="font-display mt-6 text-3xl font-bold tracking-tight text-balance sm:text-4xl"
+						>
+							Rate the models you ship with, stamp a free Reset Pass
+						</h2>
+						<p className="mx-auto mt-4 max-w-xl text-base text-muted-foreground">
+							Takes two minutes. Your first entry of the wave earns a Reset Pass
+							on your tier, and every entry sharpens the registry for the next
+							developer at the desk.
+						</p>
+						<div className="mt-8">
 							<Button size="lg" asChild>
 								<Link href="/dashboard/survey">
-									<Stamp className="mr-1.5 h-4 w-4" />
+									<Stamp aria-hidden="true" className="mr-1.5 h-4 w-4" />
 									Rate your models · get a free Reset Pass
 								</Link>
 							</Button>

--- a/apps/code/src/app/globals.css
+++ b/apps/code/src/app/globals.css
@@ -171,3 +171,61 @@
 @utility animate-accordion-up {
 	animation: accordion-up 0.2s ease-out;
 }
+
+/* Model census: passport paper + always-dark departures board.
+   Unlayered on purpose: Tailwind v4 does not emit custom classes declared
+   inside @layer components. */
+
+.census-paper {
+	background-color: #f6f1e6;
+	background-image:
+		repeating-linear-gradient(
+			0deg,
+			rgba(6, 78, 59, 0.045) 0 1px,
+			transparent 1px 9px
+		),
+		radial-gradient(circle at 30% 20%, rgba(6, 78, 59, 0.06), transparent 45%),
+		radial-gradient(circle at 75% 80%, rgba(6, 78, 59, 0.05), transparent 40%);
+}
+.dark .census-paper {
+	background-color: #161a18;
+	background-image:
+		repeating-linear-gradient(
+			0deg,
+			rgba(52, 211, 153, 0.045) 0 1px,
+			transparent 1px 9px
+		),
+		radial-gradient(
+			circle at 30% 20%,
+			rgba(52, 211, 153, 0.07),
+			transparent 45%
+		),
+		radial-gradient(
+			circle at 75% 80%,
+			rgba(52, 211, 153, 0.05),
+			transparent 40%
+		);
+}
+.census-guilloche {
+	background-image: repeating-radial-gradient(
+		circle at 50% 130%,
+		rgba(6, 78, 59, 0.07) 0 1px,
+		transparent 1px 16px
+	);
+}
+.dark .census-guilloche {
+	background-image: repeating-radial-gradient(
+		circle at 50% 130%,
+		rgba(52, 211, 153, 0.06) 0 1px,
+		transparent 1px 16px
+	);
+}
+.census-board {
+	color-scheme: dark;
+	background-color: #0c110f;
+	background-image: linear-gradient(
+		180deg,
+		rgba(255, 255, 255, 0.035),
+		transparent 30%
+	);
+}


### PR DESCRIPTION
## Problem

The DevPass Model Census page (`/data/2026`) had the right idea (passport-stamped registry) but a weak execution: 9–10px tracked labels, 1.5px score meters, a single centred column, and no way to sort or filter 27 models. The user's brief: keep the airport/passport theme, make it much better looking and far more readable, and add sort/filter.

## Approach

Same theme, pushed further, with legibility as the constraint:

- **Hero + passport data page.** The stat strip becomes an actual passport data page: document number, wave stamp, the three totals as stamped fields, and MRZ lines. Bricolage display type on the headline.
- **Boarding passes for the category leaders.** Best value, best quality, and fastest each get a tear-off boarding pass (gate = top use case, seat = score, barcode stub). Below them, one plain-language summary sentence states the leaders and totals as of today.
- **Always-dark departures board for the full registry.** A real `<table>` with large tabular numerals, five-segment score meters, recommend %, ratings, and a Cleared / Boarding / Standby status derived from the recommend rate. Registry rank stays the value-score position regardless of sort. Mobile renders the same data as stacked cards.
- **Sort + filter, URL-synced.** Click any column to sort (with direction toggle, `aria-sort`), filter by vendor chips, use case, minimum rating count, and free-text search. State is written to the query string with `history.replaceState` and parsed server-side, so a filtered view deep-links and SSRs. Model names link to their LLM Gateway model page.
- **Vendor enrichment on the server.** Model IDs are resolved against `@llmgateway/models` for display names, family, and icons; icons are rendered server-side and handed to the client component as nodes, so the shared icon set stays out of the client bundle.

## Audits run on the result

- **Accessibility (WCAG 2.2 AA, axe-core + manual):** landmark nesting fixed (the passport is a `section`, not an `aside` inside `main`), labelled search/select/fieldsets, `aria-pressed` chips, `aria-sort` headers, a polite live region for the result count, sort buttons enlarged to a 24px hit area, hand-checked contrast on the paper/board surfaces (board muted text lifted to ≥9:1; dark-mode stub labels raised to pass 4.5:1), `motion-safe` on every animation. Site-wide skip link is still missing in the DevPass header; out of scope here.
- **SEO:** title trimmed to 60 chars, description to ~160, single H1, descriptive H2s, self-referencing canonical, JSON-LD `@graph` with `Dataset` (now `dateModified`, `keywords`, `measurementTechnique`), `ItemList` of the ranked registry, `FAQPage`, and `BreadcrumbList`. Page already in the sitemap; robots allows AI crawlers.
- **AI-SEO:** first paragraph now defines the census in one sentence; a dated summary sentence with the leaders and totals; a visible FAQ with five natural-language questions mirrored in `FAQPage`; visible last-updated line.
- **Interface guidelines:** placeholder ellipsis, `name`/`spellCheck` on the search field, curly quotes, `text-balance` on section headings, `touch-manipulation` on chips.

## Verification

- `pnpm format`, `pnpm build`, eslint on the changed files.
- `apps/code/e2e/census.pw.ts`: existing test still passes; new test covers column sort, vendor filter, and URL sync.
- Rendered locally against the public results endpoint (the same anonymised aggregates the live page shows).

## Screenshots

### Hero — light (before / after)

<img width="1440" alt="Old census hero, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/92a20be4be23df0e10fb3b66f181f40f8fb22ad1/before-hero-light.png" />
<img width="1440" alt="New census hero with passport data page, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/92a20be4be23df0e10fb3b66f181f40f8fb22ad1/after-hero-light.png" />

### Registry — light (before / after)

<img width="1440" alt="Old registry list, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/92a20be4be23df0e10fb3b66f181f40f8fb22ad1/before-registry-light.png" />
<img width="1440" alt="New departures board with sort and filter toolbar, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/92a20be4be23df0e10fb3b66f181f40f8fb22ad1/after-board-light.png" />

### Category leaders — new

<img width="1440" alt="Boarding passes for best value, best quality, and fastest" src="https://raw.githubusercontent.com/theopenco/llmgateway/92a20be4be23df0e10fb3b66f181f40f8fb22ad1/after-leaders-light.png" />

### Hero — dark (before / after)

<img width="1440" alt="Old census hero, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/92a20be4be23df0e10fb3b66f181f40f8fb22ad1/before-hero-dark.png" />
<img width="1440" alt="New census hero, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/92a20be4be23df0e10fb3b66f181f40f8fb22ad1/after-hero-dark.png" />

### Registry — dark (before / after)

<img width="1440" alt="Old registry list, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/92a20be4be23df0e10fb3b66f181f40f8fb22ad1/before-registry-dark.png" />
<img width="1440" alt="New departures board, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/92a20be4be23df0e10fb3b66f181f40f8fb22ad1/after-board-dark.png" />

### Mobile — new

<img width="390" alt="Filters and board as stacked cards on a 390px viewport" src="https://raw.githubusercontent.com/theopenco/llmgateway/92a20be4be23df0e10fb3b66f181f40f8fb22ad1/after-mobile-light.png" />

https://claude.ai/code/session_01PYhNdk2Z3V49j3t6igPT6R


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a redesigned Model Census experience with passport-inspired summaries, category leaders, and a departures-board registry.
  - Added searchable, sortable, and filterable model listings across vendors, use cases, ratings, and response counts.
  - Added responsive desktop and mobile registry views with score details, status badges, rankings, and empty states.
  - Added URL-synchronized filters and sorting, including a reset-filters option.
  - Added vendor branding, visual census summaries, FAQs, and expanded structured page information.

- **Tests**
  - Added end-to-end coverage for registry rendering, URL-based sorting and filtering, and filter resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->