### PR TITLE
fix: label new SCIM audit events as system

### DIFF
--- a/apps/api/src/routes/scim.spec.ts
+++ b/apps/api/src/routes/scim.spec.ts
@@ -153,6 +153,7 @@ describe("scim audit logging", () => {
 		expect(logs[0]?.userId).toBe("test-user-id");
 		expect(logs[0]?.resourceType).toBe("scim_user");
 		expect(logs[0]?.metadata?.source).toBe("scim");
+		expect(logs[0]?.metadata?.actorType).toBe("system");
 		expect(logs[0]?.metadata?.targetUserEmail).toBe("jane@example.com");
 	});
 
@@ -353,6 +354,7 @@ describe("scim audit logging", () => {
 
 		expect(logs).toHaveLength(1);
 		expect(logs[0]?.resourceType).toBe("scim_group");
+		expect(logs[0]?.metadata?.actorType).toBe("system");
 		expect(logs[0]?.metadata?.resourceName).toBe("Engineering");
 	});
 

--- a/apps/api/src/routes/scim.ts
+++ b/apps/api/src/routes/scim.ts
@@ -92,6 +92,7 @@ async function logScimAudit(
 		resourceId: params.resourceId,
 		metadata: {
 			source: "scim",
+			actorType: "system",
 			...(params.targetUser
 				? {
 						targetUserId: params.targetUser.id,

--- a/apps/ui/src/app/dashboard/[orgId]/org/audit-logs/audit-logs-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/audit-logs/audit-logs-client.tsx
@@ -375,7 +375,9 @@ export function AuditLogsClient() {
 													</div>
 													<div className="text-sm">
 														<span className="font-medium">
-															{log.user?.email ?? log.userId}
+															{log.metadata?.actorType === "system"
+																? "System"
+																: (log.user?.email ?? log.userId)}
 														</span>
 													</div>
 													<div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -464,14 +466,20 @@ export function AuditLogsClient() {
 														/>
 													</td>
 													<td className="p-4 align-middle">
-														<div className="flex flex-col">
+														{log.metadata?.actorType === "system" ? (
 															<span className="text-sm font-medium">
-																{log.user?.name ?? "—"}
+																System
 															</span>
-															<span className="text-xs text-muted-foreground">
-																{log.user?.email ?? log.userId}
-															</span>
-														</div>
+														) : (
+															<div className="flex flex-col">
+																<span className="text-sm font-medium">
+																	{log.user?.name ?? "—"}
+																</span>
+																<span className="text-xs text-muted-foreground">
+																	{log.user?.email ?? log.userId}
+																</span>
+															</div>
+														)}
 													</td>
 													<td className="p-4 align-middle">
 														<Badge variant={getActionBadgeVariant(log.action)}>

--- a/ee/admin/src/app/organizations/[orgId]/audit-logs-tab.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/audit-logs-tab.tsx
@@ -192,7 +192,10 @@ export function AuditLogsTab({
 										{formatDateTime(log.createdAt)}
 									</TableCell>
 									<TableCell>
-										{log.user ? (
+										{(log.metadata as Record<string, unknown> | null)
+											?.actorType === "system" ? (
+											<span className="font-medium">System</span>
+										) : log.user ? (
 											<div>
 												<p className="font-medium">
 													{log.user.name ?? log.user.email}


### PR DESCRIPTION
SCIM audit rows displayed the token creator as if they performed each sync. New events now carry `actorType: "system"`, and the dashboard and admin audit views display **System**. Existing entries keep their display; user references and target details are preserved.

Validated with `pnpm format`, `pnpm build`, and all 15 tests in `pnpm test:unit apps/api/src/routes/scim.spec.ts` against an isolated database. Browser checks covered new and historical entries in both themes, including mobile.

Screenshots use local seeded data.

| View | Before | After |
| --- | --- | --- |
| Admin, light | <img width="560" alt="Admin before, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/891ba208365f65773c85d305261418ce4c744c03/admin-before-light.png" /> | <img width="560" alt="Admin after, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/891ba208365f65773c85d305261418ce4c744c03/admin-after-light.png" /> |
| Admin, dark | <img width="560" alt="Admin before, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/891ba208365f65773c85d305261418ce4c744c03/admin-before-dark.png" /> | <img width="560" alt="Admin after, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/891ba208365f65773c85d305261418ce4c744c03/admin-after-dark.png" /> |
| Dashboard, light | <img width="560" alt="Dashboard before, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/891ba208365f65773c85d305261418ce4c744c03/ui-before-light.png" /> | <img width="560" alt="Dashboard after, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/891ba208365f65773c85d305261418ce4c744c03/ui-after-light.png" /> |
| Dashboard, dark | <img width="560" alt="Dashboard before, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/891ba208365f65773c85d305261418ce4c744c03/ui-before-dark.png" /> | <img width="560" alt="Dashboard after, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/891ba208365f65773c85d305261418ce4c744c03/ui-after-dark.png" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Audit logs now identify identity provider–initiated SCIM activity as performed by the **System** actor.
  - System-generated entries display a clear “System” label across mobile and desktop audit log views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->