### PR TITLE
fix(ui): repair GPT Image 2.5 OG cards

### DIFF
--- a/apps/ui/next.config.ts
+++ b/apps/ui/next.config.ts
@@ -2,6 +2,8 @@ import { join } from "path";
 
 import { withContentCollections } from "@content-collections/next";
 
+import { prerenderedModelOgMappings } from "./src/lib/model-og-params";
+
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
@@ -427,6 +429,10 @@ const nextConfig: NextConfig = {
 	},
 	async rewrites() {
 		return {
+			beforeFiles: prerenderedModelOgMappings.map(({ name, provider }) => ({
+				source: `/models/${name}/${provider}/opengraph-image`,
+				destination: `/model-og/${name}/${provider}/opengraph-image`,
+			})),
 			afterFiles: [
 				// /llms.txt is served as a static file from public/ (which takes
 				// precedence over rewrites), so it is intentionally not proxied here.

--- a/apps/ui/src/app/model-og/[name]/[provider]/opengraph-image.tsx
+++ b/apps/ui/src/app/model-og/[name]/[provider]/opengraph-image.tsx
@@ -1,0 +1,17 @@
+import ModelProviderOgImage, {
+	size as ogSize,
+	contentType as ogContentType,
+} from "@/app/models/[name]/[provider]/opengraph-image";
+import { getModelOgStaticParams } from "@/lib/model-og";
+
+export const size = ogSize;
+export const contentType = ogContentType;
+export const dynamic = "force-static";
+export const dynamicParams = false;
+export const revalidate = false;
+
+export function generateStaticParams() {
+	return getModelOgStaticParams();
+}
+
+export default ModelProviderOgImage;

--- a/apps/ui/src/app/models/[name]/[provider]/opengraph-image.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/opengraph-image.tsx
@@ -1,14 +1,12 @@
 import { ImageResponse } from "next/og";
 
 import { discountFraction, getEffectiveProviderDiscount } from "@/lib/discount";
-import { fetchModelDiscounts } from "@/lib/fetch-models";
 import Logo from "@/lib/icons/Logo";
+import { getModelOgData } from "@/lib/model-og";
 import { formatContextSize } from "@/lib/utils";
 
 import {
-	models as modelDefinitions,
 	providers as providerDefinitions,
-	type ModelDefinition,
 	type ProviderModelMapping,
 } from "@llmgateway/models";
 import {
@@ -25,21 +23,7 @@ export const size = {
 	height: 630,
 };
 export const contentType = "image/png";
-// Keep image rendering out of requests; prices and discounts refresh on deploy.
-export const dynamic = "force-static";
-export const dynamicParams = false;
-export const revalidate = false;
-
-export function generateStaticParams() {
-	return modelDefinitions.flatMap((model) =>
-		Array.from(
-			new Set(model.providers.map((mapping) => mapping.providerId)),
-		).map((provider) => ({
-			name: encodeURIComponent(model.id),
-			provider: encodeURIComponent(provider),
-		})),
-	);
-}
+export const revalidate = 60;
 
 const getOgProviderIcon = (providerId: string) => {
 	if (providerId === "aws-bedrock" || providerId === "aws-mantle") {
@@ -107,9 +91,11 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 		const decodedName = decodeURIComponent(name);
 		const decodedProvider = decodeURIComponent(provider);
 
-		const model: ModelDefinition | undefined = modelDefinitions.find(
-			(candidate) => candidate.id === decodedName,
-		);
+		const {
+			model,
+			providers: apiProviders,
+			discounts,
+		} = await getModelOgData(decodedName, decodedProvider);
 
 		if (!model) {
 			return new ImageResponse(
@@ -161,10 +147,9 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 			);
 		}
 
-		const providerInfo = providerDefinitions.find(
-			(p) => p.id === selectedMapping.providerId,
-		);
-		const discounts = await fetchModelDiscounts(decodedName, false);
+		const providerInfo =
+			providerDefinitions.find((p) => p.id === selectedMapping.providerId) ??
+			apiProviders.find((p) => p.id === selectedMapping.providerId);
 		const ProviderIcon = selectedMapping
 			? getOgProviderIcon(selectedMapping.providerId)
 			: null;
@@ -272,7 +257,9 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 		const supportingProviders = uniqueProviderIds
 			.map((providerId) => {
 				const icon = getOgProviderIcon(providerId);
-				const info = providerDefinitions.find((p) => p.id === providerId);
+				const info =
+					providerDefinitions.find((p) => p.id === providerId) ??
+					apiProviders.find((p) => p.id === providerId);
 				return {
 					id: providerId,
 					name: info?.name ?? providerId,

--- a/apps/ui/src/app/models/[name]/[provider]/opengraph-image.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/opengraph-image.tsx
@@ -1,13 +1,14 @@
 import { ImageResponse } from "next/og";
 
-import { findPublicModelDefinition } from "@/lib/airside-model-fallback";
 import { discountFraction, getEffectiveProviderDiscount } from "@/lib/discount";
-import { fetchModelDiscounts, fetchProviders } from "@/lib/fetch-models";
+import { fetchModelDiscounts } from "@/lib/fetch-models";
 import Logo from "@/lib/icons/Logo";
 import { formatContextSize } from "@/lib/utils";
 
 import {
+	models as modelDefinitions,
 	providers as providerDefinitions,
+	type ModelDefinition,
 	type ProviderModelMapping,
 } from "@llmgateway/models";
 import {
@@ -24,7 +25,21 @@ export const size = {
 	height: 630,
 };
 export const contentType = "image/png";
-export const revalidate = 60;
+// Keep image rendering out of requests; prices and discounts refresh on deploy.
+export const dynamic = "force-static";
+export const dynamicParams = false;
+export const revalidate = false;
+
+export function generateStaticParams() {
+	return modelDefinitions.flatMap((model) =>
+		Array.from(
+			new Set(model.providers.map((mapping) => mapping.providerId)),
+		).map((provider) => ({
+			name: encodeURIComponent(model.id),
+			provider: encodeURIComponent(provider),
+		})),
+	);
+}
 
 const getOgProviderIcon = (providerId: string) => {
 	if (providerId === "aws-bedrock" || providerId === "aws-mantle") {
@@ -56,7 +71,9 @@ function getEffectivePricePerMillion(
 	if (
 		!mapping?.inputPrice &&
 		!mapping?.outputPrice &&
-		!mapping?.cachedInputPrice
+		!mapping?.cachedInputPrice &&
+		!mapping?.imageInputPrice &&
+		!mapping?.imageOutputPrice
 	) {
 		return null;
 	}
@@ -79,6 +96,8 @@ function getEffectivePricePerMillion(
 		input: applyDiscount(mapping.inputPrice),
 		output: applyDiscount(mapping.outputPrice),
 		cachedInput: applyDiscount(mapping.cachedInputPrice),
+		imageInput: applyDiscount(mapping.imageInputPrice),
+		imageOutput: applyDiscount(mapping.imageOutputPrice),
 	};
 }
 
@@ -88,14 +107,9 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 		const decodedName = decodeURIComponent(name);
 		const decodedProvider = decodeURIComponent(provider);
 
-		const [model, apiProviders, discounts] = await Promise.all([
-			findPublicModelDefinition(decodedName),
-			fetchProviders().catch((error: unknown) => {
-				console.error("Failed to fetch providers for OpenGraph image:", error);
-				return [];
-			}),
-			fetchModelDiscounts(decodedName),
-		]);
+		const model: ModelDefinition | undefined = modelDefinitions.find(
+			(candidate) => candidate.id === decodedName,
+		);
 
 		if (!model) {
 			return new ImageResponse(
@@ -147,9 +161,10 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 			);
 		}
 
-		const providerInfo =
-			providerDefinitions.find((p) => p.id === selectedMapping.providerId) ??
-			apiProviders.find((p) => p.id === selectedMapping.providerId);
+		const providerInfo = providerDefinitions.find(
+			(p) => p.id === selectedMapping.providerId,
+		);
+		const discounts = await fetchModelDiscounts(decodedName, false);
 		const ProviderIcon = selectedMapping
 			? getOgProviderIcon(selectedMapping.providerId)
 			: null;
@@ -212,10 +227,15 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 			isImageGen &&
 			perImagePrice !== undefined &&
 			Object.keys(perImagePrice).length > 0;
+		const hasImageTokenPricing =
+			isImageGen && pricing?.imageOutput !== undefined;
 		const hasPositiveTokenPrice = [
 			pricing?.input,
 			pricing?.output,
 			pricing?.cachedInput,
+			...(hasImageTokenPricing
+				? [pricing?.imageInput, pricing?.imageOutput]
+				: []),
 		].some((p) => (p?.original ?? 0) > 0);
 		// Per-image mappings declare token prices as the string "0" — placeholder
 		// values, not real token pricing — so zero token prices only count when
@@ -224,8 +244,25 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 			!isOcr &&
 			!hasCharPricing &&
 			!hasAudioHourPricing &&
-			Boolean(pricing?.input ?? pricing?.output ?? pricing?.cachedInput) &&
+			(hasImageTokenPricing ||
+				Boolean(pricing?.input ?? pricing?.output ?? pricing?.cachedInput)) &&
 			(hasPositiveTokenPrice || !hasPerImagePricing);
+		const tokenPrices = hasImageTokenPricing
+			? [
+					{ label: "Text input", price: pricing?.input },
+					{ label: "Image input", price: pricing?.imageInput },
+					{ label: "Image output", price: pricing?.imageOutput },
+				].filter(({ price }) => price !== undefined)
+			: [
+					{
+						label: hasPricingTiers ? "Input (starting at)" : "Input",
+						price: pricing?.input,
+					},
+					{
+						label: hasPricingTiers ? "Output (starting at)" : "Output",
+						price: pricing?.output,
+					},
+				];
 
 		const contextSize = selectedMapping?.contextSize ?? 0;
 
@@ -235,9 +272,7 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 		const supportingProviders = uniqueProviderIds
 			.map((providerId) => {
 				const icon = getOgProviderIcon(providerId);
-				const info =
-					providerDefinitions.find((p) => p.id === providerId) ??
-					apiProviders.find((p) => p.id === providerId);
+				const info = providerDefinitions.find((p) => p.id === providerId);
 				return {
 					id: providerId,
 					name: info?.name ?? providerId,
@@ -277,12 +312,17 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 								style={{
 									textDecoration: "line-through",
 									color: "#6B7280",
-									fontSize: 36,
+									fontSize: hasImageTokenPricing ? 30 : 36,
 								}}
 							>
 								{original}
 							</span>
-							<span style={{ fontWeight: 700, fontSize: 56 }}>
+							<span
+								style={{
+									fontWeight: 700,
+									fontSize: hasImageTokenPricing ? 48 : 56,
+								}}
+							>
 								{discounted}
 							</span>
 						</div>
@@ -298,7 +338,16 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 					</div>
 				);
 			}
-			return <span style={{ fontWeight: 700, fontSize: 56 }}>{original}</span>;
+			return (
+				<span
+					style={{
+						fontWeight: 700,
+						fontSize: hasImageTokenPricing ? 48 : 56,
+					}}
+				>
+					{original}
+				</span>
+			);
 		};
 
 		const formatUnitPrice = (value: number, unit: string) => {
@@ -507,36 +556,38 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 						style={{
 							display: "flex",
 							flexDirection: "row",
-							gap: 32,
+							gap: hasImageTokenPricing ? 24 : 32,
 						}}
 					>
 						{/* Context */}
-						<div
-							style={{
-								display: "flex",
-								flexDirection: "column",
-								gap: 10,
-								padding: "28px 36px",
-								backgroundColor: "#0A0A0A",
-								borderRadius: 20,
-								border: "1px solid #1F2937",
-							}}
-						>
-							<span
+						{!hasImageTokenPricing && (
+							<div
 								style={{
-									color: "#9CA3AF",
-									fontSize: 20,
-									fontWeight: 500,
-									textTransform: "uppercase",
-									letterSpacing: "0.05em",
+									display: "flex",
+									flexDirection: "column",
+									gap: 10,
+									padding: "28px 36px",
+									backgroundColor: "#0A0A0A",
+									borderRadius: 20,
+									border: "1px solid #1F2937",
 								}}
 							>
-								Context
-							</span>
-							<span style={{ fontSize: 56, fontWeight: 700 }}>
-								{contextSize ? formatContextSize(contextSize) : "—"}
-							</span>
-						</div>
+								<span
+									style={{
+										color: "#9CA3AF",
+										fontSize: 20,
+										fontWeight: 500,
+										textTransform: "uppercase",
+										letterSpacing: "0.05em",
+									}}
+								>
+									Context
+								</span>
+								<span style={{ fontSize: 56, fontWeight: 700 }}>
+									{contextSize ? formatContextSize(contextSize) : "—"}
+								</span>
+							</div>
+						)}
 
 						{/* Per-hour input audio price for transcription models */}
 						{hasAudioHourPricing && (
@@ -735,61 +786,35 @@ export default async function ModelProviderOgImage({ params }: ImageProps) {
 							</div>
 						)}
 
-						{/* Input - only show if has token pricing */}
-						{hasTokenPricing && (
-							<div
-								style={{
-									display: "flex",
-									flexDirection: "column",
-									gap: 10,
-									padding: "28px 36px",
-									backgroundColor: "#0A0A0A",
-									borderRadius: 20,
-									border: "1px solid #1F2937",
-								}}
-							>
-								<span
+						{hasTokenPricing &&
+							tokenPrices.map(({ label, price }) => (
+								<div
+									key={label}
 									style={{
-										color: "#9CA3AF",
-										fontSize: 20,
-										fontWeight: 500,
-										textTransform: "uppercase",
-										letterSpacing: "0.05em",
+										display: "flex",
+										flexDirection: "column",
+										...(hasImageTokenPricing ? { flex: 1 } : {}),
+										gap: 10,
+										padding: hasImageTokenPricing ? 28 : "28px 36px",
+										backgroundColor: "#0A0A0A",
+										borderRadius: 20,
+										border: "1px solid #1F2937",
 									}}
 								>
-									{hasPricingTiers ? "Input (starting at)" : "Input"}
-								</span>
-								{formatDollars(pricing?.input ?? undefined, discountNum)}
-							</div>
-						)}
-
-						{/* Output - only show if has token pricing */}
-						{hasTokenPricing && (
-							<div
-								style={{
-									display: "flex",
-									flexDirection: "column",
-									gap: 10,
-									padding: "28px 36px",
-									backgroundColor: "#0A0A0A",
-									borderRadius: 20,
-									border: "1px solid #1F2937",
-								}}
-							>
-								<span
-									style={{
-										color: "#9CA3AF",
-										fontSize: 20,
-										fontWeight: 500,
-										textTransform: "uppercase",
-										letterSpacing: "0.05em",
-									}}
-								>
-									{hasPricingTiers ? "Output (starting at)" : "Output"}
-								</span>
-								{formatDollars(pricing?.output ?? undefined, discountNum)}
-							</div>
-						)}
+									<span
+										style={{
+											color: "#9CA3AF",
+											fontSize: 20,
+											fontWeight: 500,
+											textTransform: "uppercase",
+											letterSpacing: "0.05em",
+										}}
+									>
+										{label}
+									</span>
+									{formatDollars(price, discountNum)}
+								</div>
+							))}
 					</div>
 				</div>
 

--- a/apps/ui/src/app/models/[name]/[provider]/page.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/page.tsx
@@ -33,7 +33,6 @@ import { Badge } from "@/lib/components/badge";
 import { findEffectiveProviderDiscount } from "@/lib/discount";
 import { fetchProviders } from "@/lib/fetch-models";
 import { serializeJsonLd } from "@/lib/json-ld";
-import { getModelOgImageUrl } from "@/lib/model-og";
 import { buildRatingSchema, type ModelRatingsData } from "@/lib/rating-schema";
 import { fetchServerData } from "@/lib/server-api";
 
@@ -507,7 +506,7 @@ export async function generateMetadata({
 	const title = `${model.name ?? model.id} on ${providerName}`;
 	const description = `Pricing, latency, and capabilities for ${model.name ?? model.id} via ${providerName} on LLM Gateway.`;
 	const canonical = `https://llmgateway.io/models/${encodeURIComponent(decodedName)}`;
-	const ogImageUrl = getModelOgImageUrl(decodedName, decodedProvider);
+	const ogImageUrl = `/models/${encodeURIComponent(decodedName)}/${encodeURIComponent(decodedProvider)}/opengraph-image`;
 
 	return {
 		title,

--- a/apps/ui/src/app/models/[name]/[provider]/page.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/page.tsx
@@ -33,6 +33,7 @@ import { Badge } from "@/lib/components/badge";
 import { findEffectiveProviderDiscount } from "@/lib/discount";
 import { fetchProviders } from "@/lib/fetch-models";
 import { serializeJsonLd } from "@/lib/json-ld";
+import { getModelOgImageUrl } from "@/lib/model-og";
 import { buildRatingSchema, type ModelRatingsData } from "@/lib/rating-schema";
 import { fetchServerData } from "@/lib/server-api";
 
@@ -506,7 +507,7 @@ export async function generateMetadata({
 	const title = `${model.name ?? model.id} on ${providerName}`;
 	const description = `Pricing, latency, and capabilities for ${model.name ?? model.id} via ${providerName} on LLM Gateway.`;
 	const canonical = `https://llmgateway.io/models/${encodeURIComponent(decodedName)}`;
-	const ogImageUrl = `/models/${encodeURIComponent(decodedName)}/${encodeURIComponent(decodedProvider)}/opengraph-image`;
+	const ogImageUrl = getModelOgImageUrl(decodedName, decodedProvider);
 
 	return {
 		title,

--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -45,7 +45,6 @@ import {
 } from "@/lib/discount";
 import { fetchModelDiscounts, fetchProviders } from "@/lib/fetch-models";
 import { buildFaqSchema, buildModelFaqs } from "@/lib/model-faq";
-import { getModelOgImageUrl } from "@/lib/model-og";
 import { buildRatingSchema, type ModelRatingsData } from "@/lib/rating-schema";
 import { fetchServerData } from "@/lib/server-api";
 
@@ -751,7 +750,7 @@ export async function generateMetadata({
 			: (model.description ?? pitch);
 
 	const primaryProvider = model.providers[0]?.providerId || "default";
-	const ogImageUrl = getModelOgImageUrl(decodedName, primaryProvider);
+	const ogImageUrl = `/models/${encodeURIComponent(decodedName)}/${encodeURIComponent(primaryProvider)}/opengraph-image`;
 	const canonical = `https://llmgateway.io/models/${encodeURIComponent(decodedName)}`;
 
 	return {

--- a/apps/ui/src/app/models/[name]/page.tsx
+++ b/apps/ui/src/app/models/[name]/page.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/lib/discount";
 import { fetchModelDiscounts, fetchProviders } from "@/lib/fetch-models";
 import { buildFaqSchema, buildModelFaqs } from "@/lib/model-faq";
+import { getModelOgImageUrl } from "@/lib/model-og";
 import { buildRatingSchema, type ModelRatingsData } from "@/lib/rating-schema";
 import { fetchServerData } from "@/lib/server-api";
 
@@ -750,12 +751,7 @@ export async function generateMetadata({
 			: (model.description ?? pitch);
 
 	const primaryProvider = model.providers[0]?.providerId || "default";
-	// Per-model OG cards are prerendered from the static catalogue only
-	// (dynamicParams=false keeps satori out of request time), so DB-only
-	// models advertise the site card instead of a 404ing image URL.
-	const ogImageUrl = modelDefinitions.some((m) => m.id === decodedName)
-		? `/models/${encodeURIComponent(decodedName)}/${encodeURIComponent(primaryProvider)}/opengraph-image`
-		: "/opengraph.png";
+	const ogImageUrl = getModelOgImageUrl(decodedName, primaryProvider);
 	const canonical = `https://llmgateway.io/models/${encodeURIComponent(decodedName)}`;
 
 	return {

--- a/apps/ui/src/lib/fetch-models.ts
+++ b/apps/ui/src/lib/fetch-models.ts
@@ -22,12 +22,15 @@ export const fetchModels = cache(async (): Promise<ApiModel[]> => {
 });
 
 export const fetchModelDiscounts = cache(
-	async (modelId: string): Promise<DiscountData[]> => {
+	async (
+		modelId: string,
+		revalidate: number | false = 60,
+	): Promise<DiscountData[]> => {
 		const config = getConfig();
 		try {
 			const response = await fetch(
 				`${config.apiBackendUrl}/public/discounts/model/${encodeURIComponent(modelId)}`,
-				{ next: { revalidate: 60 } },
+				{ next: { revalidate } },
 			);
 			if (!response.ok) {
 				console.error("Failed to fetch discounts:", response.statusText);

--- a/apps/ui/src/lib/model-og-params.ts
+++ b/apps/ui/src/lib/model-og-params.ts
@@ -1,0 +1,4 @@
+export const prerenderedModelOgMappings = [
+	{ name: "gpt-image-2.5-sunburst", provider: "openai" },
+	{ name: "gpt-image-2.5-flare", provider: "openai" },
+];

--- a/apps/ui/src/lib/model-og.spec.ts
+++ b/apps/ui/src/lib/model-og.spec.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { findPublicModelDefinition } from "./airside-model-fallback";
+import { fetchModelDiscounts, fetchProviders } from "./fetch-models";
+import { getModelOgData } from "./model-og";
+
+import type { ModelDefinition } from "@llmgateway/models";
+import type { ApiProvider } from "@llmgateway/shared/components";
+
+vi.mock("./airside-model-fallback", () => ({
+	findPublicModelDefinition: vi.fn(),
+}));
+vi.mock("./fetch-models", () => ({
+	fetchProviders: vi.fn(),
+	fetchModelDiscounts: vi.fn(),
+}));
+
+const liveModel: ModelDefinition = {
+	id: "approved-airside-model",
+	name: "Approved model",
+	family: "mistral",
+	providers: [
+		{
+			providerId: "mistral",
+			externalId: "approved-airside-model",
+			inputPrice: "9e-6",
+			outputPrice: "18e-6",
+			streaming: true,
+		},
+	],
+};
+const liveProvider: ApiProvider = {
+	id: "mistral",
+	name: "Approved provider",
+	createdAt: "2026-09-08T00:00:00Z",
+	description: null,
+	streaming: true,
+	cancellation: null,
+	color: null,
+	website: null,
+	announcement: null,
+	status: "active",
+};
+
+describe("model OG data", () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+		vi.mocked(findPublicModelDefinition).mockResolvedValue(liveModel);
+		vi.mocked(fetchProviders).mockResolvedValue([liveProvider]);
+		vi.mocked(fetchModelDiscounts).mockResolvedValue([]);
+	});
+
+	it.each([
+		{ modelId: "gpt-4o", providerId: "openai" },
+		{ modelId: "gpt-image-2", providerId: "openai" },
+		{ modelId: "gpt-4o", providerId: "mistral" },
+		{ modelId: "gpt-image-2", providerId: "mistral" },
+		{ modelId: "approved-airside-model", providerId: "mistral" },
+	] as const)(
+		"keeps API pricing for $modelId on $providerId",
+		async ({ modelId, providerId }) => {
+			const expected = {
+				...liveModel,
+				id: modelId,
+				providers: liveModel.providers.map((mapping) => ({
+					...mapping,
+					providerId,
+				})),
+			};
+			vi.mocked(findPublicModelDefinition).mockResolvedValue(expected);
+
+			const result = await getModelOgData(modelId, providerId);
+
+			expect(result.model).toBe(expected);
+			expect(result.providers).toEqual([liveProvider]);
+			expect(findPublicModelDefinition).toHaveBeenCalledWith(modelId);
+			expect(fetchModelDiscounts).toHaveBeenCalledWith(modelId, 60);
+		},
+	);
+
+	it.each(["gpt-image-2.5-sunburst", "gpt-image-2.5-flare"])(
+		"uses the catalogue snapshot for %s on OpenAI",
+		async (modelId) => {
+			const result = await getModelOgData(modelId, "openai");
+
+			expect(result.model?.id).toBe(modelId);
+			expect(result.model?.providers[0]?.providerId).toBe("openai");
+			expect(result.providers).toEqual([]);
+			expect(findPublicModelDefinition).not.toHaveBeenCalled();
+			expect(fetchProviders).not.toHaveBeenCalled();
+			expect(fetchModelDiscounts).toHaveBeenCalledWith(modelId, false);
+		},
+	);
+
+	it.each(["gpt-image-2.5-sunburst", "gpt-image-2.5-flare"])(
+		"keeps additional AirSide mappings live for %s",
+		async (modelId) => {
+			const expected = { ...liveModel, id: modelId };
+			vi.mocked(findPublicModelDefinition).mockResolvedValue(expected);
+
+			const result = await getModelOgData(modelId, "mistral");
+
+			expect(result.model).toBe(expected);
+			expect(result.providers).toEqual([liveProvider]);
+			expect(fetchModelDiscounts).toHaveBeenCalledWith(modelId, 60);
+		},
+	);
+
+	it("reflects API fare updates on subsequent loads", async () => {
+		const updatedModel = {
+			...liveModel,
+			providers: liveModel.providers.map((mapping) => ({
+				...mapping,
+				outputPrice: "12e-6",
+			})),
+		};
+		vi.mocked(findPublicModelDefinition)
+			.mockResolvedValueOnce(liveModel)
+			.mockResolvedValueOnce(updatedModel);
+
+		const before = await getModelOgData(liveModel.id, "mistral");
+		const after = await getModelOgData(liveModel.id, "mistral");
+
+		expect(before.model?.providers[0]?.outputPrice).toBe("18e-6");
+		expect(after.model?.providers[0]?.outputPrice).toBe("12e-6");
+	});
+});

--- a/apps/ui/src/lib/model-og.ts
+++ b/apps/ui/src/lib/model-og.ts
@@ -1,0 +1,14 @@
+import { models } from "@llmgateway/models";
+
+export function getModelOgImageUrl(
+	modelId: string,
+	providerId: string,
+): string {
+	const hasStaticMapping = models
+		.find((model) => model.id === modelId)
+		?.providers.some((mapping) => mapping.providerId === providerId);
+
+	return hasStaticMapping
+		? `/models/${encodeURIComponent(modelId)}/${encodeURIComponent(providerId)}/opengraph-image`
+		: "/opengraph.png";
+}

--- a/apps/ui/src/lib/model-og.ts
+++ b/apps/ui/src/lib/model-og.ts
@@ -1,14 +1,33 @@
-import { models } from "@llmgateway/models";
+import { models, type ModelDefinition } from "@llmgateway/models";
 
-export function getModelOgImageUrl(
-	modelId: string,
-	providerId: string,
-): string {
-	const hasStaticMapping = models
-		.find((model) => model.id === modelId)
-		?.providers.some((mapping) => mapping.providerId === providerId);
+import { findPublicModelDefinition } from "./airside-model-fallback";
+import { fetchModelDiscounts, fetchProviders } from "./fetch-models";
+import { prerenderedModelOgMappings } from "./model-og-params";
 
-	return hasStaticMapping
-		? `/models/${encodeURIComponent(modelId)}/${encodeURIComponent(providerId)}/opengraph-image`
-		: "/opengraph.png";
+export function getModelOgStaticParams() {
+	return prerenderedModelOgMappings.map((mapping) => ({ ...mapping }));
+}
+
+export async function getModelOgData(modelId: string, providerId: string) {
+	const prerendered = prerenderedModelOgMappings.some(
+		(mapping) => mapping.name === modelId && mapping.provider === providerId,
+	);
+	const staticModel: ModelDefinition | undefined = prerendered
+		? models.find((model) => model.id === modelId)
+		: undefined;
+	const [model, providers, discounts] = await Promise.all([
+		prerendered ? staticModel : findPublicModelDefinition(modelId),
+		prerendered
+			? []
+			: fetchProviders().catch((error: unknown) => {
+					console.error(
+						"Failed to fetch providers for OpenGraph image:",
+						error,
+					);
+					return [];
+				}),
+		fetchModelDiscounts(modelId, prerendered ? false : 60),
+	]);
+
+	return { model, providers, discounts };
 }


### PR DESCRIPTION
GPT Image 2.5 Sunburst and Flare OG URLs render images on demand and show a zero text-output price. Rewrite only those OpenAI URLs to a dedicated pre-rendered route and show text input, image input, and image output rates. These two snapshots refresh on deploy.

Other catalogue and AirSide mappings keep the existing API-backed renderer and live pricing, including additional providers for the two models. AirSide model pages link to their own model cards.

Validation: full `pnpm format`, final UI formatting, full `pnpm build --env-mode=loose`, and 25 focused tests. Production-mode checks covered 10 OG routes across text, image, OCR, video, an API-only AirSide model, and added AirSide mappings. Verified model-specific metadata and a fare update appearing within the existing cache interval without restarting or rebuilding. Both OpenAI images remain cache hits with the API stopped.

Local previews with the seeded discount:

| Model | Before | After |
| --- | --- | --- |
| Sunburst | <img width="480" alt="Sunburst OG before" src="https://raw.githubusercontent.com/theopenco/llmgateway/2d09faa0268fe816ef5d43d73c1cd03e6587d84e/sunburst-before.png" /> | <img width="480" alt="Sunburst OG after" src="https://raw.githubusercontent.com/theopenco/llmgateway/2d09faa0268fe816ef5d43d73c1cd03e6587d84e/sunburst-after.png" /> |
| Flare | <img width="480" alt="Flare OG before" src="https://raw.githubusercontent.com/theopenco/llmgateway/2d09faa0268fe816ef5d43d73c1cd03e6587d84e/flare-before.png" /> | <img width="480" alt="Flare OG after" src="https://raw.githubusercontent.com/theopenco/llmgateway/2d09faa0268fe816ef5d43d73c1cd03e6587d84e/flare-after.png" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Open Graph image support for model and provider pages, including dynamically generated images for models not in the static catalog.
  - Added image-token pricing displays for image-generation models, showing text input, image input, and image output rates.
  - Added static previews for select OpenAI image models.

- **Bug Fixes**
  - Improved provider information and pricing resolution when standard provider details are unavailable.
  - Model page metadata now consistently links to the model-specific Open Graph and Twitter images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->