### PR TITLE
fix(models): retire replaced DeepSeek V4 Flash mappings

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -1880,7 +1880,7 @@ describe("api", () => {
 					Authorization: "Bearer real-token-devpass-no-training",
 				},
 				body: JSON.stringify({
-					model: "deepseek-v4-flash",
+					model: "deepseek-v4.1-flash",
 					messages: [{ role: "user", content: "Hello compliance!" }],
 				}),
 			});

--- a/packages/benchmarks/src/cli.spec.ts
+++ b/packages/benchmarks/src/cli.spec.ts
@@ -42,7 +42,7 @@ describe("runBenchmarkCli", () => {
 
 		const exitCode = await runBenchmarkCli([
 			"--model",
-			"deepseek-v4-flash",
+			"deepseek-v4.1-flash",
 			"--mapping",
 			"deepseek",
 			"--suite",
@@ -81,7 +81,7 @@ describe("runBenchmarkCli", () => {
 
 		const exitCode = await runBenchmarkCli([
 			"--model",
-			"deepseek-v4-flash",
+			"deepseek-v4.1-flash",
 			"--mapping",
 			"deepseek",
 			"--external",

--- a/packages/benchmarks/src/targets.spec.ts
+++ b/packages/benchmarks/src/targets.spec.ts
@@ -6,10 +6,10 @@ describe("resolveBenchmarkTargets", () => {
 	it("resolves selected provider mappings to pinned model ids", () => {
 		const targets = resolveBenchmarkTargets({
 			modelIds: ["deepseek-v4-flash"],
-			mappings: ["deepseek", "canopywave"],
+			mappings: ["runware", "canopywave"],
 		});
 		expect(targets.map((target) => target.id)).toEqual([
-			"deepseek/deepseek-v4-flash",
+			"runware/deepseek-v4-flash",
 			"canopywave/deepseek-v4-flash",
 		]);
 	});

--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -604,6 +604,9 @@ export const deepseekModels = [
 			{
 				providerId: "deepseek",
 				externalId: "deepseek-v4-flash",
+				// Retired by DeepSeek on 2026-09-10; the slug now serves V4.1 Flash
+				// at V4.1 rates, so it must not be billed at this schedule.
+				deactivatedAt: new Date("2026-09-10"),
 				// Peak hours (01:00-04:00 and 06:00-10:00 UTC) bill at the peak
 				// rates below. All other hours and Beijing-time weekends bill at
 				// the off-peak rates.
@@ -1011,6 +1014,9 @@ export const deepseekModels = [
 			{
 				providerId: "deepseek",
 				externalId: "deepseek-v4-flash-vision-exp",
+				// Retired by DeepSeek on 2026-09-10; the slug now serves V4.1 Flash
+				// at V4.1 rates, so it must not be billed at this schedule.
+				deactivatedAt: new Date("2026-09-10"),
 				inputPrice: "0.14e-6",
 				outputPrice: "0.28e-6",
 				cachedInputPrice: "0.0028e-6",

--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -283,8 +283,6 @@ export const deepseekModels = [
 			{
 				providerId: "deepseek",
 				externalId: "deepseek-v4-pro",
-				// DeepSeek retires this deployment on 2026-09-14 and routes the slug
-				// to V4.1 Flash afterwards, so it must not be billed at Pro rates.
 				deactivatedAt: new Date("2026-09-14"),
 				// Peak hours (01:00-04:00 and 06:00-10:00 UTC) bill at the peak
 				// rates below. All other hours and Beijing-time weekends bill at
@@ -604,8 +602,6 @@ export const deepseekModels = [
 			{
 				providerId: "deepseek",
 				externalId: "deepseek-v4-flash",
-				// Retired by DeepSeek on 2026-09-10; the slug now serves V4.1 Flash
-				// at V4.1 rates, so it must not be billed at this schedule.
 				deactivatedAt: new Date("2026-09-10"),
 				// Peak hours (01:00-04:00 and 06:00-10:00 UTC) bill at the peak
 				// rates below. All other hours and Beijing-time weekends bill at
@@ -1014,8 +1010,6 @@ export const deepseekModels = [
 			{
 				providerId: "deepseek",
 				externalId: "deepseek-v4-flash-vision-exp",
-				// Retired by DeepSeek on 2026-09-10; the slug now serves V4.1 Flash
-				// at V4.1 rates, so it must not be billed at this schedule.
 				deactivatedAt: new Date("2026-09-10"),
 				inputPrice: "0.14e-6",
 				outputPrice: "0.28e-6",

--- a/packages/shared/src/onboarding.ts
+++ b/packages/shared/src/onboarding.ts
@@ -4,7 +4,7 @@
 // billed to the platform's provider account. Leaving it to the caller — or to
 // "auto", whose candidates are frontier models — would let a signup decide how
 // much we pay. Keep it cheap: it is paid for on every signup.
-export const ONBOARDING_MODEL = "deepseek/deepseek-v4-flash";
+export const ONBOARDING_MODEL = "deepseek/deepseek-v4.1-flash";
 
 // Onboarding answers are two sentences, and that one call is on us, so cap the
 // output. Applied server-side, and only to the calls we actually pay for.


### PR DESCRIPTION
## Why

Follow-up to #3996, which auto-merged before this commit landed on the branch. A review finding there pointed out that DeepSeek retired the first-party `deepseek-v4-flash` and `deepseek-v4-flash-vision-exp` slugs on 2026-09-10 and now serves V4.1 Flash on them at V4.1 rates, so the gateway still billing those mappings at the old, higher V4 Flash schedule over-bills pinned requests and the onboarding request.

## What

- `deactivatedAt: 2026-09-10` on the first-party `deepseek/deepseek-v4-flash` and `deepseek/deepseek-v4-flash-vision-exp` mappings, matching the V4 Pro retirement already in #3996 (DeepSeek routes `deepseek-v4-pro` to V4.1 Flash from 2026-09-14). Third-party V4 Flash mappings are untouched, so the canonical `deepseek-v4-flash` keeps routing.
- Dropped the inline retirement comments, including the one on the V4 Pro mapping from #3996: the dates already encode it, and the evidence belongs here.
- `ONBOARDING_MODEL` moves from `deepseek/deepseek-v4-flash` to `deepseek/deepseek-v4.1-flash`, since the pinned mapping it named is now inactive.
- The benchmark targets spec pinned the retired `deepseek/deepseek-v4-flash` mapping and fails once it is deactivated; it now uses two mappings that stay active.

## Verification

`pnpm build:core`, `pnpm lint`, and the `model-metadata`, `providers`, actions `models`, benchmarks `targets`, and gateway `costs` specs pass on top of current `main`. The V4.1 Flash mapping itself was verified end to end in #3996.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WvbS24okmE2EkNH2muCyM6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Model Updates**
  - Updated the post-signup “Try it now” experience to use DeepSeek V4.1 Flash.
  - Scheduled the deactivation of DeepSeek V4 Pro, V4 Flash, and V4 Flash Vision Experimental on their respective published dates.

- **Benchmarking**
  - Updated benchmark coverage to use the Runware-hosted DeepSeek V4 Flash target.
  - Updated benchmark scenarios to reference DeepSeek V4.1 Flash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->