### PR TITLE
fix: apply AirSide discounts to prices and cards

### DIFF
--- a/apps/airside/src/app/dashboard/fares/page.tsx
+++ b/apps/airside/src/app/dashboard/fares/page.tsx
@@ -213,7 +213,8 @@ function FareEditor({
 	);
 
 	const pending = setting.pendingFiling;
-	const adjustment = baselineMargin - margin - discount;
+	const adjustedPrice = (1 - discount) * (1 + baselineMargin - margin);
+	const adjustment = adjustedPrice - 1;
 	const dirty =
 		discount !== setting.discountPercent || margin !== setting.marginPercent;
 
@@ -277,8 +278,8 @@ function FareEditor({
 					onValueChange={([value]) => setDiscount(value / 100)}
 				/>
 				<p className="text-muted-foreground mt-1.5 text-xs">
-					A fare sale: dispatch prices you this much cheaper when electing a
-					carrier. It never changes what you're paid per token.
+					Once approved, this lowers customer prices and appears on model cards.
+					Explicit customer or platform discounts take precedence.
 				</p>
 			</div>
 

--- a/apps/api/src/lib/public-discounts.ts
+++ b/apps/api/src/lib/public-discounts.ts
@@ -1,0 +1,36 @@
+import { db, resolveEffectiveDiscount } from "@llmgateway/db";
+
+export async function loadPublicDiscounts() {
+	const [discounts, airsideSettings] = await Promise.all([
+		db.query.discount.findMany({
+			where: { organizationId: { isNull: true } },
+			orderBy: { createdAt: "desc" },
+		}),
+		db.query.providerRoutingSettings.findMany(),
+	]);
+
+	return (providerId: string, modelId: string) => {
+		const result = resolveEffectiveDiscount(
+			discounts,
+			airsideSettings,
+			null,
+			providerId,
+			modelId,
+		);
+		if (Number(result.discount) <= 0) {
+			return null;
+		}
+		const row = result.source.startsWith("airside_")
+			? airsideSettings.find((row) => row.id === result.discountId)!
+			: discounts.find((row) => row.id === result.discountId)!;
+		return {
+			id: `${result.source}:${row.id}:${providerId}:${modelId}`,
+			provider: providerId,
+			model: modelId,
+			discountPercent: result.discount,
+			reason: "reason" in row ? row.reason : null,
+			expiresAt: "expiresAt" in row ? row.expiresAt : null,
+			createdAt: row.createdAt,
+		};
+	};
+}

--- a/apps/api/src/routes/airside.spec.ts
+++ b/apps/api/src/routes/airside.spec.ts
@@ -5,7 +5,14 @@ import { createTestUser, deleteAll } from "@/testing.js";
 import * as emailUtils from "@/utils/email.js";
 
 import { encryptProviderKeyForStorage } from "@llmgateway/actions";
-import { db, eq, inArray, sql, tables } from "@llmgateway/db";
+import {
+	db,
+	eq,
+	getEffectiveDiscount,
+	inArray,
+	sql,
+	tables,
+} from "@llmgateway/db";
 import {
 	models as catalogueModels,
 	type ModelDefinition,
@@ -1141,8 +1148,8 @@ describe("airside provider portal", () => {
 			json(cookie),
 		);
 		expect(approved.status).toBe(200);
-		// 0.2 (baseline) - 0.3 (margin) - 0.2 (discount) = -0.3
-		expect((await approved.json()).filing.routingAdjustment).toBeCloseTo(-0.3);
+		// The discounted price is adjusted by the accepted margin.
+		expect((await approved.json()).filing.routingAdjustment).toBeCloseTo(-0.28);
 
 		// The admin row is untouched, and no airside row was mirrored in.
 		const multipliers = await db.query.routingScoreMultiplier.findMany({
@@ -1239,7 +1246,7 @@ describe("airside provider portal", () => {
 		});
 
 		// Accepting a larger gateway margin + a discount → negative adjustment
-		// (routing boost): 0.2 − 0.3 − 0.1 = −0.2 — but only as a pending filing.
+		// (routing boost), but only as a pending filing.
 		const filed = await app.request(
 			"/airside/routing-settings/mistral",
 			json(
@@ -1255,7 +1262,7 @@ describe("airside provider portal", () => {
 		expect(filed.status).toBe(201);
 		const { filing } = await filed.json();
 		expect(filing.status).toBe("pending");
-		expect(filing.routingAdjustment).toBeCloseTo(-0.2);
+		expect(filing.routingAdjustment).toBeCloseTo(-0.19);
 
 		// Nothing is live yet, and the portal shows the pending filing.
 		expect(
@@ -1397,6 +1404,137 @@ describe("airside provider portal", () => {
 		expect(outOfBounds.status).toBe(400);
 	});
 
+	it("publishes only approved Airside discounts across catalogue and detail feeds", async () => {
+		process.env.ADMIN_EMAILS = "ops@mistral.ai";
+		await setUserEmail("ops@mistral.ai");
+		const company = await createCompany(cookie);
+		const claim = await claimProvider(cookie, company.id);
+		expect(
+			(
+				await app.request(
+					`/admin/airside/claims/${claim.id}/approve`,
+					json(cookie),
+				)
+			).status,
+		).toBe(200);
+		const modelId = "airside-discount-model";
+		const created = await createModel(cookie, company.id, {
+			modelName: modelId,
+		});
+		expect(created.status).toBe(201);
+		const { model } = await created.json();
+		expect(
+			(
+				await app.request(
+					`/admin/airside/filings/${model.pendingFiling.id}/approve`,
+					json(cookie),
+				)
+			).status,
+		).toBe(200);
+
+		async function expectDiscount(expected: number) {
+			const catalogueResponse = await app.request("/internal/models");
+			expect(catalogueResponse.status).toBe(200);
+			const catalogue = (await catalogueResponse.json()).models.find(
+				(entry: { id: string }) => entry.id === modelId,
+			);
+			expect(Number(catalogue.mappings[0].discount)).toBeCloseTo(expected);
+			const detailsResponse = await app.request(
+				`/public/discounts/model/${modelId}`,
+			);
+			expect(detailsResponse.status).toBe(200);
+			const { discounts } = await detailsResponse.json();
+			if (expected === 0) {
+				expect(discounts).toEqual([]);
+			} else {
+				expect(discounts).toHaveLength(1);
+				expect(discounts[0]).toMatchObject({
+					provider: "mistral",
+					model: modelId,
+				});
+				expect(Number(discounts[0].discountPercent)).toBeCloseTo(expected);
+			}
+			expect(
+				Number((await getEffectiveDiscount(null, "mistral", modelId)).discount),
+			).toBeCloseTo(expected);
+		}
+
+		async function fileDiscount(discountPercent: number, override?: string) {
+			const response = await app.request(
+				"/airside/routing-settings/mistral",
+				json(
+					cookie,
+					{
+						providerCompanyId: company.id,
+						modelId: override,
+						discountPercent,
+						marginPercent: 0.2,
+					},
+					"PUT",
+				),
+			);
+			expect(response.status).toBe(201);
+			return (await response.json()).filing.id as string;
+		}
+
+		await expectDiscount(0);
+		const carrierFiling = await fileDiscount(0.2);
+		await expectDiscount(0);
+		expect(
+			(
+				await app.request(
+					`/admin/airside/routing-filings/${carrierFiling}/approve`,
+					json(cookie),
+				)
+			).status,
+		).toBe(200);
+		await expectDiscount(0.2);
+		const override = await fileDiscount(0.3, modelId);
+		await expectDiscount(0.2);
+		expect(
+			(
+				await app.request(
+					`/admin/airside/routing-filings/${override}/reject`,
+					json(cookie, {}),
+				)
+			).status,
+		).toBe(200);
+		await expectDiscount(0.2);
+		const zero = await fileDiscount(0, modelId);
+		expect(
+			(
+				await app.request(
+					`/admin/airside/routing-filings/${zero}/approve`,
+					json(cookie),
+				)
+			).status,
+		).toBe(200);
+		await expectDiscount(0);
+		const restored = await fileDiscount(0.3, modelId);
+		expect(
+			(
+				await app.request(
+					`/admin/airside/routing-filings/${restored}/approve`,
+					json(cookie),
+				)
+			).status,
+		).toBe(200);
+		await expectDiscount(0.3);
+		expect(
+			(
+				await app.request(
+					`/admin/airside/claims/${claim.id}/revoke`,
+					json(cookie, {}),
+				)
+			).status,
+		).toBe(200);
+		const details = await app.request(`/public/discounts/model/${modelId}`);
+		expect((await details.json()).discounts).toEqual([]);
+		expect(
+			Number((await getEffectiveDiscount(null, "mistral", modelId)).discount),
+		).toBe(0);
+	});
+
 	it("applies an approved fare override to one model", async () => {
 		process.env.ADMIN_EMAILS = "ops@mistral.ai";
 		await setUserEmail("ops@mistral.ai");
@@ -1452,7 +1590,7 @@ describe("airside provider portal", () => {
 		const filing = (await filed.json()).filing;
 		expect(filing).toMatchObject({
 			modelId: "mistral-model-fare",
-			routingAdjustment: expect.closeTo(-0.05),
+			routingAdjustment: expect.closeTo(-0.055),
 		});
 
 		const whilePending = await app.request(
@@ -1508,7 +1646,7 @@ describe("airside provider portal", () => {
 			overridden: true,
 			discountPercent: 0.1,
 			marginPercent: 0.15,
-			routingAdjustment: expect.closeTo(-0.05),
+			routingAdjustment: expect.closeTo(-0.055),
 		});
 	});
 
@@ -1572,7 +1710,7 @@ describe("airside provider portal", () => {
 			});
 			expect(body.providers[0].discountPercent).toBeCloseTo(0.1);
 			expect(body.providers[0].marginPercent).toBeCloseTo(0.3);
-			expect(body.providers[0].routingAdjustment).toBeCloseTo(-0.2);
+			expect(body.providers[0].routingAdjustment).toBeCloseTo(-0.19);
 			expect(body.providers[0].marginAmount30d).toBeCloseTo(5);
 			expect(body.providers[0].marginAmountTotal).toBeCloseTo(12);
 		} finally {

--- a/apps/api/src/routes/airside.spec.ts
+++ b/apps/api/src/routes/airside.spec.ts
@@ -1528,6 +1528,13 @@ describe("airside provider portal", () => {
 				)
 			).status,
 		).toBe(200);
+		const catalogue = await app.request("/internal/models");
+		expect(catalogue.status).toBe(200);
+		expect(
+			(await catalogue.json()).models.some(
+				(entry: { id: string }) => entry.id === modelId,
+			),
+		).toBe(false);
 		const details = await app.request(`/public/discounts/model/${modelId}`);
 		expect((await details.json()).discounts).toEqual([]);
 		expect(

--- a/apps/api/src/routes/internal-models.ts
+++ b/apps/api/src/routes/internal-models.ts
@@ -2,6 +2,7 @@ import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { z } from "zod";
 
 import { findArenaMatch, getArenaBenchmarks } from "@/lib/arena-benchmarks.js";
+import { loadPublicDiscounts } from "@/lib/public-discounts.js";
 
 import {
 	and,
@@ -12,9 +13,7 @@ import {
 	eq,
 	excludeRegionalMappingRows,
 	gte,
-	isNull,
 	modelProviderMappingHistory,
-	or,
 	sql,
 	tables,
 } from "@llmgateway/db";
@@ -187,7 +186,7 @@ const getModelsRoute = createRoute({
 internalModels.openapi(getModelsRoute, async (c) => {
 	const now = new Date();
 
-	const [models, activeMappings, globalDiscounts] = await Promise.all([
+	const [models, activeMappings, getPublicDiscount] = await Promise.all([
 		db.query.model.findMany({
 			where: {
 				status: { eq: "active" },
@@ -204,22 +203,7 @@ internalModels.openapi(getModelsRoute, async (c) => {
 				createdAt: "desc",
 			},
 		}),
-		db
-			.select({
-				provider: tables.discount.provider,
-				model: tables.discount.model,
-				discountPercent: tables.discount.discountPercent,
-			})
-			.from(tables.discount)
-			.where(
-				and(
-					isNull(tables.discount.organizationId),
-					or(
-						isNull(tables.discount.expiresAt),
-						gte(tables.discount.expiresAt, now),
-					),
-				),
-			),
+		loadPublicDiscounts(),
 	]);
 
 	const mappingsByModelId = new Map<string, typeof activeMappings>();
@@ -231,45 +215,6 @@ internalModels.openapi(getModelsRoute, async (c) => {
 			mappingsByModelId.set(mapping.modelId, [mapping]);
 		}
 	}
-
-	// Find the best global discount for a given provider+model. Discounts are
-	// always keyed by the canonical model ID.
-	const getGlobalDiscount = (
-		providerId: string,
-		modelId: string,
-	): string | null => {
-		// Precedence: provider+model > provider > model
-		const providerModel = globalDiscounts.find(
-			(d) => d.provider === providerId && d.model === modelId,
-		);
-		if (providerModel) {
-			return providerModel.discountPercent;
-		}
-
-		const providerOnly = globalDiscounts.find(
-			(d) => d.provider === providerId && d.model === null,
-		);
-		if (providerOnly) {
-			return providerOnly.discountPercent;
-		}
-
-		const modelOnly = globalDiscounts.find(
-			(d) => d.provider === null && d.model === modelId,
-		);
-		if (modelOnly) {
-			return modelOnly.discountPercent;
-		}
-
-		// Fully global (null provider + null model)
-		const fullyGlobal = globalDiscounts.find(
-			(d) => d.provider === null && d.model === null,
-		);
-		if (fullyGlobal) {
-			return fullyGlobal.discountPercent;
-		}
-
-		return null;
-	};
 
 	// Transform and apply effective discount
 	const transformedModels = models.map((model) => ({
@@ -283,7 +228,11 @@ internalModels.openapi(getModelsRoute, async (c) => {
 					) ?? null;
 			return {
 				...mapping,
-				discount: getGlobalDiscount(mapping.providerId, model.id),
+				discount:
+					mapping.deactivatedAt && mapping.deactivatedAt <= now
+						? null
+						: (getPublicDiscount(mapping.providerId, model.id)
+								?.discountPercent ?? null),
 				quantization: sharedMapping?.quantization ?? null,
 				// Airside-materialized mappings carry their own efforts in the DB
 				// row; static rows are served from the shared definition.

--- a/apps/api/src/routes/public-discounts.ts
+++ b/apps/api/src/routes/public-discounts.ts
@@ -1,7 +1,9 @@
 import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { z } from "zod";
 
-import { and, db, desc, eq, gte, isNull, or, tables } from "@llmgateway/db";
+import { loadPublicDiscounts } from "@/lib/public-discounts.js";
+
+import { db } from "@llmgateway/db";
 
 import type { ServerTypes } from "@/vars.js";
 
@@ -42,25 +44,21 @@ const getModelDiscounts = createRoute({
 publicDiscounts.openapi(getModelDiscounts, async (c) => {
 	const { modelId } = c.req.param();
 
+	const [getPublicDiscount, mappings] = await Promise.all([
+		loadPublicDiscounts(),
+		db.query.modelProviderMapping.findMany({
+			where: { modelId: { eq: modelId }, status: { eq: "active" } },
+		}),
+	]);
 	const now = new Date();
-	const notExpired = or(
-		isNull(tables.discount.expiresAt),
-		gte(tables.discount.expiresAt, now),
-	);
-
-	const discounts = await db
-		.select()
-		.from(tables.discount)
-		.where(
-			and(
-				isNull(tables.discount.organizationId),
-				or(isNull(tables.discount.model), eq(tables.discount.model, modelId)),
-				notExpired,
-			),
-		)
-		.orderBy(desc(tables.discount.createdAt));
+	const discounts = mappings
+		.filter((mapping) => !mapping.deactivatedAt || mapping.deactivatedAt > now)
+		.map((mapping) => getPublicDiscount(mapping.providerId, modelId))
+		.filter((discount) => discount !== null);
 
 	return c.json({
-		discounts,
+		discounts: Array.from(
+			new Map(discounts.map((discount) => [discount.id, discount])).values(),
+		),
 	});
 });

--- a/apps/code/src/app/coding-models/page.tsx
+++ b/apps/code/src/app/coding-models/page.tsx
@@ -6,7 +6,7 @@ import { Footer } from "@/components/Footer";
 import { GetDevPassButton } from "@/components/GetDevPassButton";
 import { Header } from "@/components/Header";
 import { Button } from "@/components/ui/button";
-import { codingModelCards } from "@/lib/coding-models";
+import { getCodingModelCards } from "@/lib/coding-models";
 
 import type { Metadata } from "next";
 
@@ -24,7 +24,8 @@ export const metadata: Metadata = {
 	},
 };
 
-export default function CodingModelsPage() {
+export default async function CodingModelsPage() {
+	const codingModelCards = await getCodingModelCards();
 	return (
 		<div className="min-h-screen bg-background">
 			<Header />

--- a/apps/code/src/app/page.tsx
+++ b/apps/code/src/app/page.tsx
@@ -18,7 +18,7 @@ import { FlickeringGrid } from "@/components/ui/flickering-grid";
 import { Marquee } from "@/components/ui/marquee";
 import { NumberTicker } from "@/components/ui/number-ticker";
 import { marqueeTools } from "@/lib/agent-tools";
-import { codingModelCards } from "@/lib/coding-models";
+import { getCodingModelCards } from "@/lib/coding-models";
 import { getConfig } from "@/lib/config-server";
 import { buildDevPassProductSchema } from "@/lib/product-schema";
 
@@ -96,7 +96,8 @@ const steps = [
 	},
 ];
 
-export default function LandingPage() {
+export default async function LandingPage() {
+	const codingModelCards = await getCodingModelCards();
 	const config = getConfig();
 	const credits = {
 		lite: getDevPlanCreditsLimit("lite"),

--- a/apps/code/src/components/CodingModelsShowcase.tsx
+++ b/apps/code/src/components/CodingModelsShowcase.tsx
@@ -216,6 +216,12 @@ export function CodingModelsShowcase({
 								</button>
 							</div>
 
+							{model.discount > 0 && (
+								<span className="w-fit rounded-md border px-2 py-0.5 text-xs font-medium bg-green-500/10 text-green-700 dark:text-green-400 border-green-500/20">
+									{Math.round(model.discount * 100)}% off
+								</span>
+							)}
+
 							{(model.contextSize !== null ||
 								model.inputPrice !== null ||
 								model.outputPrice !== null) && (

--- a/apps/code/src/components/CodingModelsShowcase.tsx
+++ b/apps/code/src/components/CodingModelsShowcase.tsx
@@ -159,6 +159,16 @@ export function CodingModelsShowcase({
 					? activeTab.description
 					: "The latest open-weight-lab models — high performance on coding tasks with tool support and prompt caching."}
 			</p>
+			{visibleModels.length === 0 && (
+				<p
+					role="status"
+					className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground"
+				>
+					{models.length === 0
+						? "Models are currently unavailable. Please try again shortly."
+						: "No models in this category. Browse the full directory below."}
+				</p>
+			)}
 			<div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
 				{visibleModels.map((model) => {
 					const FamilyIcon = getModelFamilyIcon(model.family);

--- a/apps/code/src/lib/coding-models.ts
+++ b/apps/code/src/lib/coding-models.ts
@@ -1,10 +1,23 @@
-import { models, type ModelDefinition } from "@llmgateway/models";
-import { isCodingModel, isPremiumModel } from "@llmgateway/shared";
-import { OPEN_WEIGHT_LAB_FAMILIES } from "@llmgateway/shared/components";
+import { getConfig } from "@/lib/config-server";
 
-// Server-side derivation of the coding-model showcase cards. Only this
-// trimmed shape crosses the RSC boundary — the full catalogue never ships
-// to the client.
+import {
+	discountFraction,
+	isCodingModel,
+	isPremiumModel,
+} from "@llmgateway/shared";
+import {
+	effectiveUnitPrice,
+	fetchModelsFromApi,
+	isMappingDeactivated,
+	OPEN_WEIGHT_LAB_FAMILIES,
+} from "@llmgateway/shared/components";
+
+import type {
+	ApiModel,
+	ApiModelProviderMapping,
+} from "@llmgateway/shared/components";
+
+// Only this trimmed shape crosses the RSC boundary.
 export interface CodingModelCard {
 	id: string;
 	name: string;
@@ -14,88 +27,79 @@ export interface CodingModelCard {
 	contextSize: number | null;
 	inputPrice: number | null;
 	outputPrice: number | null;
+	discount: number;
 }
 
-type ModelProvider = ModelDefinition["providers"][number];
-
-function isActiveMapping(provider: ModelProvider): boolean {
-	const now = new Date();
+function isActiveMapping(provider: ApiModelProviderMapping): boolean {
 	return (
-		(!provider.deprecatedAt || provider.deprecatedAt > now) &&
-		(!provider.deactivatedAt || provider.deactivatedAt > now)
+		provider.status === "active" &&
+		!isMappingDeactivated(provider) &&
+		(!provider.deprecatedAt || new Date(provider.deprecatedAt) > new Date())
 	);
 }
 
-// The gateway's DevPass gate, minus mappings that have already been retired.
-function isShowcaseCodingModel(model: ModelDefinition): boolean {
-	return isCodingModel({
-		...model,
-		providers: model.providers.filter(isActiveMapping),
-	});
-}
-
-// Newest release first; models without a release date sink to the end.
-function byNewestRelease(a: ModelDefinition, b: ModelDefinition): number {
-	const aTime = a.releasedAt?.getTime() ?? 0;
-	const bTime = b.releasedAt?.getTime() ?? 0;
-	return bTime - aTime;
-}
-
-// Pick the provider with the lowest combined input + output price so the card
-// advertises the best ("starting from") rate available for the model. Providers
-// without pricing are ranked last so we still fall back to a usable mapping.
-function getCheapestProvider(
-	providers: readonly ModelProvider[],
-): ModelProvider | undefined {
-	const cost = (p: ModelProvider): number => {
-		const input = p.inputPrice !== undefined ? Number(p.inputPrice) : undefined;
-		const output =
-			p.outputPrice !== undefined ? Number(p.outputPrice) : undefined;
-		if (input === undefined && output === undefined) {
-			return Number.POSITIVE_INFINITY;
-		}
-		return (input ?? 0) + (output ?? 0);
+function getCheapestProvider(providers: ApiModelProviderMapping[]) {
+	const cost = (provider: ApiModelProviderMapping): number => {
+		const input = effectiveUnitPrice(provider.inputPrice, provider.discount);
+		const output = effectiveUnitPrice(provider.outputPrice, provider.discount);
+		return input === null && output === null
+			? Infinity
+			: (input ?? 0) + (output ?? 0);
 	};
-	return providers.reduce<ModelProvider | undefined>((cheapest, p) => {
-		if (!cheapest) {
-			return p;
-		}
-		return cost(p) < cost(cheapest) ? p : cheapest;
-	}, undefined);
+	return providers.reduce<ApiModelProviderMapping | undefined>(
+		(cheapest, provider) =>
+			!cheapest || cost(provider) < cost(cheapest) ? provider : cheapest,
+		undefined,
+	);
 }
 
-const codingModels = (models as ModelDefinition[])
-	.filter(isShowcaseCodingModel)
-	.sort(byNewestRelease);
+export async function getCodingModelCards(): Promise<CodingModelCard[]> {
+	const models = await fetchModelsFromApi(getConfig().apiBackendUrl);
+	const codingModels = models
+		.filter((model) =>
+			isCodingModel({
+				...model,
+				providers: model.mappings.filter(isActiveMapping),
+			}),
+		)
+		.sort(
+			(a, b) =>
+				new Date(b.releasedAt ?? 0).getTime() -
+				new Date(a.releasedAt ?? 0).getTime(),
+		);
 
-// Recommended = the latest coding model from each open-weight lab, derived
-// from release dates so new catalogue entries surface without curation.
-const recommendedIds: ReadonlySet<string> = (() => {
-	const latestPerFamily = new Map<string, ModelDefinition>();
+	// Recommend the newest release from each open-weight lab.
+	const latestPerFamily = new Map<string, ApiModel>();
 	for (const model of codingModels) {
-		if (!OPEN_WEIGHT_LAB_FAMILIES.has(model.family) || !model.releasedAt) {
-			continue;
-		}
-		const current = latestPerFamily.get(model.family);
-		if (!current || model.releasedAt > current.releasedAt!) {
+		if (
+			OPEN_WEIGHT_LAB_FAMILIES.has(model.family) &&
+			model.releasedAt &&
+			!latestPerFamily.has(model.family)
+		) {
 			latestPerFamily.set(model.family, model);
 		}
 	}
-	return new Set(Array.from(latestPerFamily.values()).map((model) => model.id));
-})();
+	const recommendedIds = new Set(
+		Array.from(latestPerFamily.values()).map((model) => model.id),
+	);
 
-export const codingModelCards: CodingModelCard[] = codingModels.map((model) => {
-	const provider = getCheapestProvider(model.providers.filter(isActiveMapping));
-	return {
-		id: model.id,
-		name: model.name ?? model.id,
-		family: model.family,
-		premium: isPremiumModel(model.id),
-		recommended: recommendedIds.has(model.id),
-		contextSize: provider?.contextSize ?? null,
-		inputPrice:
-			provider?.inputPrice !== undefined ? Number(provider.inputPrice) : null,
-		outputPrice:
-			provider?.outputPrice !== undefined ? Number(provider.outputPrice) : null,
-	};
-});
+	return codingModels.map((model) => {
+		const provider = getCheapestProvider(
+			model.mappings.filter(isActiveMapping),
+		);
+		return {
+			id: model.id,
+			name: model.name ?? model.id,
+			family: model.family,
+			premium: isPremiumModel(model.id),
+			recommended: recommendedIds.has(model.id),
+			contextSize: provider?.contextSize ?? null,
+			inputPrice: effectiveUnitPrice(provider?.inputPrice, provider?.discount),
+			outputPrice: effectiveUnitPrice(
+				provider?.outputPrice,
+				provider?.discount,
+			),
+			discount: discountFraction(provider?.discount),
+		};
+	});
+}

--- a/apps/gateway/src/airside-models.spec.ts
+++ b/apps/gateway/src/airside-models.spec.ts
@@ -430,6 +430,40 @@ describe("airside-listed models", () => {
 		expect(Number(log!.cost)).toBeCloseTo(0.007, 6);
 	});
 
+	test("bills an approved Airside discount once", async () => {
+		await setup("airside-discount-token");
+		await db.insert(tables.providerRoutingSettings).values({
+			providerCompanyId: "airside-discount-token-company",
+			providerId: "mistral",
+			modelId: "gpt-5.6-luna",
+			discountPercent: "0.2",
+			marginPercent: "0.2",
+		});
+		await clearCache();
+		const requestId = "airside-discount-request";
+		const response = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer airside-discount-token",
+				"x-no-fallback": "true",
+				"x-request-id": requestId,
+			},
+			body: JSON.stringify({
+				model: "mistral/gpt-5.6-luna",
+				messages: [{ role: "user", content: "Say hi with a discount" }],
+			}),
+		});
+		expect(response.status).toBe(200);
+		const log = await waitForLogByRequestId(requestId);
+		expect(Number(log?.inputCost)).toBeCloseTo(0.0016, 6);
+		expect(Number(log?.outputCost)).toBeCloseTo(0.004, 6);
+		expect(Number(log?.cost)).toBeCloseTo(0.0056, 6);
+		await expect(
+			findAirsideRoutingAdjustment("mistral", "gpt-5.6-luna"),
+		).resolves.toBe(0);
+	});
+
 	test("lists the approved listing in /v1/models", async () => {
 		await setup("airside-v1models-token");
 		const res = await app.request("/v1/models");
@@ -673,7 +707,7 @@ describe("airside-listed models", () => {
 			).resolves.toBeCloseTo(0);
 			await expect(
 				findAirsideRoutingAdjustment("fare-provider", modelId),
-			).resolves.toBeCloseTo(-0.05);
+			).resolves.toBeCloseTo(0.05);
 			await expect(
 				findAirsideRoutingAdjustment("fare-provider", "another-model"),
 			).resolves.toBeCloseTo(0);

--- a/apps/gateway/src/lib/cached-queries.ts
+++ b/apps/gateway/src/lib/cached-queries.ts
@@ -1294,16 +1294,7 @@ export interface EffectiveRoutingScoreMultiplier {
 	multiplierId?: string;
 }
 
-/**
- * Get the internal routing score adjustment for a provider/model combination.
- * The stable SQL shape is cached by Drizzle and the result is mirrored in SWR.
- */
-/**
- * The routing-price adjustment produced by a carrier's own Airside settings
- * (accepted gateway margin + traffic discount). Deliberately separate from
- * routing_score_multiplier, which stays an admin-only prioritization knob —
- * the two combine additively at the scoring seam.
- */
+/** Approved carrier discounts and margins, with model overrides. */
 export async function findAirsideRoutingSettings(
 	provider: string,
 	model?: string,
@@ -1353,7 +1344,8 @@ export async function findAirsideRoutingAdjustment(
 		return 0;
 	}
 	return computeAirsideAdjustment(
-		settings.discountPercent,
+		// The customer discount is already included in the selection price.
+		0,
 		settings.marginPercent,
 	);
 }

--- a/apps/playground/src/components/ai-elements/tool-results.tsx
+++ b/apps/playground/src/components/ai-elements/tool-results.tsx
@@ -3,9 +3,81 @@
 import { Check, Copy, Eye, ImageIcon, Sparkles, Wrench } from "lucide-react";
 import { useState } from "react";
 
+import { ModelDiscountBadge } from "@/components/model-discount-badge";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
+import { useApi } from "@/lib/fetch-client";
+import { formatPrice } from "@/lib/model-utils";
+
+import {
+	effectiveUnitPrice,
+	isMappingDeactivated,
+} from "@llmgateway/shared/components";
+
+function CatalogPricing({
+	modelId,
+	image = false,
+}: {
+	modelId: string;
+	image?: boolean;
+}) {
+	const api = useApi();
+	const { data, isPending, isError } = api.useQuery(
+		"get",
+		"/internal/models",
+		{},
+		{ staleTime: 60_000 },
+	);
+	const model = data?.models.find((candidate) => candidate.id === modelId);
+	const mappings =
+		model?.mappings.filter(
+			(mapping) =>
+				mapping.status === "active" && !isMappingDeactivated(mapping),
+		) ?? [];
+	if (isPending || isError || mappings.length === 0) {
+		return (
+			<p className="text-xs text-muted-foreground">
+				{isPending ? "Loading prices…" : "Pricing unavailable"}
+			</p>
+		);
+	}
+	const fields = image
+		? (["requestPrice"] as const)
+		: (["inputPrice", "outputPrice"] as const);
+	return (
+		<div className="text-xs space-y-1">
+			<div className="text-muted-foreground">Pricing from:</div>
+			<div className="flex gap-3">
+				{fields.map((field) => {
+					const prices = mappings
+						.map((mapping) =>
+							effectiveUnitPrice(mapping[field], mapping.discount),
+						)
+						.filter((price): price is number => price !== null);
+					const price = prices.length ? Math.min(...prices) : null;
+					return (
+						<span key={field}>
+							<span className="font-mono font-medium">
+								{price === null
+									? "—"
+									: image
+										? `$${price.toFixed(3)}/req`
+										: formatPrice(price)}
+							</span>{" "}
+							{!image && (
+								<span className="text-muted-foreground">
+									{field === "inputPrice" ? "in" : "out"}
+								</span>
+							)}
+						</span>
+					);
+				})}
+			</div>
+			<ModelDiscountBadge mappings={mappings} />
+		</div>
+	);
+}
 
 /**
  * Model data structure from list-models tool
@@ -185,21 +257,7 @@ function ModelCard({ model }: { model: ModelData }) {
 				</div>
 			</div>
 
-			<div className="text-xs space-y-1">
-				<div className="text-muted-foreground">Pricing:</div>
-				<div className="flex gap-3">
-					<span>
-						<span className="font-mono font-medium">{model.pricing.input}</span>{" "}
-						<span className="text-muted-foreground">in</span>
-					</span>
-					<span>
-						<span className="font-mono font-medium">
-							{model.pricing.output}
-						</span>{" "}
-						<span className="text-muted-foreground">out</span>
-					</span>
-				</div>
-			</div>
+			<CatalogPricing modelId={model.id} />
 
 			{capabilities.length > 0 && (
 				<div className="flex flex-wrap gap-1">
@@ -281,15 +339,7 @@ function ImageModelCard({ model }: { model: ImageModelData }) {
 				</Button>
 			</div>
 
-			{model.requestPrice !== undefined && model.requestPrice > 0 && (
-				<div className="text-xs">
-					<span className="text-muted-foreground">Price:</span>
-					<span className="ml-1 font-mono font-medium">
-						${model.requestPrice}
-					</span>
-					<span className="text-muted-foreground"> / request</span>
-				</div>
-			)}
+			<CatalogPricing modelId={model.id} image />
 		</div>
 	);
 }

--- a/apps/playground/src/components/model-discount-badge.tsx
+++ b/apps/playground/src/components/model-discount-badge.tsx
@@ -1,0 +1,33 @@
+import { Badge } from "@/components/ui/badge";
+
+import { discountFraction } from "@llmgateway/shared";
+import { isMappingDeactivated } from "@llmgateway/shared/components";
+
+import type { ApiModelProviderMapping } from "@/lib/fetch-models";
+
+export function ModelDiscountBadge({
+	mappings,
+	exact = false,
+}: {
+	mappings: Pick<
+		ApiModelProviderMapping,
+		"discount" | "deactivatedAt" | "status"
+	>[];
+	exact?: boolean;
+}) {
+	const discount = Math.max(
+		0,
+		...mappings
+			.filter(
+				(mapping) =>
+					mapping.status === "active" && !isMappingDeactivated(mapping),
+			)
+			.map((mapping) => discountFraction(mapping.discount)),
+	);
+	return discount > 0 ? (
+		<Badge className="bg-green-500/10 text-green-700 dark:text-green-400 border-green-500/20 text-xs">
+			{!exact && "Up to "}
+			{Math.round(discount * 100)}% off
+		</Badge>
+	) : null;
+}

--- a/apps/playground/src/components/model-selector.tsx
+++ b/apps/playground/src/components/model-selector.tsx
@@ -21,6 +21,7 @@ import {
 import * as React from "react";
 import { List, type RowComponentProps } from "react-window";
 
+import { ModelDiscountBadge } from "@/components/model-discount-badge";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -1774,6 +1775,14 @@ export function ModelSelector({
 											</div>
 										</div>
 
+										<ModelDiscountBadge
+											mappings={
+												previewEntry.mapping
+													? [previewEntry.mapping]
+													: previewEntry.model.mappings
+											}
+											exact={!!previewEntry.mapping}
+										/>
 										{!previewEntry.provider ? (
 											<>
 												<p className="text-xs text-muted-foreground leading-relaxed">
@@ -2509,6 +2518,14 @@ export function ModelSelector({
 								</DialogTitle>
 							</DialogHeader>
 
+							<ModelDiscountBadge
+								mappings={
+									selectedDetails.mapping
+										? [selectedDetails.mapping]
+										: selectedDetails.model.mappings
+								}
+								exact={!!selectedDetails.mapping}
+							/>
 							<div className="space-y-4">
 								{!selectedDetails.provider ? (
 									<div className="space-y-4">

--- a/apps/ui/src/components/models/related-models.tsx
+++ b/apps/ui/src/components/models/related-models.tsx
@@ -1,10 +1,11 @@
 import { ArrowUpRight } from "lucide-react";
 import Link from "next/link";
 
-import { perMillion } from "@/lib/discount";
+import { Badge } from "@/lib/components/badge";
+import { applyDiscount, discountFraction, perMillion } from "@/lib/discount";
+import { fetchModels, type ApiModel } from "@/lib/fetch-models";
 
 import {
-	models as modelDefinitions,
 	providers as providerDefinitions,
 	type ModelDefinition,
 } from "@llmgateway/models";
@@ -12,32 +13,42 @@ import { isMappingDeactivated } from "@llmgateway/shared/components";
 
 const RELATED_MODELS_LIMIT = 6;
 
-function activeMappings(model: ModelDefinition) {
-	return model.providers.filter((p) => !isMappingDeactivated(p));
+function activeMappings(model: ApiModel) {
+	return model.mappings.filter(
+		(p) => p.status === "active" && !isMappingDeactivated(p),
+	);
 }
 
 function startingPrice(
-	model: ModelDefinition,
+	model: ApiModel,
 	field: "inputPrice" | "outputPrice",
 ): number | null {
 	const prices = activeMappings(model)
-		.map((p) => perMillion(p[field]))
+		.map((p) => {
+			const price = perMillion(p[field]);
+			return price === null ? null : applyDiscount(price, p.discount);
+		})
 		.filter((n): n is number => n !== null && Number.isFinite(n));
 	return prices.length > 0 ? Math.min(...prices) : null;
 }
 
-// Internal-linking block: other active models from the same family, newest
-// first, computed straight from the catalogue at render time.
-export function RelatedModels({ modelDef }: { modelDef: ModelDefinition }) {
-	const related = (modelDefinitions as readonly ModelDefinition[])
+export async function RelatedModels({
+	modelDef,
+}: {
+	modelDef: ModelDefinition;
+}) {
+	const related = (await fetchModels())
 		.filter(
 			(m) =>
 				m.family === modelDef.family &&
 				m.id !== modelDef.id &&
+				m.status === "active" &&
 				activeMappings(m).length > 0,
 		)
 		.sort(
-			(a, b) => (b.releasedAt?.getTime() ?? 0) - (a.releasedAt?.getTime() ?? 0),
+			(a, b) =>
+				new Date(b.releasedAt ?? b.createdAt).getTime() -
+				new Date(a.releasedAt ?? a.createdAt).getTime(),
 		)
 		.slice(0, RELATED_MODELS_LIMIT);
 
@@ -72,6 +83,9 @@ export function RelatedModels({ modelDef }: { modelDef: ModelDefinition }) {
 					);
 					const minInput = startingPrice(model, "inputPrice");
 					const minOutput = startingPrice(model, "outputPrice");
+					const discount = Math.max(
+						...activeMappings(model).map((p) => discountFraction(p.discount)),
+					);
 					return (
 						<Link
 							key={model.id}
@@ -81,6 +95,11 @@ export function RelatedModels({ modelDef }: { modelDef: ModelDefinition }) {
 							<p className="font-medium truncate group-hover:underline group-hover:underline-offset-4">
 								{model.name ?? model.id}
 							</p>
+							{discount > 0 && (
+								<Badge className="mt-2 bg-green-500/10 text-green-700 dark:text-green-400 border-green-500/20">
+									Up to {Math.round(discount * 100)}% off
+								</Badge>
+							)}
 							<p className="mt-2 text-xs text-muted-foreground space-x-2">
 								{maxContext > 0 && (
 									<span>{maxContext.toLocaleString()} context</span>

--- a/packages/db/src/airside-routing.ts
+++ b/packages/db/src/airside-routing.ts
@@ -30,7 +30,7 @@ export function computeAirsideAdjustment(
 	discountPercent: number,
 	marginPercent: number,
 ): number {
-	return clampAdjustment(
-		AIRSIDE_BASELINE_MARGIN - marginPercent - discountPercent,
-	);
+	const adjustedPrice =
+		(1 - discountPercent) * (1 + AIRSIDE_BASELINE_MARGIN - marginPercent);
+	return clampAdjustment(adjustedPrice - 1);
 }

--- a/packages/db/src/discount-helpers.spec.ts
+++ b/packages/db/src/discount-helpers.spec.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveEffectiveDiscount } from "./discount-helpers.js";
+
+type Discount = Parameters<typeof resolveEffectiveDiscount>[0][number];
+
+const carrier = {
+	id: "carrier-discount",
+	providerId: "carrier",
+	modelId: null,
+	discountPercent: "0.2",
+};
+
+const discount: Discount = {
+	id: "platform-discount",
+	organizationId: null,
+	provider: null,
+	model: null,
+	discountPercent: "0.1",
+	expiresAt: null,
+};
+
+describe("Airside discounts", () => {
+	it("inherits carrier fares and respects canonical model overrides", () => {
+		const settings = [
+			carrier,
+			{
+				...carrier,
+				id: "model-discount",
+				modelId: "canonical",
+				discountPercent: "0.3",
+			},
+		];
+		expect(
+			resolveEffectiveDiscount([], settings, null, "carrier", "canonical"),
+		).toMatchObject({ discount: "0.3", source: "airside_provider_model" });
+		expect(
+			resolveEffectiveDiscount([], settings, null, "carrier", "upstream-id"),
+		).toMatchObject({ discount: "0.2", source: "airside_provider" });
+		expect(
+			resolveEffectiveDiscount(
+				[],
+				settings,
+				null,
+				"another-carrier",
+				"canonical",
+			).discount,
+		).toBe("0");
+	});
+
+	it("lets a zero model override disable the carrier discount", () => {
+		const settings = [
+			carrier,
+			{ ...carrier, modelId: "canonical", discountPercent: "0" },
+		];
+		expect(
+			resolveEffectiveDiscount([], settings, null, "carrier", "canonical")
+				.discount,
+		).toBe("0");
+		expect(
+			resolveEffectiveDiscount([], settings, null, "carrier", "sibling")
+				.discount,
+		).toBe("0.2");
+	});
+
+	it.each([
+		{ organizationId: "org", provider: "carrier", model: "canonical" },
+		{ organizationId: "org", provider: "carrier", model: null },
+		{ organizationId: "org", provider: null, model: "canonical" },
+		{ organizationId: null, provider: "carrier", model: "canonical" },
+		{ organizationId: null, provider: "carrier", model: null },
+		{ organizationId: null, provider: null, model: "canonical" },
+		{ organizationId: null, provider: null, model: null },
+	])("preserves explicit discount precedence: %j", (scope) => {
+		expect(
+			resolveEffectiveDiscount(
+				[{ ...discount, ...scope }],
+				[carrier],
+				"org",
+				"carrier",
+				"canonical",
+			).discount,
+		).toBe("0.1");
+	});
+
+	it("ignores expired and invalid overrides and other organizations", () => {
+		const overrides = [
+			{ ...discount, expiresAt: new Date(0) },
+			{ ...discount, discountPercent: "1.2" },
+			{ ...discount, discountPercent: "NaN" },
+			{ ...discount, organizationId: "other-org", provider: "carrier" },
+		];
+		expect(
+			resolveEffectiveDiscount(
+				overrides,
+				[carrier],
+				"org",
+				"carrier",
+				"canonical",
+			).discount,
+		).toBe("0.2");
+	});
+
+	it("lets an explicit zero discount disable Airside savings", () => {
+		expect(
+			resolveEffectiveDiscount(
+				[{ ...discount, discountPercent: "0" }],
+				[carrier],
+				null,
+				"carrier",
+				"canonical",
+			).discount,
+		).toBe("0");
+	});
+});

--- a/packages/db/src/discount-helpers.ts
+++ b/packages/db/src/discount-helpers.ts
@@ -1,10 +1,27 @@
-import { and, eq, getTableName, isNull, or } from "drizzle-orm";
+import { and, desc, eq, getTableName, isNull, or } from "drizzle-orm";
 
 import { swrWrap } from "@llmgateway/cache";
 import { logger } from "@llmgateway/logger";
 
 import { cdb } from "./cdb.js";
-import { discount as discountTable } from "./schema.js";
+import {
+	discount as discountTable,
+	providerRoutingSettings,
+} from "./schema.js";
+
+type DiscountRow = Pick<
+	typeof discountTable.$inferSelect,
+	| "id"
+	| "organizationId"
+	| "provider"
+	| "model"
+	| "discountPercent"
+	| "expiresAt"
+>;
+type AirsideDiscountRow = Pick<
+	typeof providerRoutingSettings.$inferSelect,
+	"id" | "providerId" | "modelId" | "discountPercent"
+>;
 
 /**
  * Result of discount lookup with precedence information
@@ -20,6 +37,9 @@ export interface EffectiveDiscount {
 		| "global_provider_model"
 		| "global_provider"
 		| "global_model"
+		| "global"
+		| "airside_provider_model"
+		| "airside_provider"
 		| "none";
 	/** The discount record ID if from database */
 	discountId?: string;
@@ -36,6 +56,8 @@ export interface EffectiveDiscount {
  * 4. Global + Provider + Model discount
  * 5. Global + Provider discount
  * 6. Global + Model discount
+ * 7. Fully global discount
+ * 8. Approved Airside model override, or carrier default
  *
  * Discounts are always keyed by the canonical model ID — provider-specific model
  * names are reserved for upstream requests and are never persisted as a
@@ -56,7 +78,7 @@ export async function getEffectiveDiscount(
 		// known discount is served instead of silently dropping to 0%.
 		return await swrWrap(
 			`discount:${organizationId ?? "global"}:${provider}:${model}`,
-			[getTableName(discountTable)],
+			[getTableName(discountTable), getTableName(providerRoutingSettings)],
 			() => queryEffectiveDiscount(organizationId, provider, model),
 		);
 	} catch (error) {
@@ -104,15 +126,52 @@ async function queryEffectiveDiscount(
 				),
 				or(eq(discountTable.model, model), isNull(discountTable.model)),
 			),
+		)
+		.orderBy(desc(discountTable.createdAt));
+	const airsideSettings = await cdb
+		.select({
+			id: providerRoutingSettings.id,
+			providerId: providerRoutingSettings.providerId,
+			modelId: providerRoutingSettings.modelId,
+			discountPercent: providerRoutingSettings.discountPercent,
+		})
+		.from(providerRoutingSettings)
+		.where(
+			and(
+				eq(providerRoutingSettings.providerId, provider),
+				or(
+					eq(providerRoutingSettings.modelId, model),
+					isNull(providerRoutingSettings.modelId),
+				),
+			),
 		);
+	return resolveEffectiveDiscount(
+		rows,
+		airsideSettings,
+		organizationId,
+		provider,
+		model,
+	);
+}
 
+export function resolveEffectiveDiscount(
+	rows: DiscountRow[],
+	airsideSettings: AirsideDiscountRow[],
+	organizationId: string | null,
+	provider: string,
+	model: string,
+): EffectiveDiscount {
 	const now = Date.now();
 	const discounts = rows.filter(
 		// expiresAt is a Date on both a fresh query and a Drizzle cache hit (the
 		// cache stores the raw pg result and re-applies the timestamp parser on
 		// restore). Wrap in new Date() defensively so the compare is robust even
 		// if a serialized value ever reaches here.
-		(d) => d.expiresAt === null || new Date(d.expiresAt).getTime() >= now,
+		(d) =>
+			Number.isFinite(Number(d.discountPercent)) &&
+			Number(d.discountPercent) >= 0 &&
+			Number(d.discountPercent) <= 1 &&
+			(d.expiresAt === null || new Date(d.expiresAt).getTime() >= now),
 	);
 
 	const modelMatches = (discountModel: string | null): boolean =>
@@ -206,6 +265,38 @@ async function queryEffectiveDiscount(
 			discount: globalModel.discountPercent,
 			source: "global_model",
 			discountId: globalModel.id,
+		};
+	}
+	const global = discounts.find(
+		(d) => d.organizationId === null && d.provider === null && d.model === null,
+	);
+	if (global) {
+		return {
+			discount: global.discountPercent,
+			source: "global",
+			discountId: global.id,
+		};
+	}
+
+	const airside =
+		airsideSettings.find(
+			(row) => row.providerId === provider && row.modelId === model,
+		) ??
+		airsideSettings.find(
+			(row) => row.providerId === provider && row.modelId === null,
+		);
+	if (
+		airside &&
+		Number(airside.discountPercent) > 0 &&
+		Number(airside.discountPercent) <= 1
+	) {
+		return {
+			discount: airside.discountPercent,
+			source:
+				airside.modelId === null
+					? "airside_provider"
+					: "airside_provider_model",
+			discountId: airside.id,
 		};
 	}
 


### PR DESCRIPTION
Approved AirSide discounts affected routing priority but were missing from customer prices and model cards. Use the same effective discount for billing and catalogue responses, with explicit organization/platform discounts taking precedence over AirSide model overrides and carrier defaults. Routing applies the price reduction once, and fare previews reflect the resulting adjustment.

Show the savings across UI model/provider pages, related-model cards, Code directories and showcases, and Playground previews, mobile details, and model-list tool cards. Pending and rejected filings do not affect prices; revocation removes the discount and custom model from the catalogue. DevPass showcases display an explicit message when the catalogue or selected category is empty.

Validation:
- `pnpm format` and full `pnpm build` passed.
- All 246 tests in nine targeted discount, approval, billing, routing, price-formatting, catalogue-fetching, and premium-classification suites passed.
- Registered a mock carrier and models through AirSide, ran preflight with a mocked upstream, approved the listings and discounts in admin, and verified rendered prices across all three apps in desktop/mobile views and light/dark themes.

Verified DevPass catalogue failures on the homepage and coding-models page, plus populated discounted cards and empty category switching.

Before/after with an approved mock discount (seeded local data):

| Surface | Before | After |
| --- | --- | --- |
| UI directory · light | <img width="320" alt="UI directory, light, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/6d1a52e6bd51bad54ff1db1273a8ff35d15fe051/before-ui-models-card-light.png" /> | <img width="320" alt="UI directory, light, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/6d1a52e6bd51bad54ff1db1273a8ff35d15fe051/after-ui-models-card-light.png" /> |
| UI directory · dark | <img width="320" alt="UI directory, dark, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/6d1a52e6bd51bad54ff1db1273a8ff35d15fe051/before-ui-models-card-dark.png" /> | <img width="320" alt="UI directory, dark, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/6d1a52e6bd51bad54ff1db1273a8ff35d15fe051/after-ui-models-card-dark.png" /> |
| Code directory · light | <img width="320" alt="Code directory, light, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/6d1a52e6bd51bad54ff1db1273a8ff35d15fe051/before-code-models-card-light.png" /> | <img width="320" alt="Code directory, light, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/6d1a52e6bd51bad54ff1db1273a8ff35d15fe051/after-code-models-card-light.png" /> |
| Code directory · dark | <img width="320" alt="Code directory, dark, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/6d1a52e6bd51bad54ff1db1273a8ff35d15fe051/before-code-models-card-dark.png" /> | <img width="320" alt="Code directory, dark, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/6d1a52e6bd51bad54ff1db1273a8ff35d15fe051/after-code-models-card-dark.png" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Model listings, coding pages, related models, and playground views now display current provider pricing and applicable discounts.
  - Added discount badges showing available or exact savings on model cards and selectors.
  - Playground pricing now reflects active model-provider mappings and discounted rates.
  - Public discount information is consistently available across supported model views.
  - Added clearer unavailable and no-results states when models cannot be displayed.

- **Bug Fixes**
  - Improved fare and billing calculations so discounts are applied correctly and only once.
  - Clarified traffic discount messaging and discount-priority behavior in fare editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

DevPass coding showcase when the catalogue is unavailable:

| Theme | Before | After |
| --- | --- | --- |
| light | <img width="560" alt="DevPass unavailable catalogue, light, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/18a90ad3a4ae01fd3ca8f906e23117dc381d88b5/before-code-empty-light.png" /> | <img width="560" alt="DevPass unavailable catalogue, light, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/18a90ad3a4ae01fd3ca8f906e23117dc381d88b5/after-code-empty-light.png" /> |
| dark | <img width="560" alt="DevPass unavailable catalogue, dark, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/18a90ad3a4ae01fd3ca8f906e23117dc381d88b5/before-code-empty-dark.png" /> | <img width="560" alt="DevPass unavailable catalogue, dark, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/18a90ad3a4ae01fd3ca8f906e23117dc381d88b5/after-code-empty-dark.png" /> |
