### PR TITLE
fix(gateway): clamp auto reasoning effort

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -275,6 +275,7 @@ import { convertAwsEventStreamToSSE } from "./tools/parse-aws-eventstream.js";
 import { parseModelInput } from "./tools/parse-model-input.js";
 import { parseProviderResponse } from "./tools/parse-provider-response.js";
 import { parseTrailingUpstreamError } from "./tools/parse-trailing-upstream-error.js";
+import { pickAutoReasoningEffort } from "./tools/pick-auto-reasoning-effort.js";
 import {
 	exclusionReason,
 	getProviderFilterReasons,
@@ -5627,11 +5628,12 @@ chat.openapi(completions, async (c) => {
 		);
 
 		if (selectedModelSupportsReasoning) {
-			// Set reasoning_effort to "minimal" for gpt-5* models, "low" for others
-			if (usedInternalModel.startsWith("gpt-5")) {
-				reasoning_effort = "minimal";
-			} else {
-				reasoning_effort = "low";
+			const autoEffort = pickAutoReasoningEffort(
+				usedInternalModel,
+				getUsedProviderMapping()?.reasoningEfforts,
+			);
+			if (autoEffort) {
+				reasoning_effort = autoEffort;
 			}
 		}
 	}

--- a/apps/gateway/src/chat/tools/pick-auto-reasoning-effort.spec.ts
+++ b/apps/gateway/src/chat/tools/pick-auto-reasoning-effort.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { pickAutoReasoningEffort } from "./pick-auto-reasoning-effort.js";
+
+describe("pickAutoReasoningEffort", () => {
+	it("keeps minimal for gpt-5 mappings that support it", () => {
+		expect(
+			pickAutoReasoningEffort("gpt-5-mini", [
+				"minimal",
+				"low",
+				"medium",
+				"high",
+			]),
+		).toBe("minimal");
+	});
+
+	it("falls back to none when the mapping dropped minimal", () => {
+		expect(
+			pickAutoReasoningEffort("gpt-5.4-mini", [
+				"none",
+				"low",
+				"medium",
+				"high",
+				"xhigh",
+			]),
+		).toBe("none");
+	});
+
+	it("falls back to low when the mapping has neither minimal nor none", () => {
+		expect(
+			pickAutoReasoningEffort("gpt-5.2-codex", [
+				"low",
+				"medium",
+				"high",
+				"xhigh",
+			]),
+		).toBe("low");
+	});
+
+	it("sets nothing when no preferred effort is supported", () => {
+		expect(
+			pickAutoReasoningEffort("gpt-5.2-pro", ["medium", "high", "xhigh"]),
+		).toBeUndefined();
+		expect(pickAutoReasoningEffort("gpt-5-pro", ["high"])).toBeUndefined();
+	});
+
+	it("uses low for non-gpt-5 models", () => {
+		expect(
+			pickAutoReasoningEffort("claude-opus-4.5", ["low", "medium", "high"]),
+		).toBe("low");
+	});
+
+	it("keeps the previous default when the mapping declares no efforts", () => {
+		expect(pickAutoReasoningEffort("gpt-5-mini", undefined)).toBe("minimal");
+		expect(pickAutoReasoningEffort("claude-opus-4.5", undefined)).toBe("low");
+	});
+});

--- a/apps/gateway/src/chat/tools/pick-auto-reasoning-effort.ts
+++ b/apps/gateway/src/chat/tools/pick-auto-reasoning-effort.ts
@@ -1,0 +1,20 @@
+import type { ReasoningEffort } from "@llmgateway/models";
+
+/**
+ * Pick the reasoning effort auto-routing applies when the caller sent none.
+ * Newer gpt-5 mappings dropped "minimal" in favour of "none", so the effort has
+ * to be clamped to what the resolved mapping declares - otherwise the provider
+ * rejects the forwarded value with unsupported_value.
+ */
+export function pickAutoReasoningEffort(
+	modelId: string,
+	supportedEfforts: ReasoningEffort[] | undefined,
+): ReasoningEffort | undefined {
+	const preferred: ReasoningEffort[] = modelId.startsWith("gpt-5")
+		? ["minimal", "none", "low"]
+		: ["low"];
+	if (!supportedEfforts) {
+		return preferred[0];
+	}
+	return preferred.find((effort) => supportedEfforts.includes(effort));
+}


### PR DESCRIPTION
Fixes #3879

## Problem

When `model: "auto"` picks a reasoning model and the caller sent no effort, the gateway set `reasoning_effort` from the model id alone — `"minimal"` for anything starting with `gpt-5`, `"low"` otherwise — without consulting the resolved mapping's `reasoningEfforts`. Efforts are forwarded as-is, so an unsupported value comes back as `unsupported_value`.

26 of 37 `gpt-5*` mappings in the catalogue no longer declare `minimal`:

| mapping | example | was | now |
| --- | --- | --- | --- |
| `[none, low, …]` | `gpt-5.4-mini`, `gpt-5.6-sol` | `minimal` ✗ | `none` |
| `[low, medium, high, xhigh]` | `gpt-5.2-codex` | `minimal` ✗ | `low` |
| `[medium, high, xhigh]` | `gpt-5.2-pro` | `minimal` ✗ | unset |
| `[high]` | `gpt-5-pro` | `minimal` ✗ | unset |

The `"low"` branch had the same flaw for non-gpt-5 mappings that don't declare `low`.

## Approach

`pickAutoReasoningEffort` clamps the auto-set value to the mapping's declared efforts, preferring `minimal` → `none` → `low` for gpt-5 and `low` elsewhere, and returns `undefined` when none fit so the auto-set is skipped rather than guessed.

## Notes

- A mapping that declares no `reasoningEfforts` keeps the previous default, so nothing changes for it.
- Only the auto-routing default is clamped; an effort the caller sent explicitly is untouched.
- Shaped after `clamp-temperature.ts`, which solves the same class of problem for temperature ceilings.

## Verification

`pnpm vitest run apps/gateway/src/chat/tools/` — 724 passing. `openai-content-filter.spec.ts` fails 10/15 on this branch and identically on `main`; it is unrelated and pre-existing. Typecheck, eslint and prettier clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Automatic reasoning effort selection now adapts to the options supported by each provider.
  - GPT-5 models prioritize `minimal`, then fall back to `none` or `low` when necessary.
  - Other models continue to prefer `low`.
  - When no compatible effort is available, the system avoids selecting an unsupported option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->