### PR TITLE
fix: allow service tiers with custom base URLs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,8 +200,6 @@ Running the built `dist/serve.js` gives no watch (rebuild + restart after code c
 
 `beforeAllHook` stamps each provider's `baseUrl` env var (`LLM_OPENAI_BASE_URL`, `LLM_ANTHROPIC_BASE_URL`, …) onto the provider key it seeds, so exporting that var plus the matching `LLM_*_API_KEY` is enough to run the whole suite through a proxy — no test changes needed. An `http://` base URL additionally needs `ALLOW_INSECURE_PROVIDER_URLS=true`.
 
-`chat-service-tier.e2e.ts` cannot pass in that setup: `providerKeyBaseUrlSupportsServiceTier` makes a key with a non-upstream base URL ineligible for Flex/Priority, so every case 400s by design. Exclude that file rather than treating the failures as a regression.
-
 #### E2E Test Structure
 
 Reserve `*.e2e.ts` for tests that make real upstream provider requests. Tests

--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -2712,7 +2712,7 @@ describe("api", () => {
 		});
 	});
 
-	test("/v1/chat/completions rejects a Fireworks tier request on a proxied key", async () => {
+	test("/v1/chat/completions forwards a Fireworks tier request through a proxied key", async () => {
 		await db.insert(tables.apiKey).values({
 			id: "token-id-fireworks-proxy-tier",
 			...hashApiKeyForStorage("real-token-fireworks-proxy-tier"),
@@ -2721,12 +2721,6 @@ describe("api", () => {
 			createdBy: "user-id",
 		});
 
-		// Fireworks never reports the tier it served, so a priority request is
-		// billed at the tier it was sent at. A proxy base URL may silently drop
-		// the field, which would overbill — the request must be rejected instead.
-		// Deliberately not the mock URL: the harness trusts that one via
-		// SERVICE_TIER_TRUSTED_BASE_URLS so the positive tier paths stay testable,
-		// and this case is about an untrusted proxy.
 		await db.insert(tables.providerKey).values({
 			id: "provider-key-id-fireworks-proxy-tier",
 			...encryptProviderKeyForStorage(
@@ -2736,7 +2730,7 @@ describe("api", () => {
 			),
 			provider: "fireworks",
 			organizationId: "org-id",
-			baseUrl: "https://fireworks-proxy.example.com",
+			baseUrl: mockServerUrl,
 		});
 
 		const res = await app.request("/v1/chat/completions", {
@@ -2744,6 +2738,7 @@ describe("api", () => {
 			headers: {
 				"Content-Type": "application/json",
 				Authorization: "Bearer real-token-fireworks-proxy-tier",
+				"x-no-fallback": "true",
 			},
 			body: JSON.stringify({
 				model: "fireworks/kimi-k3",
@@ -2752,11 +2747,13 @@ describe("api", () => {
 			}),
 		});
 
-		expect(res.status).toBe(400);
+		expect(res.status).toBe(200);
 		const json = await res.json();
-		expect(json.error.message).toContain(
-			"requires a provider key that targets the original upstream endpoint",
-		);
+		expect(json.service_tier).toBe("priority");
+		const logs = await waitForLogs(1);
+		expect(logs[0].usedProvider).toBe("fireworks");
+		expect(logs[0].requestedServiceTier).toBe("priority");
+		expect(logs[0].usedServiceTier).toBe("priority");
 	});
 
 	test("/v1/chat/completions strips log payload when retention is disabled", async () => {

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -2398,14 +2398,7 @@ chat.openapi(completions, async (c) => {
 	// this org's env-credential reads. Undefined = base vars only.
 	const envVariant = getLicensedOrganizationEnvVariant(organization);
 
-	// Dev-plan (DevPass) orgs can default routing to cheaper flex processing via
-	// their dashboard settings to save on plan credits. Applied softly, and only
-	// when the request itself doesn't specify a service_tier: the tier kicks in
-	// only if at least one candidate mapping supports flex AND has a credential
-	// that reaches the provider's real upstream (mirroring the service-tier key
-	// eligibility enforced below), so requests to models without flex support
-	// stay on standard processing instead of failing the explicit-tier
-	// validation and eligibility checks below.
+	// Apply the dev-plan flex default only when a mapping and credential support it.
 	if (
 		isDevPlan &&
 		organization.devPlanServiceTier === "flex" &&
@@ -3438,13 +3431,7 @@ chat.openapi(completions, async (c) => {
 		}
 	}
 
-	// Flex/Priority is only honored when the request reaches the provider's real
-	// upstream endpoint — a provider key with a custom base URL (proxy) may
-	// silently drop the tier and be billed/reported as standard. Exclude
-	// providers that have no upstream-eligible credential from service-tier
-	// routing (mirroring the compliance policy): auto/model-id routing drops
-	// them, and only fails when none remain; a pinned provider with no eligible
-	// key returns a clear 400 instead of silently downgrading.
+	// Exclude providers without a credential in a tier-capable region.
 	let serviceTierOrgKeys:
 		InferSelectModel<typeof tables.providerKey>[] | undefined;
 	const isProviderServiceTierEligible = (providerId: string): boolean => {
@@ -3452,11 +3439,6 @@ chat.openapi(completions, async (c) => {
 			(key) => key.provider === providerId,
 		);
 		const hasCompliantDbKey = dbKeys.some(providerKeySupportsServiceTier);
-		// An env credential is eligible only when at least one of its (possibly
-		// comma-indexed) base URLs targets the managed upstream — a custom base URL
-		// on every env index is just as ineligible as a custom DB key. In hybrid
-		// mode env is used only when no DB key is picked, which the
-		// serviceTierKeyFilter guarantees for a custom base URL.
 		const envEligible =
 			(project.mode === "credits" || project.mode === "hybrid") &&
 			hasServiceTierEligibleEnvCredential(providerId as Provider);
@@ -3493,7 +3475,7 @@ chat.openapi(completions, async (c) => {
 			!isProviderServiceTierEligible(usedProvider);
 		if (iamFilteredModelProviders.length === 0 || pinnedIneligible) {
 			throw new HTTPException(400, {
-				message: `Service tier '${service_tier}' requires a provider key that targets the original upstream endpoint. Remove the custom base URL from the ${pinnedIneligible ? `${usedProvider} ` : ""}provider key or omit service_tier.`,
+				message: `No provider key is available in a region that supports service tier '${service_tier}'${pinnedIneligible ? ` for ${usedProvider}` : ""}.`,
 			});
 		}
 	};
@@ -5698,11 +5680,7 @@ chat.openapi(completions, async (c) => {
 			providerKeyLabel: providerKeyLabel(providerKey),
 		};
 	}
-	// Flex/Priority is only honored when the request reaches the provider's real
-	// upstream endpoint on a tier-capable location. Skip provider keys whose
-	// custom base URL (proxy) may silently drop the tier, and Vertex keys pinned
-	// to a regional endpoint, so a compliant key (or the managed env credential
-	// in hybrid mode) is used instead.
+	// Skip Vertex credentials pinned to a region that cannot serve the tier.
 	const serviceTierKeyFilter = isRequestedServiceTier(service_tier)
 		? providerKeySupportsServiceTier
 		: undefined;

--- a/apps/gateway/src/chat/tools/get-provider-env.spec.ts
+++ b/apps/gateway/src/chat/tools/get-provider-env.spec.ts
@@ -215,6 +215,10 @@ describe("service-tier env credential eligibility", () => {
 	const originalBaseUrl = process.env.LLM_GOOGLE_VERTEX_BASE_URL;
 	const originalRegion = process.env.LLM_GOOGLE_VERTEX_REGION;
 
+	beforeEach(() => {
+		delete process.env.LLM_GOOGLE_VERTEX_REGION;
+	});
+
 	afterEach(() => {
 		if (originalKey === undefined) {
 			delete process.env.LLM_GOOGLE_VERTEX_API_KEY;
@@ -233,13 +237,13 @@ describe("service-tier env credential eligibility", () => {
 		}
 	});
 
-	it("flags only the env indices whose base URL is a custom proxy", () => {
+	it("accepts both custom and canonical base URLs", () => {
 		process.env.LLM_GOOGLE_VERTEX_API_KEY = "tok-a,tok-b";
 		process.env.LLM_GOOGLE_VERTEX_BASE_URL =
 			"https://vertex-proxy.invalid,https://aiplatform.googleapis.com";
 
 		const ineligible = getServiceTierIneligibleEnvIndices("google-vertex");
-		expect([...ineligible]).toEqual([0]);
+		expect([...ineligible]).toEqual([]);
 		expect(hasServiceTierEligibleEnvCredential("google-vertex")).toBe(true);
 	});
 
@@ -253,15 +257,15 @@ describe("service-tier env credential eligibility", () => {
 		expect(hasServiceTierEligibleEnvCredential("google-vertex")).toBe(true);
 	});
 
-	it("reports no eligible credential when every index is a custom proxy", () => {
+	it("accepts credentials when every index uses a custom proxy", () => {
 		process.env.LLM_GOOGLE_VERTEX_API_KEY = "tok-a,tok-b";
 		process.env.LLM_GOOGLE_VERTEX_BASE_URL =
 			"https://proxy-one.invalid,https://proxy-two.invalid";
 
-		expect([...getServiceTierIneligibleEnvIndices("google-vertex")]).toEqual([
-			0, 1,
-		]);
-		expect(hasServiceTierEligibleEnvCredential("google-vertex")).toBe(false);
+		expect([...getServiceTierIneligibleEnvIndices("google-vertex")]).toEqual(
+			[],
+		);
+		expect(hasServiceTierEligibleEnvCredential("google-vertex")).toBe(true);
 	});
 
 	it("flags a non-global Vertex region index as ineligible", () => {
@@ -275,17 +279,15 @@ describe("service-tier env credential eligibility", () => {
 		expect(hasServiceTierEligibleEnvCredential("google-vertex")).toBe(true);
 	});
 
-	it("rejects when the only base-URL-compliant index is a non-global region", () => {
-		// index 0: proxy base URL (global region); index 1: canonical upstream but
-		// us-central1 — neither can carry the tier, so the provider is ineligible.
+	it("accepts a global proxy while excluding a non-global canonical endpoint", () => {
 		process.env.LLM_GOOGLE_VERTEX_API_KEY = "tok-a,tok-b";
 		process.env.LLM_GOOGLE_VERTEX_BASE_URL =
 			"https://vertex-proxy.invalid,https://aiplatform.googleapis.com";
 		process.env.LLM_GOOGLE_VERTEX_REGION = "global,us-central1";
 
 		expect([...getServiceTierIneligibleEnvIndices("google-vertex")]).toEqual([
-			0, 1,
+			1,
 		]);
-		expect(hasServiceTierEligibleEnvCredential("google-vertex")).toBe(false);
+		expect(hasServiceTierEligibleEnvCredential("google-vertex")).toBe(true);
 	});
 });

--- a/apps/gateway/src/chat/tools/get-provider-env.ts
+++ b/apps/gateway/src/chat/tools/get-provider-env.ts
@@ -39,15 +39,7 @@ function getEnvCredentialCount(
 }
 
 /**
- * Whether a single env credential index can carry a Flex/Priority service-tier
- * request. Requires:
- * - an eligible base URL (managed default / canonical upstream, not a proxy);
- * - for google-vertex, a global region — Flex/Priority PayGo is served only on
- *   the global endpoint, and a non-global index would have its tier header
- *   dropped by getForwardedServiceTier and be silently served as standard.
- *
- * Base URL and region are comma-indexed in lockstep with the API-key env var,
- * so this is evaluated per index.
+ * Check the region at each credential index for Vertex tier support.
  */
 function isServiceTierEligibleEnvIndex(
 	provider: Provider,
@@ -55,13 +47,6 @@ function isServiceTierEligibleEnvIndex(
 	variant?: EnvVarVariant,
 ): boolean {
 	return providerCredentialSupportsServiceTier(provider, {
-		baseUrl: getProviderEnvValue(
-			provider,
-			"baseUrl",
-			index,
-			undefined,
-			variant,
-		),
 		region: getProviderEnvValue(provider, "region", index, "global", variant),
 	});
 }
@@ -69,8 +54,7 @@ function isServiceTierEligibleEnvIndex(
 /**
  * Env credential indices that are NOT eligible to carry a Flex/Priority
  * service-tier request. Used to exclude those indices from round-robin
- * selection so a service-tier request lands on a credential that hits the real
- * upstream on a tier-capable endpoint.
+ * selection so a service-tier request lands on a tier-capable region.
  */
 export function getServiceTierIneligibleEnvIndices(
 	provider: Provider,

--- a/apps/gateway/src/chat/tools/resolve-provider-context.ts
+++ b/apps/gateway/src/chat/tools/resolve-provider-context.ts
@@ -587,12 +587,7 @@ export async function resolveProviderContext(
 	// this org's env-credential reads. Undefined = base vars only.
 	const envVariant = getLicensedOrganizationEnvVariant(organization);
 
-	// Flex/Priority is only honored when the request reaches the provider's real
-	// upstream endpoint on a tier-capable location. Skip provider keys whose
-	// custom base URL (proxy) may silently drop the tier, and Vertex keys pinned
-	// to a regional endpoint, so a compliant key (or the managed env credential)
-	// is used instead. This is what keeps an alternate-key retry from rotating a
-	// Flex request onto a credential that would serve it as standard.
+	// Skip Vertex credentials pinned to a region that cannot serve the tier.
 	const serviceTierKeyFilter = isPremiumServiceTier(options.service_tier)
 		? providerKeySupportsServiceTier
 		: undefined;

--- a/apps/gateway/src/chat/tools/service-tier.spec.ts
+++ b/apps/gateway/src/chat/tools/service-tier.spec.ts
@@ -105,16 +105,21 @@ describe("providerKeySupportsServiceTier", () => {
 		expect(providerKeySupportsServiceTier(providerKey({}))).toBe(true);
 	});
 
-	test("rejects a proxied key for upstream-only tier providers", () => {
-		expect(
-			providerKeySupportsServiceTier(
-				providerKey({
-					provider: "google-ai-studio",
-					baseUrl: "https://proxy.example.com",
-				}),
-			),
-		).toBe(false);
-	});
+	test.each(["openai", "google-ai-studio", "google-vertex", "fireworks"])(
+		"accepts custom base URLs for %s keys",
+		(provider) => {
+			for (const overrides of [
+				{ baseUrl: "https://proxy.example.com" },
+				{ config: { baseUrl: "https://proxy.example.com" } },
+			]) {
+				expect(
+					providerKeySupportsServiceTier(
+						providerKey({ provider, ...overrides }),
+					),
+				).toBe(true);
+			}
+		},
+	);
 
 	test("rejects a Vertex credential pinned to a regional endpoint", () => {
 		expect(

--- a/apps/gateway/src/chat/tools/service-tier.ts
+++ b/apps/gateway/src/chat/tools/service-tier.ts
@@ -170,7 +170,6 @@ function providerKeyRegion(key: ProviderKeyRow): string | undefined {
  */
 export function providerKeySupportsServiceTier(key: ProviderKeyRow): boolean {
 	return providerCredentialSupportsServiceTier(key.provider as Provider, {
-		baseUrl: key.config?.baseUrl ?? key.baseUrl,
 		region: providerKeyRegion(key),
 	});
 }

--- a/apps/gateway/src/test-utils/gateway-api-test-harness.ts
+++ b/apps/gateway/src/test-utils/gateway-api-test-harness.ts
@@ -148,14 +148,9 @@ export function createGatewayApiTestHarness() {
 
 	beforeAll(async () => {
 		mockServerUrl = await startMockServer();
-		// The mock stands in for every provider upstream, so service-tier requests
-		// would otherwise be rejected for not targeting the catalogue's real
-		// endpoint. Trusting it here keeps the positive tier paths exercisable.
-		process.env.SERVICE_TIER_TRUSTED_BASE_URLS = mockServerUrl;
 	});
 
 	afterAll(() => {
-		delete process.env.SERVICE_TIER_TRUSTED_BASE_URLS;
 		stopMockServer();
 	});
 

--- a/packages/actions/src/apply-service-tier.spec.ts
+++ b/packages/actions/src/apply-service-tier.spec.ts
@@ -1,11 +1,10 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import {
 	applyGoogleServiceTier,
 	assumeServedServiceTier,
 	isPremiumServiceTier,
 	providerCredentialSupportsServiceTier,
-	providerKeyBaseUrlSupportsServiceTier,
 	resolveServedServiceTier,
 } from "./apply-service-tier.js";
 
@@ -126,104 +125,6 @@ describe("isPremiumServiceTier", () => {
 	});
 });
 
-describe("providerKeyBaseUrlSupportsServiceTier", () => {
-	it("ignores trailing slashes when matching the canonical upstream", () => {
-		expect(
-			providerKeyBaseUrlSupportsServiceTier(
-				"google-vertex",
-				"https://aiplatform.googleapis.com///",
-			),
-		).toBe(true);
-	});
-
-	it("allows a key with no custom base URL (managed default)", () => {
-		expect(providerKeyBaseUrlSupportsServiceTier("google-vertex", null)).toBe(
-			true,
-		);
-		expect(
-			providerKeyBaseUrlSupportsServiceTier("google-ai-studio", undefined),
-		).toBe(true);
-	});
-
-	it("allows a key whose base URL matches the canonical upstream", () => {
-		expect(
-			providerKeyBaseUrlSupportsServiceTier(
-				"google-vertex",
-				"https://aiplatform.googleapis.com",
-			),
-		).toBe(true);
-		expect(
-			providerKeyBaseUrlSupportsServiceTier(
-				"google-ai-studio",
-				"https://generativelanguage.googleapis.com/",
-			),
-		).toBe(true);
-	});
-
-	it("rejects a custom (proxy) base URL on the google tier providers", () => {
-		expect(
-			providerKeyBaseUrlSupportsServiceTier(
-				"google-vertex",
-				"https://my-proxy.example.com",
-			),
-		).toBe(false);
-		expect(
-			providerKeyBaseUrlSupportsServiceTier(
-				"google-ai-studio",
-				"https://gateway.internal/v1",
-			),
-		).toBe(false);
-	});
-
-	it("rejects a proxy base URL on openai too", () => {
-		// OpenAI carries the tier as a body field, which an OpenAI-compatible
-		// proxy is free to ignore — the same exposure the Google providers have.
-		expect(
-			providerKeyBaseUrlSupportsServiceTier(
-				"openai",
-				"https://my-proxy.example.com",
-			),
-		).toBe(false);
-		expect(
-			providerKeyBaseUrlSupportsServiceTier("openai", "https://api.openai.com"),
-		).toBe(true);
-	});
-
-	it("ignores providers that declare no service tiers", () => {
-		expect(
-			providerKeyBaseUrlSupportsServiceTier(
-				"anthropic",
-				"https://my-proxy.example.com",
-			),
-		).toBe(true);
-	});
-
-	it("allows a custom base URL on glacier (no static default upstream)", () => {
-		expect(
-			providerKeyBaseUrlSupportsServiceTier(
-				"glacier",
-				"https://glacier.internal/v1beta",
-			),
-		).toBe(true);
-	});
-
-	it("rejects a proxy base URL on fireworks but allows its upstream", () => {
-		expect(
-			providerKeyBaseUrlSupportsServiceTier(
-				"fireworks",
-				"https://my-proxy.example.com/v1",
-			),
-		).toBe(false);
-		expect(
-			providerKeyBaseUrlSupportsServiceTier(
-				"fireworks",
-				"https://api.fireworks.ai/inference",
-			),
-		).toBe(true);
-		expect(providerKeyBaseUrlSupportsServiceTier("fireworks", null)).toBe(true);
-	});
-});
-
 describe("assumeServedServiceTier", () => {
 	it("attributes an accepted Fireworks request to the forwarded tier", () => {
 		expect(assumeServedServiceTier("fireworks", "priority", true)).toBe(
@@ -263,67 +164,9 @@ describe("providerCredentialSupportsServiceTier", () => {
 		).toBe(false);
 	});
 
-	it("still rejects a proxied base URL regardless of region", () => {
-		expect(
-			providerCredentialSupportsServiceTier("google-vertex", {
-				baseUrl: "https://my-proxy.example.com",
-				region: "global",
-			}),
-		).toBe(false);
-	});
-
 	it("ignores region for providers without an endpoint constraint", () => {
 		expect(
 			providerCredentialSupportsServiceTier("openai", { region: "us-east1" }),
 		).toBe(true);
-	});
-});
-
-describe("SERVICE_TIER_TRUSTED_BASE_URLS", () => {
-	const original = process.env.SERVICE_TIER_TRUSTED_BASE_URLS;
-
-	afterEach(() => {
-		if (original === undefined) {
-			delete process.env.SERVICE_TIER_TRUSTED_BASE_URLS;
-		} else {
-			process.env.SERVICE_TIER_TRUSTED_BASE_URLS = original;
-		}
-	});
-
-	it("accepts an explicitly trusted base URL", () => {
-		process.env.SERVICE_TIER_TRUSTED_BASE_URLS =
-			"https://mirror.example.com,https://other.example.com/";
-		expect(
-			providerKeyBaseUrlSupportsServiceTier(
-				"openai",
-				"https://mirror.example.com/",
-			),
-		).toBe(true);
-		expect(
-			providerKeyBaseUrlSupportsServiceTier(
-				"fireworks",
-				"https://other.example.com",
-			),
-		).toBe(true);
-	});
-
-	it("still rejects base URLs outside the allowlist", () => {
-		process.env.SERVICE_TIER_TRUSTED_BASE_URLS = "https://mirror.example.com";
-		expect(
-			providerKeyBaseUrlSupportsServiceTier(
-				"openai",
-				"https://elsewhere.example.com",
-			),
-		).toBe(false);
-	});
-
-	it("is strict when unset", () => {
-		delete process.env.SERVICE_TIER_TRUSTED_BASE_URLS;
-		expect(
-			providerKeyBaseUrlSupportsServiceTier(
-				"openai",
-				"https://mirror.example.com",
-			),
-		).toBe(false);
 	});
 });

--- a/packages/actions/src/apply-service-tier.ts
+++ b/packages/actions/src/apply-service-tier.ts
@@ -8,10 +8,6 @@
  * provider — an OpenAI-compatible body field, a Vertex request header (see
  * getProviderHeaders) — but the eligibility and served-tier rules do not.
  */
-import { getProviderDefinition } from "@llmgateway/models";
-
-import { getProviderDefaultBaseUrl } from "./get-provider-endpoint.js";
-
 import type { ProviderId, ProviderRequestBody } from "@llmgateway/models";
 
 /**
@@ -46,24 +42,6 @@ export function applyGoogleServiceTier(
 }
 
 /**
- * A premium tier only applies when the request reaches the provider's real
- * upstream. Whether the tier travels as a body field (OpenAI, the Gemini
- * Developer API, Fireworks) or a request header (Vertex), a key pointing at a
- * proxy / custom base URL may silently drop it — the request is then served,
- * and billed, as standard, and the caller has no way to tell. Service-tier
- * routing is therefore restricted to credentials targeting the provider's
- * default base URL.
- *
- * Derived from the catalogue rather than hardcoded: any provider that declares
- * `serviceTiers` is subject to the rule automatically. A hardcoded list silently
- * exempted OpenAI, which is both the most-used tier provider and the one most
- * likely to sit behind an OpenAI-compatible proxy.
- */
-function isUpstreamOnlyTierProvider(provider: ProviderId): boolean {
-	return Boolean(getProviderDefinition(provider)?.serviceTiers?.length);
-}
-
-/**
  * The OpenAI-compatible processing tiers that select premium (Flex / Priority)
  * inference. Shared so every service-tier code path agrees on the accepted
  * values instead of re-inlining the literal union.
@@ -75,89 +53,12 @@ export function isPremiumServiceTier(
 }
 
 /**
- * Base URLs an operator has declared to reach a provider's genuine upstream, so
- * they may carry a premium tier despite not being the catalogue default —
- * comma-separated in `SERVICE_TIER_TRUSTED_BASE_URLS`.
- *
- * Unset in production, where only the provider's own endpoint is trusted. It
- * exists for deployments fronting a provider with a mirror they control (and for
- * the test harness, whose mock server stands in for every upstream). Declaring a
- * URL here asserts that it forwards `service_tier` untouched; a proxy that
- * silently drops it will serve, and bill, standard.
- */
-function isTrustedServiceTierBaseUrl(baseUrl: string): boolean {
-	const trusted = process.env.SERVICE_TIER_TRUSTED_BASE_URLS;
-	if (!trusted) {
-		return false;
-	}
-	const normalized = normalizeServiceTierBaseUrl(baseUrl);
-	return trusted
-		.split(",")
-		.map((entry) => normalizeServiceTierBaseUrl(entry))
-		.filter((entry) => entry.length > 0)
-		.includes(normalized);
-}
-
-function normalizeServiceTierBaseUrl(baseUrl: string): string {
-	// Strip trailing slashes without a backtracking regex (avoids the
-	// polynomial-ReDoS CodeQL flags for `/\/+$/` on attacker-influenced input).
-	const trimmed = baseUrl.trim();
-	let end = trimmed.length;
-	while (end > 0 && trimmed[end - 1] === "/") {
-		end--;
-	}
-	return trimmed.slice(0, end).toLowerCase();
-}
-
-/**
- * Whether a provider key's base URL is eligible to carry a Flex/Priority
- * service-tier request. Eligible when the provider declares no service tiers at
- * all, when the key uses the managed default (no custom base URL), or when the
- * custom base URL exactly matches the provider's default base URL (its real
- * upstream). Providers with no static default base URL (e.g. glacier, an
- * env-defined deployment) have no canonical upstream to compare against, so
- * they pass, as do base URLs an operator has explicitly trusted via
- * SERVICE_TIER_TRUSTED_BASE_URLS.
- */
-export function providerKeyBaseUrlSupportsServiceTier(
-	provider: ProviderId,
-	baseUrl: string | null | undefined,
-): boolean {
-	if (!isUpstreamOnlyTierProvider(provider) || !baseUrl) {
-		return true;
-	}
-	if (isTrustedServiceTierBaseUrl(baseUrl)) {
-		return true;
-	}
-	const upstream = getProviderDefaultBaseUrl(provider);
-	if (!upstream) {
-		return true;
-	}
-	return (
-		normalizeServiceTierBaseUrl(baseUrl) ===
-		normalizeServiceTierBaseUrl(upstream)
-	);
-}
-
-/**
- * Whether a credential (BYOK key, platform-managed key, or env-var index) can
- * carry a Flex/Priority request, given the upstream it targets.
- *
- * Extends the base-URL rule with Google Vertex's endpoint constraint: Flex and
- * Priority PayGo are only served on the `global` location, so a credential
- * pinned to a regional endpoint would have its tier header dropped upstream and
- * be served — and billed — as standard. Every credential-selection path (BYOK
- * key filtering, managed-credential filtering, env round-robin) shares this
- * predicate so a service-tier request can never rotate onto a credential that
- * silently downgrades it.
+ * Vertex Flex/Priority credentials must use the global region.
  */
 export function providerCredentialSupportsServiceTier(
 	provider: ProviderId,
-	credential: { baseUrl?: string | null; region?: string | null },
+	credential: { region?: string | null },
 ): boolean {
-	if (!providerKeyBaseUrlSupportsServiceTier(provider, credential.baseUrl)) {
-		return false;
-	}
 	if (provider === "google-vertex") {
 		return (credential.region ?? "global") === "global";
 	}

--- a/packages/actions/src/get-provider-endpoint.ts
+++ b/packages/actions/src/get-provider-endpoint.ts
@@ -189,13 +189,8 @@ export function getGoogleVertexPublisherModelPath(
 }
 
 /**
- * Static default base URLs for providers whose canonical upstream is a fixed
- * host. Single source of truth for "the provider's default base URL":
- * getProviderEndpoint falls back to these when no key base URL or env
- * override is configured, and service-tier key eligibility compares custom
- * base URLs against them. Providers absent from this map derive their
- * endpoint from env vars, key options (e.g. the Azure resource), or region
- * maps and have no static default.
+ * Static fallback URLs when no key or env override is configured. Providers
+ * absent from this map derive endpoints from env vars, key options, or regions.
  */
 const PROVIDER_DEFAULT_BASE_URLS: Partial<Record<ProviderId, string>> = {
 	openai: "https://api.openai.com",


### PR DESCRIPTION
Flex/Priority requests were rejected when provider keys used custom base URLs. Remove the canonical-URL check and `SERVICE_TIER_TRUSTED_BASE_URLS` allowlist across BYOK, managed, and environment credentials, and update regression tests and stale guidance. Model support and Vertex's global-region requirement still apply.

Validation: `pnpm format`, `pnpm build`, and five sequential test files against an isolated database (294 passed, 2 skipped).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Service-tier requests can now use supported provider credentials with custom base URLs.
  - Service-tier support is determined by provider and region rather than endpoint URL.
  - Google Vertex service tiers remain available only through global-region credentials.

- **Bug Fixes**
  - Improved service-tier handling for Fireworks, Google Vertex, Google AI Studio, and OpenAI integrations.
  - Updated error messaging when no eligible service-tier credential is available.
  - Priority-tier requests now correctly forward and report the selected tier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->