### PR TITLE
fix(worker): backfill provider-key model stats

### DIFF
--- a/apps/worker/src/services/global-stats-aggregator.spec.ts
+++ b/apps/worker/src/services/global-stats-aggregator.spec.ts
@@ -15,7 +15,10 @@ import {
 	user,
 } from "@llmgateway/db";
 
-import { aggregateWindowIntoStats } from "./global-stats-aggregator.js";
+import {
+	aggregateProviderKeyWindowIntoStats,
+	aggregateWindowIntoStats,
+} from "./global-stats-aggregator.js";
 
 const HOUR_MS = 60 * 60 * 1000;
 
@@ -75,7 +78,10 @@ describe("global stats aggregation", () => {
 		});
 
 	const aggregate = () =>
-		db.transaction((tx) => aggregateWindowIntoStats(tx, WINDOW_START, HOUR_MS));
+		db.transaction(async (tx) => {
+			await aggregateWindowIntoStats(tx, WINDOW_START, HOUR_MS);
+			await aggregateProviderKeyWindowIntoStats(tx, WINDOW_START, HOUR_MS);
+		});
 
 	const readModelStats = () =>
 		db

--- a/apps/worker/src/services/global-stats-aggregator.ts
+++ b/apps/worker/src/services/global-stats-aggregator.ts
@@ -60,7 +60,12 @@ if (DAY_MS % BUCKET_MS !== 0) {
 	);
 }
 
-const STATE_ROW_ID = "singleton";
+type AggregationScope = "global" | "provider-key";
+
+const STATE_ROW_IDS = {
+	global: "singleton",
+	"provider-key": "provider-key-model",
+} as const;
 
 // Columns the aggregator sums into the daily totals. Excludes id / createdAt
 // / updatedAt / dimension columns.
@@ -256,6 +261,22 @@ export async function aggregateWindowIntoStats(
 				},
 			});
 	}
+}
+
+export async function aggregateProviderKeyWindowIntoStats(
+	database: Tx,
+	windowStart: Date,
+	windowMs: number,
+): Promise<void> {
+	const startTimestamp = formatUTCTimestamp(windowStart);
+	const endTimestamp = formatUTCTimestamp(
+		new Date(windowStart.getTime() + windowMs),
+	);
+	const dayTimestamp = formatUTCTimestamp(floorToDay(windowStart));
+	const window = and(
+		sql`${log.createdAt} >= ${startTimestamp}::timestamp`,
+		sql`${log.createdAt} < ${endTimestamp}::timestamp`,
+	);
 
 	// Per-credential model split. Requests served by env-var credentials carry
 	// no providerKeyId and are skipped, exactly like providerKeyHourlyStats.
@@ -316,174 +337,241 @@ export async function aggregateWindowIntoStats(
 	}
 }
 
