### PR TITLE
fix: restrict billing to organization admins

### DIFF
--- a/apps/api/src/lib/billing-organization.ts
+++ b/apps/api/src/lib/billing-organization.ts
@@ -8,7 +8,14 @@ export async function getBillingOrganization(
 	organizationId?: string,
 ) {
 	const membership = await db.query.userOrganization.findFirst({
-		where: organizationId ? { userId, organizationId } : { userId },
+		where: organizationId
+			? { userId, organizationId }
+			: {
+					userId,
+					role: { in: ["owner", "admin"] },
+					organization: { status: { ne: "deleted" } },
+				},
+		orderBy: { createdAt: "asc", id: "asc" },
 		with: { organization: true, user: true },
 	});
 	if (

--- a/apps/api/src/lib/billing-organization.ts
+++ b/apps/api/src/lib/billing-organization.ts
@@ -1,0 +1,26 @@
+import { HTTPException } from "hono/http-exception";
+
+import { db } from "@llmgateway/db";
+import { isOrganizationAdmin } from "@llmgateway/shared/organization-roles";
+
+export async function getBillingOrganization(
+	userId: string,
+	organizationId?: string,
+) {
+	const membership = await db.query.userOrganization.findFirst({
+		where: organizationId ? { userId, organizationId } : { userId },
+		with: { organization: true, user: true },
+	});
+	if (
+		!membership?.organization ||
+		membership.organization.status === "deleted"
+	) {
+		throw new HTTPException(404, { message: "Organization not found" });
+	}
+	if (!isOrganizationAdmin(membership.role)) {
+		throw new HTTPException(403, {
+			message: "Only organization owners and admins can access billing",
+		});
+	}
+	return { ...membership, organization: membership.organization };
+}

--- a/apps/api/src/routes/billing-authorization.spec.ts
+++ b/apps/api/src/routes/billing-authorization.spec.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db, eq, tables } from "@llmgateway/db";
+
+const stripeMock = vi.hoisted(() => ({
+	customers: { update: vi.fn() },
+	setupIntents: { create: vi.fn() },
+	paymentIntents: { create: vi.fn() },
+	paymentMethods: { retrieve: vi.fn() },
+}));
+
+vi.mock("stripe", () => ({
+	default: function MockStripe() {
+		return stripeMock;
+	},
+}));
+
+const orgId = "test-org-id";
+const paymentMethodId = "test-payment-method";
+
+const paymentRequests = [
+	{ method: "GET", path: "/payments/top-up-limit" },
+	{ method: "GET", path: "/payments/payment-methods" },
+	{
+		method: "POST",
+		path: "/payments/create-payment-intent",
+		body: { amount: 10 },
+	},
+	{ method: "POST", path: "/payments/create-setup-intent", body: {} },
+	{
+		method: "POST",
+		path: "/payments/payment-methods/default",
+		body: { paymentMethodId },
+	},
+	{ method: "DELETE", path: `/payments/payment-methods/${paymentMethodId}` },
+	{
+		method: "POST",
+		path: "/payments/top-up-with-saved-method",
+		body: { amount: 10, paymentMethodId },
+	},
+	{
+		method: "POST",
+		path: "/payments/create-checkout-session",
+		body: { amount: 10 },
+	},
+	{
+		method: "POST",
+		path: "/payments/calculate-fees",
+		body: { amount: 10, paymentMethodId },
+	},
+];
+
+describe("billing authorization", () => {
+	let token: string;
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_mock");
+		vi.stubEnv("GATEWAY_TOPUP_VELOCITY_ENABLED", "false");
+		token = await createTestUser();
+		await db
+			.delete(tables.userOrganization)
+			.where(eq(tables.userOrganization.userId, "test-user-id"));
+		await db.insert(tables.organization).values({
+			id: orgId,
+			name: "Test Organization",
+			billingEmail: "admin@example.com",
+			stripeCustomerId: "cus_test_billing",
+		});
+		await db.insert(tables.userOrganization).values({
+			userId: "test-user-id",
+			organizationId: orgId,
+			role: "owner",
+		});
+		await db.insert(tables.paymentMethod).values({
+			id: paymentMethodId,
+			organizationId: orgId,
+			stripePaymentMethodId: "pm_test_billing",
+			type: "card",
+			isDefault: true,
+		});
+		stripeMock.paymentIntents.create.mockResolvedValue({
+			id: "pi_test_billing",
+			client_secret: "test-payment-secret",
+		});
+		stripeMock.setupIntents.create.mockResolvedValue({
+			client_secret: "test-setup-secret",
+		});
+		stripeMock.paymentMethods.retrieve.mockResolvedValue({
+			card: { brand: "visa", last4: "4242", exp_month: 12, exp_year: 2030 },
+		});
+	});
+
+	afterEach(async () => {
+		vi.unstubAllEnvs();
+		await deleteAll();
+	});
+
+	async function setRole(
+		role: "owner" | "admin" | "project_admin" | "developer",
+	) {
+		await db
+			.update(tables.userOrganization)
+			.set({ role })
+			.where(eq(tables.userOrganization.organizationId, orgId));
+	}
+
+	describe.each(["developer", "project_admin"] as const)("%s", (role) => {
+		test.each(paymentRequests)(
+			"cannot use $method $path",
+			async ({ method, path, body }) => {
+				await setRole(role);
+				for (const organizationId of [orgId, undefined]) {
+					const url =
+						!body && organizationId
+							? `${path}?organizationId=${organizationId}`
+							: path;
+					const response = await app.request(url, {
+						method,
+						headers: { Cookie: token, "Content-Type": "application/json" },
+						body: body
+							? JSON.stringify({ ...body, organizationId })
+							: undefined,
+					});
+					expect(response.status).toBe(403);
+					expect(await response.json()).toMatchObject({
+						message: "Only organization owners and admins can access billing",
+					});
+				}
+				expect(stripeMock.setupIntents.create).not.toHaveBeenCalled();
+				expect(stripeMock.paymentIntents.create).not.toHaveBeenCalled();
+				expect(stripeMock.paymentMethods.retrieve).not.toHaveBeenCalled();
+			},
+		);
+
+		test.each([
+			"status",
+			"create-pro-subscription",
+			"cancel-pro-subscription",
+			"resume-pro-subscription",
+			"upgrade-to-yearly",
+		])("cannot access subscription %s", async (path) => {
+			await setRole(role);
+			const response = await app.request(
+				`/subscriptions/${path}?organizationId=${orgId}`,
+				{
+					method: path === "status" ? "GET" : "POST",
+					headers: { Cookie: token, "Content-Type": "application/json" },
+					body: path === "status" ? undefined : JSON.stringify({}),
+				},
+			);
+			expect(response.status).toBe(403);
+		});
+
+		test.each([
+			"transactions",
+			"transactions/test-transaction/invoice",
+			"credits-runway",
+			"limits",
+		])("cannot read %s", async (path) => {
+			await setRole(role);
+			const response = await app.request(`/orgs/${orgId}/${path}`, {
+				headers: { Cookie: token },
+			});
+			expect(response.status).toBe(403);
+		});
+
+		test("cannot update billing settings", async () => {
+			await setRole(role);
+			const response = await app.request(`/orgs/${orgId}`, {
+				method: "PATCH",
+				headers: { Cookie: token, "Content-Type": "application/json" },
+				body: JSON.stringify({
+					billingEmail: "billing@example.com",
+					autoTopUpEnabled: true,
+				}),
+			});
+			expect(response.status).toBe(403);
+		});
+	});
+
+	test.each(["developer", "project_admin"] as const)(
+		"DevPass does not inherit billing details from a %s membership",
+		async (role) => {
+			await setRole(role);
+			await db
+				.update(tables.organization)
+				.set({ billingCompany: "Team billing company" })
+				.where(eq(tables.organization.id, orgId));
+			await db.insert(tables.organization).values({
+				id: "personal-org-id",
+				name: "DevPass",
+				kind: "devpass",
+				billingEmail: "admin@example.com",
+			});
+			await db.insert(tables.userOrganization).values({
+				userId: "test-user-id",
+				organizationId: "personal-org-id",
+				role: "owner",
+			});
+			const response = await app.request("/dev-plans/billing-details", {
+				headers: { Cookie: token },
+			});
+			expect(response.status).toBe(200);
+			const result = (await response.json()) as {
+				own: Record<string, unknown>;
+				default: Record<string, unknown>;
+			};
+			expect(result.default).toEqual(result.own);
+			expect(result.default.billingCompany).toBeNull();
+		},
+	);
+
+	test.each(["owner", "admin"] as const)(
+		"%s can read billing and add a payment method",
+		async (role) => {
+			await setRole(role);
+			for (const path of [
+				"/payments/payment-methods",
+				"/subscriptions/status",
+			]) {
+				const response = await app.request(`${path}?organizationId=${orgId}`, {
+					headers: { Cookie: token },
+				});
+				expect(response.status).toBe(200);
+			}
+			const response = await app.request("/payments/create-setup-intent", {
+				method: "POST",
+				headers: { Cookie: token, "Content-Type": "application/json" },
+				body: JSON.stringify({ organizationId: orgId }),
+			});
+			expect(response.status).toBe(200);
+			expect(stripeMock.setupIntents.create).toHaveBeenCalledWith(
+				expect.objectContaining({ customer: "cus_test_billing" }),
+			);
+		},
+	);
+
+	test.each(["owner", "admin"] as const)(
+		"%s can initiate a credit top-up",
+		async (role) => {
+			await setRole(role);
+			const response = await app.request("/payments/create-payment-intent", {
+				method: "POST",
+				headers: { Cookie: token, "Content-Type": "application/json" },
+				body: JSON.stringify({ organizationId: orgId, amount: 10 }),
+			});
+			expect(response.status).toBe(200);
+			expect(stripeMock.paymentIntents.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					metadata: expect.objectContaining({ organizationId: orgId }),
+				}),
+			);
+		},
+	);
+
+	test("billing access follows each organization's role and a subsequent demotion", async () => {
+		await db.insert(tables.organization).values({
+			id: "other-org-id",
+			name: "Other Organization",
+			billingEmail: "billing@example.com",
+		});
+		await db.insert(tables.userOrganization).values({
+			userId: "test-user-id",
+			organizationId: "other-org-id",
+			role: "developer",
+		});
+		for (const path of ["/payments/payment-methods", "/subscriptions/status"]) {
+			const response = await app.request(
+				`${path}?organizationId=other-org-id`,
+				{ headers: { Cookie: token } },
+			);
+			expect(response.status).toBe(403);
+		}
+		await setRole("developer");
+		const response = await app.request(
+			`/payments/payment-methods?organizationId=${orgId}`,
+			{ headers: { Cookie: token } },
+		);
+		expect(response.status).toBe(403);
+	});
+
+	test("admins cannot manage another organization's billing", async () => {
+		await db.insert(tables.organization).values({
+			id: "other-org-id",
+			name: "Other Organization",
+			billingEmail: "billing@example.com",
+		});
+		const response = await app.request(
+			"/payments/payment-methods?organizationId=other-org-id",
+			{ headers: { Cookie: token } },
+		);
+		expect(response.status).toBe(404);
+	});
+});

--- a/apps/api/src/routes/billing-authorization.spec.ts
+++ b/apps/api/src/routes/billing-authorization.spec.ts
@@ -125,9 +125,11 @@ describe("billing authorization", () => {
 							? JSON.stringify({ ...body, organizationId })
 							: undefined,
 					});
-					expect(response.status).toBe(403);
+					expect(response.status).toBe(organizationId ? 403 : 404);
 					expect(await response.json()).toMatchObject({
-						message: "Only organization owners and admins can access billing",
+						message: organizationId
+							? "Only organization owners and admins can access billing"
+							: "Organization not found",
 					});
 				}
 				expect(stripeMock.setupIntents.create).not.toHaveBeenCalled();
@@ -256,6 +258,105 @@ describe("billing authorization", () => {
 			);
 		},
 	);
