### PR TITLE
fix(admin): distinguish provider credentials

### DIFF
--- a/apps/api/src/routes/admin-provider-credentials.spec.ts
+++ b/apps/api/src/routes/admin-provider-credentials.spec.ts
@@ -163,7 +163,7 @@ describe("admin provider credentials", () => {
 		const credentials = await list();
 		expect(
 			credentials.map((credential) => credential.maskedToken).sort(),
-		).toEqual(["sk-s•••••1234", "sk-s•••••5678"]);
+		).toEqual(["sk-sha•••••1234", "sk-sha•••••5678"]);
 		expect(JSON.stringify(credentials)).not.toContain("sk-shared-prefix-");
 	});
 

--- a/apps/api/src/routes/admin-provider-credentials.spec.ts
+++ b/apps/api/src/routes/admin-provider-credentials.spec.ts
@@ -143,6 +143,30 @@ describe("admin provider credentials", () => {
 		expect(body).not.toContain("sk-secret-value-here");
 	});
 
+	test("shows distinct suffixes for existing keys with the same stored mask", async () => {
+		await db.insert(tables.providerKey).values(
+			["1234", "5678"].map((suffix) => {
+				const id = `managed-mask-${suffix}`;
+				return {
+					id,
+					provider: "openai",
+					managed: true,
+					...encryptProviderKeyForStorage(
+						`sk-shared-prefix-${suffix}`,
+						id,
+						null,
+					),
+				};
+			}),
+		);
+
+		const credentials = await list();
+		expect(
+			credentials.map((credential) => credential.maskedToken).sort(),
+		).toEqual(["sk-s•••••1234", "sk-s•••••5678"]);
+		expect(JSON.stringify(credentials)).not.toContain("sk-shared-prefix-");
+	});
+
 	test("encrypts the token under the managed scope", async () => {
 		await create({ provider: "openai", token: "sk-encrypt-me" });
 

--- a/apps/api/src/routes/admin-provider-credentials.ts
+++ b/apps/api/src/routes/admin-provider-credentials.ts
@@ -217,7 +217,7 @@ function toCredential(row: CredentialRow) {
 		config: row.config ?? {},
 		usageLimit: row.usageLimit,
 		usage: row.usage,
-		maskedToken: maskToken(readProviderKey(row), 4, 4),
+		maskedToken: maskToken(readProviderKey(row), 6, 4),
 		tokenHash: row.tokenHash,
 		allowedModels: row.allowedModels,
 	};
@@ -1056,7 +1056,7 @@ adminProviderCredentials.openapi(getSpendOverview, async (c) => {
 					variant: key.variant,
 					region: key.region,
 					comment: key.comment,
-					maskedToken: maskToken(readProviderKey(key), 4, 4),
+					maskedToken: maskToken(readProviderKey(key), 6, 4),
 					status: key.status,
 					usage: key.usage,
 					usageLimit: key.usageLimit,

--- a/apps/api/src/routes/admin-provider-credentials.ts
+++ b/apps/api/src/routes/admin-provider-credentials.ts
@@ -30,7 +30,6 @@ import {
 	providerKeyEncryptionScope,
 	readProviderEnvInventory,
 	readProviderKey,
-	readProviderKeyMask,
 	redactToken,
 	validateProviderKey,
 } from "@llmgateway/actions";
@@ -218,7 +217,7 @@ function toCredential(row: CredentialRow) {
 		config: row.config ?? {},
 		usageLimit: row.usageLimit,
 		usage: row.usage,
-		maskedToken: readProviderKeyMask(row),
+		maskedToken: maskToken(readProviderKey(row), 4, 4),
 		tokenHash: row.tokenHash,
 		allowedModels: row.allowedModels,
 	};
@@ -1057,7 +1056,7 @@ adminProviderCredentials.openapi(getSpendOverview, async (c) => {
 					variant: key.variant,
 					region: key.region,
 					comment: key.comment,
-					maskedToken: readProviderKeyMask(key),
+					maskedToken: maskToken(readProviderKey(key), 4, 4),
 					status: key.status,
 					usage: key.usage,
 					usageLimit: key.usageLimit,

--- a/packages/actions/src/provider-key/env-inventory.spec.ts
+++ b/packages/actions/src/provider-key/env-inventory.spec.ts
@@ -69,7 +69,7 @@ describe("collectProviderEnvCredentials", () => {
 			collectProviderEnvCredentials("alibaba").map(
 				(entry) => entry.maskedToken,
 			),
-		).toEqual(["sk-s•••••1234", "sk-s•••••5678"]);
+		).toEqual(["sk-sha•••••1234", "sk-sha•••••5678"]);
 	});
 
 	it("covers variant and regional override slots", () => {

--- a/packages/actions/src/provider-key/env-inventory.spec.ts
+++ b/packages/actions/src/provider-key/env-inventory.spec.ts
@@ -62,6 +62,16 @@ describe("collectProviderEnvCredentials", () => {
 		expect(entry.tokenHash).toBe(getApiKeyFingerprint("sk-secret-value"));
 	});
 
+	it("distinguishes keys with the same prefix by their last four characters", () => {
+		vi.stubEnv(BASE, "sk-shared-prefix-1234,sk-shared-prefix-5678");
+
+		expect(
+			collectProviderEnvCredentials("alibaba").map(
+				(entry) => entry.maskedToken,
+			),
+		).toEqual(["sk-s•••••1234", "sk-s•••••5678"]);
+	});
+
 	it("covers variant and regional override slots", () => {
 		vi.stubEnv(BASE, "sk-base");
 		vi.stubEnv(ENTERPRISE, "sk-ent");

--- a/packages/actions/src/provider-key/env-inventory.ts
+++ b/packages/actions/src/provider-key/env-inventory.ts
@@ -155,7 +155,7 @@ export function collectProviderEnvCredentials(
 				variant: slot.variant,
 				region: slot.region,
 				index,
-				maskedToken: maskToken(key),
+				maskedToken: maskToken(key, 4, 4),
 				tokenHash: getApiKeyFingerprint(key),
 			});
 		});

--- a/packages/actions/src/provider-key/env-inventory.ts
+++ b/packages/actions/src/provider-key/env-inventory.ts
@@ -155,7 +155,7 @@ export function collectProviderEnvCredentials(
 				variant: slot.variant,
 				region: slot.region,
 				index,
-				maskedToken: maskToken(key, 4, 4),
+				maskedToken: maskToken(key, 6, 4),
 				tokenHash: getApiKeyFingerprint(key),
 			});
 		});

--- a/packages/shared/src/mask-token.spec.ts
+++ b/packages/shared/src/mask-token.spec.ts
@@ -3,6 +3,25 @@ import { describe, expect, it } from "vitest";
 import { maskToken } from "./mask-token.js";
 
 describe("maskToken", () => {
+	it("shows a prefix and suffix when trailing characters are requested", () => {
+		expect(maskToken("12345678901234567890", 4, 4)).toBe("1234•••••7890");
+	});
+
+	it.each([
+		["", ""],
+		["abc", "••••"],
+		["abcd", "••••"],
+		["abcde", "••••e"],
+		["abcdefgh", "••••efgh"],
+		["abcdefghi", "a••••fghi"],
+		["abcdefghijkl", "abcd••••ijkl"],
+	])(
+		"keeps at least four characters hidden in %j with a suffix",
+		(token, mask) => {
+			expect(maskToken(token, 4, 4)).toBe(mask);
+		},
+	);
+
 	it("masks all characters after the visible ones", () => {
 		const masked = maskToken("12345678901234567890", 12);
 		expect(masked).toBe("123456789012•••••");

--- a/packages/shared/src/mask-token.ts
+++ b/packages/shared/src/mask-token.ts
@@ -9,26 +9,32 @@ const MIN_MASKED_CHARS = 4;
 const MAX_MASK_BULLETS = 5;
 
 /**
- * Returns a display-safe version of a secret token. The trailing
- * MIN_MASKED_CHARS characters are always replaced with bullets so a short
- * token (e.g. a custom-provider key shorter than visibleChars) cannot leak
- * through as plaintext into provider_key.token_masked or UI list responses.
+ * Returns a display-safe token with at least MIN_MASKED_CHARS hidden.
+ * Optional trailing characters take priority over the prefix on short tokens.
  *
  * Empty input returns empty.
  */
-export function maskToken(token: string, visibleChars = 12): string {
+export function maskToken(
+	token: string,
+	visibleChars = 12,
+	trailingChars = 0,
+): string {
 	if (token.length === 0) {
 		return "";
 	}
+	const effectiveTrailing = Math.max(
+		0,
+		Math.min(trailingChars, token.length - MIN_MASKED_CHARS),
+	);
 	const effectiveVisible = Math.max(
 		0,
-		Math.min(visibleChars, token.length - MIN_MASKED_CHARS),
+		Math.min(visibleChars, token.length - effectiveTrailing - MIN_MASKED_CHARS),
 	);
 	const maskedLength = Math.max(
-		token.length - effectiveVisible,
+		token.length - effectiveVisible - effectiveTrailing,
 		MIN_MASKED_CHARS,
 	);
 	return `${token.substring(0, effectiveVisible)}${"\u2022".repeat(
 		Math.min(maskedLength, MAX_MASK_BULLETS),
-	)}`;
+	)}${token.substring(token.length - effectiveTrailing)}`;
 }


### PR DESCRIPTION
Provider credentials sharing a prefix were indistinguishable in the admin Key column. Show the first six and last four characters for managed and environment credentials, while keeping at least four characters hidden for short keys.

Existing managed credentials get the new mask from their encrypted value on admin reads; no key rotation or data migration is needed.

Validation: `pnpm format`, `pnpm build`, 102 tests across the masking, environment inventory, and admin credential suites.

Screenshots use synthetic local credentials.

| Theme | Before | After |
| --- | --- | --- |
| Light | <img width="520" alt="Before credential masks in light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/1dc1fa18313ebedb6f219eeb967aef042c77ba4f/before-light.png" /> | <img width="520" alt="After credential masks in light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/1dc1fa18313ebedb6f219eeb967aef042c77ba4f/after-light.png" /> |
| Dark | <img width="520" alt="Before credential masks in dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/1dc1fa18313ebedb6f219eeb967aef042c77ba4f/before-dark.png" /> | <img width="520" alt="After credential masks in dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/1dc1fa18313ebedb6f219eeb967aef042c77ba4f/after-dark.png" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved credential masking so managed and environment-based provider keys retain more of their visible prefix and the final four characters.
  - Credentials with similar prefixes are now easier to distinguish in credential lists and spend overviews.
  - Short tokens continue to maintain a protected masked section while displaying available prefix and suffix characters appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->