### PR TITLE
feat(admin): warn on high license seat usage

### DIFF
--- a/ee/admin/src/components/admin-shell.tsx
+++ b/ee/admin/src/components/admin-shell.tsx
@@ -46,6 +46,7 @@ import {
 	SidebarTrigger,
 	useSidebar,
 } from "@/components/ui/sidebar";
+import { WhiteLabelSeatWarning } from "@/components/white-label-seat-warning";
 import { useUser } from "@/hooks/useUser";
 import { useAuth } from "@/lib/auth-client";
 
@@ -339,6 +340,9 @@ export function AdminShell({ children, signedIn }: AdminShellProps) {
 			</Sidebar>
 			<SidebarInset>
 				<MobileHeader />
+				{user?.isAdmin && license?.kind === "white_label" && (
+					<WhiteLabelSeatWarning />
+				)}
 				{whiteLabelExpiryTerm && (
 					<Alert
 						className={

--- a/ee/admin/src/components/white-label-seat-warning.tsx
+++ b/ee/admin/src/components/white-label-seat-warning.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { useApi } from "@/lib/fetch-client";
+
+export function WhiteLabelSeatWarning() {
+	const api = useApi();
+	const { data } = api.useQuery(
+		"get",
+		"/admin/license",
+		{},
+		{
+			staleTime: 60_000,
+			refetchInterval: 60_000,
+			refetchOnWindowFocus: true,
+		},
+	);
+
+	if (
+		!data ||
+		data.kind !== "white_label" ||
+		!data.enterpriseEnabled ||
+		data.maxSeats === null ||
+		data.maxSeats <= 0 ||
+		data.seatsUsed / data.maxSeats < 0.8
+	) {
+		return null;
+	}
+
+	const atCapacity = data.seatsUsed >= data.maxSeats;
+	const percentUsed = Math.floor((data.seatsUsed / data.maxSeats) * 100);
+
+	return (
+		<Alert
+			className={
+				atCapacity
+					? "rounded-none border-x-0 border-t-0 border-red-500/40 bg-red-500/10 px-6 text-red-950 dark:text-red-100"
+					: "rounded-none border-x-0 border-t-0 border-orange-500/40 bg-orange-500/10 px-6 text-orange-950 dark:text-orange-100"
+			}
+		>
+			<AlertTriangle aria-hidden="true" />
+			<AlertTitle className="line-clamp-none">
+				{atCapacity
+					? "White-label seat limit reached"
+					: "White-label seats are running low"}
+			</AlertTitle>
+			<AlertDescription className="text-current/90">
+				<p>
+					{data.seatsUsed.toLocaleString("en-US")} of{" "}
+					{data.maxSeats.toLocaleString("en-US")} seats used across enterprise
+					organizations ({percentUsed}%).{" "}
+					{atCapacity
+						? "New enterprise members are blocked. Install a license with more seats to resume provisioning."
+						: "Install a license with more seats before provisioning is blocked."}
+				</p>
+			</AlertDescription>
+		</Alert>
+	);
+}


### PR DESCRIPTION
Admins need advance notice before the white-label seat limit blocks provisioning. Show a dashboard-wide warning at 80% usage and a critical alert at or above capacity, including seats used, total capacity, and guidance to install a license with more seats.

Uses the existing license endpoint and refreshes usage every minute.

Validation: `pnpm format`, full `pnpm build`, and 11 Playwright checks covering thresholds, uncapped and organization licenses, mobile layout, navigation, and signed-out access. Screenshots use seeded local data with mocked license capacity.

| State | Light | Dark |
| --- | --- | --- |
| Before | <img width="720" alt="Admin dashboard: Before, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/4de87a3d4612715237e1e30316499b889901bc03/before-light.png" /> | <img width="720" alt="Admin dashboard: Before, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/4de87a3d4612715237e1e30316499b889901bc03/before-dark.png" /> |
| 80% warning | <img width="720" alt="Admin dashboard: 80% warning, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/4de87a3d4612715237e1e30316499b889901bc03/after-80-light.png" /> | <img width="720" alt="Admin dashboard: 80% warning, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/4de87a3d4612715237e1e30316499b889901bc03/after-80-dark.png" /> |
| 100% capacity | <img width="720" alt="Admin dashboard: 100% capacity, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/4de87a3d4612715237e1e30316499b889901bc03/after-100-light.png" /> | <img width="720" alt="Admin dashboard: 100% capacity, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/4de87a3d4612715237e1e30316499b889901bc03/after-100-dark.png" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added seat usage warnings for enterprise white-label licenses when usage reaches 80% or more.
  * Displays guidance when seat capacity is nearly reached or has been exceeded.
  * License usage information refreshes automatically every 60 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->