### PR TITLE
fix(gateway): retry Runware thinking failures

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -257,6 +257,7 @@ import {
 	preferProvidersWithKeys,
 } from "./tools/hybrid-provider-routing.js";
 import { isModelTrulyFree } from "./tools/is-model-truly-free.js";
+import { isRunwareThinkingError } from "./tools/is-runware-thinking-error.js";
 import { mapFinishReasonToOpenai } from "./tools/map-finish-reason-to-openai.js";
 import {
 	getAudioFormatsFromMessages,
@@ -8833,10 +8834,15 @@ chat.openapi(completions, async (c) => {
 							: null;
 
 						// Determine the finish reason for error handling
-						const finishReason = getFinishReasonFromError(
+						const retryableBadRequest = isRunwareThinkingError(
+							usedProvider,
 							res.status,
 							errorResponseText,
+							requestBody,
 						);
+						const finishReason = retryableBadRequest
+							? "upstream_error"
+							: getFinishReasonFromError(res.status, errorResponseText);
 
 						if (
 							finishReason !== "client_error" &&
@@ -8907,6 +8913,7 @@ chat.openapi(completions, async (c) => {
 								sessionSticky: sessionStickyEnabled,
 								errorType: finishReason,
 								statusCode: res.status,
+								retryableBadRequest,
 								envVarName,
 								envKeyCount: getEnvKeyCount(envVarName),
 								hasOtherProvider: (routingMetadata?.providerScores ?? []).some(
@@ -13172,10 +13179,15 @@ chat.openapi(completions, async (c) => {
 			}
 
 			// Determine the finish reason first
-			const finishReason = getFinishReasonFromError(
+			const retryableBadRequest = isRunwareThinkingError(
+				usedProvider,
 				res.status,
 				errorResponseText,
+				requestBody,
 			);
+			const finishReason = retryableBadRequest
+				? "upstream_error"
+				: getFinishReasonFromError(res.status, errorResponseText);
 
 			if (
 				finishReason !== "client_error" &&
@@ -13242,6 +13254,7 @@ chat.openapi(completions, async (c) => {
 					sessionSticky: sessionStickyEnabled,
 					errorType: finishReason,
 					statusCode: res.status,
+					retryableBadRequest,
 					envVarName,
 					envKeyCount: getEnvKeyCount(envVarName),
 					hasOtherProvider: (routingMetadata?.providerScores ?? []).some(

--- a/apps/gateway/src/chat/tools/is-runware-thinking-error.spec.ts
+++ b/apps/gateway/src/chat/tools/is-runware-thinking-error.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { isRunwareThinkingError } from "./is-runware-thinking-error.js";
+
+describe("isRunwareThinkingError", () => {
+	const error = {
+		message:
+			"Unsupported parameter 'chat_template_kwargs.enable_thinking'; use 'reasoning_effort'.",
+		type: "invalid_request_error",
+		param: "chat_template_kwargs.enable_thinking",
+		code: "invalid_value",
+	};
+	const body = { model: "zai-glm-5-2", reasoning_effort: "high" };
+	const errorText = JSON.stringify({ error });
+
+	it("recognizes the exact rejection of an unsent flag", () => {
+		expect(isRunwareThinkingError("runware", 400, errorText, body)).toBe(true);
+	});
+
+	it("does not reclassify a request that actually sent chat-template parameters", () => {
+		expect(
+			isRunwareThinkingError("runware", 400, errorText, {
+				...body,
+				chat_template_kwargs: { enable_thinking: true },
+			}),
+		).toBe(false);
+	});
+
+	it.each([undefined, null, "{}"])(
+		"requires the outbound request body: %s",
+		(requestBody) => {
+			expect(
+				isRunwareThinkingError("runware", 400, errorText, requestBody),
+			).toBe(false);
+		},
+	);
+
+	it("does not match another provider or HTTP status", () => {
+		expect(isRunwareThinkingError("novita", 400, errorText, body)).toBe(false);
+		expect(isRunwareThinkingError("runware", 422, errorText, body)).toBe(false);
+	});
+
+	it.each([
+		{ param: "reasoning_effort" },
+		{ code: "unsupported_content_type" },
+		{ type: "content_filter" },
+		{ message: "This parameter is not supported for this model" },
+	])("requires the known structured error: %j", (override) => {
+		expect(
+			isRunwareThinkingError(
+				"runware",
+				400,
+				JSON.stringify({ error: { ...error, ...override } }),
+				body,
+			),
+		).toBe(false);
+	});
+
+	it.each(["not JSON", "null", "{}", '{"error":null}', '{"error":"invalid"}'])(
+		"ignores other error bodies: %s",
+		(text) => {
+			expect(isRunwareThinkingError("runware", 400, text, body)).toBe(false);
+		},
+	);
+});

--- a/apps/gateway/src/chat/tools/is-runware-thinking-error.ts
+++ b/apps/gateway/src/chat/tools/is-runware-thinking-error.ts
@@ -1,0 +1,41 @@
+// Runware can reject an internal thinking flag absent from our request. This
+// specific rejection is a provider failure; actual invalid parameters stay 400s.
+export function isRunwareThinkingError(
+	provider: string,
+	status: number,
+	errorText: string,
+	requestBody: unknown,
+): boolean {
+	if (
+		provider !== "runware" ||
+		status !== 400 ||
+		!requestBody ||
+		typeof requestBody !== "object" ||
+		"chat_template_kwargs" in requestBody
+	) {
+		return false;
+	}
+
+	try {
+		const payload: unknown = JSON.parse(errorText);
+		if (!payload || typeof payload !== "object" || !("error" in payload)) {
+			return false;
+		}
+		const error = payload.error;
+		return (
+			!!error &&
+			typeof error === "object" &&
+			"type" in error &&
+			error.type === "invalid_request_error" &&
+			"code" in error &&
+			error.code === "invalid_value" &&
+			"param" in error &&
+			error.param === "chat_template_kwargs.enable_thinking" &&
+			"message" in error &&
+			error.message ===
+				"Unsupported parameter 'chat_template_kwargs.enable_thinking'; use 'reasoning_effort'."
+		);
+	} catch {
+		return false;
+	}
+}

--- a/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.spec.ts
@@ -313,6 +313,16 @@ describe("shouldRetrySameKey", () => {
 		}
 	});
 
+	it("allows a verified provider-side 400 within the same retry budget", () => {
+		const opts = { ...defaultOpts, statusCode: 400, retryableBadRequest: true };
+		expect(shouldRetrySameKey(opts)).toBe(true);
+		expect(shouldRetrySameKey({ ...opts, retryCount: 2 })).toBe(false);
+		expect(shouldRetrySameKey({ ...opts, statusCode: 429 })).toBe(false);
+		expect(shouldRetrySameKey({ ...opts, errorType: "client_error" })).toBe(
+			false,
+		);
+	});
+
 	it("retries 5xx and network failures (statusCode 0)", () => {
 		for (const statusCode of [500, 502, 503, 529]) {
 			expect(

--- a/apps/gateway/src/chat/tools/retry-with-fallback.ts
+++ b/apps/gateway/src/chat/tools/retry-with-fallback.ts
@@ -133,8 +133,8 @@ export function sameKeyRetryDelay(attempt: number): Promise<void> {
  * provider (bad credentials, unknown model, out of funds) can legitimately
  * succeed on another — retrying the *same* key against the *same* provider
  * only helps for transient faults. Deterministic failures are excluded:
- * gateway_error (auth/config/payment) and all 4xx responses — the identical
- * request on the identical key will almost certainly fail the same way
+ * gateway_error (auth/config/payment) and 4xx responses, except a verified
+ * provider-side 400 — the identical request will otherwise fail the same way
  * (and re-firing a 429 would amplify rate-limit pressure). BYOK/custom
  * providers (envVarName unset) are also excluded.
  *
@@ -148,6 +148,8 @@ export function shouldRetrySameKey(opts: {
 	usedProvider: string;
 	errorType: string;
 	statusCode?: number;
+	/** A verified provider-side 400 for a parameter absent from our request. */
+	retryableBadRequest?: boolean;
 	envVarName: string | undefined;
 	envKeyCount: number;
 	hasOtherProvider: boolean;
@@ -177,12 +179,16 @@ export function shouldRetrySameKey(opts: {
 	if (opts.errorType === "gateway_error") {
 		return false;
 	}
-	// Any 4xx is deterministic for the identical request on the identical
-	// key — it will almost certainly fail the same way on a retry.
+	// Keep 4xx non-retryable unless the caller verified a provider-side 400.
 	if (
 		opts.statusCode !== undefined &&
 		opts.statusCode >= 400 &&
-		opts.statusCode < 500
+		opts.statusCode < 500 &&
+		!(
+			opts.statusCode === 400 &&
+			opts.errorType === "upstream_error" &&
+			opts.retryableBadRequest
+		)
 	) {
 		return false;
 	}

--- a/apps/gateway/src/runware-thinking-error.spec.ts
+++ b/apps/gateway/src/runware-thinking-error.spec.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { db, tables } from "@llmgateway/db";
+import { hashApiKeyForStorage } from "@llmgateway/shared/api-key-hash";
+
+import { app } from "./app.js";
+import { createGatewayApiTestHarness } from "./test-utils/gateway-api-test-harness.js";
+import { waitForLogs } from "./test-utils/test-helpers.js";
+
+describe("Runware thinking parameter rejection", () => {
+	const harness = createGatewayApiTestHarness();
+	const thinkingError = {
+		message:
+			"Unsupported parameter 'chat_template_kwargs.enable_thinking'; use 'reasoning_effort'.",
+		type: "invalid_request_error",
+		param: "chat_template_kwargs.enable_thinking",
+		code: "invalid_value",
+	};
+	let upstreamError = thinkingError;
+	let failures: number;
+	let requests: Record<string, unknown>[];
+
+	beforeEach(async () => {
+		upstreamError = thinkingError;
+		failures = 1;
+		requests = [];
+		await harness.setProjectMode("credits");
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			...hashApiKeyForStorage("real-token"),
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+		vi.stubEnv("LLM_RUNWARE_API_KEY", "sk-test-key");
+		vi.stubEnv("SAME_KEY_MAX_RETRIES", "2");
+		const originalFetch = globalThis.fetch;
+		vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+			const url = input instanceof Request ? input.url : String(input);
+			if (url.endsWith("/chat/completions")) {
+				requests.push(
+					JSON.parse(String(init?.body)) as Record<string, unknown>,
+				);
+				if (requests.length <= failures) {
+					return Response.json({ error: upstreamError }, { status: 400 });
+				}
+				return await originalFetch(
+					`${harness.mockServerUrl}/v1/chat/completions`,
+					init,
+				);
+			}
+			return await originalFetch(input, init);
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllEnvs();
+	});
+
+	async function request(stream: boolean) {
+		const response = await app.request("/v1/messages", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer real-token",
+				"x-no-fallback": "true",
+			},
+			body: JSON.stringify({
+				model: "runware/glm-5.2",
+				max_tokens: 32000,
+				stream,
+				thinking: { type: "adaptive" },
+				output_config: { effort: "high" },
+				messages: [
+					{ role: "user", content: "Background task completed. Say OK." },
+				],
+				tools: [
+					{
+						name: "get_weather",
+						input_schema: { type: "object", properties: {} },
+					},
+				],
+			}),
+		});
+		return { response, body: await response.text() };
+	}
+
+	describe.each([false, true])("stream=%s", (stream) => {
+		test("retries the pinned provider when it rejects a flag we never sent", async () => {
+			const { response, body } = await request(stream);
+			expect(response.status, body).toBe(200);
+			expect(body).not.toContain("event: error");
+			if (stream) {
+				expect(body).toContain("event: message_stop");
+			} else {
+				expect(JSON.parse(body)).toMatchObject({ type: "message" });
+			}
+			expect(requests).toHaveLength(2);
+			for (const sent of requests) {
+				expect(sent).toMatchObject({
+					model: "zai-glm-5-2",
+					reasoning_effort: "high",
+					stream,
+				});
+				expect(sent).not.toHaveProperty("chat_template_kwargs");
+			}
+			expect(requests[1]).toEqual(requests[0]);
+			const logs = await waitForLogs(2);
+			expect(logs.find((log) => log.hasError)).toMatchObject({
+				finishReason: "upstream_error",
+				errorDetails: { statusCode: 400 },
+				retried: true,
+			});
+		});
+
+		test("bounds retries and reports a persistent rejection as an API error", async () => {
+			failures = Infinity;
+			const { response, body } = await request(stream);
+			expect(requests).toHaveLength(3);
+			if (stream) {
+				expect(body).toContain("event: error");
+				expect(body).toContain('"type":"api_error"');
+			} else {
+				expect(response.status).toBe(500);
+				expect(JSON.parse(body)).toMatchObject({
+					error: { type: "api_error" },
+				});
+			}
+		});
+
+		test("preserves ordinary parameter errors without retrying", async () => {
+			upstreamError = {
+				...thinkingError,
+				param: "reasoning_effort",
+				message: "Invalid reasoning_effort",
+			};
+			const { response, body } = await request(stream);
+			expect(requests).toHaveLength(1);
+			if (!stream) {
+				expect(response.status).toBe(400);
+			}
+			expect(body).toContain('"type":"invalid_request_error"');
+		});
+	});
+});


### PR DESCRIPTION
Runware's `400` rejection of `chat_template_kwargs.enable_thinking` aborts Claude Code as an invalid request, even when the gateway sent `reasoning_effort` and no chat-template flag.

Recognize only that exact structured Runware error when the flag is absent from the outbound request. Classify it as an upstream failure and allow bounded same-key retries for a pinned platform provider. Persistent failures surface as an Anthropic `api_error`. Ordinary validation errors, provider pins, and retry limits retain their existing behavior.

This fixes gateway recovery from the reported rejection. The original upstream cause remains unconfirmed; current live Runware requests with `high` effort succeed. No reasoning metadata changes are included.

Validation: replaying the exact error through `/v1/messages` failed before the change and recovers afterward with an identical request, in both streaming modes. All 185 tests across six relevant suites passed, including the existing fallback suite. Tests also cover persistent failures, ordinary 400s, and exact-match guards. `pnpm format` and the full `pnpm build` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Runware provider errors involving unsupported thinking parameters.
  - Automatically retries affected requests with compatible settings for both streaming and standard responses.
  - Prevents unnecessary retries for unrelated request errors and rate limits.
  - Reports persistent provider rejections with clearer error classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->