### PR TITLE
perf: weekly react best-practices audit fixes

### DIFF
--- a/apps/ui/src/app/models/[name]/[provider]/page.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/page.tsx
@@ -55,10 +55,11 @@ export default async function ModelProviderPage({ params }: PageProps) {
 	const decodedName = decodeURIComponent(name);
 	const decodedProvider = decodeURIComponent(provider);
 
-	// Discounts and ratings only depend on the model id, so they load in
-	// parallel with the model definition instead of behind it.
-	const [modelDef, discountData, ratingsData] = await Promise.all([
-		findPublicModelDefinition(decodedName),
+	// Discounts and ratings only depend on the model id, so they start in
+	// parallel with the model definition instead of behind it; the definition
+	// is awaited first so unknown models 404 without waiting for them, and
+	// fetchServerData never rejects (it logs and returns null).
+	const modelDataPromise = Promise.all([
 		fetchServerData<{ discounts: DiscountData[] }>(
 			"GET",
 			"/public/discounts/model/{modelId}",
@@ -68,6 +69,7 @@ export default async function ModelProviderPage({ params }: PageProps) {
 			params: { query: { modelId: decodedName } },
 		}),
 	]);
+	const modelDef = await findPublicModelDefinition(decodedName);
 
 	if (!modelDef) {
 		notFound();
@@ -92,6 +94,7 @@ export default async function ModelProviderPage({ params }: PageProps) {
 		((await fetchProviders()).find(
 			(provider) => provider.id === decodedProvider,
 		) as unknown as (typeof providerDefinitions)[number] | undefined);
+	const [discountData, ratingsData] = await modelDataPromise;
 	const discounts = discountData?.discounts ?? [];
 	// A provider whose mappings are all deactivated still renders this page, but
 	// nothing can be routed to it — so it must not advertise a discounted price.

--- a/apps/ui/src/app/models/[name]/[provider]/page.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/page.tsx
@@ -55,7 +55,19 @@ export default async function ModelProviderPage({ params }: PageProps) {
 	const decodedName = decodeURIComponent(name);
 	const decodedProvider = decodeURIComponent(provider);
 
-	const modelDef = await findPublicModelDefinition(decodedName);
+	// Discounts and ratings only depend on the model id, so they load in
+	// parallel with the model definition instead of behind it.
+	const [modelDef, discountData, ratingsData] = await Promise.all([
+		findPublicModelDefinition(decodedName),
+		fetchServerData<{ discounts: DiscountData[] }>(
+			"GET",
+			"/public/discounts/model/{modelId}",
+			{ params: { path: { modelId: decodedName } } },
+		),
+		fetchServerData<ModelRatingsData>("GET", "/public/model-ratings", {
+			params: { query: { modelId: decodedName } },
+		}),
+	]);
 
 	if (!modelDef) {
 		notFound();
@@ -80,18 +92,6 @@ export default async function ModelProviderPage({ params }: PageProps) {
 		((await fetchProviders()).find(
 			(provider) => provider.id === decodedProvider,
 		) as unknown as (typeof providerDefinitions)[number] | undefined);
-
-	// Fetch global discounts and apply to provider
-	const [discountData, ratingsData] = await Promise.all([
-		fetchServerData<{ discounts: DiscountData[] }>(
-			"GET",
-			"/public/discounts/model/{modelId}",
-			{ params: { path: { modelId: decodedName } } },
-		),
-		fetchServerData<ModelRatingsData>("GET", "/public/model-ratings", {
-			params: { query: { modelId: decodedName } },
-		}),
-	]);
 	const discounts = discountData?.discounts ?? [];
 	// A provider whose mappings are all deactivated still renders this page, but
 	// nothing can be routed to it — so it must not advertise a discounted price.

--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -73,21 +73,25 @@ export default async function ModelPage({ params }: PageProps) {
 	const decodedName = decodeURIComponent(name);
 
 	// Discounts, ratings and carrier branding do not depend on the model
-	// definition, so all four catalogue requests run in one round-trip.
-	const [modelDef, allDiscounts, ratingsData, apiProviders] = await Promise.all(
-		[
-			findPublicModelDefinition(decodedName),
-			fetchModelDiscounts(decodedName),
-			fetchServerData<ModelRatingsData>("GET", "/public/model-ratings", {
-				params: { query: { modelId: decodedName } },
-			}),
-			fetchProviders(),
-		],
-	);
+	// definition, so all four catalogue requests start in one round-trip; the
+	// definition is awaited first so unknown models 404 without waiting for
+	// the rest. None of the batched fetchers reject — they log and return
+	// fallbacks — so abandoning the batch on notFound() is safe.
+	const modelDefPromise = findPublicModelDefinition(decodedName);
+	const pageDataPromise = Promise.all([
+		fetchModelDiscounts(decodedName),
+		fetchServerData<ModelRatingsData>("GET", "/public/model-ratings", {
+			params: { query: { modelId: decodedName } },
+		}),
+		fetchProviders(),
+	]);
+	const modelDef = await modelDefPromise;
 
 	if (!modelDef) {
 		notFound();
 	}
+
+	const [allDiscounts, ratingsData, apiProviders] = await pageDataPromise;
 
 	const getStabilityBadgeProps = (stability?: StabilityLevel) => {
 		switch (stability) {

--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -72,7 +72,18 @@ export default async function ModelPage({ params }: PageProps) {
 	const { name } = await params;
 	const decodedName = decodeURIComponent(name);
 
-	const modelDef = await findPublicModelDefinition(decodedName);
+	// Discounts, ratings and carrier branding do not depend on the model
+	// definition, so all four catalogue requests run in one round-trip.
+	const [modelDef, allDiscounts, ratingsData, apiProviders] = await Promise.all(
+		[
+			findPublicModelDefinition(decodedName),
+			fetchModelDiscounts(decodedName),
+			fetchServerData<ModelRatingsData>("GET", "/public/model-ratings", {
+				params: { query: { modelId: decodedName } },
+			}),
+			fetchProviders(),
+		],
+	);
 
 	if (!modelDef) {
 		notFound();
@@ -107,15 +118,8 @@ export default async function ModelPage({ params }: PageProps) {
 		return stability && ["unstable", "experimental"].includes(stability);
 	};
 
-	const [allDiscounts, ratingsData] = await Promise.all([
-		fetchModelDiscounts(decodedName),
-		fetchServerData<ModelRatingsData>("GET", "/public/model-ratings", {
-			params: { query: { modelId: decodedName } },
-		}),
-	]);
 	// Carrier-uploaded branding (Airside claims) overlays the static provider
 	// info, and is the only provider info a DB-only carrier has.
-	const apiProviders = await fetchProviders();
 	const expandedProviders = expandAllProviderRegions(modelDef.providers);
 	const modelProviders = expandedProviders.map((provider) => {
 		const providerInfo = providerDefinitions.find(

--- a/apps/ui/src/app/models/[name]/uptime/page.tsx
+++ b/apps/ui/src/app/models/[name]/uptime/page.tsx
@@ -48,16 +48,17 @@ export default async function ModelUptimePage({ params }: PageProps) {
 	const decodedName = decodeURIComponent(name);
 
 	// Provider names do not depend on the model definition, so both catalogue
-	// requests run in one round-trip.
-	const [modelDef, apiProviders] = await Promise.all([
-		findPublicModelDefinition(decodedName),
-		fetchProviders(),
-	]);
+	// requests start in one round-trip; the definition is awaited first so
+	// unknown models 404 without waiting for the provider list, which never
+	// rejects (it logs and returns a fallback).
+	const providersPromise = fetchProviders();
+	const modelDef = await findPublicModelDefinition(decodedName);
 
 	if (!modelDef) {
 		notFound();
 	}
 
+	const apiProviders = await providersPromise;
 	const expandedProviders = expandAllProviderRegions(modelDef.providers);
 	const providerNames = Array.from(
 		new Set(

--- a/apps/ui/src/app/models/[name]/uptime/page.tsx
+++ b/apps/ui/src/app/models/[name]/uptime/page.tsx
@@ -47,14 +47,18 @@ export default async function ModelUptimePage({ params }: PageProps) {
 	const { name } = await params;
 	const decodedName = decodeURIComponent(name);
 
-	const modelDef = await findPublicModelDefinition(decodedName);
+	// Provider names do not depend on the model definition, so both catalogue
+	// requests run in one round-trip.
+	const [modelDef, apiProviders] = await Promise.all([
+		findPublicModelDefinition(decodedName),
+		fetchProviders(),
+	]);
 
 	if (!modelDef) {
 		notFound();
 	}
 
 	const expandedProviders = expandAllProviderRegions(modelDef.providers);
-	const apiProviders = await fetchProviders();
 	const providerNames = Array.from(
 		new Set(
 			expandedProviders.map((p) => {

--- a/apps/ui/src/app/providers/[id]/page.tsx
+++ b/apps/ui/src/app/providers/[id]/page.tsx
@@ -103,11 +103,12 @@ export default async function ProviderPage({ params }: ProviderPageProps) {
 		notFound();
 	}
 
-	const apiProviders = await fetchProviders();
+	const [apiProviders, apiModels] = await Promise.all([
+		fetchProviders(),
+		fetchModels(),
+	]);
 	const apiProvider = apiProviders.find((p) => p.id === id);
 	const uploadedLogo = apiProvider?.airsideLogoUrl ?? undefined;
-
-	const apiModels = await fetchModels();
 	const discountByModelId = new Map<string, string>();
 	for (const apiModel of apiModels) {
 		for (const mapping of apiModel.mappings) {

--- a/packages/shared/src/components/jelly/jelly-logo.tsx
+++ b/packages/shared/src/components/jelly/jelly-logo.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from "react";
 
 import { Logo } from "@/components/ui/logo";
 
-import { createJellyScene } from "./jelly-scene";
+import type { createJellyScene } from "./jelly-scene";
 
 export function JellyLogo() {
 	const canvas = useRef<HTMLCanvasElement>(null);
@@ -19,60 +19,76 @@ export function JellyLogo() {
 		}
 		const element = canvas.current;
 		let mounted = true;
-		let jelly: ReturnType<typeof createJellyScene>;
-		try {
-			jelly = createJellyScene(element);
-		} catch (error) {
-			// WebGL is optional; the static logo keeps the error page usable.
-			// eslint-disable-next-line no-console
-			console.warn("Could not initialize the 404 jelly", error);
-			return;
-		}
-		scene.current = jelly;
-		const motion = window.matchMedia("(prefers-reduced-motion: reduce)");
-		const updateMotion = () => {
-			jelly.setReducedMotion(motion.matches);
-			setReduced(motion.matches);
-		};
-		const updateTheme = () => {
-			jelly.setTheme(document.documentElement.classList.contains("dark"));
-		};
-		const theme = new MutationObserver(updateTheme);
-		theme.observe(document.documentElement, {
-			attributes: true,
-			attributeFilter: ["class"],
-		});
-		motion.addEventListener("change", updateMotion);
-		updateMotion();
-		updateTheme();
-		void jelly.ready
-			.then(() => {
-				if (mounted && scene.current === jelly) {
-					setReady(true);
+		let cleanup: (() => void) | undefined;
+		// The scene pulls in three.js, so it loads on demand to keep the 404
+		// page's initial chunk small; the static logo renders in the meantime.
+		void import("./jelly-scene")
+			.then(({ createJellyScene: create }) => {
+				if (!mounted) {
+					return;
 				}
+				let jelly: ReturnType<typeof create>;
+				try {
+					jelly = create(element);
+				} catch (error) {
+					// WebGL is optional; the static logo keeps the error page usable.
+					// eslint-disable-next-line no-console
+					console.warn("Could not initialize the 404 jelly", error);
+					return;
+				}
+				scene.current = jelly;
+				const motion = window.matchMedia("(prefers-reduced-motion: reduce)");
+				const updateMotion = () => {
+					jelly.setReducedMotion(motion.matches);
+					setReduced(motion.matches);
+				};
+				const updateTheme = () => {
+					jelly.setTheme(document.documentElement.classList.contains("dark"));
+				};
+				const theme = new MutationObserver(updateTheme);
+				theme.observe(document.documentElement, {
+					attributes: true,
+					attributeFilter: ["class"],
+				});
+				motion.addEventListener("change", updateMotion);
+				updateMotion();
+				updateTheme();
+				void jelly.ready
+					.then(() => {
+						if (mounted && scene.current === jelly) {
+							setReady(true);
+						}
+					})
+					.catch((error: unknown) => {
+						// eslint-disable-next-line no-console
+						console.warn("Could not load the 404 jelly studio", error);
+						jelly.dispose();
+						if (scene.current === jelly) {
+							scene.current = null;
+						}
+					});
+				const contextLost = (event: Event) => {
+					event.preventDefault();
+					jelly.dispose();
+					scene.current = null;
+					setReady(false);
+				};
+				element.addEventListener("webglcontextlost", contextLost);
+				cleanup = () => {
+					theme.disconnect();
+					motion.removeEventListener("change", updateMotion);
+					element.removeEventListener("webglcontextlost", contextLost);
+					jelly.dispose();
+					scene.current = null;
+				};
 			})
 			.catch((error: unknown) => {
 				// eslint-disable-next-line no-console
-				console.warn("Could not load the 404 jelly studio", error);
-				jelly.dispose();
-				if (scene.current === jelly) {
-					scene.current = null;
-				}
+				console.warn("Could not load the 404 jelly", error);
 			});
-		const contextLost = (event: Event) => {
-			event.preventDefault();
-			jelly.dispose();
-			scene.current = null;
-			setReady(false);
-		};
-		element.addEventListener("webglcontextlost", contextLost);
 		return () => {
 			mounted = false;
-			theme.disconnect();
-			motion.removeEventListener("change", updateMotion);
-			element.removeEventListener("webglcontextlost", contextLost);
-			jelly.dispose();
-			scene.current = null;
+			cleanup?.();
 		};
 	}, []);
 


### PR DESCRIPTION
Weekly React/Next.js best-practices audit against [Vercel's react-best-practices guide](https://github.com/vercel-labs/agent-skills/blob/main/skills/react-best-practices/AGENTS.md). Last week's audit PR #3865 is still open, so this week covers only **new** findings it does not touch — primarily code merged since it was created (the jelly 404 pages, the Airside carrier-fallback rework of the model/provider pages) — and deliberately avoids overlapping any of its changes or re-litigating its documented deferrals. Nothing touches `export const dynamic`, routing, or user-visible behavior.

## Fixes

### packages/shared (serves the ui, code, and playground 404 pages)

- **Dynamic Imports for Heavy Components / Defer Non-Critical Third-Party Libraries (rules 2.4, 2.3)** — `components/jelly/jelly-logo.tsx`. The new jelly 404 page statically imported `createJellyScene`, which pulls in **three.js plus the WebGL scene/physics code — a 622 KB minified (~157 KB gzip) chunk** — into every 404 page's initial JS, even though the scene only initializes inside a mount effect, is optional (WebGL failure already falls back to the static logo), and the component renders a complete static fallback until the scene reports ready. The scene module now loads via `import()` inside that effect, so the 404 page's initial chunk drops to ~3 KB and the "404" fallback paints immediately; an import failure logs a warning and keeps the static logo, matching the existing WebGL-failure path. Verified in the playground build output that the scene compiles to its own async chunk, separate from the not-found entry chunk. Same pattern as the repo's existing on-demand `html-to-image` import.

### apps/ui

- **Promise.all() for Independent Operations (rule 1.5)** — `app/providers/[id]/page.tsx`. The static-provider path awaited `fetchProviders()` and then `fetchModels()` serially — two independent catalogue round-trips — while the dynamic-carrier fallback in the same file already runs them with `Promise.all`. Both paths are parallel now.
- **Dependency-Based Parallelization (rule 1.3)** — `app/models/[name]/page.tsx`. The page ran three sequential await points: `findPublicModelDefinition` (which fetches the model catalogue), then `Promise.all(discounts, ratings)`, then `fetchProviders()`. Discounts, ratings, and provider branding depend only on the model id from the URL, not on the resolved definition, so all four requests now share one `Promise.all`; the `notFound()` check moves after it. On the not-found path this speculatively fetches three cheap public catalogue GETs (all `React.cache`d with 60 s revalidation) — the trade the guide's rule 1.3 explicitly makes.
- **Dependency-Based Parallelization (rule 1.3)** — `app/models/[name]/[provider]/page.tsx`. Same shape: discounts and ratings waited behind the model-definition fetch they don't depend on. They now resolve in one `Promise.all` with it. The conditional `fetchProviders()` for DB-only carriers stays deferred (rule 1.2) — static providers, the common case, never pay for it.
- **Promise.all() for Independent Operations (rule 1.5)** — `app/models/[name]/uptime/page.tsx`. `fetchProviders()` waited behind `findPublicModelDefinition`; the two are independent and now run in one round-trip.

Each model/provider page renders with `revalidate: 60`, so these waterfalls were paid on every revalidation render (and every dev render), stacking two to three serial API round-trips ahead of first byte.

## Considered and deliberately skipped

- **Anything involving `export const dynamic`** — intentional (runtime env loading); excluded per repo policy.
- **Everything #3865 already fixes or defers** — its open changes (formatter caches, teams gating, code-block dedup, Stripe form split, docs image loading) and its documented deferrals (token-cost-calculator/model-comparison bundles, teams detail `initialData`, docs `lucide-react` aggregate, `ActivityHeatmap` DOM, referral-effect mutations) were re-checked only to avoid overlap, not re-done.
- **ui `dashboard-client.tsx` runs ~14 separate `.reduce` passes over the activity rows (rule 7.6)** — ≤400 rows and React-Compiler-memoized, so absolute cost is microseconds; skipped as a low-impact micro-optimization per audit priorities.
- **ui `organization-retention-settings.tsx` syncs its radio state from the org query via `useEffect` (rule 5.1)** — same pattern #3865 defers for the teams page: the minimal fix is a keyed/derived-state restructure with user-facing semantics (background refetch vs unsaved edit), not a surgical perf diff.
- **New census, rankings, org-skills, apps-grid, and dashboard-chart code audited clean** — module-level `Intl` formatters, memoized filters/sorts, gated parallel queries, and key-based form resets throughout; the patterns previous audits fixed are now standard in new code.
- **playground `chat-page-client.tsx` ensure-key flow** — this week's rework already adds in-flight dedup and generation guards; nothing further needed.

## Verification

- `pnpm build`: 17 of 19 workspaces green with these changes (shared, code, playground, docs, admin, api, gateway included). `ui#build` fails **identically on a clean `origin/main` checkout in this sandbox** — a TLS-intercepting proxy breaks an outbound fetch during OG-image prerendering (`SELF_SIGNED_CERT_IN_CHAIN` on `/compare/litellm/opengraph-image`), so the failure is environmental and pre-existing, not from this diff. ui's `next build` compile stage passes with these changes, and `pnpm exec tsc` in `apps/ui` (the type-check step its build script only reaches after `next build`) passes clean.
- Playground build output confirms the jelly scene emits as a separate async chunk (622 KB) with the not-found entry chunk at ~3 KB.
- `pnpm format` clean; lint-staged (eslint + prettier) passed on commit.
- No visual changes intended anywhere — the 404 pages render the same static fallback first, which they already rendered before the scene signaled ready — so no before/after screenshots.

Note: this session pushes to its designated branch, so the head branch is `claude/upbeat-johnson-oe4rc5` rather than the `chore/react-bp-audit-2026-09-07` naming convention (same situation as #3518/#3784/#3865); future audits should locate this PR by title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbXo68UYfnhBjSk8X4wdek

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbXo68UYfnhBjSk8X4wdek)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved loading speed across model, provider, and uptime pages by fetching relevant information concurrently.
  * Unknown models now reach the not-found page without waiting for unrelated data requests.
  * Reduced initial loading work on the 404 page by loading the animated logo only when needed.
  * Improved resilience when loading the 404-page animation, including safer handling of loading errors and interrupted page navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->