### PR TITLE
docs(blog): mention dedicated inference capacity

### DIFF
--- a/apps/ui/src/content/blog/2025-05-10-custom-providers.md
+++ b/apps/ui/src/content/blog/2025-05-10-custom-providers.md
@@ -43,6 +43,8 @@ curl -X POST "https://api.llmgateway.io/v1/chat/completions" \
 
 Your custom provider appears in your analytics dashboard alongside OpenAI, Anthropic, and others—giving you a unified view of all your LLM usage.
 
+For sustained production workloads, it's also worth evaluating dedicated inference capacity. Providers like Morph offer [dedicated inference capacity](https://www.morphllm.com/dedicated-inference?utm_source=llmgateway.io) with reserved capacity and managed model serving. Compare the reservation against your actual usage, including idle time, to determine whether it fits your workload.
+
 For setup details and troubleshooting, see the [Custom Providers documentation](https://docs.llmgateway.io/features/custom-providers).
 
 <BlogCta variant="gateway" location="bottom" />


### PR DESCRIPTION
## Problem

The custom providers article covers connecting self-hosted or OpenAI-compatible endpoints but says nothing about capacity options for sustained production workloads.

## Approach

Add one paragraph to `apps/ui/src/content/blog/2025-05-10-custom-providers.md` noting that dedicated inference capacity is worth evaluating for sustained workloads, linking "dedicated inference capacity" to Morph's dedicated inference page, and advising readers to compare the reservation (including idle time) against actual usage.

Content-only markdown change, so no screenshots per repo convention. Verified with `pnpm format` and a full `apps/ui` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RU7mHaj3FJ8VhpRwkGEJw

---
_Generated by [Claude Code](https://claude.ai/code/session_018RU7mHaj3FJ8VhpRwkGEJw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for evaluating dedicated inference capacity for sustained production workloads.
  - Documented considerations for comparing reserved capacity with actual usage and idle time.
  - Included information about managed serving options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->