### PR TITLE
fix(airside): show approved provider names

### DIFF
--- a/apps/airside/e2e/airside.pw.ts
+++ b/apps/airside/e2e/airside.pw.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 
+import type { paths } from "@/lib/api/v1";
 import type { Page, Route } from "@playwright/test";
 
 // Requires a freshly seeded local stack (`pnpm setup` + dev servers): the
@@ -50,6 +51,68 @@ test("seeded carrier sees operations and its claimed provider", async ({
 	await expect(operations).toContainText("Mistral");
 	// Seeded pending filings surface on the overview.
 	await expect(operations).toContainText("mistral-large-4");
+});
+
+test("dashboard labels follow approved provider branding", async ({ page }) => {
+	type CompaniesResponse =
+		paths["/airside/companies"]["get"]["responses"]["200"]["content"]["application/json"];
+	let providerName = "Approved Carrier";
+	let pendingBranding: { name: string } | null = { name: "Pending Carrier" };
+	let claimStatuses: ("active" | "pending" | "rejected")[] = [
+		"active",
+		"pending",
+		"rejected",
+	];
+	await page.route("**/airside/companies", async (route) => {
+		const response = await route.fetch();
+		const data = (await response.json()) as CompaniesResponse;
+		await route.fulfill({
+			response,
+			json: {
+				companies: data.companies.map((company) => ({
+					...company,
+					name: "Original Company",
+					claims: claimStatuses.map((status, index) => ({
+						...company.claims[0],
+						id: `branding-claim-${index}`,
+						providerId: `branding-provider-${index}`,
+						providerName,
+						pendingBranding,
+						status,
+					})),
+				})),
+			},
+		});
+	});
+	await login(page);
+	const heading = page.getByRole("heading", { level: 1 });
+	const selector = page.getByTestId("company-select");
+	await expect(heading).toHaveText("Approved Carrier");
+	await expect(selector).toHaveText("Approved Carrier");
+
+	providerName = "Updated Carrier";
+	pendingBranding = null;
+	await expect(heading).toHaveText("Updated Carrier", { timeout: 40_000 });
+	await expect(selector).toHaveText("Updated Carrier");
+	await selector.click();
+	await expect(
+		page.getByRole("option", { name: "Updated Carrier", exact: true }),
+	).toBeVisible();
+	await page.keyboard.press("Escape");
+	await page.reload();
+	await expect(heading).toHaveText("Updated Carrier");
+	await expect(selector).toHaveText("Updated Carrier");
+
+	for (const statuses of [
+		["active", "active"],
+		["pending", "rejected"],
+		[],
+	] as const) {
+		claimStatuses = [...statuses];
+		await page.reload();
+		await expect(heading).toHaveText("Original Company");
+		await expect(selector).toHaveText("Original Company");
+	}
 });
 
 test("fleet lists seeded models with their filing states", async ({ page }) => {

--- a/apps/airside/src/app/dashboard/page.tsx
+++ b/apps/airside/src/app/dashboard/page.tsx
@@ -115,7 +115,7 @@ export default function OperationsPage() {
 						Operations · last 30 days
 					</p>
 					<h1 className="font-display text-3xl font-black tracking-tight">
-						{company.name}
+						{company.displayName}
 					</h1>
 				</div>
 				<div className="flex flex-wrap gap-2">

--- a/apps/airside/src/components/dashboard/DashboardShell.tsx
+++ b/apps/airside/src/components/dashboard/DashboardShell.tsx
@@ -70,7 +70,7 @@ export function DashboardShell({ children }: { children: ReactNode }) {
 								<SelectContent>
 									{companies.map((c) => (
 										<SelectItem key={c.id} value={c.id}>
-											{c.name}
+											{c.displayName}
 										</SelectItem>
 									))}
 								</SelectContent>

--- a/apps/airside/src/components/dashboard/company-context.tsx
+++ b/apps/airside/src/components/dashboard/company-context.tsx
@@ -10,7 +10,9 @@ import type { ReactNode } from "react";
 type CompaniesResponse =
 	paths["/airside/companies"]["get"]["responses"]["200"]["content"]["application/json"];
 
-export type AirsideCompany = CompaniesResponse["companies"][number];
+export type AirsideCompany = CompaniesResponse["companies"][number] & {
+	displayName: string;
+};
 
 interface CompanyContextValue {
 	companies: AirsideCompany[];
@@ -23,11 +25,27 @@ const CompanyContext = createContext<CompanyContextValue | null>(null);
 
 export function CompanyProvider({ children }: { children: ReactNode }) {
 	const api = useApi();
-	const { data, isLoading } = api.useQuery("get", "/airside/companies", {});
+	const { data, isLoading } = api.useQuery(
+		"get",
+		"/airside/companies",
+		{},
+		{ refetchInterval: 30_000, refetchOnWindowFocus: "always" },
+	);
 	const [companyId, setCompanyId] = useState<string | null>(null);
 
 	const value = useMemo<CompanyContextValue>(() => {
-		const companies = data?.companies ?? [];
+		const companies = (data?.companies ?? []).map((company) => {
+			const activeClaims = company.claims.filter(
+				(claim) => claim.status === "active",
+			);
+			return {
+				...company,
+				displayName:
+					activeClaims.length === 1
+						? activeClaims[0].providerName
+						: company.name,
+			};
+		});
 		const company =
 			companies.find((c) => c.id === companyId) ?? companies[0] ?? null;
 		return { companies, company, setCompanyId, isLoading };


### PR DESCRIPTION
AirSide kept the registered company name in the Operations heading and company picker after a provider rename was approved.

Use the approved provider name when a company has one active claim, including previously approved renames. Keep the company name when there are zero or multiple active claims. Refresh company data every 30 seconds and when returning to the tab.

Validation:

- `pnpm format`
- `pnpm build --concurrency=1 --cache=local:r`
- `pnpm test:unit apps/api/src/routes/airside.spec.ts` — 50 passed
- Two scoped AirSide browser tests passed; the new regression failed on the original UI. Covers approved and pending names, automatic refresh, reloads, and company-name fallbacks.
- Verified a real local branding submission and admin approval: the public provider API, open dashboard, and refreshed dashboard all show the approved name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Company names in the dashboard now use approved provider branding when exactly one active claim applies.
  * Updated branding appears consistently in the dashboard heading and company selector.

* **Tests**
  * Added coverage verifying branding updates across reloads and claim status changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->