### PR TITLE
ci: run Playwright specs automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,6 @@ jobs:
   test:
     uses: ./.github/workflows/test-unit.yml
     secrets: inherit
+
+  playwright:
+    uses: ./.github/workflows/test-playwright.yml

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -1,0 +1,61 @@
+name: test-playwright
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      STACK_SUFFIX: -playwright
+      API_URL: http://localhost:4002
+      UI_URL: http://localhost:3002
+      APP_URL: http://localhost:3002
+      GATEWAY_URL: http://localhost:4001
+      PLAYGROUND_URL: http://localhost:3003
+      CODE_URL: http://localhost:3004
+      DOCS_URL: http://localhost:3005
+      AIRSIDE_URL: http://localhost:3007
+      SSO_ENABLED: "true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup
+
+      - name: Install Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Build apps for the local stack
+        # Next.js rewrites embed these URLs at build time. Do not restore
+        # remote build artifacts made with the production URL defaults.
+        run: pnpm build --env-mode=loose --cache=local:rw
+
+      - name: Seed the database
+        run: pnpm run setup
+
+      - name: Run browser tests
+        run: |
+          export ONBOARDING_SPONSOR_SECRET="$(openssl rand -hex 32)"
+          pnpm test:browser
+
+      - name: Upload Playwright results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-results
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Stop services
+        if: always()
+        run: docker compose down -v

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ out-*.json
 output-*.png
 generate-image-*.png
 .playwright-mcp
+playwright-report/
+test-results/
 *.mp4
 # Shipped marketing assets, deliberately committed despite the blanket *.mp4 rule
 # above (which exists to keep stray local screen recordings out of the repo).

--- a/apps/ui/e2e/onboarding.pw.ts
+++ b/apps/ui/e2e/onboarding.pw.ts
@@ -131,7 +131,7 @@ test("a brand new account completes onboarding without verifying its email", asy
 	// An API key is provisioned for the new project.
 	const apiKey = page.getByTestId("onboarding-api-key");
 	await expect(apiKey).toBeVisible({ timeout: 30_000 });
-	await expect(apiKey).toContainText("llmgtwy_");
+	await expect(apiKey).toHaveText(/^llmg(?:twy|dev)_[A-Za-z0-9]+$/);
 
 	const completion = page.waitForResponse(
 		(response: Response) =>

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"setup": "pnpm build:core && docker compose down -v && docker compose up -d && pnpm wait-for-services && pnpm push-test && pnpm push-dev && pnpm seed",
 		"sync": "pnpm push-dev; pnpm push-test",
 		"stripe:listen": "stripe listen --api-key \"$(grep -E '^STRIPE_SECRET_KEY=' .env | head -1 | cut -d= -f2-)\" --forward-to localhost:4002/stripe/webhook",
+		"test:browser": "playwright test",
 		"test:e2e": "pnpm build:core && E2E_TEST=true vitest run -c vitest/vitest.e2e.config.mts --no-file-parallelism",
 		"test:unit": "pnpm build:core && vitest run --no-file-parallelism",
 		"wait-for-services": "./scripts/wait-for-services.sh"
@@ -39,6 +40,7 @@
 	"prettier": "@steebchen/prettier-config",
 	"devDependencies": {
 		"@abinnovision/eslint-config-react": "3.1.1",
+		"@playwright/test": "1.61.1",
 		"@semantic-release/exec": "^7.1.0",
 		"@semantic-release/npm": "^13.1.5",
 		"@steebchen/commitlint-config": "^1.7.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,66 @@
+import { defineConfig } from "@playwright/test";
+
+const apps = [
+	{ name: "ui", url: process.env.UI_URL ?? "http://localhost:3002" },
+	{
+		name: "playground",
+		url: process.env.PLAYGROUND_URL ?? "http://localhost:3003",
+	},
+	{ name: "code", url: process.env.CODE_URL ?? "http://localhost:3004" },
+	{ name: "airside", url: process.env.AIRSIDE_URL ?? "http://localhost:3007" },
+];
+
+// Seeded enterprise features and repeated signups need development backends.
+const backendEnv = {
+	NODE_ENV: "development",
+	DOTENV_CONFIG_PATH: "/dev/null",
+};
+
+export default defineConfig({
+	testMatch: "**/*.pw.ts",
+	workers: 1,
+	forbidOnly: !!process.env.CI,
+	timeout: 90_000,
+	reporter: process.env.CI
+		? [["github"], ["html", { open: "never" }]]
+		: [["list"], ["html", { open: "never" }]],
+	use: {
+		trace: "retain-on-failure",
+		video: "retain-on-failure",
+		screenshot: "only-on-failure",
+	},
+	projects: apps.map(({ name, url }) => ({
+		name,
+		testDir: `./apps/${name}/e2e`,
+		use: { baseURL: url },
+	})),
+	webServer: [
+		{
+			name: "api",
+			command: "node apps/api/dist/serve.js",
+			url: process.env.API_URL ?? "http://localhost:4002",
+			env: backendEnv,
+		},
+		{
+			name: "gateway",
+			command: "node apps/gateway/dist/serve.js",
+			url: process.env.GATEWAY_URL ?? "http://localhost:4001",
+			env: backendEnv,
+		},
+		{
+			name: "worker",
+			command: "node apps/worker/dist/index.js",
+			wait: { stdout: /Starting worker loops/ },
+			env: backendEnv,
+		},
+		...[
+			...apps,
+			{ name: "docs", url: process.env.DOCS_URL ?? "http://localhost:3005" },
+		].map(({ name, url }) => ({
+			name,
+			command: `node apps/${name}/.next/standalone/apps/${name}/server.js`,
+			url,
+			env: { PORT: new URL(url).port, HOSTNAME: "127.0.0.1" },
+		})),
+	],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@abinnovision/eslint-config-react':
         specifier: 3.1.1
         version: 3.1.1(eslint@9.38.0(jiti@2.6.1))(tailwindcss@4.3.0)(typescript@5.9.2)
+      '@playwright/test':
+        specifier: 1.61.1
+        version: 1.61.1
       '@semantic-release/exec':
         specifier: ^7.1.0
         version: 7.1.0(semantic-release@24.2.9(typescript@5.9.2))


### PR DESCRIPTION
Playwright suites were excluded from CI. Add a browser-test job to PRs, main pushes, and merge queues, running all four app suites sequentially against a seeded local stack.

The runner starts the API, gateway, worker, docs, and frontends, installs Chromium in CI, and uploads HTML reports and failure artifacts. Build with local gateway/docs URLs to keep rewrites local. Fix the onboarding assertion to accept both supported API-key prefixes.

Validation: formatting, full build, Actionlint, and runner type-check passed. Unit tests: 6,259 passed, 3 skipped. Browser tests: 52 passed initially; both onboarding tests passed after correcting the prefix assertion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated browser testing across key web applications and workflows.
  * Improved onboarding validation to confirm API keys use the complete expected format.
  * Added test reporting and failure artifacts for easier troubleshooting.

* **Chores**
  * Added commands and configuration for running browser tests locally and in continuous integration.
  * Added automated setup and cleanup for the local test environment.
  * Excluded generated browser test reports and results from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->