### PR TITLE
docs: explain Copilot app reasoning effort setup

### DIFF
--- a/apps/docs/content/guides/github-copilot.mdx
+++ b/apps/docs/content/guides/github-copilot.mdx
@@ -72,6 +72,17 @@ LLM Gateway's `/v1` endpoint is fully OpenAI-compatible. The Copilot app fetches
 
 All models available to your account show up in the app's model picker; agent sessions work with models that support tool calling and streaming. Browse the [models page](https://llmgateway.io/models) to compare capabilities and pricing, or check [discounted models](https://llmgateway.io/models?discounted=true) for savings up to 90%.
 
+## Reasoning Effort Levels
+
+The Copilot app discovers only model IDs from a BYOK provider — it cannot learn which reasoning effort levels a model supports, so the composer's reasoning control stays on the app default (Medium) and any level you pick reverts until you configure the model:
+
+1. In the app, open **Settings** → **Model Providers** and select your LLM Gateway provider
+2. Edit the model and set its **supported reasoning effort levels** (available since app v1.1.8)
+
+Enter only levels the model actually supports: the gateway forwards your selection to the provider as-is, and providers reject levels their model doesn't accept. To find the right values for a model, open it on the [models page](https://llmgateway.io/models) and check the **Reasoning Efforts** badges on the provider entry, or query the API — each entry in `GET https://api.llmgateway.io/v1/models` lists them under `providers[].reasoning_efforts`.
+
+While unconfigured, sessions still work: the app sends no reasoning effort and the provider uses its default.
+
 ## Good to Know
 
 - **Keys stay local** — the app stores your API key in the OS keychain and never reads it back into the UI.
@@ -103,6 +114,10 @@ Your API key is invalid or was revoked. Generate a new key in the dashboard and 
 ### 402 or credit errors
 
 Your LLM Gateway organization is out of credits. Top up in the [dashboard](https://llmgateway.io/dashboard) — BYOK sessions bill through LLM Gateway, not Copilot premium requests.
+
+### Reasoning effort resets to Medium
+
+The app can't discover reasoning support from a BYOK provider, so the control reverts until you set the model's supported levels by hand — see [Reasoning Effort Levels](#reasoning-effort-levels).
 
 ### Provider option is missing
 

--- a/apps/docs/content/guides/github-copilot.mdx
+++ b/apps/docs/content/guides/github-copilot.mdx
@@ -79,7 +79,7 @@ The Copilot app discovers only model IDs from a BYOK provider — it cannot lear
 1. In the app, open **Settings** → **Model Providers** and select your LLM Gateway provider
 2. Edit the model and set its **supported reasoning effort levels** (available since app v1.1.8)
 
-Enter only levels the model actually supports: the gateway forwards your selection to the provider as-is, and providers reject levels their model doesn't accept. To find the right values for a model, open it on the [models page](https://llmgateway.io/models) and check the **Reasoning Efforts** badges on the provider entry, or query the API — each entry in `GET https://api.llmgateway.io/v1/models` lists them under `providers[].reasoning_efforts`.
+Enter only levels the model actually supports: the gateway forwards your selection to the provider as-is, and providers reject levels their model doesn't accept. To find the right values for a model, open it on the [models page](https://llmgateway.io/models) and check the **Reasoning Efforts** badges on the provider entry, or query the API — each entry in `GET https://api.llmgateway.io/v1/models` lists them under `providers[].reasoning_efforts` (omitted for provider entries that don't declare their supported values).
 
 While unconfigured, sessions still work: the app sends no reasoning effort and the provider uses its default.
 

--- a/apps/ui/src/content/guides/github-copilot.md
+++ b/apps/ui/src/content/guides/github-copilot.md
@@ -47,6 +47,17 @@ LLM Gateway's `/v1` endpoint is fully OpenAI-compatible. The Copilot app fetches
 
 All models available to your account show up in the app's model picker; agent sessions work with models that support tool calling and streaming. Browse the [models page](https://llmgateway.io/models) to compare capabilities and pricing, or check [discounted models](/models?discounted=true) for savings up to 90%.
 
+## Reasoning Effort Levels
+
+The Copilot app discovers only model IDs from a BYOK provider — it cannot learn which reasoning effort levels a model supports, so the composer's reasoning control stays on the app default (Medium) and any level you pick reverts until you configure the model:
+
+1. In the app, open **Settings** → **Model Providers** and select your LLM Gateway provider
+2. Edit the model and set its **supported reasoning effort levels** (available since app v1.1.8)
+
+Enter only levels the model actually supports: the gateway forwards your selection to the provider as-is, and providers reject levels their model doesn't accept. To find the right values for a model, open it on the [models page](https://llmgateway.io/models) and check the **Reasoning Efforts** badges on the provider entry, or query the API — each entry in `GET https://api.llmgateway.io/v1/models` lists them under `providers[].reasoning_efforts`.
+
+While unconfigured, sessions still work: the app sends no reasoning effort and the provider uses its default.
+
 ## Good to Know
 
 - **Keys stay local** — the app stores your API key in the OS keychain and never reads it back into the UI.

--- a/apps/ui/src/content/guides/github-copilot.md
+++ b/apps/ui/src/content/guides/github-copilot.md
@@ -54,7 +54,7 @@ The Copilot app discovers only model IDs from a BYOK provider — it cannot lear
 1. In the app, open **Settings** → **Model Providers** and select your LLM Gateway provider
 2. Edit the model and set its **supported reasoning effort levels** (available since app v1.1.8)
 
-Enter only levels the model actually supports: the gateway forwards your selection to the provider as-is, and providers reject levels their model doesn't accept. To find the right values for a model, open it on the [models page](https://llmgateway.io/models) and check the **Reasoning Efforts** badges on the provider entry, or query the API — each entry in `GET https://api.llmgateway.io/v1/models` lists them under `providers[].reasoning_efforts`.
+Enter only levels the model actually supports: the gateway forwards your selection to the provider as-is, and providers reject levels their model doesn't accept. To find the right values for a model, open it on the [models page](https://llmgateway.io/models) and check the **Reasoning Efforts** badges on the provider entry, or query the API — each entry in `GET https://api.llmgateway.io/v1/models` lists them under `providers[].reasoning_efforts` (omitted for provider entries that don't declare their supported values).
 
 While unconfigured, sessions still work: the app sends no reasoning effort and the provider uses its default.
 


