### PR TITLE
fix(ui): hardcode Airside link on add-provider

### DIFF
--- a/apps/ui/src/app/add-provider/page.tsx
+++ b/apps/ui/src/app/add-provider/page.tsx
@@ -1,7 +1,6 @@
 import { AddProviderForm } from "@/components/add-provider/add-provider-form";
 import Footer from "@/components/landing/footer";
 import { HeroRSC } from "@/components/landing/hero-rsc";
-import { getConfig } from "@/lib/config-server";
 
 import type { Metadata } from "next";
 
@@ -27,16 +26,12 @@ export default async function AddProviderPage({
 	const { payment } = await searchParams;
 	const initialPayment =
 		payment === "success" || payment === "canceled" ? payment : null;
-	const { airsideUrl } = getConfig();
 
 	return (
 		<div className="min-h-screen bg-white text-black dark:bg-black dark:text-white">
 			<main>
 				<HeroRSC navbarOnly />
-				<AddProviderForm
-					initialPayment={initialPayment}
-					airsideUrl={airsideUrl}
-				/>
+				<AddProviderForm initialPayment={initialPayment} />
 			</main>
 			<Footer />
 		</div>

--- a/apps/ui/src/components/add-provider/add-provider-form.tsx
+++ b/apps/ui/src/components/add-provider/add-provider-form.tsx
@@ -86,10 +86,8 @@ const complianceOptions = [
 
 export function AddProviderForm({
 	initialPayment,
-	airsideUrl,
 }: {
 	initialPayment?: "success" | "canceled" | null;
-	airsideUrl: string;
 }) {
 	const api = useApi();
 	const posthog = usePostHog();
@@ -231,7 +229,7 @@ export function AddProviderForm({
 								</p>
 								<div className="mt-5 flex flex-col gap-3 sm:flex-row sm:items-center">
 									<Button asChild size="lg" className="w-full sm:w-auto">
-										<a href={airsideUrl}>
+										<a href="https://airside.llmgateway.io">
 											Claim your carrier on Airside
 											<span
 												aria-hidden="true"

--- a/apps/ui/src/lib/config-server.ts
+++ b/apps/ui/src/lib/config-server.ts
@@ -10,7 +10,6 @@ export interface AppConfig {
 	docsUrl: string;
 	playgroundUrl: string;
 	adminUrl: string;
-	airsideUrl: string;
 	posthogKey?: string;
 	posthogHost?: string;
 	githubAuth: boolean;
@@ -33,7 +32,6 @@ export function getConfig(): AppConfig {
 		docsUrl: process.env.DOCS_URL ?? "http://localhost:3005",
 		playgroundUrl: process.env.PLAYGROUND_URL ?? "http://localhost:3003",
 		adminUrl: process.env.ADMIN_URL ?? "http://localhost:3006",
-		airsideUrl: process.env.AIRSIDE_URL ?? "http://localhost:3007",
 		posthogKey: process.env.POSTHOG_KEY,
 		posthogHost: process.env.POSTHOG_HOST,
 		githubAuth: !!process.env.GITHUB_CLIENT_ID,


### PR DESCRIPTION
## Problem

The "Claim your carrier on Airside" CTA on `/add-provider` built its href from `AIRSIDE_URL`, which the UI deployment does not set, so production linked users to `http://localhost:3007`.

## Approach

- Hardcode `https://airside.llmgateway.io` in the CTA.
- Drop the `airsideUrl` prop and the matching `getConfig()` entry, which had no other consumers in `apps/ui`.

No visual change; only the link target differs.

## Verification

- `pnpm format`
- `turbo run build --filter=ui`

https://claude.ai/code/session_01E5xexchcBJnXdyyzhkbgSh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - The “Claim your carrier on Airside” link now directs to Airside’s standard website.
  - The add-provider page continues to support existing payment success and cancellation states.
  - The page layout and provider setup flow remain unchanged.
  - Environment-based customization of the Airside link is no longer supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->