-async function readState() {
-	const [row] = await db
-		.select()
-		.from(globalAggregationState)
-		.where(eq(globalAggregationState.id, STATE_ROW_ID))
-		.limit(1);
-	return row;
+async function readState(scope: AggregationScope) {
+	return await db.query.globalAggregationState.findFirst({
+		where: { id: STATE_ROW_IDS[scope] },
+	});
 }
 
-async function setLastProcessedHour(database: Tx, hour: Date): Promise<void> {
+async function setLastProcessedHour(
+	database: Tx,
+	hour: Date,
+	scope: AggregationScope,
+): Promise<void> {
 	await database
 		.insert(globalAggregationState)
-		.values({ id: STATE_ROW_ID, lastProcessedHour: hour })
+		.values({ id: STATE_ROW_IDS[scope], lastProcessedHour: hour })
 		.onConflictDoUpdate({
 			target: globalAggregationState.id,
 			set: { lastProcessedHour: hour, updatedAt: new Date() },
 		});
 }
 
-async function setLastSafetyNetDay(day: Date): Promise<void> {
-	await db
+async function setLastSafetyNetDay(
+	database: Tx,
+	day: Date,
+	scope: AggregationScope,
+): Promise<void> {
+	await database
 		.insert(globalAggregationState)
-		.values({ id: STATE_ROW_ID, lastSafetyNetDay: day })
+		.values({ id: STATE_ROW_IDS[scope], lastSafetyNetDay: day })
 		.onConflictDoUpdate({
 			target: globalAggregationState.id,
 			set: { lastSafetyNetDay: day, updatedAt: new Date() },
 		});
 }
 
-// Recompute a closed day from scratch: wipe its rows, then re-aggregate each
-// of its 24 hours into the now-empty bucket. Catches late-arriving logs that
-// the incremental path missed. Walks in 1-hour chunks regardless of the
-// configured BUCKET_MS so the safety net keeps a bounded number of queries
-// (24/day) even when small dev buckets are in use.
-//
-// Returns true on full completion. Returns false if stop was requested
-// mid-walk; the caller must NOT mark the day as recomputed in that case so the
-// next worker start retries from the partially-recomputed state.
-async function recomputeDayFully(day: Date): Promise<boolean> {
-	const dayStr = formatUTCTimestamp(day);
+class AggregationStoppedError extends Error {}
 
-	await db.transaction(async (tx) => {
+// Keep replacement and its checkpoint atomic, including shutdown mid-day.
+async function recomputeDayFully(
+	tx: Tx,
+	day: Date,
+	scope: AggregationScope,
+): Promise<void> {
+	const dayStr = formatUTCTimestamp(day);
+	if (scope === "global") {
 		await tx
 			.delete(globalModelStats)
 			.where(sql`${globalModelStats.dayTimestamp} = ${dayStr}::timestamp`);
 		await tx
 			.delete(globalSourceStats)
 			.where(sql`${globalSourceStats.dayTimestamp} = ${dayStr}::timestamp`);
+	} else {
 		await tx
 			.delete(globalProviderKeyModelStats)
 			.where(
 				sql`${globalProviderKeyModelStats.dayTimestamp} = ${dayStr}::timestamp`,
 			);
-	});
+	}
 
 	for (let h = 0; h < 24; h++) {
 		if (isStopRequested()) {
-			logger.info(
-				`[global-safety-net] Stop requested mid-recompute of ${dayStr}, leaving lastSafetyNetDay unchanged so next start retries`,
-			);
-			return false;
+			throw new AggregationStoppedError();
 		}
 		const hour = new Date(day.getTime() + h * HOUR_MS); // eslint-disable-line no-mixed-operators
-		await db.transaction(async (tx) => {
-			await aggregateWindowIntoStats(tx, hour, HOUR_MS);
-		});
+		await AGGREGATORS[scope](tx, hour, HOUR_MS);
 	}
-
-	return true;
 }
 
-async function runSafetyNetIfNeeded(now: Date): Promise<void> {
+async function runSafetyNetIfNeeded(
+	now: Date,
+	scope: AggregationScope,
+): Promise<void> {
 	const todayStart = floorToDay(now);
-
 	const yesterdayStart = new Date(todayStart.getTime() - DAY_MS);
+	const needsSafetyNet = (state: Awaited<ReturnType<typeof readState>>) =>
+		state?.lastProcessedHour &&
+		state.lastProcessedHour >= todayStart &&
+		(!state.lastSafetyNetDay || state.lastSafetyNetDay < yesterdayStart);
 
-	const state = await readState();
-	if (state?.lastSafetyNetDay && state.lastSafetyNetDay >= yesterdayStart) {
+	// Each scope must finish yesterday before its safety net can replace it.
+	if (!needsSafetyNet(await readState(scope))) {
 		return;
 	}
 
-	// Defer the safety net while the incremental walker is still catching up.
-	// If we wiped + recomputed yesterday now and the walker reached yesterday
-	// later, its ADD-upserts would double the row. The walker has finished
-	// yesterday once its watermark crosses todayStart.
-	if (!state?.lastProcessedHour || state.lastProcessedHour < todayStart) {
-		logger.debug(
-			`[global-safety-net] Walker has not reached today yet (watermark=${state?.lastProcessedHour ? formatUTCTimestamp(state.lastProcessedHour) : "none"}), deferring`,
+	await db.transaction(async (tx) => {
+		const [state] = await tx
+			.select()
+			.from(globalAggregationState)
+			.where(eq(globalAggregationState.id, STATE_ROW_IDS[scope]))
+			.for("update");
+		if (!needsSafetyNet(state)) {
+			return;
+		}
+
+		logger.info(
+			`[global-${scope}-safety-net] Recomputing ${formatUTCTimestamp(yesterdayStart)} from logs`,
 		);
-		return;
-	}
-
-	logger.info(
-		`[global-safety-net] Recomputing ${formatUTCTimestamp(yesterdayStart)} from logs`,
-	);
-
-	const completed = await recomputeDayFully(yesterdayStart);
-	if (!completed) {
-		return;
-	}
-
-	await setLastSafetyNetDay(yesterdayStart);
-
-	logger.info(
-		`[global-safety-net] Recompute complete for ${formatUTCTimestamp(yesterdayStart)}`,
-	);
+		await recomputeDayFully(tx, yesterdayStart, scope);
+		await setLastSafetyNetDay(tx, yesterdayStart, scope);
+	});
 }
 
-export async function processClosedHours(): Promise<void> {
+const AGGREGATORS = {
+	global: aggregateWindowIntoStats,
+	"provider-key": aggregateProviderKeyWindowIntoStats,
+};
+
+async function processScopeClosedHours(
+	now: Date,
+	scope: AggregationScope,
+): Promise<boolean> {
 	const start = Date.now();
-	const now = new Date();
 	const settlingMs = SETTLING_BUFFER_MINUTES * 60 * 1000;
 	const cutoffMs = now.getTime() - BUCKET_MS - settlingMs;
 	const latestSafeBucket = floorToBucket(new Date(cutoffMs), BUCKET_MS);
 
-	const state = await readState();
+	const state = await readState(scope);
 
 	let nextBucket: Date;
 	if (state?.lastProcessedHour) {
 		nextBucket = new Date(state.lastProcessedHour.getTime() + BUCKET_MS);
+	} else if (scope === "provider-key") {
+		// No existing rollup has the key/model dimensions together. Retention
+		// clears log payloads but preserves attribution and metering columns.
+		const [oldest] = await db
+			.select({ createdAt: log.createdAt })
+			.from(log)
+			.where(isNotNull(log.providerKeyId))
+			.orderBy(log.createdAt)
+			.limit(1);
+		if (!oldest) {
+			return false;
+		}
+		nextBucket = floorToDay(oldest.createdAt);
+		logger.info(
+			`[global-provider-key] Backfilling from ${formatUTCTimestamp(nextBucket)}`,
+		);
 	} else {
 		const lookbackMs = INITIAL_LOOKBACK_DAYS * DAY_MS;
 		nextBucket = floorToBucket(new Date(now.getTime() - lookbackMs), BUCKET_MS);
 		logger.info(
-			`[global] No watermark, seeding from ${formatUTCTimestamp(nextBucket)}`,
+			`[global-${scope}] No watermark, seeding from ${formatUTCTimestamp(nextBucket)}`,
 		);
 	}
 
 	let processed = 0;
 	while (nextBucket <= latestSafeBucket && processed < MAX_BUCKETS_PER_TICK) {
 		if (isStopRequested()) {
-			logger.info(`[global] Stop requested, processed ${processed} buckets`);
+			logger.info(
+				`[global-${scope}] Stop requested, processed ${processed} buckets`,
+			);
 			break;
 		}
 
 		const bucket = nextBucket;
-		await db.transaction(async (tx) => {
-			await aggregateWindowIntoStats(tx, bucket, BUCKET_MS);
-			await setLastProcessedHour(tx, bucket);
+		const lastProcessed = await db.transaction(async (tx) => {
+			await tx
+				.insert(globalAggregationState)
+				.values({ id: STATE_ROW_IDS[scope] })
+				.onConflictDoNothing();
+			const [currentState] = await tx
+				.select()
+				.from(globalAggregationState)
+				.where(eq(globalAggregationState.id, STATE_ROW_IDS[scope]))
+				.for("update");
+			// Serialize replicas before touching ADD-style aggregates.
+			if (
+				currentState.lastProcessedHour &&
+				currentState.lastProcessedHour >= bucket
+			) {
+				return currentState.lastProcessedHour;
+			}
+
+			// The previous deployment may already have populated part of this
+			// day. Clear it once before replaying; commit each hour with its cursor.
+			if (
+				scope === "provider-key" &&
+				(!currentState.lastProcessedHour ||
+					bucket.getTime() === floorToDay(bucket).getTime())
+			) {
+				const dayStr = formatUTCTimestamp(floorToDay(bucket));
+				await tx
+					.delete(globalProviderKeyModelStats)
+					.where(
+						sql`${globalProviderKeyModelStats.dayTimestamp} = ${dayStr}::timestamp`,
+					);
+			}
+			await AGGREGATORS[scope](tx, bucket, BUCKET_MS);
+			await setLastProcessedHour(tx, bucket, scope);
+			return bucket;
 		});
 
 		processed++;
-		nextBucket = new Date(bucket.getTime() + BUCKET_MS);
+		nextBucket = new Date(lastProcessed.getTime() + BUCKET_MS);
 	}
 
 	if (processed >= MAX_BUCKETS_PER_TICK && nextBucket <= latestSafeBucket) {
 		logger.info(
-			`[global] Hit per-tick cap (${MAX_BUCKETS_PER_TICK}), more buckets pending — will continue next tick`,
+			`[global-${scope}] Hit per-tick cap (${MAX_BUCKETS_PER_TICK}), more buckets pending — will continue next tick`,
 		);
 	}
 
 	if (processed > 0) {
 		const lastProcessed = new Date(nextBucket.getTime() - BUCKET_MS);
 		logger.info(
-			`[global] Processed ${processed} closed bucket(s) in ${Date.now() - start}ms (watermark now ${formatUTCTimestamp(lastProcessed)})`,
+			`[global-${scope}] Processed ${processed} closed bucket(s) in ${Date.now() - start}ms (watermark now ${formatUTCTimestamp(lastProcessed)})`,
 		);
 	} else {
-		logger.debug("[global] No new closed buckets to process");
+		logger.debug(`[global-${scope}] No new closed buckets to process`);
 	}
 
 	if (!isStopRequested()) {
 		try {
-			await runSafetyNetIfNeeded(now);
+			await runSafetyNetIfNeeded(now, scope);
 		} catch (error) {
+			if (error instanceof AggregationStoppedError) {
+				return false;
+			}
 			logger.error(
-				"[global-safety-net] Failed",
+				`[global-${scope}-safety-net] Failed`,
 				error instanceof Error ? error : new Error(String(error)),
 			);
 		}
 	}
+	return nextBucket <= latestSafeBucket;
+}
+
+export async function processClosedHours(): Promise<boolean> {
+	const now = new Date();
+	const globalPending = await processScopeClosedHours(now, "global");
+	if (!isStopRequested()) {
+		const providerKeyPending = await processScopeClosedHours(
+			now,
+			"provider-key",
+		);
+		return globalPending || providerKeyPending;
+	}
+	return globalPending;
 }

--- a/apps/worker/src/services/global-stats-backfill.spec.ts
+++ b/apps/worker/src/services/global-stats-backfill.spec.ts
@@ -1,0 +1,277 @@
+import { randomUUID } from "node:crypto";
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { requestStop, resetShutdown } from "@/shutdown.js";
+
+import {
+	db,
+	eq,
+	globalAggregationState,
+	globalModelStats,
+	globalProviderKeyModelStats,
+	globalSourceStats,
+	log,
+} from "@llmgateway/db";
+
+import {
+	aggregateProviderKeyWindowIntoStats,
+	aggregateWindowIntoStats,
+	processClosedHours,
+} from "./global-stats-aggregator.js";
+
+const HOUR_MS = 3_600_000;
+const NOW = new Date("2026-06-15T12:10:00Z");
+const TODAY = new Date("2026-06-15T00:00:00Z");
+const YESTERDAY = new Date("2026-06-14T00:00:00Z");
+const LATEST_HOUR = new Date("2026-06-15T11:00:00Z");
+
+const insertLog = (
+	createdAt: Date,
+	providerKeyId: string | null = "backfill-key",
+) =>
+	db.insert(log).values({
+		requestId: randomUUID(),
+		createdAt,
+		organizationId: "backfill-org",
+		projectId: "backfill-project",
+		apiKeyId: "backfill-api-key",
+		providerKeyId,
+		requestedModel: "backfill-model",
+		usedModel: "backfill-model",
+		usedProvider: "openai",
+		mode: "credits",
+		usedMode: "credits",
+		cost: 0.25,
+		promptTokens: "10",
+		completionTokens: "20",
+		totalTokens: "30",
+		duration: 100,
+		responseSize: 0,
+		dataRetentionCleanedUp: true,
+		messages: null,
+		content: null,
+	});
+
+const readProviderStats = () =>
+	db.query.globalProviderKeyModelStats.findMany({
+		orderBy: { dayTimestamp: "asc" },
+	});
+
+const readProviderState = () =>
+	db.query.globalAggregationState.findFirst({
+		where: { id: "provider-key-model" },
+	});
+
+async function clearStats() {
+	await db.delete(globalAggregationState);
+	await db.delete(globalProviderKeyModelStats);
+	await db.delete(globalModelStats);
+	await db.delete(globalSourceStats);
+	await db.delete(log);
+}
+
+describe("provider-key global stats backfill", () => {
+	beforeEach(async () => {
+		vi.useFakeTimers({ toFake: ["Date"] });
+		vi.setSystemTime(NOW);
+		resetShutdown();
+		await clearStats();
+		await db.insert(globalAggregationState).values({
+			id: "singleton",
+			lastProcessedHour: LATEST_HOUR,
+			lastSafetyNetDay: YESTERDAY,
+		});
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+		resetShutdown();
+		await clearStats();
+	});
+
+	test("backfills beyond the global lookback without changing existing totals", async () => {
+		const oldHour = new Date("2026-05-01T08:00:00Z");
+		await insertLog(oldHour);
+		await db.transaction((tx) =>
+			aggregateWindowIntoStats(tx, oldHour, HOUR_MS),
+		);
+		const globalBefore = await db.query.globalModelStats.findMany();
+		const sourceBefore = await db.query.globalSourceStats.findMany();
+		const stateBefore = await db.query.globalAggregationState.findFirst({
+			where: { id: "singleton" },
+		});
+
+		expect(await processClosedHours()).toBe(true);
+
+		const [row] = await readProviderStats();
+		expect(row).toMatchObject({
+			dayTimestamp: new Date("2026-05-01T00:00:00Z"),
+			providerKeyId: "backfill-key",
+			orgKind: "unknown",
+			requestCount: 1,
+			cost: 0.25,
+			totalTokens: "30",
+		});
+		expect((await readProviderState())?.lastProcessedHour).toEqual(
+			new Date("2026-05-05T03:00:00Z"),
+		);
+		expect(await db.query.globalModelStats.findMany()).toEqual(globalBefore);
+		expect(await db.query.globalSourceStats.findMany()).toEqual(sourceBefore);
+		expect(
+			await db.query.globalAggregationState.findFirst({
+				where: { id: "singleton" },
+			}),
+		).toEqual(stateBefore);
+
+		await processClosedHours();
+		expect((await readProviderState())?.lastProcessedHour).toEqual(
+			new Date("2026-05-09T07:00:00Z"),
+		);
+		expect(await readProviderStats()).toEqual([row]);
+	});
+
+	test("replaces overlapping days and hands off to incremental aggregation", async () => {
+		await insertLog(new Date("2026-06-13T23:30:00Z"));
+		await insertLog(new Date("2026-06-14T00:30:00Z"));
+		await insertLog(new Date("2026-06-14T12:30:00Z"));
+		await insertLog(new Date("2026-06-15T00:30:00Z"));
+		await insertLog(new Date("2026-06-15T11:30:00Z"));
+		await insertLog(new Date("2026-06-15T11:45:00Z"), null);
+		await insertLog(new Date("2026-06-15T12:01:00Z"));
+		// Simulate the merged worker having populated only some recent hours.
+		await db.transaction(async (tx) => {
+			await aggregateProviderKeyWindowIntoStats(tx, YESTERDAY, HOUR_MS);
+			await aggregateProviderKeyWindowIntoStats(tx, TODAY, HOUR_MS);
+		});
+
+		expect(await processClosedHours()).toBe(false);
+		const rows = await readProviderStats();
+		expect(rows.map((row) => row.requestCount)).toEqual([1, 2, 2]);
+		expect(rows.map((row) => row.cost)).toEqual([0.25, 0.5, 0.5]);
+		expect(rows.map((row) => row.totalTokens)).toEqual(["30", "60", "60"]);
+		expect((await readProviderState())?.lastProcessedHour).toEqual(LATEST_HOUR);
+		expect((await readProviderState())?.lastSafetyNetDay).toEqual(YESTERDAY);
+
+		await processClosedHours();
+		expect(await readProviderStats()).toEqual(rows);
+
+		vi.setSystemTime(new Date("2026-06-15T13:04:00Z"));
+		await processClosedHours();
+		expect(await readProviderStats()).toEqual(rows);
+		vi.setSystemTime(new Date("2026-06-15T13:05:00Z"));
+		await processClosedHours();
+		expect((await readProviderStats()).map((row) => row.requestCount)).toEqual([
+			1, 2, 3,
+		]);
+	});
+
+	test("resumes a committed partial day after shutdown without clearing it again", async () => {
+		await insertLog(new Date("2026-06-15T00:30:00Z"));
+		await insertLog(new Date("2026-06-15T01:30:00Z"));
+		const transaction = db.transaction.bind(db);
+		vi.spyOn(db, "transaction").mockImplementationOnce(async (callback) => {
+			const result = await transaction(callback);
+			requestStop();
+			return result;
+		});
+
+		await processClosedHours();
+		expect((await readProviderState())?.lastProcessedHour).toEqual(TODAY);
+		expect((await readProviderStats())[0].requestCount).toBe(1);
+
+		resetShutdown();
+		await processClosedHours();
+		expect((await readProviderStats())[0].requestCount).toBe(2);
+		expect((await readProviderState())?.lastProcessedHour).toEqual(LATEST_HOUR);
+	});
+
+	test("rolls back the day reset and cursor together when a bucket fails", async () => {
+		await insertLog(new Date("2026-06-15T00:30:00Z"));
+		await db.transaction((tx) =>
+			aggregateProviderKeyWindowIntoStats(tx, TODAY, HOUR_MS),
+		);
+		const rows = await readProviderStats();
+		const transaction = db.transaction.bind(db);
+		vi.spyOn(db, "transaction").mockImplementationOnce((callback) =>
+			transaction(async (tx) => {
+				await callback(tx);
+				throw new Error("Backfill interrupted");
+			}),
+		);
+
+		await expect(processClosedHours()).rejects.toThrow("Backfill interrupted");
+		expect(await readProviderStats()).toEqual(rows);
+		expect(await readProviderState()).toBeUndefined();
+
+		await processClosedHours();
+		expect((await readProviderStats())[0].requestCount).toBe(1);
+		expect((await readProviderState())?.lastProcessedHour).toEqual(LATEST_HOUR);
+	});
+
+	test("runs the provider-key safety net independently of the global cursor", async () => {
+		await insertLog(new Date("2026-06-14T12:30:00Z"));
+		await processClosedHours();
+		await insertLog(new Date("2026-06-14T13:30:00Z"));
+		await db
+			.update(globalAggregationState)
+			.set({ lastSafetyNetDay: null })
+			.where(eq(globalAggregationState.id, "provider-key-model"));
+
+		await processClosedHours();
+		expect((await readProviderStats())[0].requestCount).toBe(2);
+		await processClosedHours();
+		expect((await readProviderStats())[0].requestCount).toBe(2);
+	});
+
+	test("waits for attributed traffic and skips earlier unattributed history", async () => {
+		await insertLog(new Date("2025-01-01T00:30:00Z"), null);
+		expect(await processClosedHours()).toBe(false);
+		expect(await readProviderState()).toBeUndefined();
+
+		await insertLog(new Date("2026-06-15T00:30:00Z"));
+		expect(await processClosedHours()).toBe(false);
+		expect((await readProviderStats())[0].requestCount).toBe(1);
+		expect((await readProviderState())?.lastProcessedHour).toEqual(LATEST_HOUR);
+	});
+
+	test("serializes overlapping workers without double counting", async () => {
+		await insertLog(new Date("2026-06-14T00:30:00Z"));
+		await insertLog(new Date("2026-06-15T00:30:00Z"));
+
+		await Promise.all([processClosedHours(), processClosedHours()]);
+
+		expect((await readProviderStats()).map((row) => row.requestCount)).toEqual([
+			1, 1,
+		]);
+		expect((await readProviderState())?.lastProcessedHour).toEqual(LATEST_HOUR);
+		expect((await readProviderState())?.lastSafetyNetDay).toEqual(YESTERDAY);
+	});
+
+	test("preserves a complete day if the safety-net transaction fails", async () => {
+		await insertLog(new Date("2026-06-14T00:30:00Z"));
+		await processClosedHours();
+		await insertLog(new Date("2026-06-14T01:30:00Z"));
+		await db
+			.update(globalAggregationState)
+			.set({ lastSafetyNetDay: null })
+			.where(eq(globalAggregationState.id, "provider-key-model"));
+		const rows = await readProviderStats();
+		const transaction = db.transaction.bind(db);
+		vi.spyOn(db, "transaction").mockImplementationOnce((callback) =>
+			transaction(async (tx) => {
+				await callback(tx);
+				throw new Error("Safety net interrupted");
+			}),
+		);
+
+		await processClosedHours();
+		expect(await readProviderStats()).toEqual(rows);
+		expect((await readProviderState())?.lastSafetyNetDay).toBeNull();
+
+		await processClosedHours();
+		expect((await readProviderStats())[0].requestCount).toBe(2);
+		expect((await readProviderState())?.lastSafetyNetDay).toEqual(YESTERDAY);
+	});
+});

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -2484,9 +2484,9 @@ async function runGlobalStatsLoop() {
 	try {
 		while (!isStopRequested()) {
 			try {
-				await processClosedHours();
+				const pending = await processClosedHours();
 
-				await interruptibleSleep(interval);
+				await interruptibleSleep(pending ? Math.min(interval, 5000) : interval);
 			} catch (error) {
 				logger.error(
 					"Error in global daily stats loop",

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -5894,7 +5894,8 @@ export const globalProviderKeyModelStats = pgTable(
 	],
 );
 
-// Singleton state row for the incremental global-stats aggregator.
+// Independent cursors for global stats ("singleton") and provider-key model
+// stats ("provider-key-model"), so adding a rollup cannot skip its history.
 // `lastProcessedHour` is the last UTC bucket that has been folded into the
 // daily stats. `lastSafetyNetDay` is the most recent UTC day that has been
 // fully recomputed by the safety-net pass.


### PR DESCRIPTION
Provider-key reports introduced in #3971 skipped historical traffic because the new rollup reused an already-advanced global watermark. This addresses the [critical backfill finding](https://github.com/theopenco/llmgateway/pull/3971#discussion_r3948896271).

Give provider-key model stats an independent persisted cursor and replay from the oldest attributed log. Reset overlapping daily buckets before replaying, commit each hour with its cursor, serialize overlapping workers, and make safety-net replacement atomic. Bounded catch-up batches resume after five seconds.

Recovery starts automatically with the updated worker, without a migration or resetting the global model/source rollups. Retention clears payloads but preserves the attribution and metering fields needed here; requests without a provider key remain unattributed.

Validation: `pnpm format`, full `pnpm build`, and 28 passing tests across the aggregation, backfill/retry/concurrency, and admin global-stats API suites, run sequentially against an isolated database.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider-key-level model statistics aggregation alongside global statistics.
  * Improved backfilling and recovery for partially processed or interrupted aggregation periods.
  * Workers now check for pending closed-hour data more frequently when processing is active.

* **Bug Fixes**
  * Prevented duplicate counting during overlapping processing runs.
  * Preserved aggregation state and results when processing transactions fail.

* **Documentation**
  * Clarified that global and provider-key statistics maintain independent processing progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->