### PR DESCRIPTION
## Problem

A user reported that in the GitHub Copilot app (BYOK via LLM Gateway), the reasoning effort selector always reverts to Medium no matter what they pick, for every model. They eventually got it working only by manually configuring the model's parameters in the app, and asked whether the gateway could provide the model info automatically — or failing that, make the right parameters easy to find on the website.

## Investigation

This is not a gateway bug — the gateway's `/v1/models` already publishes each mapping's accepted effort values (`providers[].reasoning_efforts`), and `reasoning_effort` on chat completions is forwarded and mapped correctly (verified against the GLM 5.3 mappings and `prepare-request-body.ts`).

The limitation is on the Copilot app side, verified against the app itself (v1.1.15) and its changelog:

- The app's BYOK catalog fetch deserializes only the model `id` from an OpenAI-compatible `/models` response — nothing else. No capability metadata can reach it automatically.
- Reasoning effort support is a per-model setting the user must enter by hand; the app added this in v1.1.8 ("You can now configure supported reasoning effort levels for custom provider models in Settings → Model providers"). Its own schema migration states the rationale: "Providers are BYOK, so the capability can't be known at build time and has to live alongside the rest of the per-model settings."
- Until configured, the model has no declared effort levels, so the composer control falls back to the app default (Medium) — exactly the reported symptom.

Since the app consumes nothing beyond model IDs, there is no gateway-side change that could make discovery automatic today.

## Approach

Documentation fix in both Copilot guides (`apps/docs` guide and the mirrored `apps/ui` guide):

- New **Reasoning Effort Levels** section: why the selector reverts to Medium, how to configure supported levels per model in the app (Settings → Model Providers, app v1.1.8+), and where to find each model's correct values — the **Reasoning Efforts** badges on the [models page](https://llmgateway.io/models) or `providers[].reasoning_efforts` in `GET /v1/models`.
- Notes that the gateway forwards the chosen level as-is (providers reject unsupported values), and that unconfigured models still work at the provider's default effort.
- New troubleshooting entry "Reasoning effort resets to Medium" linking to the section.

## Verification

- `pnpm format` clean; `turbo run build --filter=docs` green (MDX compiles).
- `turbo run build --filter=ui` fails identically with and without this change in this sandbox (OG-image prerender needs external network) — pre-existing, unrelated to this content-only change.
- No screenshots: content-only docs/guide prose, no dashboard UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KnVAUVFa7oMVPGfBNznGMK

---
_Generated by [Claude Code](https://claude.ai/code/session_01KnVAUVFa7oMVPGfBNznGMK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for configuring supported reasoning effort levels for BYOK models in Settings → Model Providers.
  - Explained how to find valid reasoning levels through model badges or the models API.
  - Clarified that unsupported selections may be rejected by providers, while unconfigured sessions continue using the provider’s default.
  - Added troubleshooting guidance for reasoning effort resetting to Medium.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->