### PR TITLE
feat: filter model discovery by API key

### DIFF
--- a/apps/docs/content/features/models-directory.mdx
+++ b/apps/docs/content/features/models-directory.mdx
@@ -46,6 +46,28 @@ With an enabled compliance policy (Enterprise), the directory evaluates every pr
 	active.
 </Callout>
 
+## Discover models with an API key
+
+Call `GET /v1/models` with your API key to list models available under your
+organization's compliance policy, inherited team and member IAM rules, and the
+key's own IAM rules. Blocked provider mappings are omitted; models with no
+remaining mappings are omitted too. Pricing and capabilities reflect the
+remaining mappings. Accessible custom models use `{customProvider}/{modelName}` IDs.
+
+```bash
+curl "https://api.llmgateway.io/v1/models" \
+  -H "Authorization: Bearer $LLM_GATEWAY_API_KEY"
+```
+
+The endpoint also accepts the `x-api-key` header. Without either authentication
+header, it returns the public catalogue. Invalid, inactive, or expired credentials
+return `401`.
+
+Use `?mapped=true` for provider-prefixed entries. Existing query filters, including
+`no_training`, apply alongside access restrictions. Discovery reflects model
+permissions and project configuration; it does not check remaining credits,
+usage budgets, or current provider health.
+
 ## Related
 
 - [Knowledge base → Models](/learn/models) — a walkthrough of the page itself.

--- a/apps/docs/content/features/models-directory.mdx
+++ b/apps/docs/content/features/models-directory.mdx
@@ -63,6 +63,12 @@ The endpoint also accepts the `x-api-key` header. Without either authentication
 header, it returns the public catalogue. Invalid, inactive, or expired credentials
 return `401`.
 
+Set `?include_restricted=true` to return the full public catalogue even with an
+authenticated API key. This skips organization, team, member, key, project, and
+plan filtering for discovery. Private custom models are omitted. Other query
+filters still apply, and inference requests still enforce all access restrictions.
+The default is `false`, which keeps authenticated results filtered.
+
 Use `?mapped=true` for provider-prefixed entries. Existing query filters, including
 `no_training`, apply alongside access restrictions. Discovery reflects model
 permissions and project configuration; it does not check remaining credits,

--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -61,6 +61,7 @@ import {
 	shouldBillCancelledRequests,
 	zeroInferenceCosts,
 } from "@/lib/costs.js";
