### PR TITLE
chore: deactivate Kimi K2.6 on gonka24

### DIFF
--- a/packages/models/src/models/moonshot.ts
+++ b/packages/models/src/models/moonshot.ts
@@ -503,6 +503,7 @@ export const moonshotModels = [
 			{
 				providerId: "gonka24",
 				externalId: "kimi-k2.6",
+				deactivatedAt: new Date("2026-09-06"),
 				inputPrice: "0.22e-6",
 				cachedInputPrice: "0.048e-6",
 				outputPrice: "1.137e-6",


### PR DESCRIPTION
The Gonka network has discontinued support for Kimi K2.6, so the `gonka24` provider mapping for `kimi-k2.6` is now deactivated as of today (2026-09-06).

The mapping is kept (per catalogue policy, mappings are never removed) with `deactivatedAt: new Date("2026-09-06")`, so routing skips it while historical usage lookups keep resolving. `kimi-k2.6` remains available on its other providers.

`gonka24` mappings for other models are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUShSaLM8NDX5TNYv1cLnh

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUShSaLM8NDX5TNYv1cLnh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Availability**
  * The `kimi-k2.6` deployment is no longer served as of September 6, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->