### PR TITLE
perf: improve core web vitals

### DIFF
--- a/apps/code/src/app/dashboard/components/ActivityHeatmap.tsx
+++ b/apps/code/src/app/dashboard/components/ActivityHeatmap.tsx
@@ -195,10 +195,13 @@ export default function ActivityHeatmap({ projectId }: ActivityHeatmapProps) {
 	}
 
 	return (
-		<section className="rounded-2xl border bg-card overflow-hidden">
-			<div className="flex flex-col gap-1 border-b bg-gradient-to-br from-card to-card/40 px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
+		<section
+			className="rounded-2xl border bg-card overflow-hidden"
+			aria-busy={isLoading}
+		>
+			<div className="flex min-h-[132px] flex-col gap-1 border-b bg-gradient-to-br from-card to-card/40 px-6 py-5 sm:min-h-0 sm:flex-row sm:items-center sm:justify-between">
 				<div className="flex items-start gap-3">
-					<div className="mt-0.5 flex h-9 w-9 items-center justify-center rounded-lg bg-emerald-500/10 ring-1 ring-emerald-500/20">
+					<div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10 ring-1 ring-emerald-500/20">
 						<Activity className="h-4 w-4 text-emerald-500" />
 					</div>
 					<div>
@@ -223,23 +226,22 @@ export default function ActivityHeatmap({ projectId }: ActivityHeatmapProps) {
 
 			<div className="overflow-x-auto px-6 py-6">
 				<div className="mx-auto flex w-fit flex-col gap-1.5">
+					<div className="flex h-3.5 gap-[3px] pl-7 text-[10px] text-muted-foreground">
+						{weeks.map((_, w) => {
+							const mark = monthMarks.find((m) => m.weekIndex === w);
+							return (
+								<div key={w} className="w-3 flex-shrink-0">
+									{mark?.label ?? ""}
+								</div>
+							);
+						})}
+					</div>
 					{isLoading ? (
-						<div className="flex h-[126px] items-center text-xs text-muted-foreground">
+						<div className="flex h-[131px] items-center justify-center text-xs text-muted-foreground">
 							Loading your activity…
 						</div>
 					) : (
 						<>
-							<div className="flex h-3.5 gap-[3px] pl-7 text-[10px] text-muted-foreground">
-								{weeks.map((_, w) => {
-									const mark = monthMarks.find((m) => m.weekIndex === w);
-									return (
-										<div key={w} className="w-3 flex-shrink-0">
-											{mark?.label ?? ""}
-										</div>
-									);
-								})}
-							</div>
-
 							<div className="flex gap-[3px]">
 								<div className="flex w-6 flex-shrink-0 flex-col gap-[3px] pr-1 text-[10px] text-muted-foreground">
 									<div className="h-3" />

--- a/apps/playground/e2e/lounge-first-paint.pw.ts
+++ b/apps/playground/e2e/lounge-first-paint.pw.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+
+test("signed-out welcome is visible before hydration", async ({
+	browser,
+	baseURL,
+}) => {
+	const context = await browser.newContext({
+		baseURL,
+		javaScriptEnabled: false,
+		viewport: { width: 390, height: 844 },
+	});
+	const page = await context.newPage();
+	await page.goto("/?model=auto");
+	const welcome = page.getByRole("dialog");
+	await expect(welcome).toBeVisible();
+	await expect(
+		welcome.getByRole("link", { name: "Start free" }),
+	).toHaveAttribute("href", "/signup?returnUrl=%2F%3Fmodel%3Dauto");
+	await context.close();
+});
+
+test("a pending session does not show the signed-out welcome", async ({
+	context,
+	page,
+	baseURL,
+}) => {
+	await context.addCookies([
+		{ name: "better-auth.session_token", value: "test-session", url: baseURL! },
+	]);
+	await page.route("**/user/me", () => {});
+	await page.goto("/");
+	await expect(page.getByRole("combobox").first()).toBeVisible();
+	await expect(page.getByRole("dialog")).toHaveCount(0);
+});

--- a/apps/playground/src/app/playground-shell.tsx
+++ b/apps/playground/src/app/playground-shell.tsx
@@ -264,6 +264,10 @@ export async function renderPlaygroundShell({
 			) : null}
 			{isMember ? <PlaygroundSeoSection variant="chat" /> : null}
 			<ChatPageClient
+				initiallySignedOut={
+					!cookieStore.has("better-auth.session_token") &&
+					!cookieStore.has("__Secure-better-auth.session_token")
+				}
 				models={models.filter(
 					(m) =>
 						!m.output?.includes("embedding") && !m.output?.includes("rerank"),

--- a/apps/playground/src/components/playground/chat-page-client.tsx
+++ b/apps/playground/src/components/playground/chat-page-client.tsx
@@ -250,6 +250,7 @@ function buildEditedUserMessage(
 }
 
 interface ChatPageClientProps {
+	initiallySignedOut?: boolean;
 	models: ApiModel[];
 	providers: ApiProvider[];
 	organizations: Organization[];
@@ -292,6 +293,7 @@ function getSelectedMapping(
 }
 
 export default function ChatPageClient({
+	initiallySignedOut = false,
 	models,
 	providers,
 	organizations,
@@ -1134,7 +1136,7 @@ export default function ChatPageClient({
 	]);
 
 	const isAuthenticated = !isUserLoading && !!user;
-	const showAuthDialog = !isAuthenticated && !isUserLoading && !user;
+	const showAuthDialog = !user && (!isUserLoading || initiallySignedOut);
 
 	const returnUrl = useMemo(() => {
 		const search = searchParams.toString();

--- a/apps/ui/e2e/auth-first-paint.pw.ts
+++ b/apps/ui/e2e/auth-first-paint.pw.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "@playwright/test";
+
+for (const path of ["/login", "/signup"]) {
+	test(`${path} is visible before hydration`, async ({ browser, baseURL }) => {
+		const context = await browser.newContext({
+			baseURL,
+			javaScriptEnabled: false,
+			viewport: { width: 390, height: 844 },
+		});
+		const page = await context.newPage();
+		await page.goto(path);
+		const heading = page.getByRole("heading", { level: 1 });
+		await expect(heading).toBeVisible();
+		expect(
+			await heading.evaluate((element) => {
+				for (
+					let ancestor: Element | null = element;
+					ancestor;
+					ancestor = ancestor.parentElement
+				) {
+					if (getComputedStyle(ancestor).opacity === "0") {
+						return false;
+					}
+				}
+				return true;
+			}),
+		).toBe(true);
+		await context.close();
+	});
+}

--- a/apps/ui/e2e/dashboard-first-paint.pw.ts
+++ b/apps/ui/e2e/dashboard-first-paint.pw.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "@playwright/test";
+
+test("the default dashboard range renders before hydration", async ({
+	browser,
+	baseURL,
+}) => {
+	const context = await browser.newContext({
+		baseURL,
+		javaScriptEnabled: false,
+	});
+	const apiUrl = process.env.PW_API_URL ?? "http://localhost:4002";
+	const login = await context.request.post(`${apiUrl}/auth/sign-in/email`, {
+		data: { email: "admin@example.com", password: "admin@example.com" },
+	});
+	expect(login.ok()).toBe(true);
+	const page = await context.newPage();
+	await page.goto("/dashboard/test-org-id/test-project-id");
+	const requests = page
+		.locator(".min-w-0.flex-1")
+		.filter({ has: page.getByText("Total Requests", { exact: true }) })
+		.last();
+	await expect(requests.locator("p.tabular-nums")).toHaveText(/^[\d,]+$/);
+	await context.close();
+});

--- a/apps/ui/e2e/model-directory.pw.ts
+++ b/apps/ui/e2e/model-directory.pw.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "@playwright/test";
+
+for (const width of [390, 1440]) {
+	test(`model filters stay local and survive reload at ${width}px`, async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width, height: 900 });
+		await page.goto("/models?view=grid&page=2&from=devpass#directory");
+		const search = page.getByPlaceholder("Search models...");
+		const cards = page.locator('[data-slot="card"][role="link"]');
+		await expect(cards.first()).toBeVisible();
+		const secondPageModel = await cards.first().locator("h2").innerText();
+
+		const navigations: string[] = [];
+		page.on("request", (request) => {
+			const url = new URL(request.url());
+			if (
+				url.pathname === "/models" &&
+				url.searchParams.get("from") === "devpass" &&
+				request.headers().rsc === "1" &&
+				!request.headers()["next-router-prefetch"]
+			) {
+				navigations.push(request.url());
+			}
+		});
+
+		await search.pressSequentially("claude");
+		await expect(search).toHaveValue("claude");
+		await expect(page).toHaveURL(/q=claude/);
+		await expect(page).not.toHaveURL(/page=2/);
+		await expect(cards.first().locator("h2")).toContainText(/claude/i);
+		await expect(page).toHaveURL(/from=devpass/);
+		await expect(page).toHaveURL(/#directory$/);
+
+		await page.getByRole("button", { name: /^Filters/ }).click();
+		await expect(page).toHaveURL(/filters=1/);
+		expect(navigations).toEqual([]);
+
+		await page.reload();
+		await expect(search).toHaveValue("claude");
+		await expect(cards.first().locator("h2")).toContainText(/claude/i);
+		await page.getByRole("button", { name: "Clear", exact: true }).click();
+		await expect(search).toHaveValue("");
+		await expect(page).not.toHaveURL(/[?&]q=/);
+		await expect(page).toHaveURL(/from=devpass/);
+
+		await expect(cards).toHaveCount(12);
+		const pagination = page.getByRole("navigation", { name: "Pagination" });
+		await pagination.getByRole("button", { name: "Next", exact: true }).click();
+		await expect(page).toHaveURL(/page=2/);
+		await expect(cards.first().locator("h2")).toHaveText(secondPageModel);
+		await pagination
+			.getByRole("button", { name: "Previous", exact: true })
+			.click();
+		await expect(page).not.toHaveURL(/page=2/);
+		await expect(cards.first().locator("h2")).not.toHaveText(secondPageModel);
+
+		await page.getByRole("button", { name: "Table", exact: true }).click();
+		await expect(page).toHaveURL(/view=table/);
+		const rows = page.locator("tbody > tr");
+		await expect(rows).toHaveCount(50);
+		const firstRow = await rows.first().innerText();
+		await pagination.getByRole("button", { name: "Next", exact: true }).click();
+		await expect(page).toHaveURL(/page=2/);
+		await expect(rows.first()).not.toHaveText(firstRow, { useInnerText: true });
+		await pagination
+			.getByRole("button", { name: "Previous", exact: true })
+			.click();
+		await expect(rows.first()).toHaveText(firstRow, { useInnerText: true });
+		expect(navigations).toEqual([]);
+	});
+}

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/page.tsx
@@ -61,6 +61,7 @@ export default async function Dashboard({
 	return (
 		<DashboardClient
 			initialActivityData={initialActivityData ?? undefined}
+			initialActivityRange={{ from: fromParam, to: toParam }}
 			initialActivityTimeZone={timeZone}
 		/>
 	);

--- a/apps/ui/src/app/login/page.tsx
+++ b/apps/ui/src/app/login/page.tsx
@@ -3,7 +3,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { WebAuthnAbortService } from "@simplewebauthn/browser";
 import { useQueryClient } from "@tanstack/react-query";
-import { motion } from "framer-motion";
 import {
 	Loader2,
 	KeySquare,
@@ -239,12 +238,7 @@ export default function Login() {
 	}
 
 	return (
-		<motion.div
-			initial={{ opacity: 0, y: 12 }}
-			animate={{ opacity: 1, y: 0 }}
-			transition={{ duration: 0.4, ease: "easeOut" }}
-			className="mx-auto w-full max-w-[400px]"
-		>
+		<div className="mx-auto w-full max-w-[400px]">
 			{/* Mobile brand header */}
 			<div className="mb-6 lg:hidden">
 				<p className="text-sm font-medium uppercase tracking-widest text-primary">
@@ -403,6 +397,6 @@ export default function Login() {
 					Don&apos;t have an account? Sign up
 				</Link>
 			</p>
-		</motion.div>
+		</div>
 	);
 }

--- a/apps/ui/src/app/signup/page.tsx
+++ b/apps/ui/src/app/signup/page.tsx
@@ -2,7 +2,6 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
-import { motion } from "framer-motion";
 import { Loader2, Eye, EyeOff } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -144,12 +143,7 @@ export default function Signup() {
 	}
 
 	return (
-		<motion.div
-			initial={{ opacity: 0, y: 12 }}
-			animate={{ opacity: 1, y: 0 }}
-			transition={{ duration: 0.4, ease: "easeOut" }}
-			className="mx-auto w-full max-w-[400px]"
-		>
+		<div className="mx-auto w-full max-w-[400px]">
 			{/* Mobile brand header */}
 			<div className="mb-6 lg:hidden">
 				<p className="text-sm font-medium uppercase tracking-widest text-primary">
@@ -316,6 +310,6 @@ export default function Signup() {
 					Already have an account? Sign in
 				</Link>
 			</p>
-		</motion.div>
+		</div>
 	);
 }

--- a/apps/ui/src/components/dashboard/dashboard-client.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-client.tsx
@@ -74,6 +74,7 @@ import type { ActivitT } from "@/types/activity";
 
 interface DashboardClientProps {
 	initialActivityData?: ActivitT;
+	initialActivityRange?: { from: string; to: string };
 	/** Zone the server fetched `initialActivityData` in, so the client can tell
 	 *  whether it still matches the zone it now wants to render. */
 	initialActivityTimeZone?: string;
@@ -222,6 +223,7 @@ function StatCell({
 
 export function DashboardClient({
 	initialActivityData,
+	initialActivityRange,
 	initialActivityTimeZone,
 }: DashboardClientProps) {
 	const router = useRouter();
@@ -285,13 +287,12 @@ export function DashboardClient({
 		},
 		{
 			enabled: !!selectedProject?.id,
-			// Only seed the server payload when it was bucketed in the zone this
-			// query asks for. The client can detect a different zone than the
-			// cookie held (first visit, or the machine moved), and a mismatched
-			// payload would sit there labelled as the new zone for the whole
-			// staleTime.
+			// Reuse the server payload for the matching range and time zone,
+			// including the default range before dates are added to the URL.
 			initialData:
-				searchParams.get("from") && initialActivityTimeZone === displayTimeZone
+				initialActivityRange?.from === fromStr &&
+				initialActivityRange.to === toStr &&
+				initialActivityTimeZone === displayTimeZone
 					? initialActivityData
 					: undefined,
 			refetchOnWindowFocus: false,

--- a/apps/ui/src/components/landing/hero-rsc.tsx
+++ b/apps/ui/src/components/landing/hero-rsc.tsx
@@ -1,18 +1,26 @@
+import { Suspense } from "react";
+
 import { GitHubStars } from "./github-stars";
 import { Hero } from "./hero";
 import { allMigrations } from "content-collections";
 
-export const HeroRSC = async ({
+export const HeroRSC = ({
 	navbarOnly,
 	sticky = true,
 }: {
 	navbarOnly?: boolean;
 	sticky?: boolean;
 }) => {
+	const githubStars = (
+		<Suspense fallback={<span className="block h-8 w-16" aria-hidden />}>
+			<GitHubStars />
+		</Suspense>
+	);
+
 	if (navbarOnly) {
 		return (
 			<Hero navbarOnly sticky={sticky}>
-				<GitHubStars />
+				{githubStars}
 			</Hero>
 		);
 	}
@@ -31,7 +39,7 @@ export const HeroRSC = async ({
 
 	return (
 		<Hero navbarOnly={navbarOnly} sticky={sticky} migrations={migrations}>
-			<GitHubStars />
+			{githubStars}
 		</Hero>
 	);
 };

--- a/packages/shared/src/components/models-directory/all-models.tsx
+++ b/packages/shared/src/components/models-directory/all-models.tsx
@@ -45,7 +45,13 @@ import {
 } from "lucide-react";
 import Link from "next/link.js";
 import { usePathname, useRouter, useSearchParams } from "next/navigation.js";
-import React, { useMemo, useState, useCallback, useEffect } from "react";
+import React, {
+	useMemo,
+	useState,
+	useCallback,
+	useEffect,
+	useDeferredValue,
+} from "react";
 
 import { getProviderIcon } from "@/components/provider-icons";
 import { Badge } from "@/components/ui/badge";
@@ -843,7 +849,8 @@ const ModelTableRow = React.memo(
 	},
 );
 
-const MODELS_PER_PAGE = 50;
+const TABLE_ROWS_PER_PAGE = 50;
+const GRID_MODELS_PER_PAGE = 12;
 
 export function AllModels({
 	children,
@@ -886,6 +893,7 @@ export function AllModels({
 
 	// Search and filter states
 	const [searchQuery, setSearchQuery] = useState(searchParams.get("q") ?? "");
+	const deferredSearchQuery = useDeferredValue(searchQuery);
 	const [showFilters, setShowFilters] = useState(
 		searchParams.get("filters") === "1",
 	);
@@ -1022,7 +1030,8 @@ export function AllModels({
 
 	const updateUrlWithFilters = useCallback(
 		(newParams: Record<string, string | undefined>) => {
-			const params = new URLSearchParams(searchParams.toString());
+			const url = new URL(window.location.href);
+			const params = url.searchParams;
 			Object.entries(newParams).forEach(([key, value]) => {
 				if (value !== undefined && value !== "") {
 					params.set(key, value);
@@ -1030,9 +1039,10 @@ export function AllModels({
 					params.delete(key);
 				}
 			});
-			router.replace(`?${params.toString()}`, { scroll: false });
+			// Filtering is local; avoid refetching the catalogue on each keystroke.
+			window.history.replaceState(null, "", url);
 		},
-		[router, searchParams],
+		[],
 	);
 
 	const setStatusFilter = useCallback(
@@ -1125,7 +1135,7 @@ export function AllModels({
 
 		const filteredModels = preFilteredModels.filter((model) => {
 			// Improved fuzzy search: token-based, accent-insensitive, ignores punctuation
-			if (searchQuery) {
+			if (deferredSearchQuery) {
 				const normalize = (str: string) =>
 					str
 						.toLowerCase()
@@ -1133,7 +1143,7 @@ export function AllModels({
 						.replace(/[\u0300-\u036f]/g, "") // strip accents
 						.replace(/[^a-z0-9]/g, "");
 
-				const queryTokens = searchQuery
+				const queryTokens = deferredSearchQuery
 					.trim()
 					.toLowerCase()
 					.split(/\s+/)
@@ -1152,7 +1162,7 @@ export function AllModels({
 					...providerStrings,
 				];
 				const haystack = normalize(haystackParts.join(" "));
-				const normalizedQuery = normalize(searchQuery);
+				const normalizedQuery = normalize(deferredSearchQuery);
 
 				const containsAllTokens = queryTokens.every((t: string) =>
 					haystack.includes(t),
@@ -1432,7 +1442,7 @@ export function AllModels({
 			.sort((a, b) => compareSortValues(a.key, b.key, sortDirection))
 			.map(({ model }) => model);
 	}, [
-		searchQuery,
+		deferredSearchQuery,
 		filters,
 		priceUnit,
 		sortField,
@@ -1576,9 +1586,9 @@ export function AllModels({
 		1,
 		Math.floor(Number(searchParams.get("page")) || 1),
 	);
-	const totalTablePages = Math.ceil(flattenedRows.length / MODELS_PER_PAGE);
+	const totalTablePages = Math.ceil(flattenedRows.length / TABLE_ROWS_PER_PAGE);
 	const totalGridPages = Math.ceil(
-		modelsWithProviders.length / MODELS_PER_PAGE,
+		modelsWithProviders.length / GRID_MODELS_PER_PAGE,
 	);
 	const totalPages = viewMode === "table" ? totalTablePages : totalGridPages;
 	const safePage = Math.min(currentPage, Math.max(1, totalPages));
@@ -1592,13 +1602,13 @@ export function AllModels({
 	}, [currentPage, safePage, updateUrlWithFilters]);
 
 	const paginatedFlattenedRows = flattenedRows.slice(
-		(safePage - 1) * MODELS_PER_PAGE,
-		safePage * MODELS_PER_PAGE,
+		(safePage - 1) * TABLE_ROWS_PER_PAGE,
+		safePage * TABLE_ROWS_PER_PAGE,
 	);
 
 	const paginatedModels = modelsWithProviders.slice(
-		(safePage - 1) * MODELS_PER_PAGE,
-		safePage * MODELS_PER_PAGE,
+		(safePage - 1) * GRID_MODELS_PER_PAGE,
+		safePage * GRID_MODELS_PER_PAGE,
 	);
 
 	const goToPage = useCallback(
@@ -2637,7 +2647,7 @@ export function AllModels({
 											onChange={(e) => {
 												const value = e.target.value;
 												setSearchQuery(value);
-												updateUrlWithFilters({ q: value ?? undefined });
+												updateUrlWithFilters({ q: value, page: undefined });
 											}}
 											className="pl-8"
 										/>


### PR DESCRIPTION
Cold loads waited for client rendering, model searches triggered repeated catalogue navigation, and the DevPass activity loader moved surrounding content. The affected routes were prioritized using PostHog traffic and Web Vitals.

- Render login, signup, and the signed-out Lounge welcome in the initial HTML.
- Reuse dashboard activity for the matching date range and time zone, including the default range.
- Keep model filters local, defer search results, and paginate grid views in groups of 12; table views retain 50 rows.
- Keep GitHub star fetching out of the page’s loading boundary.
- Reserve the activity header and heatmap dimensions while data loads.

Production-build lab comparison, cold browser cache, 4× CPU slowdown, 150 ms latency, 1.6 Mbps download / 0.75 Mbps upload. Mobile: 390×844; desktop: 1440×900. Analytics disabled in both runs. Light-theme measurements below; both themes checked.

| Page | Metric | Before | After |
| --- | --- | ---: | ---: |
| Models, mobile | INP | 392 ms | 136 ms |
| Login, mobile | LCP | 6,880 ms | 1,740 ms |
| Signup, mobile | LCP | 6,792 ms | 1,732 ms |
| Dashboard, desktop | LCP | 7,568 ms | 1,796 ms |
| Lounge, mobile | LCP | 9,424 ms | 1,352 ms |
| DevPass dashboard, desktop | CLS | 0.113 | <0.001 |

Desktop directory LCP ranged from 2.16–2.57 s in the final cold runs. These are lab measurements; field improvement needs confirmation after deployment.

Validation: `pnpm format`; full `pnpm build`; 6,222 unit tests; 10 browser checks covering initial HTML, authentication, date ranges, filters, and pagination. Delayed heatmap responses kept the same height at 320, 390, 640, and 1440 px with empty and populated activity.

Screenshots use local seeded data. Login and signup show the initial HTML with JavaScript disabled.

<details>
<summary>Models</summary>

| View | Before | After |
| --- | --- | --- |
| Desktop, light | <img width="600" alt="Models, desktop, light, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/models-desktop-light-before.png" /> | <img width="600" alt="Models, desktop, light, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/models-desktop-light-after.png" /> |
| Desktop, dark | <img width="600" alt="Models, desktop, dark, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/models-desktop-dark-before.png" /> | <img width="600" alt="Models, desktop, dark, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/models-desktop-dark-after.png" /> |
| Mobile, light | <img width="240" alt="Models, mobile, light, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/models-mobile-light-before.png" /> | <img width="240" alt="Models, mobile, light, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/models-mobile-light-after.png" /> |
| Mobile, dark | <img width="240" alt="Models, mobile, dark, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/models-mobile-dark-before.png" /> | <img width="240" alt="Models, mobile, dark, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/models-mobile-dark-after.png" /> |

</details>

<details>
<summary>Dashboard</summary>

| View | Before | After |
| --- | --- | --- |
| Desktop, light | <img width="600" alt="Dashboard, desktop, light, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/dashboard-desktop-light-before.png" /> | <img width="600" alt="Dashboard, desktop, light, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/dashboard-desktop-light-after.png" /> |
| Desktop, dark | <img width="600" alt="Dashboard, desktop, dark, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/dashboard-desktop-dark-before.png" /> | <img width="600" alt="Dashboard, desktop, dark, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/dashboard-desktop-dark-after.png" /> |

</details>

<details>
<summary>DevPass dashboard</summary>

| View | Before | After |
| --- | --- | --- |
| Desktop, light | <img width="600" alt="DevPass dashboard, desktop, light, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/devpass-dashboard-desktop-light-before.png" /> | <img width="600" alt="DevPass dashboard, desktop, light, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/devpass-dashboard-desktop-light-after.png" /> |
| Desktop, dark | <img width="600" alt="DevPass dashboard, desktop, dark, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/devpass-dashboard-desktop-dark-before.png" /> | <img width="600" alt="DevPass dashboard, desktop, dark, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/devpass-dashboard-desktop-dark-after.png" /> |
| Mobile, light | <img width="240" alt="DevPass dashboard, mobile, light, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/devpass-dashboard-mobile-light-before.png" /> | <img width="240" alt="DevPass dashboard, mobile, light, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/devpass-dashboard-mobile-light-after.png" /> |
| Mobile, dark | <img width="240" alt="DevPass dashboard, mobile, dark, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/devpass-dashboard-mobile-dark-before.png" /> | <img width="240" alt="DevPass dashboard, mobile, dark, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/devpass-dashboard-mobile-dark-after.png" /> |

</details>

<details>
<summary>Signup, before hydration</summary>

| View | Before | After |
| --- | --- | --- |
| Mobile, light | <img width="240" alt="Signup, before hydration, mobile, light, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/signup-mobile-light-before.png" /> | <img width="240" alt="Signup, before hydration, mobile, light, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/signup-mobile-light-after.png" /> |
| Mobile, dark | <img width="240" alt="Signup, before hydration, mobile, dark, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/signup-mobile-dark-before.png" /> | <img width="240" alt="Signup, before hydration, mobile, dark, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/signup-mobile-dark-after.png" /> |

</details>

<details>
<summary>Login, before hydration</summary>

| View | Before | After |
| --- | --- | --- |
| Mobile, light | <img width="240" alt="Login, before hydration, mobile, light, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/login-mobile-light-before.png" /> | <img width="240" alt="Login, before hydration, mobile, light, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/login-mobile-light-after.png" /> |
| Mobile, dark | <img width="240" alt="Login, before hydration, mobile, dark, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/login-mobile-dark-before.png" /> | <img width="240" alt="Login, before hydration, mobile, dark, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/login-mobile-dark-after.png" /> |

</details>

<details>
<summary>Homepage</summary>

| View | Before | After |
| --- | --- | --- |
| Desktop, light | <img width="600" alt="Homepage, desktop, light, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/home-desktop-light-before.png" /> | <img width="600" alt="Homepage, desktop, light, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/home-desktop-light-after.png" /> |
| Desktop, dark | <img width="600" alt="Homepage, desktop, dark, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/home-desktop-dark-before.png" /> | <img width="600" alt="Homepage, desktop, dark, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/6fa14a5c033168a5241836f8c8d05d237de80a7d/home-desktop-dark-after.png" /> |

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved first-load rendering for signed-out users, login, signup, and dashboard pages, including clearer loading behavior.
  - Dashboard activity data now displays the selected date range immediately.
  - Model directory search and filtering feel more responsive without unnecessary page reloads.
  - Model directory pagination now adapts to grid and table views, while preserving filters and search state after reloads.
  - Updated activity heatmap loading layout for better responsiveness and accessibility.
  - Simplified login and signup page transitions for a more immediate display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->