+
+	describe.each(["developer", "project_admin"] as const)(
+		"legacy requests with a %s membership",
+		(memberRole) => {
+			test.each(["owner", "admin"] as const)(
+				"select the organization where the user is %s",
+				async (adminRole) => {
+					await setRole(memberRole);
+					await db.insert(tables.organization).values({
+						id: "admin-org-id",
+						name: "Admin Organization",
+						billingEmail: "admin@example.com",
+						stripeCustomerId: "cus_test_admin",
+					});
+					await db.insert(tables.userOrganization).values({
+						userId: "test-user-id",
+						organizationId: "admin-org-id",
+						role: adminRole,
+					});
+					for (const path of [
+						"/payments/payment-methods",
+						"/subscriptions/status",
+					]) {
+						const implicitResponse = await app.request(path, {
+							headers: { Cookie: token },
+						});
+						expect(implicitResponse.status).toBe(200);
+						const explicitResponse = await app.request(
+							`${path}?organizationId=${orgId}`,
+							{ headers: { Cookie: token } },
+						);
+						expect(explicitResponse.status).toBe(403);
+					}
+					const response = await app.request(
+						"/payments/create-payment-intent",
+						{
+							method: "POST",
+							headers: { Cookie: token, "Content-Type": "application/json" },
+							body: JSON.stringify({ amount: 10 }),
+						},
+					);
+					expect(response.status).toBe(200);
+					expect(stripeMock.paymentIntents.create).toHaveBeenCalledWith(
+						expect.objectContaining({
+							customer: "cus_test_admin",
+							metadata: expect.objectContaining({
+								organizationId: "admin-org-id",
+							}),
+						}),
+					);
+				},
+			);
+		},
+	);
+
+	test("legacy requests select the earliest active administrative membership", async () => {
+		await db.insert(tables.organization).values([
+			{
+				id: "deleted-org-id",
+				name: "Deleted Organization",
+				billingEmail: "admin@example.com",
+				status: "deleted",
+			},
+			{
+				id: "older-org-id",
+				name: "Older Organization",
+				billingEmail: "admin@example.com",
+				stripeCustomerId: "cus_test_older",
+			},
+		]);
+		await db.insert(tables.userOrganization).values([
+			{
+				userId: "test-user-id",
+				organizationId: "older-org-id",
+				role: "admin",
+				createdAt: new Date("2025-01-02"),
+			},
+			{
+				userId: "test-user-id",
+				organizationId: "deleted-org-id",
+				role: "owner",
+				createdAt: new Date("2025-01-01"),
+			},
+		]);
+		const response = await app.request("/payments/create-setup-intent", {
+			method: "POST",
+			headers: { Cookie: token, "Content-Type": "application/json" },
+			body: JSON.stringify({}),
+		});
+		expect(response.status).toBe(200);
+		expect(stripeMock.setupIntents.create).toHaveBeenCalledWith(
+			expect.objectContaining({ customer: "cus_test_older" }),
+		);
+		const deletedResponse = await app.request(
+			"/payments/payment-methods?organizationId=deleted-org-id",
+			{ headers: { Cookie: token } },
+		);
+		expect(deletedResponse.status).toBe(404);
+	});
 
 	test("billing access follows each organization's role and a subsequent demotion", async () => {
 		await db.insert(tables.organization).values({

--- a/apps/api/src/routes/organization.spec.ts
+++ b/apps/api/src/routes/organization.spec.ts
@@ -161,10 +161,83 @@ describe("organization route", () => {
 			where: { id: { eq: "test-org-id" } },
 		});
 		const extended = { ...stored!, futureInternalField: "internal" };
-		expect(serializeOrganization(extended)).not.toHaveProperty(
+		expect(serializeOrganization(extended, "owner")).not.toHaveProperty(
 			"futureInternalField",
 		);
 	});
+
+	test.each(["developer", "project_admin"] as const)(
+		"GET /orgs omits billing fields for %s memberships",
+		async (role) => {
+			await db
+				.update(tables.userOrganization)
+				.set({ role })
+				.where(eq(tables.userOrganization.organizationId, "test-org-id"));
+			await db.insert(tables.organization).values({
+				id: "owned-org-id",
+				name: "Owned Organization",
+				billingEmail: "admin@example.com",
+			});
+			await db.insert(tables.userOrganization).values({
+				userId: "test-user-id",
+				organizationId: "owned-org-id",
+				role: "owner",
+			});
+			const response = await app.request(
+				"/orgs?includeChat=true&includePersonal=true",
+				{ headers: { Cookie: token } },
+			);
+			expect(response.status).toBe(200);
+			const { organizations } = (await response.json()) as {
+				organizations: Record<string, unknown>[];
+			};
+			const memberOrg = organizations.find((org) => org.id === "test-org-id");
+			expect(memberOrg).toMatchObject({
+				id: "test-org-id",
+				name: "Test Organization",
+				role,
+				plan: "free",
+			});
+			for (const field of [
+				"credits",
+				"billingEmail",
+				"billingCompany",
+				"billingAddress",
+				"billingTaxId",
+				"billingNotes",
+				"autoTopUpEnabled",
+				"autoTopUpThreshold",
+				"autoTopUpAmount",
+				"referralEarnings",
+				"referralBonusEnabled",
+				"referralBonusPercent",
+				"devPlanCycle",
+				"devPlanCreditsUsed",
+				"devPlanCreditsLimit",
+				"devPlanPremiumCreditsUsed",
+				"devPlanPremiumWeekStart",
+				"devPlanResetPassesLite",
+				"devPlanResetPassesPro",
+				"devPlanResetPassesMax",
+				"devPlanIncludedResetPassesUsed",
+				"devPlanBillingCycleStart",
+				"devPlanPaygEnabled",
+				"devPlanBillingOverride",
+				"chatPlanCycle",
+				"chatPlanCreditsUsed",
+				"chatPlanCreditsLimit",
+				"chatPlanBillingCycleStart",
+			]) {
+				expect(memberOrg).not.toHaveProperty(field);
+			}
+			expect(
+				organizations.find((org) => org.id === "owned-org-id"),
+			).toHaveProperty("credits");
+			expect(
+				organizations.find((org) => org.id === "owned-org-id"),
+			).toMatchObject({ role: "owner", billingEmail: "admin@example.com" });
+		},
+	);
 
 	test("PATCH /orgs/{id} logs enabling auto top-up in audit log", async () => {
 		const response = await app.request("/orgs/test-org-id", {

--- a/apps/api/src/routes/organization.ts
+++ b/apps/api/src/routes/organization.ts
@@ -35,6 +35,7 @@ import {
 } from "@llmgateway/actions";
 import { logAuditEvent } from "@llmgateway/audit";
 import { redisClient } from "@llmgateway/cache";
+import { organizationBillingFields } from "@llmgateway/db";
 import {
 	and,
 	cdb,
@@ -140,82 +141,84 @@ const providerCompliancePolicySchema = z.object({
 	allowedModels: z.array(complianceModelRefSchema).max(500).optional(),
 });
 
-const organizationSchema = z.object({
-	id: z.string(),
-	createdAt: z.date(),
-	updatedAt: z.date(),
-	name: z.string(),
-	logo: z.string().nullable(),
-	billingEmail: z.string(),
-	billingCompany: z.string().nullable(),
-	billingAddress: z.string().nullable(),
-	billingTaxId: z.string().nullable(),
-	billingNotes: z.string().nullable(),
-	credits: z.string(),
-	plan: z.enum(["free", "pro", "enterprise"]),
-	planExpiresAt: z.date().nullable(),
-	// Start of the current plan term; null when it was never recorded.
-	planStartedAt: z.date().nullable(),
-	// Enterprise trial window. While `isTrialActive` is set, the trial end is
-	// the date that decides whether the org keeps its enterprise features.
-	isTrialActive: z.boolean(),
-	trialStartDate: z.date().nullable(),
-	trialEndDate: z.date().nullable(),
-	// Manual seat-limit override; null = use the plan default.
-	seats: z.number().nullable(),
-	// Manual API-key-limit override; null = use the plan default.
-	apiKeyLimit: z.number().nullable(),
-	// Manual project-limit override; null = use the plan default.
-	projectLimit: z.number().nullable(),
-	retentionLevel: z.enum(["retain", "none"]),
-	providerCompliancePolicy: providerCompliancePolicySchema.nullable(),
-	ssoAutoJoinDomain: z.string().nullable(),
-	status: z.enum(["active", "inactive", "deleted"]).nullable(),
-	autoTopUpEnabled: z.boolean(),
-	autoTopUpThreshold: z.string().nullable(),
-	autoTopUpAmount: z.string().nullable(),
-	referralEarnings: z.string(),
-	referralBonusEnabled: z.boolean(),
-	referralBonusPercent: z.string(),
-	// Organization kind: "default" (regular dashboard org), "devpass" (per-user
-	// Dev Plans org), or "chat" (per-user lounge.llmgateway.io org).
-	kind: z.enum(["default", "chat", "devpass"]),
-	devPlan: z.enum(["none", "lite", "pro", "max"]),
-	devPlanCycle: z.enum(["monthly", "annual"]),
-	devPlanCreditsUsed: z.string(),
-	devPlanCreditsLimit: z.string(),
-	devPlanPremiumCreditsUsed: z.string(),
-	devPlanPremiumWeekStart: z.date().nullable(),
-	devPlanResetPassesLite: z.number(),
-	devPlanResetPassesPro: z.number(),
-	devPlanResetPassesMax: z.number(),
-	devPlanIncludedResetPassesUsed: z.number(),
-	devPlanBillingCycleStart: z.date().nullable(),
-	devPlanExpiresAt: z.date().nullable(),
-	devPlanServiceTier: z.enum(["default", "flex"]),
-	devPlanPaygEnabled: z.boolean(),
-	devPlanBillingOverride: z.boolean(),
-	// Chat Plans fields
-	chatPlan: z.enum(["none", "starter", "plus", "pro"]),
-	chatPlanCycle: z.enum(["monthly"]),
-	chatPlanCreditsUsed: z.string(),
-	chatPlanCreditsLimit: z.string(),
-	chatPlanBillingCycleStart: z.date().nullable(),
-	chatPlanExpiresAt: z.date().nullable(),
-	// Org-wide default developer budget (managed on the Teams page).
-	defaultDeveloperMaxApiKeys: z.number().nullable(),
-	defaultDeveloperUsageLimit: z.string().nullable(),
-	defaultDeveloperPeriodUsageLimit: z.string().nullable(),
-	defaultDeveloperPeriodUsageDurationValue: z.number().nullable(),
-	defaultDeveloperPeriodUsageDurationUnit: z
-		.enum(["hour", "day", "week", "month"])
-		.nullable(),
-	// The authenticated user's role in this org. Populated by GET /orgs so the
-	// dashboard can gate org-level UI (e.g. hide org nav from project-scoped
-	// "developer" members). Omitted by single-org endpoints.
-	role: z.enum(["owner", "admin", "project_admin", "developer"]).optional(),
-	enterpriseAccess: z.boolean().optional(),
-});
+const organizationSchema = z
+	.object({
+		id: z.string(),
+		createdAt: z.date(),
+		updatedAt: z.date(),
+		name: z.string(),
+		logo: z.string().nullable(),
+		billingEmail: z.string(),
+		billingCompany: z.string().nullable(),
+		billingAddress: z.string().nullable(),
+		billingTaxId: z.string().nullable(),
+		billingNotes: z.string().nullable(),
+		credits: z.string(),
+		plan: z.enum(["free", "pro", "enterprise"]),
+		planExpiresAt: z.date().nullable(),
+		// Start of the current plan term; null when it was never recorded.
+		planStartedAt: z.date().nullable(),
+		// Enterprise trial window. While `isTrialActive` is set, the trial end is
+		// the date that decides whether the org keeps its enterprise features.
+		isTrialActive: z.boolean(),
+		trialStartDate: z.date().nullable(),
+		trialEndDate: z.date().nullable(),
+		// Manual seat-limit override; null = use the plan default.
+		seats: z.number().nullable(),
+		// Manual API-key-limit override; null = use the plan default.
+		apiKeyLimit: z.number().nullable(),
+		// Manual project-limit override; null = use the plan default.
+		projectLimit: z.number().nullable(),
+		retentionLevel: z.enum(["retain", "none"]),
+		providerCompliancePolicy: providerCompliancePolicySchema.nullable(),
+		ssoAutoJoinDomain: z.string().nullable(),
+		status: z.enum(["active", "inactive", "deleted"]).nullable(),
+		autoTopUpEnabled: z.boolean(),
+		autoTopUpThreshold: z.string().nullable(),
+		autoTopUpAmount: z.string().nullable(),
+		referralEarnings: z.string(),
+		referralBonusEnabled: z.boolean(),
+		referralBonusPercent: z.string(),
+		// Organization kind: "default" (regular dashboard org), "devpass" (per-user
+		// Dev Plans org), or "chat" (per-user lounge.llmgateway.io org).
+		kind: z.enum(["default", "chat", "devpass"]),
+		devPlan: z.enum(["none", "lite", "pro", "max"]),
+		devPlanCycle: z.enum(["monthly", "annual"]),
+		devPlanCreditsUsed: z.string(),
+		devPlanCreditsLimit: z.string(),
+		devPlanPremiumCreditsUsed: z.string(),
+		devPlanPremiumWeekStart: z.date().nullable(),
+		devPlanResetPassesLite: z.number(),
+		devPlanResetPassesPro: z.number(),
+		devPlanResetPassesMax: z.number(),
+		devPlanIncludedResetPassesUsed: z.number(),
+		devPlanBillingCycleStart: z.date().nullable(),
+		devPlanExpiresAt: z.date().nullable(),
+		devPlanServiceTier: z.enum(["default", "flex"]),
+		devPlanPaygEnabled: z.boolean(),
+		devPlanBillingOverride: z.boolean(),
+		// Chat Plans fields
+		chatPlan: z.enum(["none", "starter", "plus", "pro"]),
+		chatPlanCycle: z.enum(["monthly"]),
+		chatPlanCreditsUsed: z.string(),
+		chatPlanCreditsLimit: z.string(),
+		chatPlanBillingCycleStart: z.date().nullable(),
+		chatPlanExpiresAt: z.date().nullable(),
+		// Org-wide default developer budget (managed on the Teams page).
+		defaultDeveloperMaxApiKeys: z.number().nullable(),
+		defaultDeveloperUsageLimit: z.string().nullable(),
+		defaultDeveloperPeriodUsageLimit: z.string().nullable(),
+		defaultDeveloperPeriodUsageDurationValue: z.number().nullable(),
+		defaultDeveloperPeriodUsageDurationUnit: z
+			.enum(["hour", "day", "week", "month"])
+			.nullable(),
+		// The authenticated user's role in this org. Populated by GET /orgs so the
+		// dashboard can gate org-level UI (e.g. hide org nav from project-scoped
+		// "developer" members). Omitted by single-org endpoints.
+		role: z.enum(["owner", "admin", "project_admin", "developer"]).optional(),
+		enterpriseAccess: z.boolean().optional(),
+	})
+	.partial(organizationBillingFields);
 
 const projectSchema = z.object({
 	id: z.string(),
@@ -402,7 +405,7 @@ organization.openapi(getOrganizations, async (c) => {
 
 	let organizations = userOrganizations
 		.map((uo) => ({
-			...serializeOrganization(uo.organization!),
+			...serializeOrganization(uo.organization!, uo.role),
 			role: uo.role,
 			enterpriseAccess: hasOrganizationEnterpriseAccess(
 				uo.organization?.id,
@@ -428,7 +431,7 @@ organization.openapi(getOrganizations, async (c) => {
 		) {
 			organizations = [
 				{
-					...serializeOrganization(defaultOrganization),
+					...serializeOrganization(defaultOrganization, "owner"),
 					role: "owner" as const,
 					enterpriseAccess: hasOrganizationEnterpriseAccess(
 						defaultOrganization.id,
@@ -597,7 +600,7 @@ organization.openapi(createOrganization, async (c) => {
 	});
 
 	return c.json({
-		organization: serializeOrganization(newOrganization),
+		organization: serializeOrganization(newOrganization, "owner"),
 	});
 });
 
@@ -1092,7 +1095,10 @@ organization.openapi(updateOrganization, async (c) => {
 
 	return c.json({
 		message: "Organization updated successfully",
-		organization: serializeOrganization(updatedOrganization),
+		organization: serializeOrganization(
+			updatedOrganization,
+			userOrganization.role,
+		),
 	});
 });
 

--- a/apps/api/src/routes/payments.ts
+++ b/apps/api/src/routes/payments.ts
@@ -4,6 +4,7 @@ import Stripe from "stripe";
 import { z } from "zod";
 
 import { assertOrganizationNotHighRisk } from "@/lib/account-risk.js";
+import { getBillingOrganization } from "@/lib/billing-organization.js";
 import { assertCreditPurchaseAllowed } from "@/lib/credit-purchase-guard.js";
 import { computeReferralBonus } from "@/lib/referral-bonus.js";
 import { forcedThreeDSecureOptions } from "@/lib/three-d-secure.js";
@@ -75,25 +76,6 @@ const creditTopUpAmountSchema = z
 	)
 	.max(CREDIT_TOP_UP_MAX_AMOUNT, "Maximum top-up amount is $5000.");
 
-/**
- * Resolves the organization a payment operation should target.
- *
- * When an `organizationId` is provided (e.g. the user is acting within a
- * non-default organization they switched to in the dashboard), it is looked up
- * scoped to the user's memberships so a user can only ever target an org they
- * belong to. When omitted, it falls back to the user's first organization for
- * backward compatibility.
- */
-async function findUserOrganization(userId: string, organizationId?: string) {
-	return await db.query.userOrganization.findFirst({
-		where: organizationId ? { userId, organizationId } : { userId },
-		with: {
-			organization: true,
-			user: true,
-		},
-	});
-}
-
 const getTopUpLimit = createRoute({
 	method: "get",
 	path: "/top-up-limit",
@@ -125,10 +107,10 @@ payments.openapi(getTopUpLimit, async (c) => {
 	}
 
 	const { organizationId } = c.req.valid("query");
-	const userOrganization = await findUserOrganization(user.id, organizationId);
-	if (!userOrganization?.organization) {
-		throw new HTTPException(404, { message: "Organization not found" });
-	}
+	const userOrganization = await getBillingOrganization(
+		user.id,
+		organizationId,
+	);
 
 	const allowance = await getTopUpVelocityAllowance(
 		userOrganization.organization,
@@ -210,16 +192,10 @@ payments.openapi(createPaymentIntent, async (c) => {
 		organizationId: requestedOrganizationId,
 	} = c.req.valid("json");
 
-	const userOrganization = await findUserOrganization(
+	const userOrganization = await getBillingOrganization(
 		user.id,
 		requestedOrganizationId,
 	);
-
-	if (!userOrganization || !userOrganization.organization) {
-		throw new HTTPException(404, {
-			message: "Organization not found",
-		});
-	}
 
 	const organizationId = userOrganization.organization.id;
 
@@ -404,16 +380,10 @@ payments.openapi(createSetupIntent, async (c) => {
 
 	const { organizationId: requestedOrganizationId } = c.req.valid("json") ?? {};
 
-	const userOrganization = await findUserOrganization(
+	const userOrganization = await getBillingOrganization(
 		user.id,
 		requestedOrganizationId,
 	);
-
-	if (!userOrganization || !userOrganization.organization) {
-		throw new HTTPException(404, {
-			message: "Organization not found",
-		});
-	}
 
 	const organizationId = userOrganization.organization.id;
 
@@ -485,16 +455,10 @@ payments.openapi(getPaymentMethods, async (c) => {
 
 	const { organizationId: requestedOrganizationId } = c.req.valid("query");
 
-	const userOrganization = await findUserOrganization(
+	const userOrganization = await getBillingOrganization(
 		user.id,
 		requestedOrganizationId,
 	);
-
-	if (!userOrganization || !userOrganization.organization) {
-		throw new HTTPException(404, {
-			message: "Organization not found",
-		});
-	}
 
 	const organizationId = userOrganization.organization.id;
 
@@ -573,16 +537,10 @@ payments.openapi(setDefaultPaymentMethod, async (c) => {
 	const { paymentMethodId, organizationId: requestedOrganizationId } =
 		c.req.valid("json");
 
-	const userOrganization = await findUserOrganization(
+	const userOrganization = await getBillingOrganization(
 		user.id,
 		requestedOrganizationId,
 	);
-
-	if (!userOrganization || !userOrganization.organization) {
-		throw new HTTPException(404, {
-			message: "Organization not found",
-		});
-	}
 
 	const organizationId = userOrganization.organization.id;
 
@@ -663,16 +621,10 @@ payments.openapi(deletePaymentMethod, async (c) => {
 	const { id } = c.req.valid("param");
 	const { organizationId: requestedOrganizationId } = c.req.valid("query");
 
-	const userOrganization = await findUserOrganization(
+	const userOrganization = await getBillingOrganization(
 		user.id,
 		requestedOrganizationId,
 	);
-
-	if (!userOrganization || !userOrganization.organization) {
-		throw new HTTPException(404, {
-			message: "Organization not found",
-		});
-	}
 
 	const organizationId = userOrganization.organization.id;
 
@@ -787,6 +739,11 @@ payments.openapi(topUpWithSavedMethod, async (c) => {
 		organizationId?: string;
 	} = c.req.valid("json");
 
+	const userOrganization = await getBillingOrganization(
+		user.id,
+		requestedOrganizationId,
+	);
+
 	const paymentMethod = await db.query.paymentMethod.findFirst({
 		where: {
 			id: paymentMethodId,
@@ -799,16 +756,7 @@ payments.openapi(topUpWithSavedMethod, async (c) => {
 		});
 	}
 
-	const userOrganization = await findUserOrganization(
-		user.id,
-		requestedOrganizationId,
-	);
-
-	if (
-		!userOrganization ||
-		!userOrganization.organization ||
-		userOrganization.organization.id !== paymentMethod.organizationId
-	) {
+	if (userOrganization.organization.id !== paymentMethod.organizationId) {
 		throw new HTTPException(403, {
 			message: "Unauthorized access to payment method",
 		});
@@ -1012,16 +960,10 @@ payments.openapi(createCheckoutSession, async (c) => {
 		organizationId: requestedOrganizationId,
 	} = c.req.valid("json");
 
-	const userOrganization = await findUserOrganization(
+	const userOrganization = await getBillingOrganization(
 		user.id,
 		requestedOrganizationId,
 	);
-
-	if (!userOrganization || !userOrganization.organization) {
-		throw new HTTPException(404, {
-			message: "Organization not found",
-		});
-	}
 
 	const organizationId = userOrganization.organization.id;
 
@@ -1210,16 +1152,10 @@ payments.openapi(calculateFeesRoute, async (c) => {
 		organizationId?: string;
 	} = c.req.valid("json");
 
-	const userOrganization = await findUserOrganization(
+	const userOrganization = await getBillingOrganization(
 		user.id,
 		requestedOrganizationId,
 	);
-
-	if (!userOrganization || !userOrganization.organization) {
-		throw new HTTPException(404, {
-			message: "Organization not found",
-		});
-	}
 
 	let isInternational = false;
 	if (paymentMethodId) {

--- a/apps/api/src/routes/subscriptions.ts
+++ b/apps/api/src/routes/subscriptions.ts
@@ -2,11 +2,11 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
+import { getBillingOrganization } from "@/lib/billing-organization.js";
 import { forcedThreeDSecureOptions } from "@/lib/three-d-secure.js";
 import { ensureStripeCustomer } from "@/stripe.js";
 
 import { logAuditEvent } from "@llmgateway/audit";
-import { db } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
 
 import { getStripe } from "./payments.js";
@@ -15,10 +15,13 @@ import type { ServerTypes } from "@/vars.js";
 
 export const subscriptions = new OpenAPIHono<ServerTypes>();
 
+const organizationQuery = z.object({ organizationId: z.string().optional() });
+
 const createProSubscription = createRoute({
 	method: "post",
 	path: "/create-pro-subscription",
 	request: {
+		query: organizationQuery,
 		body: {
 			content: {
 				"application/json": {
@@ -63,20 +66,11 @@ subscriptions.openapi(createProSubscription, async (c) => {
 		});
 	}
 
-	const userOrganization = await db.query.userOrganization.findFirst({
-		where: {
-			userId: user.id,
-		},
-		with: {
-			organization: true,
-		},
-	});
-
-	if (!userOrganization || !userOrganization.organization) {
-		throw new HTTPException(404, {
-			message: "Organization or user not found",
-		});
-	}
+	const { organizationId } = c.req.valid("query");
+	const userOrganization = await getBillingOrganization(
+		user.id,
+		organizationId,
+	);
 
 	// Only owners can manage subscriptions
 	if (userOrganization.role !== "owner") {
@@ -180,7 +174,7 @@ subscriptions.openapi(createProSubscription, async (c) => {
 const cancelProSubscription = createRoute({
 	method: "post",
 	path: "/cancel-pro-subscription",
-	request: {},
+	request: { query: organizationQuery },
 	responses: {
 		200: {
 			content: {
@@ -204,20 +198,11 @@ subscriptions.openapi(cancelProSubscription, async (c) => {
 		});
 	}
 
-	const userOrganization = await db.query.userOrganization.findFirst({
-		where: {
-			userId: user.id,
-		},
-		with: {
-			organization: true,
-		},
-	});
-
-	if (!userOrganization || !userOrganization.organization) {
-		throw new HTTPException(404, {
-			message: "Organization not found",
-		});
-	}
+	const { organizationId } = c.req.valid("query");
+	const userOrganization = await getBillingOrganization(
+		user.id,
+		organizationId,
+	);
 
 	// Only owners can manage subscriptions
 	if (userOrganization.role !== "owner") {
@@ -270,7 +255,7 @@ subscriptions.openapi(cancelProSubscription, async (c) => {
 const resumeProSubscription = createRoute({
 	method: "post",
 	path: "/resume-pro-subscription",
-	request: {},
+	request: { query: organizationQuery },
 	responses: {
 		200: {
 			content: {
@@ -294,20 +279,11 @@ subscriptions.openapi(resumeProSubscription, async (c) => {
 		});
 	}
 
-	const userOrganization = await db.query.userOrganization.findFirst({
-		where: {
-			userId: user.id,
-		},
-		with: {
-			organization: true,
-		},
-	});
-
-	if (!userOrganization || !userOrganization.organization) {
-		throw new HTTPException(404, {
-			message: "Organization not found",
-		});
-	}
+	const { organizationId } = c.req.valid("query");
+	const userOrganization = await getBillingOrganization(
+		user.id,
+		organizationId,
+	);
 
 	// Only owners can manage subscriptions
 	if (userOrganization.role !== "owner") {
@@ -371,7 +347,7 @@ subscriptions.openapi(resumeProSubscription, async (c) => {
 const upgradeToYearlyPlan = createRoute({
 	method: "post",
 	path: "/upgrade-to-yearly",
-	request: {},
+	request: { query: organizationQuery },
 	responses: {
 		200: {
 			content: {
@@ -395,20 +371,11 @@ subscriptions.openapi(upgradeToYearlyPlan, async (c) => {
 		});
 	}
 
-	const userOrganization = await db.query.userOrganization.findFirst({
-		where: {
-			userId: user.id,
-		},
-		with: {
-			organization: true,
-		},
-	});
-
-	if (!userOrganization || !userOrganization.organization) {
-		throw new HTTPException(404, {
-			message: "Organization not found",
-		});
-	}
+	const { organizationId } = c.req.valid("query");
+	const userOrganization = await getBillingOrganization(
+		user.id,
+		organizationId,
+	);
 
 	// Only owners can manage subscriptions
 	if (userOrganization.role !== "owner") {
@@ -486,7 +453,7 @@ subscriptions.openapi(upgradeToYearlyPlan, async (c) => {
 const getSubscriptionStatus = createRoute({
 	method: "get",
 	path: "/status",
-	request: {},
+	request: { query: organizationQuery },
 	responses: {
 		200: {
 			content: {
@@ -514,20 +481,11 @@ subscriptions.openapi(getSubscriptionStatus, async (c) => {
 		});
 	}
 
-	const userOrganization = await db.query.userOrganization.findFirst({
-		where: {
-			userId: user.id,
-		},
-		with: {
-			organization: true,
-		},
-	});
-
-	if (!userOrganization || !userOrganization.organization) {
-		throw new HTTPException(404, {
-			message: "Organization not found",
-		});
-	}
+	const { organizationId } = c.req.valid("query");
+	const userOrganization = await getBillingOrganization(
+		user.id,
+		organizationId,
+	);
 
 	const organization = userOrganization.organization;
 

--- a/apps/api/src/utils/default-org.ts
+++ b/apps/api/src/utils/default-org.ts
@@ -34,7 +34,7 @@ function isActiveDashboardOrganization(userOrganization: {
 // user can join/leave multiple organizations they don't own. Requiring
 // ownership prevents mirroring invoice details from someone else's org that
 // merely happens to carry this user's email as its billing email. Only fall
-// back to the first-active organization when no owned billing-email match
+// back to an organization they administer when no owned billing-email match
 // exists.
 export async function findDefaultOrganization(
 	userId: string,
@@ -43,6 +43,7 @@ export async function findDefaultOrganization(
 	const userOrganizations = await db.query.userOrganization.findMany({
 		where: {
 			userId,
+			role: { in: ["owner", "admin"] },
 		},
 		with: {
 			organization: true,

--- a/apps/api/src/utils/serialize-organization.ts
+++ b/apps/api/src/utils/serialize-organization.ts
@@ -1,9 +1,13 @@
+import { organizationBillingFields } from "@llmgateway/db";
+import { isOrganizationAdmin } from "@llmgateway/shared/organization-roles";
+
 import type { Organization, SerializedOrganization } from "@llmgateway/db";
 
 export function serializeOrganization(
 	organization: Organization,
+	role: string | undefined,
 ): SerializedOrganization {
-	return {
+	const serialized: SerializedOrganization = {
 		id: organization.id,
 		createdAt: organization.createdAt.toISOString(),
 		updatedAt: organization.updatedAt.toISOString(),
@@ -68,4 +72,13 @@ export function serializeOrganization(
 		defaultDeveloperPeriodUsageDurationUnit:
 			organization.defaultDeveloperPeriodUsageDurationUnit,
 	};
+
+	if (isOrganizationAdmin(role)) {
+		return serialized;
+	}
+	return Object.fromEntries(
+		Object.entries(serialized).filter(
+			([field]) => !Object.hasOwn(organizationBillingFields, field),
+		),
+	) as SerializedOrganization;
 }

--- a/apps/playground/e2e/billing-access.pw.ts
+++ b/apps/playground/e2e/billing-access.pw.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+
+const apiUrl = process.env.PW_API_URL ?? "http://localhost:4002";
+const orgId = "enterprise-org-id";
+
+for (const email of ["developer@example.com", "project-admin@example.com"]) {
+	test(`${email} can use the Playground without billing controls`, async ({
+		page,
+	}) => {
+		const login = await page.request.post(`${apiUrl}/auth/sign-in/email`, {
+			data: { email, password: email },
+		});
+		expect(login.ok()).toBe(true);
+		const billingRequests: string[] = [];
+		page.on("request", (request) => {
+			if (request.url().startsWith(`${apiUrl}/payments/`)) {
+				billingRequests.push(request.url());
+			}
+		});
+		for (const path of ["/", "/image", "/video", "/audio"]) {
+			await page.goto(`${path}?orgId=${orgId}&projectId=enterprise-project-id`);
+			await expect(
+				page.getByRole("navigation", { name: "Studios" }),
+			).toBeVisible();
+			await expect(page.getByRole("button", { name: /^Credits/ })).toHaveCount(
+				0,
+			);
+			await expect(page.getByRole("button", { name: /top up/i })).toHaveCount(
+				0,
+			);
+			await expect(page.getByText(/Low credits remaining/)).toHaveCount(0);
+		}
+		expect(billingRequests).toEqual([]);
+	});
+}
+
+test("an owner can top up the selected organization's credits", async ({
+	page,
+}) => {
+	const email = "enterprise@example.com";
+	const login = await page.request.post(`${apiUrl}/auth/sign-in/email`, {
+		data: { email, password: email },
+	});
+	expect(login.ok()).toBe(true);
+	await page.goto(`/?orgId=${orgId}`);
+	const methods = page.waitForRequest((request) =>
+		request.url().startsWith(`${apiUrl}/payments/payment-methods`),
+	);
+	await page.getByRole("button", { name: /^Credits/ }).click();
+	expect(
+		new URL((await methods).url()).searchParams.get("organizationId"),
+	).toBe(orgId);
+	await expect(page.getByRole("dialog")).toBeVisible();
+});

--- a/apps/playground/src/app/playground-shell.tsx
+++ b/apps/playground/src/app/playground-shell.tsx
@@ -10,6 +10,8 @@ import { CHAT_CONTEXT_COOKIE } from "@/lib/constants";
 import { fetchModels, fetchProviders } from "@/lib/fetch-models";
 import { fetchServerData } from "@/lib/server-api";
 
+import { isOrganizationAdmin } from "@llmgateway/shared/organization-roles";
+
 import type { Organization, Project } from "@/lib/types";
 
 export interface GatewayModel {
@@ -109,13 +111,9 @@ export async function renderPlaygroundShell({
 
 	const organizations = allOrganizations.filter((o) => o.kind === "default");
 
-	// The Chat plan context is only the right default for subscribers (or users
-	// who topped up the Chat org). Unsubscribed users with a funded dashboard
-	// org land on that org instead; the Chat plan context stays the default only
-	// when no org has credits, so the plan upsell can take over. Runs before the
-	// chat-org fetch so redirected users never get a Chat org provisioned.
-	// Skipped when the user explicitly picked the Chat plan context in the org
-	// switcher (cookie) — this fallback must not override an explicit choice.
+	// Prefer an available team org when the user has no Chat plan. Member
+	// balances are private, so let the gateway decide whether they can spend.
+	// An explicitly selected Chat plan context skips this fallback.
 	if (shouldCheckChatPlan) {
 		const chatPlanStatus =
 			chatPlanStatusData &&
@@ -128,17 +126,17 @@ export async function renderPlaygroundShell({
 			chatPlanStatus.chatPlan !== "none" ||
 			Number(chatPlanStatus.regularCredits) > 0;
 		if (!hasChatPlanAccess) {
-			const fundedOrganization = organizations.find(
-				(o) => Number(o.credits) > 0,
+			const availableOrganization = organizations.find(
+				(o) => !isOrganizationAdmin(o.role) || Number(o.credits) > 0,
 			);
-			if (fundedOrganization) {
+			if (availableOrganization) {
 				const nextParams = new URLSearchParams();
 				for (const [key, value] of Object.entries(searchParams)) {
 					if (typeof value === "string") {
 						nextParams.set(key, value);
 					}
 				}
-				nextParams.set("orgId", fundedOrganization.id);
+				nextParams.set("orgId", availableOrganization.id);
 				redirect(`/?${nextParams.toString()}`);
 			}
 		}

--- a/apps/playground/src/app/playground-shell.tsx
+++ b/apps/playground/src/app/playground-shell.tsx
@@ -8,9 +8,8 @@ import { LoungeLandingSections } from "@/components/seo/lounge-landing-sections"
 import { PlaygroundSeoSection } from "@/components/seo/playground-seo-section";
 import { CHAT_CONTEXT_COOKIE } from "@/lib/constants";
 import { fetchModels, fetchProviders } from "@/lib/fetch-models";
+import { findFallbackOrganization } from "@/lib/organization-fallback";
 import { fetchServerData } from "@/lib/server-api";
-
-import { isOrganizationAdmin } from "@llmgateway/shared/organization-roles";
 
 import type { Organization, Project } from "@/lib/types";
 
@@ -111,8 +110,8 @@ export async function renderPlaygroundShell({
 
 	const organizations = allOrganizations.filter((o) => o.kind === "default");
 
-	// Prefer an available team org when the user has no Chat plan. Member
-	// balances are private, so let the gateway decide whether they can spend.
+	// Prefer a funded admin org when the user has no Chat plan, then fall back
+	// to memberships with private balances and let the gateway check spending.
 	// An explicitly selected Chat plan context skips this fallback.
 	if (shouldCheckChatPlan) {
 		const chatPlanStatus =
@@ -126,9 +125,7 @@ export async function renderPlaygroundShell({
 			chatPlanStatus.chatPlan !== "none" ||
 			Number(chatPlanStatus.regularCredits) > 0;
 		if (!hasChatPlanAccess) {
-			const availableOrganization = organizations.find(
-				(o) => !isOrganizationAdmin(o.role) || Number(o.credits) > 0,
-			);
+			const availableOrganization = findFallbackOrganization(organizations);
 			if (availableOrganization) {
 				const nextParams = new URLSearchParams();
 				for (const [key, value] of Object.entries(searchParams)) {

--- a/apps/playground/src/components/credits/credits-display.tsx
+++ b/apps/playground/src/components/credits/credits-display.tsx
@@ -7,14 +7,11 @@ import Link from "next/link";
 import { useApi } from "@/lib/fetch-client";
 import { formatCredits } from "@/lib/format-credits";
 
+import { isOrganizationAdmin } from "@llmgateway/shared/organization-roles";
+
 import { TopUpCreditsDialog } from "./top-up-credits-dialog";
 
-interface Organization {
-	id: string;
-	name: string;
-	credits: string;
-	plan: "free" | "pro" | "enterprise";
-}
+import type { Organization } from "@/lib/types";
 
 interface CreditsDisplayProps {
 	organization: Organization | null;
@@ -37,6 +34,10 @@ export function CreditsDisplay({
 	});
 	const plan = planQuery.data;
 	const hasActivePlan = isChatPlanOrg && plan && plan.chatPlan !== "none";
+
+	if (!isChatPlanOrg && !isOrganizationAdmin(organization?.role)) {
+		return null;
+	}
 
 	if (isLoading) {
 		return (

--- a/apps/playground/src/components/credits/top-up-credits-dialog.tsx
+++ b/apps/playground/src/components/credits/top-up-credits-dialog.tsx
@@ -31,6 +31,7 @@ import {
 	CREDIT_TOP_UP_MIN_AMOUNT,
 	isCreditTopUpAmountInRange,
 } from "@llmgateway/shared";
+import { isOrganizationAdmin } from "@llmgateway/shared/organization-roles";
 
 import type React from "react";
 
@@ -49,12 +50,36 @@ interface TopUpCreditsDialogProps {
 	children?: React.ReactNode;
 	open?: boolean;
 	onOpenChange?: (open: boolean) => void;
-	// The org credits should be added to (the playground's Chat org). When
-	// omitted, the API falls back to the user's first organization.
+	// The organization receiving the credits.
 	organizationId?: string;
 }
 
-export function TopUpCreditsDialog({
+export function TopUpCreditsDialog(props: TopUpCreditsDialogProps) {
+	const api = useApi();
+	const { data } = api.useQuery(
+		"get",
+		"/orgs",
+		{
+			params: { query: { includeChat: "true" } },
+		},
+		{ enabled: Boolean(props.organizationId) },
+	);
+	const organization = data?.organizations.find(
+		(org) => org.id === props.organizationId,
+	);
+	if (!organization || !isOrganizationAdmin(organization.role)) {
+		return null;
+	}
+	return (
+		<BillingTopUpCreditsDialog
+			key={organization.id}
+			{...props}
+			organizationId={organization.id}
+		/>
+	);
+}
+
+function BillingTopUpCreditsDialog({
 	children,
 	open: controlledOpen,
 	onOpenChange: controlledOnOpenChange,
@@ -81,7 +106,7 @@ export function TopUpCreditsDialog({
 		api.useQuery(
 			"get",
 			"/payments/payment-methods",
-			{},
+			{ params: { query: { organizationId } } },
 			{
 				enabled: open, // Only fetch when dialog is open
 			},
@@ -273,7 +298,7 @@ function AmountStep({
 		"post",
 		"/payments/calculate-fees",
 		{
-			body: { amount },
+			body: { amount, organizationId },
 		},
 		{
 			enabled: isAmountValid,
@@ -493,7 +518,9 @@ function PaymentStep({
 			let stripePaymentMethodId: string | undefined;
 
 			if (saveCard) {
-				const { clientSecret: setupSecret } = await setupIntentMutation({});
+				const { clientSecret: setupSecret } = await setupIntentMutation({
+					body: { organizationId },
+				});
 
 				const setupResult = await stripe.confirmCardSetup(setupSecret, {
 					payment_method: {
@@ -755,7 +782,7 @@ function ConfirmPaymentStep({
 		"post",
 		"/payments/calculate-fees",
 		{
-			body: { amount, paymentMethodId },
+			body: { amount, paymentMethodId, organizationId },
 		},
 	);
 

--- a/apps/playground/src/components/playground/audio-page-client.tsx
+++ b/apps/playground/src/components/playground/audio-page-client.tsx
@@ -23,6 +23,7 @@ import { getModelAudioConfig } from "@/lib/audio-gen";
 import {
 	chatPlanCreditErrorMessage,
 	isInsufficientCreditsError,
+	organizationCreditErrorMessage,
 } from "@/lib/credit-error";
 import { useApi } from "@/lib/fetch-client";
 import { mapModels } from "@/lib/mapmodels";
@@ -32,6 +33,8 @@ import {
 	setModelPreferenceCookie,
 } from "@/lib/model-preferences";
 import { shouldDisableFallback } from "@/lib/no-fallback";
+
+import { isOrganizationAdmin } from "@llmgateway/shared/organization-roles";
 
 import type { AudioFormat, AudioGalleryItem } from "@/lib/audio-gen";
 import type { ApiModel, ApiProvider } from "@/lib/fetch-models";
@@ -480,7 +483,11 @@ export default function AudioPageClient({
 								isChatPlanContext &&
 									isInsufficientCreditsError(response.status, rawMessage)
 									? chatPlanCreditErrorMessage(chatPlanSubscribed, "audio")
-									: rawMessage,
+									: organizationCreditErrorMessage(
+											rawMessage,
+											selectedOrganization?.role,
+											response.status,
+										),
 							);
 						}
 
@@ -704,20 +711,22 @@ export default function AudioPageClient({
 						onComparisonModeChange={handleComparisonModeChange}
 						hideCompare={displayItems.length > 0}
 					/>
-					{isLowCredits && !isChatPlanContext && (
-						<div className="bg-yellow-50 dark:bg-yellow-900/20 border-b px-4 py-2 flex items-center justify-between">
-							<p className="text-sm text-yellow-800 dark:text-yellow-200">
-								Low credits remaining. Top up to continue generating audio.
-							</p>
-							<Button
-								variant="outline"
-								size="sm"
-								onClick={() => setShowTopUp(true)}
-							>
-								Top Up
-							</Button>
-						</div>
-					)}
+					{isLowCredits &&
+						!isChatPlanContext &&
+						isOrganizationAdmin(selectedOrganization?.role) && (
+							<div className="bg-yellow-50 dark:bg-yellow-900/20 border-b px-4 py-2 flex items-center justify-between">
+								<p className="text-sm text-yellow-800 dark:text-yellow-200">
+									Low credits remaining. Top up to continue generating audio.
+								</p>
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={() => setShowTopUp(true)}
+								>
+									Top Up
+								</Button>
+							</div>
+						)}
 					<AudioControls
 						prompt={prompt}
 						setPrompt={setPrompt}

--- a/apps/playground/src/components/playground/chat-page-client.tsx
+++ b/apps/playground/src/components/playground/chat-page-client.tsx
@@ -41,6 +41,7 @@ import { useMcpServers } from "@/hooks/useMcpServers";
 import { useOrganization } from "@/hooks/useOrganization";
 import { useSkills, type Skill } from "@/hooks/useSkills";
 import { useUser } from "@/hooks/useUser";
+import { organizationCreditErrorMessage } from "@/lib/credit-error";
 import { useApi } from "@/lib/fetch-client";
 import { getModelImageConfig } from "@/lib/image-gen";
 import { parseImageFile } from "@/lib/image-utils";
@@ -52,6 +53,8 @@ import {
 } from "@/lib/model-utils";
 import { shouldDisableFallback } from "@/lib/no-fallback";
 import { getErrorMessage } from "@/lib/utils";
+
+import { isOrganizationAdmin } from "@llmgateway/shared/organization-roles";
 
 import type {
 	ApiModel,
@@ -439,7 +442,12 @@ export default function ChatPageClient({
 				streamingChatIdRef.current = null;
 				isSendingRef.current = false;
 				errorOccurredRef.current = true;
-				const msg = getErrorMessage(e);
+				const msg = selectedOrganization
+					? organizationCreditErrorMessage(
+							getErrorMessage(e),
+							selectedOrganization.role,
+						)
+					: getErrorMessage(e);
 				setError(msg);
 				toast.error(msg);
 
@@ -1266,7 +1274,10 @@ export default function ChatPageClient({
 		if (selectedOrganization) {
 			// Chat plan credits live on the Chat org and never fund dashboard-org
 			// requests, so only the org's own credits count here.
-			if (Number(selectedOrganization.credits) <= 0) {
+			if (
+				isOrganizationAdmin(selectedOrganization.role) &&
+				Number(selectedOrganization.credits) <= 0
+			) {
 				setShowTopUp(true);
 				return false;
 			}
@@ -2311,6 +2322,7 @@ export default function ChatPageClient({
 											className="hidden md:flex flex-col h-full min-h-0"
 										>
 											<ExtraChatPanel
+												organizationRole={selectedOrganization?.role}
 												panelIndex={index + 2}
 												models={models}
 												providers={providers}
@@ -2439,6 +2451,7 @@ export default function ChatPageClient({
 	);
 }
 interface ExtraChatPanelProps {
+	organizationRole?: string;
 	panelIndex: number;
 	models: ApiModel[];
 	providers: ApiProvider[];
@@ -2464,6 +2477,7 @@ interface ExtraChatPanelProps {
 }
 
 function ExtraChatPanel({
+	organizationRole,
 	panelIndex,
 	models,
 	providers,
@@ -2584,7 +2598,9 @@ function ExtraChatPanel({
 	const { messages, setMessages, sendMessage, status, stop, regenerate } =
 		useChat({
 			onError: async (e) => {
-				const msg = getErrorMessage(e);
+				const msg = organizationRole
+					? organizationCreditErrorMessage(getErrorMessage(e), organizationRole)
+					: getErrorMessage(e);
 				toast.error(msg);
 			},
 			onFinish: async ({ message }) => {

--- a/apps/playground/src/components/playground/image-page-client.tsx
+++ b/apps/playground/src/components/playground/image-page-client.tsx
@@ -681,6 +681,7 @@ export default function ImagePageClient({
 			posthog,
 			requiresImageInput,
 			selectedOrganization?.id,
+			selectedOrganization?.role,
 			isChatPlanContext,
 			chatPlanSubscribed,
 		],

--- a/apps/playground/src/components/playground/image-page-client.tsx
+++ b/apps/playground/src/components/playground/image-page-client.tsx
@@ -24,6 +24,7 @@ import { useAppConfig } from "@/lib/config";
 import {
 	chatPlanCreditErrorMessage,
 	isInsufficientCreditsError,
+	organizationCreditErrorMessage,
 } from "@/lib/credit-error";
 import { useApi } from "@/lib/fetch-client";
 import {
@@ -38,6 +39,8 @@ import {
 	setModelPreferenceCookie,
 } from "@/lib/model-preferences";
 import { shouldDisableFallback } from "@/lib/no-fallback";
+
+import { isOrganizationAdmin } from "@llmgateway/shared/organization-roles";
 
 import type { ApiModel, ApiProvider } from "@/lib/fetch-models";
 import type { AspectRatio, GalleryItem } from "@/lib/image-gen";
@@ -592,7 +595,11 @@ export default function ImagePageClient({
 									isChatPlanContext &&
 										isInsufficientCreditsError(error.status, error.message)
 										? chatPlanCreditErrorMessage(chatPlanSubscribed, "images")
-										: error.message,
+										: organizationCreditErrorMessage(
+												error.message,
+												selectedOrganization?.role,
+												error.status,
+											),
 								);
 							}
 							throw error;
@@ -835,20 +842,22 @@ export default function ImagePageClient({
 						onComparisonModeChange={handleComparisonModeChange}
 						hideCompare={displayItems.length > 0}
 					/>
-					{isLowCredits && !isChatPlanContext && (
-						<div className="bg-yellow-50 dark:bg-yellow-900/20 border-b px-4 py-2 flex items-center justify-between">
-							<p className="text-sm text-yellow-800 dark:text-yellow-200">
-								Low credits remaining. Top up to continue generating images.
-							</p>
-							<Button
-								variant="outline"
-								size="sm"
-								onClick={() => setShowTopUp(true)}
-							>
-								Top Up
-							</Button>
-						</div>
-					)}
+					{isLowCredits &&
+						!isChatPlanContext &&
+						isOrganizationAdmin(selectedOrganization?.role) && (
+							<div className="bg-yellow-50 dark:bg-yellow-900/20 border-b px-4 py-2 flex items-center justify-between">
+								<p className="text-sm text-yellow-800 dark:text-yellow-200">
+									Low credits remaining. Top up to continue generating images.
+								</p>
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={() => setShowTopUp(true)}
+								>
+									Top Up
+								</Button>
+							</div>
+						)}
 					<ImageControls
 						prompt={prompt}
 						setPrompt={setPrompt}

--- a/apps/playground/src/components/playground/video-page-client.tsx
+++ b/apps/playground/src/components/playground/video-page-client.tsx
@@ -855,6 +855,7 @@ export default function VideoPageClient({
 			updateGalleryModel,
 			someModelsRequireImage,
 			selectedOrganization?.id,
+			selectedOrganization?.role,
 			isChatPlanContext,
 			chatPlanSubscribed,
 		],

--- a/apps/playground/src/components/playground/video-page-client.tsx
+++ b/apps/playground/src/components/playground/video-page-client.tsx
@@ -23,6 +23,7 @@ import { useAppConfig } from "@/lib/config";
 import {
 	chatPlanCreditErrorMessage,
 	isInsufficientCreditsError,
+	organizationCreditErrorMessage,
 } from "@/lib/credit-error";
 import { useApi, useFetchClient } from "@/lib/fetch-client";
 import { mapModels } from "@/lib/mapmodels";
@@ -41,6 +42,8 @@ import {
 	supportsVideoReferenceVideoInput,
 	supportsVideoReferenceAudioInput,
 } from "@/lib/video-gen";
+
+import { isOrganizationAdmin } from "@llmgateway/shared/organization-roles";
 
 import type { ApiModel, ApiProvider } from "@/lib/fetch-models";
 import type { ComboboxModel, Organization, Project } from "@/lib/types";
@@ -766,7 +769,11 @@ export default function VideoPageClient({
 								isChatPlanContext &&
 									isInsufficientCreditsError(response.status, rawMessage)
 									? chatPlanCreditErrorMessage(chatPlanSubscribed, "videos")
-									: rawMessage,
+									: organizationCreditErrorMessage(
+											rawMessage,
+											selectedOrganization?.role,
+											response.status,
+										),
 							);
 						}
 
@@ -997,20 +1004,22 @@ export default function VideoPageClient({
 						onComparisonModeChange={handleComparisonModeChange}
 						hideCompare={displayItems.length > 0}
 					/>
-					{isLowCredits && !isChatPlanContext && (
-						<div className="bg-yellow-50 dark:bg-yellow-900/20 border-b px-4 py-2 flex items-center justify-between">
-							<p className="text-sm text-yellow-800 dark:text-yellow-200">
-								Low credits remaining. Top up to continue generating videos.
-							</p>
-							<Button
-								variant="outline"
-								size="sm"
-								onClick={() => setShowTopUp(true)}
-							>
-								Top Up
-							</Button>
-						</div>
-					)}
+					{isLowCredits &&
+						!isChatPlanContext &&
+						isOrganizationAdmin(selectedOrganization?.role) && (
+							<div className="bg-yellow-50 dark:bg-yellow-900/20 border-b px-4 py-2 flex items-center justify-between">
+								<p className="text-sm text-yellow-800 dark:text-yellow-200">
+									Low credits remaining. Top up to continue generating videos.
+								</p>
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={() => setShowTopUp(true)}
+								>
+									Top Up
+								</Button>
+							</div>
+						)}
 					<VideoControls
 						prompt={prompt}
 						setPrompt={setPrompt}

--- a/apps/playground/src/lib/credit-error.spec.ts
+++ b/apps/playground/src/lib/credit-error.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
 	chatPlanCreditErrorMessage,
 	isInsufficientCreditsError,
+	organizationCreditErrorMessage,
 } from "./credit-error";
 
 describe("isInsufficientCreditsError", () => {
@@ -38,6 +39,29 @@ describe("isInsufficientCreditsError", () => {
 			false,
 		);
 		expect(isInsufficientCreditsError(undefined, undefined)).toBe(false);
+	});
+});
+
+describe("organizationCreditErrorMessage", () => {
+	it.each(["developer", "project_admin", undefined])(
+		"directs %s to an administrator",
+		(role) => {
+			expect(
+				organizationCreditErrorMessage("Please add credits", role, 402),
+			).toBe(
+				"Your organization has insufficient credits. Contact an organization administrator.",
+			);
+		},
+	);
+	it.each(["owner", "admin"])("preserves top-up guidance for %s", (role) => {
+		expect(
+			organizationCreditErrorMessage("Please add credits", role, 402),
+		).toBe("Please add credits");
+	});
+	it("preserves unrelated errors", () => {
+		expect(
+			organizationCreditErrorMessage("Invalid image size", "developer", 400),
+		).toBe("Invalid image size");
 	});
 });
 

--- a/apps/playground/src/lib/credit-error.ts
+++ b/apps/playground/src/lib/credit-error.ts
@@ -1,3 +1,5 @@
+import { isOrganizationAdmin } from "@llmgateway/shared/organization-roles";
+
 const CREDIT_ERROR_PATTERN =
 	/(available credits|insufficient (?:credits|balance|funds)|add credits|out of credits|not enough credits)/i;
 
@@ -24,4 +26,15 @@ export function chatPlanCreditErrorMessage(
 	return subscribed
 		? `You've used all your plan credits. Upgrade your plan to continue generating ${noun}.`
 		: `Subscribe to a plan to continue generating ${noun}.`;
+}
+
+export function organizationCreditErrorMessage(
+	message: string,
+	role: string | undefined,
+	status?: number,
+): string {
+	return !isOrganizationAdmin(role) &&
+		isInsufficientCreditsError(status, message)
+		? "Your organization has insufficient credits. Contact an organization administrator."
+		: message;
 }

--- a/apps/playground/src/lib/organization-fallback.spec.ts
+++ b/apps/playground/src/lib/organization-fallback.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { findFallbackOrganization } from "./organization-fallback";
+
+describe.each(["developer", "project_admin"] as const)(
+	"%s membership",
+	(role) => {
+		const memberOrganization = { id: "team-org", role };
+
+		it.each(["owner", "admin"] as const)(
+			"prefers a funded %s organization regardless of list order",
+			(adminRole) => {
+				const fundedOrganization = {
+					id: "funded-org",
+					role: adminRole,
+					credits: "10",
+				};
+				for (const organizations of [
+					[memberOrganization, fundedOrganization],
+					[fundedOrganization, memberOrganization],
+				]) {
+					expect(findFallbackOrganization(organizations)).toBe(
+						fundedOrganization,
+					);
+				}
+			},
+		);
+
+		it("falls back to the membership with hidden credits when admin orgs are unfunded", () => {
+			expect(
+				findFallbackOrganization([
+					{ id: "empty-org", role: "owner", credits: "0" },
+					memberOrganization,
+				]),
+			).toBe(memberOrganization);
+		});
+	},
+);
+
+it("does not select an admin organization without spendable credits", () => {
+	expect(
+		findFallbackOrganization([
+			{ id: "empty-org", role: "owner", credits: "0" },
+			{ id: "negative-org", role: "admin", credits: "-1" },
+			{ id: "unknown-org", role: "owner" },
+		]),
+	).toBeUndefined();
+});
+
+it("has no fallback without memberships", () => {
+	expect(findFallbackOrganization([])).toBeUndefined();
+});

--- a/apps/playground/src/lib/organization-fallback.ts
+++ b/apps/playground/src/lib/organization-fallback.ts
@@ -1,0 +1,18 @@
+import { isOrganizationAdmin } from "@llmgateway/shared/organization-roles";
+
+import type { Organization } from "@/lib/types";
+
+export function findFallbackOrganization(
+	organizations: Pick<Organization, "id" | "role" | "credits">[],
+) {
+	return (
+		organizations.find(
+			(organization) =>
+				isOrganizationAdmin(organization.role) &&
+				Number(organization.credits) > 0,
+		) ??
+		organizations.find(
+			(organization) => !isOrganizationAdmin(organization.role),
+		)
+	);
+}

--- a/apps/playground/src/lib/types.ts
+++ b/apps/playground/src/lib/types.ts
@@ -78,7 +78,8 @@ export interface Organization {
 	updatedAt: string;
 	name: string;
 	kind: "default" | "chat" | "devpass";
-	credits: string;
+	role?: "owner" | "admin" | "project_admin" | "developer";
+	credits?: string;
 	chatPlan?: "none" | "starter" | "plus" | "pro";
 	chatPlanCreditsLimit?: string | null;
 	chatPlanCreditsUsed?: string | null;
@@ -88,7 +89,7 @@ export interface Organization {
 	planExpiresAt: string | null;
 	retentionLevel: "retain" | "none";
 	status: "active" | "inactive" | "deleted" | null;
-	autoTopUpEnabled: boolean;
-	autoTopUpThreshold: string | null;
-	autoTopUpAmount: string | null;
+	autoTopUpEnabled?: boolean;
+	autoTopUpThreshold?: string | null;
+	autoTopUpAmount?: string | null;
 }

--- a/apps/ui/e2e/billing-access.pw.ts
+++ b/apps/ui/e2e/billing-access.pw.ts
@@ -52,6 +52,32 @@ test("an owner can open billing and the top-up dialog", async ({ page }) => {
 	).toBeVisible();
 });
 
+for (const { email, isOwner } of [
+	{ email: "enterprise@example.com", isOwner: true },
+	{ email: "admin@example.com", isOwner: false },
+]) {
+	test(`${email} sees payment status and an appropriate auto top-up prompt`, async ({
+		page,
+	}) => {
+		await signIn(page, email);
+		await page.goto(`/dashboard/${orgId}/org/billing?success=true`);
+		await expect(
+			page.getByText("Payment successful", { exact: true }),
+		).toHaveCount(1);
+		const nudge = page.getByText("Never run out of credits", { exact: true });
+		if (isOwner) {
+			await expect(nudge).toBeVisible();
+			await page.getByRole("button", { name: "Dismiss", exact: true }).click();
+		}
+		await expect(nudge).toHaveCount(0);
+		await page.goto(`/dashboard/${orgId}/org/billing?canceled=true`);
+		await expect(
+			page.getByText("Payment canceled", { exact: true }),
+		).toHaveCount(1);
+		await expect(nudge).toHaveCount(0);
+	});
+}
+
 test("billing remains inaccessible without browser JavaScript", async ({
 	browser,
 	baseURL,

--- a/apps/ui/e2e/billing-access.pw.ts
+++ b/apps/ui/e2e/billing-access.pw.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "@playwright/test";
+
+import type { Page } from "@playwright/test";
+
+const apiUrl = process.env.PW_API_URL ?? "http://localhost:4002";
+const orgId = "enterprise-org-id";
+
+async function signIn(page: Page, email: string) {
+	const response = await page.request.post(`${apiUrl}/auth/sign-in/email`, {
+		data: { email, password: email },
+	});
+	expect(response.ok()).toBe(true);
+}
+
+for (const email of ["developer@example.com", "project-admin@example.com"]) {
+	test(`${email} cannot open billing or transactions`, async ({ page }) => {
+		await signIn(page, email);
+		const billingRequests: string[] = [];
+		page.on("request", (request) => {
+			if (request.url().startsWith(`${apiUrl}/payments/`)) {
+				billingRequests.push(request.url());
+			}
+		});
+		for (const path of ["billing", "transactions"]) {
+			await page.goto(`/dashboard/${orgId}/org/${path}`);
+			await expect(
+				page.getByRole("heading", { name: "Unauthorized", exact: true }),
+			).toBeVisible();
+			await expect(
+				page.getByRole("button", { name: /top up credits/i }),
+			).toHaveCount(0);
+			await expect(
+				page.getByRole("link", { name: "Billing", exact: true }),
+			).toHaveCount(0);
+		}
+		expect(billingRequests).toEqual([]);
+	});
+}
+
+test("an owner can open billing and the top-up dialog", async ({ page }) => {
+	await signIn(page, "enterprise@example.com");
+	await page.goto(`/dashboard/${orgId}/org/billing`);
+	await expect(
+		page.getByRole("heading", { name: "Billing", exact: true }),
+	).toBeVisible();
+	await expect(page.getByLabel("Email Address", { exact: true })).toBeEnabled();
+	await page
+		.getByRole("button", { name: "Top Up Credits", exact: true })
+		.click();
+	await expect(
+		page.getByRole("dialog", { name: "Top up credits", exact: true }),
+	).toBeVisible();
+});
+
+test("billing remains inaccessible without browser JavaScript", async ({
+	browser,
+	baseURL,
+}) => {
+	const context = await browser.newContext({
+		baseURL,
+		javaScriptEnabled: false,
+	});
+	try {
+		const page = await context.newPage();
+		await signIn(page, "developer@example.com");
+		await page.goto(`/dashboard/${orgId}/org/billing`);
+		await expect(
+			page.getByRole("heading", { name: "Unauthorized", exact: true }),
+		).toBeVisible();
+		await expect(
+			page.getByRole("button", { name: /top up credits/i }),
+		).toHaveCount(0);
+	} finally {
+		await context.close();
+	}
+});

--- a/apps/ui/src/app/dashboard/[orgId]/org/billing/page.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/billing/page.tsx
@@ -2,6 +2,7 @@ import { AutoTopUpSettings } from "@/components/billing/auto-topup-settings";
 import { PlanManagement } from "@/components/billing/plan-management";
 import { PaymentMethodsManagement } from "@/components/credits/payment-methods-management";
 import { TopUpCreditsButton } from "@/components/credits/top-up-credits-dialog";
+import { UnauthorizedView } from "@/components/dashboard/unauthorized-view";
 import { OrganizationBillingEmailSettings } from "@/components/settings/organization-billing-email-settings";
 import {
 	Card,
@@ -10,6 +11,9 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/lib/components/card";
+import { getOrganizations } from "@/lib/server-api";
+
+import { isOrganizationAdmin } from "@llmgateway/shared/organization-roles";
 
 import { CreditsBalance } from "./credits-balance";
 import { PaymentStatusHandler } from "./payment-status-handler";
@@ -24,8 +28,22 @@ interface BillingPageProps {
 	}>;
 }
 
-export default async function BillingPage({ searchParams }: BillingPageProps) {
-	const { success, canceled } = await searchParams;
+export default async function BillingPage({
+	params,
+	searchParams,
+}: BillingPageProps) {
+	const [{ orgId }, { success, canceled }, data] = await Promise.all([
+		params,
+		searchParams,
+		getOrganizations(),
+	]);
+	if (
+		!isOrganizationAdmin(
+			data?.organizations.find((org) => org.id === orgId)?.role,
+		)
+	) {
+		return <UnauthorizedView resource="organization" />;
+	}
 
 	const paymentStatus = success ? "success" : canceled ? "canceled" : undefined;
 

--- a/apps/ui/src/app/dashboard/[orgId]/org/billing/payment-status-handler.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/billing/payment-status-handler.tsx
@@ -28,6 +28,7 @@ export function PaymentStatusHandler({
 	const [saving, setSaving] = useState(false);
 	const updateOrganization = api.useMutation("patch", "/orgs/{id}");
 
+	const isOwner = selectedOrganization?.role === "owner";
 	const alreadyHasAutoTopUp = selectedOrganization?.autoTopUpEnabled ?? false;
 
 	useEffect(() => {
@@ -45,7 +46,7 @@ export function PaymentStatusHandler({
 				title: "Payment successful",
 				description: "Your payment has been processed successfully.",
 			});
-			if (!alreadyHasAutoTopUp) {
+			if (isOwner && !alreadyHasAutoTopUp) {
 				setShowNudge(true);
 				posthog.capture("auto_topup_nudge_shown");
 			}
@@ -56,7 +57,7 @@ export function PaymentStatusHandler({
 				variant: "destructive",
 			});
 		}
-	}, [paymentStatus, toast, alreadyHasAutoTopUp, posthog]);
+	}, [paymentStatus, toast, alreadyHasAutoTopUp, posthog, isOwner]);
 
 	const handleEnable = async () => {
 		if (!selectedOrganization) {

--- a/apps/ui/src/app/dashboard/[orgId]/org/billing/payment-status-handler.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/billing/payment-status-handler.tsx
@@ -22,7 +22,8 @@ export function PaymentStatusHandler({
 	const api = useApi();
 	const queryClient = useQueryClient();
 	const { selectedOrganization } = useDashboardState();
-	const handled = useRef(false);
+	const toastHandled = useRef(false);
+	const nudgeHandled = useRef(false);
 	const [showNudge, setShowNudge] = useState(false);
 	const [autoTopUpEnabled, setAutoTopUpEnabled] = useState(true);
 	const [saving, setSaving] = useState(false);
@@ -32,24 +33,20 @@ export function PaymentStatusHandler({
 	const alreadyHasAutoTopUp = selectedOrganization?.autoTopUpEnabled ?? false;
 
 	useEffect(() => {
-		if (handled.current) {
+		if (toastHandled.current) {
 			return;
 		}
 		if (!paymentStatus) {
 			return;
 		}
 
-		handled.current = true;
+		toastHandled.current = true;
 
 		if (paymentStatus === "success") {
 			toast({
 				title: "Payment successful",
 				description: "Your payment has been processed successfully.",
 			});
-			if (isOwner && !alreadyHasAutoTopUp) {
-				setShowNudge(true);
-				posthog.capture("auto_topup_nudge_shown");
-			}
 		} else if (paymentStatus === "canceled") {
 			toast({
 				title: "Payment canceled",
@@ -57,10 +54,31 @@ export function PaymentStatusHandler({
 				variant: "destructive",
 			});
 		}
-	}, [paymentStatus, toast, alreadyHasAutoTopUp, posthog, isOwner]);
+	}, [paymentStatus, toast]);
+
+	useEffect(() => {
+		if (
+			nudgeHandled.current ||
+			paymentStatus !== "success" ||
+			!selectedOrganization
+		) {
+			return;
+		}
+		nudgeHandled.current = true;
+		if (isOwner && !alreadyHasAutoTopUp) {
+			setShowNudge(true);
+			posthog.capture("auto_topup_nudge_shown");
+		}
+	}, [
+		paymentStatus,
+		selectedOrganization,
+		alreadyHasAutoTopUp,
+		posthog,
+		isOwner,
+	]);
 
 	const handleEnable = async () => {
-		if (!selectedOrganization) {
+		if (!selectedOrganization || !isOwner) {
 			return;
 		}
 		setSaving(true);
@@ -99,7 +117,7 @@ export function PaymentStatusHandler({
 		setShowNudge(false);
 	};
 
-	if (!showNudge) {
+	if (!showNudge || !isOwner) {
 		return null;
 	}
 

--- a/apps/ui/src/components/activity/recent-logs.tsx
+++ b/apps/ui/src/components/activity/recent-logs.tsx
@@ -48,8 +48,11 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/lib/components/select";
+import { useDashboardState } from "@/lib/dashboard-state";
 import { useApi } from "@/lib/fetch-client";
 import { cn } from "@/lib/utils";
+
+import { isOrganizationAdmin } from "@llmgateway/shared/organization-roles";
 
 import type { paths } from "@/lib/api/v1";
 import type { Log } from "@llmgateway/db";
@@ -125,6 +128,7 @@ function setCookie(name: string, value: string, days = 365) {
 }
 
 function FirstLogTopUpPrompt() {
+	const { selectedOrganization } = useDashboardState();
 	const [dismissed, setDismissed] = useState(true);
 
 	useEffect(() => {
@@ -134,7 +138,7 @@ function FirstLogTopUpPrompt() {
 		}
 	}, []);
 
-	if (dismissed) {
+	if (dismissed || !isOrganizationAdmin(selectedOrganization?.role)) {
 		return null;
 	}
 

--- a/apps/ui/src/components/billing/auto-topup-settings.tsx
+++ b/apps/ui/src/components/billing/auto-topup-settings.tsx
@@ -28,6 +28,7 @@ function AutoTopUpSettings() {
 
 	const { selectedOrganization } = useDashboardState();
 	const organizationId = selectedOrganization?.id;
+	const isOwner = selectedOrganization?.role === "owner";
 	const { data: paymentMethods } = api.useQuery(
 		"get",
 		"/payments/payment-methods",
@@ -150,6 +151,11 @@ function AutoTopUpSettings() {
 				</CardDescription>
 			</CardHeader>
 			<CardContent className="space-y-4">
+				{!isOwner && (
+					<p className="text-sm text-muted-foreground">
+						Only organization owners can change auto top-up settings.
+					</p>
+				)}
 				<div className="flex items-center justify-between">
 					<div className="space-y-0.5">
 						<Label htmlFor="auto-topup-enabled">Enable</Label>
@@ -162,7 +168,7 @@ function AutoTopUpSettings() {
 						id="auto-topup-enabled"
 						checked={enabled}
 						onCheckedChange={(checked) => setEnabled(!!checked)}
-						disabled={!hasDefaultPaymentMethod}
+						disabled={!isOwner || !hasDefaultPaymentMethod}
 					/>
 				</div>
 
@@ -191,7 +197,7 @@ function AutoTopUpSettings() {
 							min={5}
 							value={threshold}
 							onChange={(e) => setThreshold(Number(e.target.value))}
-							disabled={!enabled}
+							disabled={!isOwner || !enabled}
 						/>
 						<p className="text-xs text-muted-foreground">
 							Minimum $5. Top-up when credits fall below this amount.
@@ -207,7 +213,7 @@ function AutoTopUpSettings() {
 							step={1}
 							value={amount}
 							onChange={(e) => setAmount(Number(e.target.value))}
-							disabled={!enabled}
+							disabled={!isOwner || !enabled}
 						/>
 						<p className="text-xs text-muted-foreground">
 							Minimum $10. Maximum $
@@ -266,6 +272,7 @@ function AutoTopUpSettings() {
 					<Button
 						onClick={handleSave}
 						disabled={
+							!isOwner ||
 							Boolean(updateOrganization.isPending) ||
 							threshold < 5 ||
 							amount < 10 ||

--- a/apps/ui/src/components/billing/plan-management.tsx
+++ b/apps/ui/src/components/billing/plan-management.tsx
@@ -31,6 +31,8 @@ const ENTERPRISE_FEATURES = [
 
 export function PlanManagement() {
 	const { selectedOrganization } = useDashboardState();
+	const organizationId = selectedOrganization?.id;
+	const isOwner = selectedOrganization?.role === "owner";
 	const { toast } = useToast();
 	const queryClient = useQueryClient();
 	const api = useApi();
@@ -39,6 +41,8 @@ export function PlanManagement() {
 	const { data: subscriptionStatus } = api.useQuery(
 		"get",
 		"/subscriptions/status",
+		{ params: { query: { organizationId } } },
+		{ enabled: Boolean(organizationId) },
 	);
 
 	// Keep cancel/resume mutations for existing Pro subscribers (backward compatibility)
@@ -63,9 +67,13 @@ export function PlanManagement() {
 
 		posthog.capture("subscription_cancel_initiated");
 
-		await cancelSubscriptionMutation.mutateAsync({});
+		await cancelSubscriptionMutation.mutateAsync({
+			params: { query: { organizationId } },
+		});
 		await queryClient.invalidateQueries({
-			queryKey: api.queryOptions("get", "/subscriptions/status").queryKey,
+			queryKey: api.queryOptions("get", "/subscriptions/status", {
+				params: { query: { organizationId } },
+			}).queryKey,
 		});
 		toast({
 			title: "Subscription Canceled",
@@ -85,9 +93,13 @@ export function PlanManagement() {
 
 		posthog.capture("subscription_resume_initiated");
 
-		await resumeSubscriptionMutation.mutateAsync({});
+		await resumeSubscriptionMutation.mutateAsync({
+			params: { query: { organizationId } },
+		});
 		await queryClient.invalidateQueries({
-			queryKey: api.queryOptions("get", "/subscriptions/status").queryKey,
+			queryKey: api.queryOptions("get", "/subscriptions/status", {
+				params: { query: { organizationId } },
+			}).queryKey,
 		});
 		toast({
 			title: "Subscription Resumed",
@@ -253,7 +265,7 @@ export function PlanManagement() {
 							<Button
 								variant="outline"
 								onClick={handleCancelSubscription}
-								disabled={cancelSubscriptionMutation.isPending}
+								disabled={!isOwner || cancelSubscriptionMutation.isPending}
 							>
 								{cancelSubscriptionMutation.isPending
 									? "Canceling..."
@@ -266,7 +278,7 @@ export function PlanManagement() {
 								<Button
 									variant="default"
 									onClick={handleResumeSubscription}
-									disabled={resumeSubscriptionMutation.isPending}
+									disabled={!isOwner || resumeSubscriptionMutation.isPending}
 								>
 									{resumeSubscriptionMutation.isPending
 										? "Resuming..."

--- a/apps/ui/src/components/credits/top-up-credits-dialog.tsx
+++ b/apps/ui/src/components/credits/top-up-credits-dialog.tsx
@@ -46,6 +46,7 @@ import {
 	CREDIT_TOP_UP_MIN_AMOUNT,
 	isCreditTopUpAmountInRange,
 } from "@llmgateway/shared";
+import { isOrganizationAdmin } from "@llmgateway/shared/organization-roles";
 
 import type React from "react";
 
@@ -64,7 +65,17 @@ interface TopUpCreditsDialogProps {
 	children: React.ReactNode;
 }
 
-export function TopUpCreditsDialog({ children }: TopUpCreditsDialogProps) {
+export function TopUpCreditsDialog(props: TopUpCreditsDialogProps) {
+	const { selectedOrganization } = useDashboardState();
+	if (!isOrganizationAdmin(selectedOrganization?.role)) {
+		return null;
+	}
+	return (
+		<BillingTopUpCreditsDialog key={selectedOrganization?.id} {...props} />
+	);
+}
+
+function BillingTopUpCreditsDialog({ children }: TopUpCreditsDialogProps) {
 	const [open, setOpen] = useState(false);
 	const [step, setStep] = useState<
 		"amount" | "payment" | "select-payment" | "confirm-payment" | "success"
@@ -261,6 +272,7 @@ function AmountStep({
 	alreadyHasAutoTopUp: boolean;
 	onNext: () => void;
 }) {
+	const { selectedOrganization } = useDashboardState();
 	const presets: { value: number; badge?: string }[] = [
 		{ value: 10 },
 		{ value: 25 },
@@ -567,7 +579,7 @@ function AmountStep({
 				) : null}
 
 				{/* Auto-reload toggle */}
-				{!alreadyHasAutoTopUp ? (
+				{selectedOrganization?.role === "owner" && !alreadyHasAutoTopUp ? (
 					<div className="flex items-center justify-between rounded-lg border border-dashed p-3">
 						<div className="space-y-0.5 pr-3">
 							<p className="text-sm font-medium">Never run out of credits</p>
@@ -906,7 +918,10 @@ function SuccessStep({
 	const [saving, setSaving] = useState(false);
 	const [autoTopUpApplied, setAutoTopUpApplied] = useState(false);
 
-	const shouldOfferAutoTopUp = !alreadyHasAutoTopUp && autoTopUpIntent;
+	const shouldOfferAutoTopUp =
+		selectedOrganization?.role === "owner" &&
+		!alreadyHasAutoTopUp &&
+		autoTopUpIntent;
 
 	useEffect(() => {
 		const duration = 2000;

--- a/apps/ui/src/components/dashboard/dashboard-layout-client.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-layout-client.tsx
@@ -6,8 +6,8 @@ import { type ReactNode, useEffect } from "react";
 import { DashboardSidebar } from "@/components/dashboard/dashboard-sidebar";
 import { EnterpriseLicenseBanner } from "@/components/dashboard/enterprise-license-banner";
 import { MobileHeader } from "@/components/dashboard/mobile-header";
+import { OrganizationRouteGuard } from "@/components/dashboard/organization-route-guard";
 import { PlanExpiryBanner } from "@/components/dashboard/plan-expiry-banner";
-import { ProjectAdminRouteGuard } from "@/components/dashboard/project-admin-route-guard";
 import { TopBar } from "@/components/dashboard/top-bar";
 import { EmailVerificationBanner } from "@/components/email-verification-banner";
 import { DashboardProvider } from "@/lib/dashboard-context";
@@ -89,7 +89,7 @@ export function DashboardLayoutClient({
 						<EnterpriseLicenseBanner />
 						<PlanExpiryBanner />
 						<main className="bg-background relative w-full flex-1 overflow-y-auto overflow-x-hidden pt-10 pb-4 px-4 md:p-6 lg:p-8">
-							<ProjectAdminRouteGuard>{children}</ProjectAdminRouteGuard>
+							<OrganizationRouteGuard>{children}</OrganizationRouteGuard>
 						</main>
 					</div>
 				</div>

--- a/apps/ui/src/components/dashboard/organization-route-guard.tsx
+++ b/apps/ui/src/components/dashboard/organization-route-guard.tsx
@@ -5,9 +5,11 @@ import { usePathname } from "next/navigation";
 import { UnauthorizedView } from "@/components/dashboard/unauthorized-view";
 import { useDashboardNavigation } from "@/hooks/useDashboardNavigation";
 
+import { isOrganizationAdmin } from "@llmgateway/shared/organization-roles";
+
 import type { ReactNode } from "react";
 
-export function ProjectAdminRouteGuard({ children }: { children: ReactNode }) {
+export function OrganizationRouteGuard({ children }: { children: ReactNode }) {
 	const pathname = usePathname();
 	const { selectedOrganization, buildOrgUrl } = useDashboardNavigation();
 	const isOrgPage = pathname.startsWith(`${buildOrgUrl("org")}/`);
@@ -18,7 +20,7 @@ export function ProjectAdminRouteGuard({ children }: { children: ReactNode }) {
 	);
 
 	if (
-		selectedOrganization?.role === "project_admin" &&
+		!isOrganizationAdmin(selectedOrganization?.role) &&
 		isOrgPage &&
 		!isSharedResource
 	) {

--- a/apps/ui/src/components/provider-keys/credits-recommendation-banner.tsx
+++ b/apps/ui/src/components/provider-keys/credits-recommendation-banner.tsx
@@ -5,11 +5,15 @@ import { useState } from "react";
 
 import { TopUpCreditsDialog } from "@/components/credits/top-up-credits-dialog";
 import { Button } from "@/lib/components/button";
+import { useDashboardState } from "@/lib/dashboard-state";
+
+import { isOrganizationAdmin } from "@llmgateway/shared/organization-roles";
 
 export function CreditsRecommendationBanner() {
+	const { selectedOrganization } = useDashboardState();
 	const [dismissed, setDismissed] = useState(false);
 
-	if (dismissed) {
+	if (dismissed || !isOrganizationAdmin(selectedOrganization?.role)) {
 		return null;
 	}
 

--- a/apps/ui/src/components/settings/organization-billing-email-settings.tsx
+++ b/apps/ui/src/components/settings/organization-billing-email-settings.tsx
@@ -110,7 +110,10 @@ export function OrganizationBillingEmailSettings() {
 	};
 
 	return (
-		<div className="space-y-4">
+		<fieldset
+			disabled={selectedOrganization.role !== "owner"}
+			className="space-y-4"
+		>
 			<div>
 				<h3 className="text-lg font-medium">Billing Information</h3>
 				<p className="text-muted-foreground text-sm">
@@ -210,6 +213,6 @@ export function OrganizationBillingEmailSettings() {
 					{updateOrganization.isPending ? "Saving..." : "Save Settings"}
 				</Button>
 			</div>
-		</div>
+		</fieldset>
 	);
 }

--- a/apps/ui/src/lib/components/use-toast.ts
+++ b/apps/ui/src/lib/components/use-toast.ts
@@ -166,6 +166,7 @@ function useToast() {
 
 	React.useEffect(() => {
 		listeners.push(setState);
+		setState(memoryState);
 		return () => {
 			const index = listeners.indexOf(setState);
 			if (index > -1) {

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -179,7 +179,7 @@ export type LogInsertData = Omit<
 	id?: string;
 };
 
-export type SerializedOrganization = Omit<
+type SerializedOrganizationBase = Omit<
 	Organization,
 	| "createdAt"
 	| "updatedAt"
@@ -234,6 +234,46 @@ export type SerializedOrganization = Omit<
 	chatPlanBillingCycleStart: string | null;
 	chatPlanExpiresAt: string | null;
 };
+
+// Omitted from organization responses for non-admin members.
+export const organizationBillingFields = {
+	billingEmail: true,
+	billingCompany: true,
+	billingAddress: true,
+	billingTaxId: true,
+	billingNotes: true,
+	credits: true,
+	autoTopUpEnabled: true,
+	autoTopUpThreshold: true,
+	autoTopUpAmount: true,
+	referralEarnings: true,
+	referralBonusEnabled: true,
+	referralBonusPercent: true,
+	devPlanCycle: true,
+	devPlanCreditsUsed: true,
+	devPlanCreditsLimit: true,
+	devPlanPremiumCreditsUsed: true,
+	devPlanPremiumWeekStart: true,
+	devPlanResetPassesLite: true,
+	devPlanResetPassesPro: true,
+	devPlanResetPassesMax: true,
+	devPlanIncludedResetPassesUsed: true,
+	devPlanBillingCycleStart: true,
+	devPlanPaygEnabled: true,
+	devPlanBillingOverride: true,
+	chatPlanCycle: true,
+	chatPlanCreditsUsed: true,
+	chatPlanCreditsLimit: true,
+	chatPlanBillingCycleStart: true,
+} as const;
+
+export type SerializedOrganization = Omit<
+	SerializedOrganizationBase,
+	keyof typeof organizationBillingFields
+> &
+	Partial<
+		Pick<SerializedOrganizationBase, keyof typeof organizationBillingFields>
+	>;
 
 export type SerializedProject = Omit<Project, "createdAt" | "updatedAt"> & {
 	createdAt: string;


### PR DESCRIPTION
Standard members could read organization billing data and use payment APIs. Restrict billing reads and payment operations to owners and organization admins, omit billing fields from other members' organization responses, and enforce matching dashboard and Playground access controls.

Billing requests now target the selected organization. Legacy requests without an organization ID use the user's earliest owner/admin membership in a non-deleted organization. The Playground prefers funded owner/admin organizations before falling back to memberships with hidden balances. Personal plans only inherit billing details from organizations the user administers. Existing owner-only subscription and billing-setting permissions are preserved.

Credit error messages follow role changes, and the auto top-up prompt after payment waits for owner details to load. Payment notifications render even when emitted before the toast component subscribes.

Validated with `pnpm format`, `pnpm build`, 111 focused Vitest tests, and 9 Playwright tests, including direct billing access with JavaScript disabled.

Seeded developer opening the billing URL:

| Theme | Before | After |
| --- | --- | --- |
| Light | <img width="720" alt="Developer billing access before, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/9647234476570414180cff8ae5367ecc58c0aecf/billing-before-light.png" /> | <img width="720" alt="Developer billing access after, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/9647234476570414180cff8ae5367ecc58c0aecf/billing-after-light.png" /> |
| Dark | <img width="720" alt="Developer billing access before, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/9647234476570414180cff8ae5367ecc58c0aecf/billing-before-dark.png" /> | <img width="720" alt="Developer billing access after, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/9647234476570414180cff8ae5367ecc58c0aecf/billing-after-dark.png" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Billing access is now controlled by organization role.
  * Owners and admins can manage billing, while developers and project admins cannot access billing controls or sensitive billing details.
  * Billing actions and subscription management now support selecting a specific organization.
  * Credits, top-up prompts, auto-reload, and billing settings display controls appropriate to the user’s role.
  * Organization listings hide billing information from unauthorized members.

* **Bug Fixes**
  * Improved organization fallback selection and clearer insufficient-credit messages.

* **Tests**
  * Added comprehensive API, UI, and playground coverage for billing authorization and role-based behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->