+import { customModelToProviderMapping } from "@/lib/custom-model.js";
 import { getPublishedDynamicRoute } from "@/lib/dynamic-route-loader.js";
 import {
 	assertOriginAllowed,
@@ -402,41 +403,6 @@ function toDataStorageCostNumber(
 	);
 	const num = Number(str);
 	return Number.isFinite(num) ? num : null;
-}
-
-/**
- * Builds a synthetic provider mapping (providerId "custom") from an enterprise
- * custom model catalog entry. Used both to override the mock model info for
- * limit/capability enforcement and as the `customPricing` override threaded into
- * calculateCosts so custom-provider requests are billed at the catalog rates.
- */
-function customModelToProviderMapping(cm: CustomModel): ProviderModelMapping {
-	const streaming: boolean | "only" =
-		cm.streaming === "only" ? "only" : cm.streaming !== "false";
-	return {
-		providerId: "custom",
-		externalId: cm.modelName,
-		inputPrice: cm.inputPrice ?? undefined,
-		outputPrice: cm.outputPrice ?? undefined,
-		cachedInputPrice: cm.cachedInputPrice ?? undefined,
-		cacheReadInputPrice: cm.cacheReadInputPrice ?? undefined,
-		cacheWriteInputPrice: cm.cacheWriteInputPrice ?? undefined,
-		cacheWriteInputPrice1h: cm.cacheWriteInputPrice1h ?? undefined,
-		requestPrice: cm.requestPrice ?? undefined,
-		webSearchPrice: cm.webSearchPrice ?? undefined,
-		imageInputPrice: cm.imageInputPrice ?? undefined,
-		inputAudioPrice: cm.audioInputPrice ?? undefined,
-		contextSize: cm.contextSize ?? undefined,
-		maxOutput: cm.maxOutput ?? undefined,
-		vision: cm.vision ?? undefined,
-		tools: cm.tools ?? undefined,
-		reasoning: cm.reasoning ?? undefined,
-		jsonOutput: cm.jsonOutput ?? undefined,
-		jsonOutputSchema: cm.jsonOutput ?? undefined,
-		audio: cm.audio ?? undefined,
-		supportedParameters: cm.supportedParameters ?? undefined,
-		streaming,
-	};
 }
 
 type CustomAutoRoutingMapping = ProviderModelMapping & {

--- a/apps/gateway/src/lib/custom-model.ts
+++ b/apps/gateway/src/lib/custom-model.ts
@@ -1,0 +1,34 @@
+import type { CustomModel } from "@/lib/cached-queries.js";
+import type { ProviderModelMapping } from "@llmgateway/models";
+
+/** Shared custom-model pricing and capabilities for routing and discovery. */
+export function customModelToProviderMapping(
+	cm: CustomModel,
+): ProviderModelMapping {
+	const streaming: boolean | "only" =
+		cm.streaming === "only" ? "only" : cm.streaming !== "false";
+	return {
+		providerId: "custom",
+		externalId: cm.modelName,
+		inputPrice: cm.inputPrice ?? undefined,
+		outputPrice: cm.outputPrice ?? undefined,
+		cachedInputPrice: cm.cachedInputPrice ?? undefined,
+		cacheReadInputPrice: cm.cacheReadInputPrice ?? undefined,
+		cacheWriteInputPrice: cm.cacheWriteInputPrice ?? undefined,
+		cacheWriteInputPrice1h: cm.cacheWriteInputPrice1h ?? undefined,
+		requestPrice: cm.requestPrice ?? undefined,
+		webSearchPrice: cm.webSearchPrice ?? undefined,
+		imageInputPrice: cm.imageInputPrice ?? undefined,
+		inputAudioPrice: cm.audioInputPrice ?? undefined,
+		contextSize: cm.contextSize ?? undefined,
+		maxOutput: cm.maxOutput ?? undefined,
+		vision: cm.vision ?? undefined,
+		tools: cm.tools ?? undefined,
+		reasoning: cm.reasoning ?? undefined,
+		jsonOutput: cm.jsonOutput ?? undefined,
+		jsonOutputSchema: cm.jsonOutput ?? undefined,
+		audio: cm.audio ?? undefined,
+		supportedParameters: cm.supportedParameters ?? undefined,
+		streaming,
+	};
+}

--- a/apps/gateway/src/lib/iam.ts
+++ b/apps/gateway/src/lib/iam.ts
@@ -58,6 +58,25 @@ const scopeDenialSuffix = {
 
 type IamRuleScope = keyof typeof scopeDenialSuffix;
 
+type RequestIamRules = Record<IamRuleScope, IamRule[]>;
+
+/** Load once when checking access to multiple models in one request. */
+export async function findRequestIamRules(
+	apiKey: GatewayApiKey,
+	organizationId: string,
+): Promise<RequestIamRules> {
+	const [key, member, team] = await Promise.all([
+		findActiveIamRules(apiKey.id),
+		apiKey.keyType === "user"
+			? findActiveUserIamRules(apiKey.createdBy, organizationId)
+			: [],
+		apiKey.keyType === "user"
+			? findActiveTeamIamRules(apiKey.createdBy, organizationId)
+			: [],
+	]);
+	return { key, member, team };
+}
+
 // Whether a rule's provider entry matches a provider id. Custom providers all
 // share the provider id "custom", so rules can address one of them
 // individually with a `custom:<name>` entry; the plain "custom" entry keeps
@@ -265,6 +284,7 @@ export async function validateRequestModelAccess(params: {
 	// (moderations): model/pricing allowlists can never name that model, so
 	// evaluating them would deny with no way to allowlist it.
 	applicableRuleTypes?: readonly IamRule["ruleType"][];
+	iamRules?: RequestIamRules;
 }): Promise<IamValidationResult> {
 	const {
 		apiKey,
@@ -276,6 +296,7 @@ export async function validateRequestModelAccess(params: {
 		clientIp,
 		autoRouting,
 		applicableRuleTypes,
+		iamRules,
 	} = params;
 
 	const filterRules = (rules: IamRule[]) =>
@@ -316,13 +337,15 @@ export async function validateRequestModelAccess(params: {
 	// infrastructure whose `createdBy` is merely whoever clicked create, and
 	// end-user sessions were already handled above.
 	const memberRules =
-		apiKey.keyType === "user"
+		iamRules?.member ??
+		(apiKey.keyType === "user"
 			? await findActiveUserIamRules(apiKey.createdBy, organizationId)
-			: [];
+			: []);
 	const teamRules =
-		apiKey.keyType === "user"
+		iamRules?.team ??
+		(apiKey.keyType === "user"
 			? await findActiveTeamIamRules(apiKey.createdBy, organizationId)
-			: [];
+			: []);
 
 	const teamResult = await evaluateIamRuleSet(
 		filterRules(teamRules),
@@ -350,7 +373,7 @@ export async function validateRequestModelAccess(params: {
 		return memberResult;
 	}
 
-	const keyRules = await findActiveIamRules(apiKey.id);
+	const keyRules = iamRules?.key ?? (await findActiveIamRules(apiKey.id));
 	return await evaluateIamRuleSet(
 		filterRules(keyRules),
 		modelDef,

--- a/apps/gateway/src/models/model-access.spec.ts
+++ b/apps/gateway/src/models/model-access.spec.ts
@@ -102,6 +102,41 @@ describe("Authenticated model discovery", () => {
 		expect(
 			filtered[0].providers.map((provider) => provider.providerId),
 		).toEqual(["openai"]);
+		expect(await list("?include_restricted=false")).toEqual(filtered);
+	});
+
+	test.each([
+		"",
+		"mapped=true",
+		"include_deactivated=true&exclude_deprecated=true&no_training=true",
+	])(
+		"include_restricted returns the public catalogue with %s",
+		async (query) => {
+			await seedCustomModels();
+			await setPolicy({ enabled: true, allowedModels: ["gpt-4o-mini"] });
+			await addKeyRule("deny_models", { models: ["gpt-4o-mini"] });
+			expect(await list()).toEqual([]);
+			const publicModels = await list(query ? `?${query}` : "", {});
+			const credentials: Record<string, string>[] = [
+				headers,
+				{ "x-api-key": "test-token" },
+			];
+			for (const requestHeaders of credentials) {
+				expect(
+					await list(`?include_restricted=true&${query}`, requestHeaders),
+				).toEqual(publicModels);
+			}
+			expect(
+				publicModels.some((model) => model.id.includes("test-model")),
+			).toBe(false);
+		},
+	);
+
+	test("include_restricted still rejects invalid credentials", async () => {
+		const res = await app.request("/v1/models?include_restricted=true", {
+			headers: { Authorization: "Bearer invalid-token" },
+		});
+		expect(res.status).toBe(401);
 	});
 
 	test("prices and limits use only compliant mappings in both views", async () => {
@@ -126,7 +161,7 @@ describe("Authenticated model discovery", () => {
 		}
 	});
 
-	test("deny lists win and query flags cannot restore blocked models", async () => {
+	test("lifecycle filters do not bypass access restrictions", async () => {
 		await setPolicy({
 			enabled: true,
 			allowedModels: ["gpt-4o-mini"],
@@ -191,6 +226,7 @@ describe("Authenticated model discovery", () => {
 		]);
 		await setPolicy({ enabled: true, blockedProviders: ["openai"] });
 		expect(await list()).toEqual([]);
+		expect(await list("?include_restricted=true")).toEqual(await list("", {}));
 	});
 
 	test("honors IP and pricing rules using the request IP", async () => {

--- a/apps/gateway/src/models/model-access.spec.ts
+++ b/apps/gateway/src/models/model-access.spec.ts
@@ -1,0 +1,402 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { app } from "@/app.js";
+import { createGatewayApiTestHarness } from "@/test-utils/gateway-api-test-harness.js";
+
+import { encryptProviderKeyForStorage } from "@llmgateway/actions";
+import { cdb as db, eq, tables } from "@llmgateway/db";
+import { models, providers } from "@llmgateway/models";
+import { hashApiKeyForStorage } from "@llmgateway/shared/api-key-hash";
+
+import type {
+	ModelDefinition,
+	ProviderCompliancePolicy,
+} from "@llmgateway/models";
+
+interface ListedModel {
+	id: string;
+	providers: { providerId: string; externalId: string }[];
+	pricing: { prompt: string; completion: string };
+	context_length?: number;
+	max_output?: number;
+}
+
+describe("Authenticated model discovery", () => {
+	const harness = createGatewayApiTestHarness();
+	const headers = { Authorization: "Bearer test-token" };
+
+	beforeEach(async () => {
+		await db.insert(tables.apiKey).values({
+			id: "models-key",
+			...hashApiKeyForStorage("test-token"),
+			projectId: "project-id",
+			createdBy: "user-id",
+			description: "Model discovery test key",
+		});
+		await harness.setProjectMode("credits");
+	});
+
+	async function setPolicy(policy: ProviderCompliancePolicy) {
+		await db
+			.update(tables.organization)
+			.set({ providerCompliancePolicy: policy })
+			.where(eq(tables.organization.id, "org-id"));
+	}
+
+	async function list(
+		query = "",
+		requestHeaders: Record<string, string> = headers,
+	) {
+		const response = await app.request(`/v1/models${query}`, {
+			headers: requestHeaders,
+		});
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as { data: ListedModel[] };
+		return body.data;
+	}
+
+	async function addKeyRule(
+		ruleType: typeof tables.apiKeyIamRule.$inferInsert.ruleType,
+		ruleValue: typeof tables.apiKeyIamRule.$inferInsert.ruleValue,
+	) {
+		await db
+			.insert(tables.apiKeyIamRule)
+			.values({ apiKeyId: "models-key", ruleType, ruleValue });
+	}
+
+	async function seedCustomModels() {
+		await harness.setProjectMode("hybrid");
+		for (const name of ["approved", "unattested"]) {
+			await db.insert(tables.providerKey).values({
+				id: `${name}-key`,
+				organizationId: "org-id",
+				provider: "custom",
+				name,
+				...encryptProviderKeyForStorage("test-token", `${name}-key`, "org-id"),
+				baseUrl: harness.mockServerUrl,
+				complianceAttestation:
+					name === "approved" ? { apiTraining: false } : null,
+			});
+			await db.insert(tables.customModel).values({
+				organizationId: "org-id",
+				providerKeyId: `${name}-key`,
+				modelName: "test-model",
+				inputPrice: "1e-6",
+				outputPrice: "2e-6",
+				contextSize: 8192,
+			});
+		}
+	}
+
+	test("public requests keep the full catalogue even with an active policy", async () => {
+		await setPolicy({
+			enabled: true,
+			allowedModels: ["gpt-4o-mini"],
+			allowedProviders: ["openai"],
+		});
+		const publicModels = await list("", {});
+		expect(publicModels.length).toBeGreaterThan(1);
+		expect(publicModels.some((model) => model.id === "gpt-4.1")).toBe(true);
+		const filtered = await list();
+		expect(filtered.map((model) => model.id)).toEqual(["gpt-4o-mini"]);
+		expect(
+			filtered[0].providers.map((provider) => provider.providerId),
+		).toEqual(["openai"]);
+	});
+
+	test("prices and limits use only compliant mappings in both views", async () => {
+		await setPolicy({
+			enabled: true,
+			allowedModels: ["gpt-4o-mini"],
+			allowedProviders: ["openai"],
+		});
+		const mapping = models
+			.find((model) => model.id === "gpt-4o-mini")!
+			.providers.find((provider) => provider.providerId === "openai")!;
+		for (const query of ["", "?mapped=true&no_training=true"]) {
+			const listed = await list(query);
+			expect(listed).toHaveLength(1);
+			expect(listed[0].id).toBe(query ? "openai/gpt-4o-mini" : "gpt-4o-mini");
+			expect(listed[0].pricing).toMatchObject({
+				prompt: mapping.inputPrice,
+				completion: mapping.outputPrice,
+			});
+			expect(listed[0].context_length).toBe(mapping.contextSize);
+			expect(listed[0].max_output).toBe(mapping.maxOutput);
+		}
+	});
+
+	test("deny lists win and query flags cannot restore blocked models", async () => {
+		await setPolicy({
+			enabled: true,
+			allowedModels: ["gpt-4o-mini"],
+			blockedModels: ["gpt-4o-mini"],
+		});
+		expect(await list("?include_deactivated=true&mapped=true")).toEqual([]);
+	});
+
+	test("data policies fail closed for unknown provider posture", async () => {
+		await setPolicy({ enabled: true, blockApiTraining: true });
+		const listed = await list();
+		expect(listed.length).toBeGreaterThan(0);
+		for (const model of listed) {
+			for (const mapping of model.providers) {
+				expect(
+					providers.find((provider) => provider.id === mapping.providerId)
+						?.dataPolicy?.apiTraining,
+				).toBe(false);
+			}
+		}
+	});
+
+	test("disabled policies leave unrestricted keys with the public catalogue", async () => {
+		await setPolicy({ enabled: false, allowedModels: ["gpt-4o-mini"] });
+		expect((await list()).map((model) => model.id)).toEqual(
+			(await list("", {})).map((model) => model.id),
+		);
+	});
+
+	test("combines team, member, key and compliance restrictions", async () => {
+		await db.insert(tables.organizationTeam).values({
+			id: "models-team",
+			organizationId: "org-id",
+			name: "Model discovery team",
+		});
+		await db
+			.insert(tables.organizationTeamProject)
+			.values({ teamId: "models-team", projectId: "project-id" });
+		await db
+			.insert(tables.userProject)
+			.values({ userOrganizationId: "user-org-id", projectId: "project-id" });
+		await db
+			.update(tables.userOrganization)
+			.set({ role: "developer", teamId: "models-team" })
+			.where(eq(tables.userOrganization.id, "user-org-id"));
+		await db.insert(tables.organizationTeamIamRule).values({
+			teamId: "models-team",
+			ruleType: "allow_models",
+			ruleValue: { models: ["gpt-4o-mini", "gpt-4.1"] },
+		});
+		await db.insert(tables.userIamRule).values({
+			userOrganizationId: "user-org-id",
+			ruleType: "deny_models",
+			ruleValue: { models: ["gpt-4.1"] },
+		});
+		await addKeyRule("allow_providers", { providers: ["openai"] });
+		await setPolicy({ enabled: true, blockApiTraining: true });
+		const listed = await list();
+		expect(listed.map((model) => model.id)).toEqual(["gpt-4o-mini"]);
+		expect(listed[0].providers.map((provider) => provider.providerId)).toEqual([
+			"openai",
+		]);
+		await setPolicy({ enabled: true, blockedProviders: ["openai"] });
+		expect(await list()).toEqual([]);
+	});
+
+	test("honors IP and pricing rules using the request IP", async () => {
+		await addKeyRule("allow_ip_cidrs", { ipCidrs: ["192.0.2.0/24"] });
+		await addKeyRule("allow_pricing", { pricingType: "paid" });
+		expect(await list()).toEqual([]);
+		const listed = await list("", {
+			...headers,
+			"x-forwarded-for": "192.0.2.1",
+		});
+		expect(listed.length).toBeGreaterThan(0);
+		for (const model of listed) {
+			expect(
+				(
+					models.find((definition) => definition.id === model.id) as
+						ModelDefinition | undefined
+				)?.free === true,
+			).toBe(false);
+		}
+	});
+
+	test.each<Record<string, string>>([
+		{ Authorization: "Bearer invalid-token" },
+		{ Authorization: "Basic invalid-token" },
+		{ Authorization: "" },
+		{ "x-api-key": "" },
+	])("rejects invalid credentials %j", async (requestHeaders) => {
+		const res = await app.request("/v1/models", { headers: requestHeaders });
+		expect(res.status).toBe(401);
+	});
+
+	test.each(["inactive", "expired"])("rejects %s keys", async (state) => {
+		await db
+			.update(tables.apiKey)
+			.set(
+				state === "inactive"
+					? { status: "inactive" }
+					: { expiresAt: new Date(0) },
+			)
+			.where(eq(tables.apiKey.id, "models-key"));
+		expect((await app.request("/v1/models", { headers })).status).toBe(401);
+	});
+
+	test("accepts x-api-key and prevents shared response caching", async () => {
+		const res = await app.request("/v1/models", {
+			headers: { "x-api-key": "test-token" },
+		});
+		expect(res.status).toBe(200);
+		expect(res.headers.get("Cache-Control")).toBe("private, no-store");
+		for (const response of [res, await app.request("/v1/models")]) {
+			expect(response.headers.get("Vary")).toContain("Authorization");
+			expect(response.headers.get("Vary")).toContain("x-api-key");
+		}
+	});
+
+	test("publishable identifiers cannot discover organization models", async () => {
+		await db
+			.update(tables.apiKey)
+			.set({ keyType: "platform_publishable" })
+			.where(eq(tables.apiKey.id, "models-key"));
+		expect((await app.request("/v1/models", { headers })).status).toBe(403);
+	});
+
+	test("rejects archived projects and revoked member access", async () => {
+		await db
+			.update(tables.project)
+			.set({ status: "deleted" })
+			.where(eq(tables.project.id, "project-id"));
+		expect((await app.request("/v1/models", { headers })).status).toBe(410);
+		await db
+			.update(tables.project)
+			.set({ status: "active" })
+			.where(eq(tables.project.id, "project-id"));
+		await db
+			.delete(tables.userOrganization)
+			.where(eq(tables.userOrganization.id, "user-org-id"));
+		expect((await app.request("/v1/models", { headers })).status).toBe(403);
+	});
+
+	test("BYOK projects only list providers with active credentials", async () => {
+		await harness.setProjectMode("api-keys");
+		await db.insert(tables.providerKey).values({
+			id: "openai-key",
+			organizationId: "org-id",
+			provider: "openai",
+			...encryptProviderKeyForStorage("test-token", "openai-key", "org-id"),
+		});
+		const listed = await list();
+		expect(listed.some((model) => model.id === "gpt-4o-mini")).toBe(true);
+		expect(
+			listed
+				.flatMap((model) => model.providers)
+				.every((provider) =>
+					["openai", "llmgateway"].includes(provider.providerId),
+				),
+		).toBe(true);
+	});
+
+	test("custom models are private and use routable IDs in both views", async () => {
+		await seedCustomModels();
+		for (const query of ["", "?mapped=true"]) {
+			const listed = await list(query);
+			const custom = listed.find((model) => model.id === "approved/test-model");
+			expect(custom?.pricing).toMatchObject({
+				prompt: "1e-6",
+				completion: "2e-6",
+			});
+			expect(custom?.context_length).toBe(8192);
+			expect(
+				(await list(query, {})).some((model) =>
+					model.id.includes("test-model"),
+				),
+			).toBe(false);
+		}
+	});
+
+	test("another organization's key cannot discover private custom models", async () => {
+		await seedCustomModels();
+		await db.insert(tables.organization).values({
+			id: "other-org",
+			name: "Test Organization",
+			billingEmail: "admin@example.com",
+		});
+		await db.insert(tables.project).values({
+			id: "other-project",
+			name: "Test Project",
+			organizationId: "other-org",
+			mode: "credits",
+		});
+		await db
+			.insert(tables.userOrganization)
+			.values({ userId: "user-id", organizationId: "other-org" });
+		await db.insert(tables.apiKey).values({
+			id: "other-key",
+			...hashApiKeyForStorage("other-test-token"),
+			projectId: "other-project",
+			createdBy: "user-id",
+			description: "Other model discovery key",
+		});
+		expect(
+			(await list()).some((model) => model.id === "approved/test-model"),
+		).toBe(true);
+		expect(
+			(await list("", { Authorization: "Bearer other-test-token" })).some(
+				(model) => model.id.includes("test-model"),
+			),
+		).toBe(false);
+	});
+
+	test("retired mappings cannot keep a model visible by default", async () => {
+		const now = new Date();
+		const definition = (models as ModelDefinition[]).find(
+			(model) =>
+				model.providers.some(
+					(provider) => provider.deactivatedAt && provider.deactivatedAt < now,
+				) &&
+				model.providers.some(
+					(provider) => !provider.deactivatedAt || provider.deactivatedAt > now,
+				),
+		)!;
+		expect(definition).toBeDefined();
+		const retired = definition.providers.find(
+			(provider) => provider.deactivatedAt && provider.deactivatedAt < now,
+		)!;
+		await setPolicy({
+			enabled: true,
+			allowedModels: [definition.id],
+			allowedProviders: [retired.providerId],
+		});
+		expect(await list()).toEqual([]);
+		expect(
+			(await list("?include_deactivated=true")).map((model) => model.id),
+		).toEqual([definition.id]);
+	});
+
+	test("custom models require compliant attestations and pass named IAM rules", async () => {
+		await seedCustomModels();
+		await setPolicy({ enabled: true, blockApiTraining: true });
+		await addKeyRule("allow_models", {
+			models: ["approved/test-model", "unattested/test-model"],
+		});
+		for (const query of ["", "?mapped=true&no_training=true"]) {
+			expect((await list(query)).map((model) => model.id)).toEqual([
+				"approved/test-model",
+			]);
+		}
+		await addKeyRule("deny_providers", { providers: ["custom:approved"] });
+		expect(await list()).toEqual([]);
+	});
+
+	test("credits projects cannot discover custom models", async () => {
+		await seedCustomModels();
+		await harness.setProjectMode("credits");
+		expect(
+			(await list()).some((model) => model.id.includes("test-model")),
+		).toBe(false);
+	});
+
+	test("DevPass discovery respects coding eligibility and disallows pinned IDs", async () => {
+		await harness.setDevPlan({ devPlan: "pro" });
+		await setPolicy({
+			enabled: true,
+			allowedModels: ["gpt-4o-mini", "text-embedding-3-small"],
+			allowedProviders: ["openai"],
+		});
+		expect((await list()).map((model) => model.id)).toEqual(["gpt-4o-mini"]);
+		expect(await list("?mapped=true")).toEqual([]);
+	});
+});

--- a/apps/gateway/src/models/model-access.ts
+++ b/apps/gateway/src/models/model-access.ts
@@ -1,0 +1,209 @@
+import { HTTPException } from "hono/http-exception";
+
+import { isModelTrulyFree } from "@/chat/tools/is-model-truly-free.js";
+import { assertMemberProjectAccess } from "@/lib/api-key-usage-limits.js";
+import {
+	findActiveCustomModels,
+	findActiveProviderKeys,
+	findApiKeyByToken,
+	findOrganizationById,
+	findProjectById,
+} from "@/lib/cached-queries.js";
+import { getClientIpFromRequest } from "@/lib/client-ip.js";
+import {
+	isCodingModel,
+	providerSupportsCachedInput,
+} from "@/lib/coding-models.js";
+import {
+	getActiveCompliancePolicy,
+	isModelIdCompliant,
+	isProviderIdCompliant,
+} from "@/lib/compliance.js";
+import { customModelToProviderMapping } from "@/lib/custom-model.js";
+import {
+	assertOriginAllowed,
+	loadEndUserWallet,
+} from "@/lib/end-user-session.js";
+import { extractApiToken } from "@/lib/extract-api-token.js";
+import { findRequestIamRules, validateRequestModelAccess } from "@/lib/iam.js";
+import { assertOrganizationUsable } from "@/lib/organization-access.js";
+
+import { customModelRef } from "@llmgateway/models";
+import { isChatPlanModelAllowed } from "@llmgateway/shared";
+
+import type { ComplianceCheckContext } from "@/lib/compliance.js";
+import type { ModelDefinition } from "@llmgateway/models";
+import type { Context } from "hono";
+
+export async function getModelsAccess(c: Context) {
+	if (
+		!c.req.raw.headers.has("Authorization") &&
+		!c.req.raw.headers.has("x-api-key")
+	) {
+		return undefined;
+	}
+
+	c.header("Cache-Control", "private, no-store");
+	const apiKey = await findApiKeyByToken(extractApiToken(c));
+	if (!apiKey || apiKey.status !== "active") {
+		throw new HTTPException(401, { message: "Invalid or inactive API key" });
+	}
+	if (apiKey.keyType !== "user" && !apiKey.endUserSession) {
+		throw new HTTPException(403, {
+			message: "Model discovery requires a regular API key or end-user session",
+		});
+	}
+	if (apiKey.expiresAt && new Date(apiKey.expiresAt).getTime() <= Date.now()) {
+		throw new HTTPException(401, { message: "API key has expired" });
+	}
+
+	const project = await findProjectById(apiKey.projectId);
+	if (!project) {
+		throw new HTTPException(500, { message: "Could not find project" });
+	}
+	if (project.status === "deleted") {
+		throw new HTTPException(410, { message: "Project has been archived" });
+	}
+	const organization = await findOrganizationById(project.organizationId);
+	if (!organization) {
+		throw new HTTPException(500, { message: "Could not find organization" });
+	}
+	assertOrganizationUsable(organization);
+	await assertMemberProjectAccess(apiKey, organization.id);
+	const wallet = await loadEndUserWallet(apiKey);
+	if (wallet) {
+		assertOriginAllowed(c, project);
+	}
+	const iamRules = await findRequestIamRules(apiKey, organization.id);
+	return {
+		apiKey,
+		project,
+		organization,
+		wallet,
+		iamRules,
+		clientIp: getClientIpFromRequest(c),
+	};
+}
+
+type ModelsAccess = NonNullable<Awaited<ReturnType<typeof getModelsAccess>>>;
+
+export async function filterAccessibleModels(
+	models: ModelDefinition[],
+	access: ModelsAccess,
+	options: {
+		mapped: boolean;
+		noTraining: boolean;
+		includeDeactivated: boolean;
+		excludeDeprecated: boolean;
+		currentDate: Date;
+	},
+): Promise<ModelDefinition[]> {
+	const { apiKey, organization, project, wallet, iamRules, clientIp } = access;
+	const policy = getActiveCompliancePolicy(organization);
+	const isDevPlan =
+		organization.kind === "devpass" && organization.devPlan !== "none";
+	const providerKeys = await findActiveProviderKeys(organization.id);
+	const providerIds = new Set(providerKeys.map((key) => key.provider));
+	const candidates: {
+		model: ModelDefinition;
+		context?: ComplianceCheckContext;
+	}[] = models.map((model) => ({ model }));
+
+	if (!isDevPlan && !wallet && project.mode !== "credits") {
+		const keysById = new Map(providerKeys.map((key) => [key.id, key]));
+		for (const custom of await findActiveCustomModels(organization.id)) {
+			const key = keysById.get(custom.providerKeyId);
+			if (
+				key?.provider !== "custom" ||
+				!key.name ||
+				(options.noTraining && key.complianceAttestation?.apiTraining !== false)
+			) {
+				continue;
+			}
+			candidates.push({
+				model: {
+					id: custom.modelName,
+					name: custom.displayName ?? custom.modelName,
+					family: "custom",
+					providers: [customModelToProviderMapping(custom)],
+				},
+				context: {
+					customProviderName: key.name,
+					customAttestation: key.complianceAttestation,
+				},
+			});
+		}
+	}
+
+	const result: ModelDefinition[] = [];
+	for (const { model, context } of candidates) {
+		const activeModel = {
+			...model,
+			providers: model.providers.filter(
+				(provider) =>
+					(options.includeDeactivated ||
+						!provider.deactivatedAt ||
+						options.currentDate <= provider.deactivatedAt) &&
+					(!options.excludeDeprecated ||
+						!provider.deprecatedAt ||
+						options.currentDate <= provider.deprecatedAt),
+			),
+		};
+		if (
+			activeModel.providers.length === 0 ||
+			(isDevPlan && (!isCodingModel(activeModel) || options.mapped)) ||
+			(organization.kind === "chat" &&
+				organization.chatPlan === "starter" &&
+				!isChatPlanModelAllowed("starter", model.id)) ||
+			(wallet?.mode === "test" && !isModelTrulyFree(activeModel)) ||
+			(policy && !isModelIdCompliant(model.id, policy, context))
+		) {
+			continue;
+		}
+		const validate = (requestedProvider?: string) =>
+			validateRequestModelAccess({
+				apiKey,
+				organizationId: organization.id,
+				requestedModel: model.id,
+				requestedProvider,
+				customProviderName: context?.customProviderName,
+				activeModelInfo: activeModel,
+				clientIp,
+				iamRules,
+			});
+		const validation = options.mapped
+			? undefined
+			: await validate(context ? "custom" : undefined);
+		if (validation && !validation.allowed) {
+			continue;
+		}
+		const allowedProviders = [];
+		for (const provider of activeModel.providers) {
+			if (
+				(validation?.allowedProviders &&
+					!validation.allowedProviders.includes(provider.providerId)) ||
+				(options.mapped && !(await validate(provider.providerId)).allowed) ||
+				(policy &&
+					!isProviderIdCompliant(provider.providerId, policy, context)) ||
+				(isDevPlan && !providerSupportsCachedInput(provider)) ||
+				(!wallet &&
+					project.mode === "api-keys" &&
+					provider.providerId !== "llmgateway" &&
+					!providerIds.has(provider.providerId))
+			) {
+				continue;
+			}
+			allowedProviders.push(provider);
+		}
+		if (allowedProviders.length > 0) {
+			result.push({
+				...model,
+				id: context?.customProviderName
+					? customModelRef(context.customProviderName, model.id)
+					: model.id,
+				providers: allowedProviders,
+			});
+		}
+	}
+	return result;
+}

--- a/apps/gateway/src/models/models.ts
+++ b/apps/gateway/src/models/models.ts
@@ -157,12 +157,20 @@ const listModels = createRoute({
 	operationId: "v1_models",
 	summary: "Models",
 	description:
-		"List the public model catalogue without authentication. With an API key, return only models and provider mappings allowed by its organization compliance policy, IAM rules, and project access, including accessible custom models.",
+		"List the public model catalogue without authentication. With an API key, return only models and provider mappings allowed by its organization compliance policy, IAM rules, and project access, including accessible custom models. Set include_restricted=true to return the public catalogue regardless of these restrictions.",
 	security: modelsSecurity,
 	method: "get",
 	path: "/",
 	request: {
 		query: z.object({
+			include_restricted: z
+				.string()
+				.optional()
+				.transform((val) => val === "true")
+				.describe(
+					"Return the public catalogue instead of the authenticated caller's accessible models. Other query filters still apply. Does not grant permission to call restricted models or include private custom models.",
+				)
+				.openapi({ example: "false" }),
 			include_deactivated: z
 				.string()
 				.optional()
@@ -305,7 +313,7 @@ modelsApi.openapi(listModels, async (c): Promise<any> => {
 					.filter((model) => model.providers.length > 0)
 			: deactivationFilteredModels;
 
-		if (access) {
+		if (access && !query.include_restricted) {
 			filteredModels = await filterAccessibleModels(filteredModels, access, {
 				mapped,
 				noTraining,

--- a/apps/gateway/src/models/models.ts
+++ b/apps/gateway/src/models/models.ts
@@ -3,8 +3,14 @@ import { HTTPException } from "hono/http-exception";
 
 import { airsideListingToModelDefinition } from "@/chat/tools/resolve-airside-model.js";
 import { listAirsideModels } from "@/lib/cached-queries.js";
-import { rateLimitHeaders } from "@/lib/error-schemas.js";
-import { publicErrorResponses } from "@/lib/error-schemas.js";
+import {
+	rateLimitHeaders,
+	standardErrorResponses,
+} from "@/lib/error-schemas.js";
+import {
+	filterAccessibleModels,
+	getModelsAccess,
+} from "@/models/model-access.js";
 
 import { logger, toError } from "@llmgateway/logger";
 import {
@@ -15,6 +21,7 @@ import {
 } from "@llmgateway/models";
 
 import type { ServerTypes } from "@/vars.js";
+import type { RouteConfig } from "@hono/zod-openapi";
 
 export const modelsApi = new OpenAPIHono<ServerTypes>();
 
@@ -144,10 +151,14 @@ const listModelsResponseSchema = z.object({
 	data: z.array(modelSchema),
 });
 
+const modelsSecurity: RouteConfig["security"] = [{}, { bearerAuth: [] }];
+
 const listModels = createRoute({
 	operationId: "v1_models",
 	summary: "Models",
-	description: "List all available models",
+	description:
+		"List the public model catalogue without authentication. With an API key, return only models and provider mappings allowed by its organization compliance policy, IAM rules, and project access, including accessible custom models.",
+	security: modelsSecurity,
 	method: "get",
 	path: "/",
 	request: {
@@ -192,12 +203,14 @@ const listModels = createRoute({
 			},
 			description: "List of available models",
 		},
-		...publicErrorResponses(),
+		...standardErrorResponses(),
 	},
 });
 
 modelsApi.openapi(listModels, async (c): Promise<any> => {
 	try {
+		c.header("Vary", "Authorization, x-api-key", { append: true });
+		const access = await getModelsAccess(c);
 		const query = c.req.valid("query");
 		const includeDeactivated = query.include_deactivated || false;
 		const excludeDeprecated = query.exclude_deprecated || false;
@@ -281,7 +294,7 @@ modelsApi.openapi(listModels, async (c): Promise<any> => {
 
 		// When requested, keep only provider mappings whose provider does not
 		// train on API data, and drop models left with no eligible mappings.
-		const filteredModels = noTraining
+		let filteredModels = noTraining
 			? deactivationFilteredModels
 					.map((model: ModelDefinition) => ({
 						...model,
@@ -291,6 +304,16 @@ modelsApi.openapi(listModels, async (c): Promise<any> => {
 					}))
 					.filter((model) => model.providers.length > 0)
 			: deactivationFilteredModels;
+
+		if (access) {
+			filteredModels = await filterAccessibleModels(filteredModels, access, {
+				mapped,
+				noTraining,
+				includeDeactivated,
+				excludeDeprecated,
+				currentDate,
+			});
+		}
 
 		// Mapped view: one entry per provider mapping, addressed the way the
 		// gateway accepts provider-pinned requests (`provider/model-id`). The
@@ -344,7 +367,10 @@ modelsApi.openapi(listModels, async (c): Promise<any> => {
 						)[] = model.output ?? ["text"];
 
 						return {
-							id: `${provider.providerId}/${model.id}`,
+							id:
+								provider.providerId === "custom"
+									? model.id
+									: `${provider.providerId}/${model.id}`,
 							name,
 							display_name: name,
 							aliases: model.aliases?.map(
@@ -489,6 +515,9 @@ modelsApi.openapi(listModels, async (c): Promise<any> => {
 
 		return c.json({ data: modelData });
 	} catch (error) {
+		if (error instanceof HTTPException) {
+			throw error;
+		}
 		logger.error("Error in models endpoint", toError(error));
 		throw new HTTPException(500, { message: "Internal server error" });
 	}


### PR DESCRIPTION
`GET /v1/models` ignored API keys, so clients saw models blocked by their organization's policies.

Authenticate when a credential header is present and reuse gateway compliance, IAM, project-access, and plan checks to filter models and provider mappings. Include accessible custom models, derive pricing and capabilities from the remaining mappings, and preserve the public catalogue for unauthenticated requests. Invalid credentials return an error, and personalized responses disable shared caching.

Add `include_restricted=true` to return the public catalogue with an authenticated key. The default remains filtered. The override respects other query filters, excludes private custom models, and does not change inference permissions.

Validation:

- `pnpm format` and full `pnpm build` passed.
- All 161 focused tests passed, including 27 new discovery tests.
- Earlier full unit suite: 6,251 passed, 2 skipped, 2 failed. The failures in `admin-devpass-payg.spec.ts` (date-range reporting) and `onboarding-sponsorship.spec.ts` (log count) both reproduce on a clean `origin/main` checkout with the same local configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated model discovery through the Models API, including filtering based on access permissions, compliance policies, project settings, and available providers.
  * Added support for discovering accessible custom models using custom provider/model identifiers.
  * Added `include_restricted=true` to view the public model catalogue while retaining valid-credential checks.
  * Added support for API-key authentication via the `x-api-key` header.

* **Documentation**
  * Documented model discovery behavior, filtering options, authentication, and response scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->