### PR TITLE
fix(refunds): use credits for plan eligibility

### DIFF
--- a/apps/api/src/lib/self-refund.spec.ts
+++ b/apps/api/src/lib/self-refund.spec.ts
@@ -269,12 +269,10 @@ describe("computeSelfRefundEligibility", () => {
 		});
 	});
 
-	test("dev plan renewal gates on the dollar price, not the virtual allowance", async () => {
+	test("dev plan renewal at 20% of the allowance is not eligible", async () => {
 		await seedOrg({
 			devPlan: "pro",
-			// 16 > 20% of $79 ($15.80) while still far under 20% of the
-			// 237-credit allowance (47.4) — the dollar gate is what decides.
-			devPlanCreditsUsed: "16",
+			devPlanCreditsUsed: "47.4",
 			devPlanCreditsLimit: "237",
 			devPlanStripeSubscriptionId: "sub_test_1",
 		});
@@ -300,35 +298,38 @@ describe("computeSelfRefundEligibility", () => {
 		});
 	});
 
-	test("dev plan renewal under 20% of the price is eligible; the start is no longer refundable", async () => {
-		await seedOrg({
-			devPlan: "pro",
-			devPlanCreditsUsed: "15",
-			devPlanCreditsLimit: "237",
-			devPlanStripeSubscriptionId: "sub_test_1",
-		});
-		const start = await seedTransaction({
-			type: "dev_plan_start",
-			amount: "79",
-			creditAmount: "237",
-			stripePaymentIntentId: null,
-			stripeInvoiceId: "in_test_1",
-			createdAt: daysAgo(10),
-		});
-		const renewal = await seedTransaction({
-			type: "dev_plan_renewal",
-			amount: "79",
-			creditAmount: "237",
-			stripePaymentIntentId: null,
-			stripeInvoiceId: "in_test_2",
-		});
+	test.each(["dev_plan_start", "dev_plan_renewal"] as const)(
+		"repeat %s under 20% of the allowance is eligible; the older payment is not",
+		async (type) => {
+			await seedOrg({
+				devPlan: "pro",
+				devPlanCreditsUsed: "47",
+				devPlanCreditsLimit: "237",
+				devPlanStripeSubscriptionId: "sub_test_1",
+			});
+			const start = await seedTransaction({
+				type: "dev_plan_start",
+				amount: "79",
+				creditAmount: "237",
+				stripePaymentIntentId: null,
+				stripeInvoiceId: "in_test_1",
+				createdAt: daysAgo(10),
+			});
+			const renewal = await seedTransaction({
+				type,
+				amount: "79",
+				creditAmount: "237",
+				stripePaymentIntentId: null,
+				stripeInvoiceId: "in_test_2",
+			});
 
-		expect(await getEligibility(renewal.id)).toEqual({ eligible: true });
-		expect(await getEligibility(start.id)).toEqual({
-			eligible: false,
-			reason: "not_latest_purchase",
-		});
-	});
+			expect(await getEligibility(renewal.id)).toEqual({ eligible: true });
+			expect(await getEligibility(start.id)).toEqual({
+				eligible: false,
+				reason: "not_latest_purchase",
+			});
+		},
+	);
 
 	test("plan payments are not eligible once the plan is inactive", async () => {
 		await seedOrg({
@@ -390,6 +391,45 @@ describe("computeSelfRefundEligibility", () => {
 
 		expect(await getEligibility(tx.id)).toEqual({ eligible: true });
 	});
+
+	describe.each(["chat_plan_start", "chat_plan_renewal"] as const)(
+		"repeat %s",
+		(type) => {
+			test.each([
+				{ used: "9", limit: "47.5", eligible: true },
+				{ used: "9.5", limit: "47.5", eligible: false },
+				{ used: "0", limit: "0", eligible: false },
+			])(
+				"usage $used of $limit: eligible=$eligible",
+				async ({ used, limit, eligible }) => {
+					await seedOrg({
+						kind: "chat",
+						chatPlan: "plus",
+						chatPlanCreditsUsed: used,
+						chatPlanCreditsLimit: limit,
+						chatPlanStripeSubscriptionId: "sub_test_chat",
+					});
+					await seedTransaction({
+						type: "chat_plan_start",
+						amount: "19",
+						creditAmount: "47.5",
+						createdAt: daysAgo(30),
+					});
+					const tx = await seedTransaction({
+						type,
+						amount: "19",
+						creditAmount: "47.5",
+					});
+
+					expect(await getEligibility(tx.id)).toEqual(
+						eligible
+							? { eligible: true }
+							: { eligible: false, reason: "usage_exceeded" },
+					);
+				},
+			);
+		},
+	);
 
 	test("unused reset pass within 7 days is eligible", async () => {
 		await seedOrg({
@@ -888,6 +928,72 @@ describe("self-refund endpoints", () => {
 		expect(feedback).toHaveLength(1);
 		expect(feedback[0]?.kind).toBe("devpass");
 	});
+
+	describe.each(["dev_plan_start", "dev_plan_renewal"] as const)(
+		"repeat DevPass %s",
+		(type) => {
+			test.each([
+				{ used: "12", eligible: true },
+				{ used: "17.4", eligible: false },
+			])(
+				"billing and refund enforce the credit threshold at $used used",
+				async ({ used, eligible }) => {
+					await seedOrg({
+						kind: "devpass",
+						devPlan: "lite",
+						devPlanCreditsUsed: used,
+						devPlanCreditsLimit: "87",
+						devPlanStripeSubscriptionId: "sub_test_1",
+						devPlanCancelled: true,
+					});
+					await seedTransaction({
+						type: "dev_plan_start",
+						amount: "79",
+						creditAmount: "237",
+						createdAt: daysAgo(30),
+					});
+					const tx = await seedTransaction({
+						type,
+						amount: "29",
+						creditAmount: "87",
+					});
+
+					const invoices = await app.request("/dev-plans/invoices", {
+						headers: { Cookie: token },
+					});
+					expect(invoices.status).toBe(200);
+					expect(await invoices.json()).toMatchObject({
+						invoices: expect.arrayContaining([
+							expect.objectContaining({
+								id: tx.id,
+								refund: eligible
+									? { eligible: true }
+									: { eligible: false, reason: "usage_exceeded" },
+							}),
+						]),
+					});
+
+					const response = await app.request(
+						`/dev-plans/invoices/${tx.id}/refund`,
+						{
+							method: "POST",
+							headers: { Cookie: token, "Content-Type": "application/json" },
+							body: JSON.stringify({ reason: "too_expensive" }),
+						},
+					);
+					expect(response.status).toBe(eligible ? 200 : 400);
+					if (eligible) {
+						expect(stripeMock.refunds.create).toHaveBeenCalledWith(
+							{ payment_intent: "pi_test_1", reason: "requested_by_customer" },
+							{ idempotencyKey: `self-refund-${tx.id}` },
+						);
+					} else {
+						expect(stripeMock.refunds.create).not.toHaveBeenCalled();
+					}
+				},
+			);
+		},
+	);
 
 	test("rejects ineligible transactions with 400 and does not call Stripe", async () => {
 		await seedOrg({ credits: "50" });

--- a/apps/api/src/lib/self-refund.ts
+++ b/apps/api/src/lib/self-refund.ts
@@ -8,8 +8,6 @@ import { getPaymentIntentFromInvoicePayments } from "@/stripe.js";
 import { logAuditEvent } from "@llmgateway/audit";
 import { db, tables } from "@llmgateway/db";
 import {
-	CHAT_PLAN_PRICES,
-	DEV_PLAN_PRICES,
 	DEV_PLAN_RESET_PASS_PRICES,
 	isRefundFeedbackComplete,
 	REFUND_COMMENTS_MAX_LENGTH,
@@ -17,7 +15,6 @@ import {
 	RESET_PASS_SELF_REFUND_WINDOW_DAYS,
 	SELF_REFUND_USAGE_PERCENT,
 	SELF_REFUND_WINDOW_DAYS,
-	type ChatPlanTier,
 	type DevPlanTier,
 } from "@llmgateway/shared";
 
@@ -259,31 +256,7 @@ function checkPlanEligibility(
 		return ineligible("not_latest_purchase");
 	}
 
-	const isFirstPurchase =
-		transaction.type === (isDev ? "dev_plan_start" : "chat_plan_start") &&
-		planPayments.length === 1;
-
-	if (isFirstPurchase) {
-		// First-ever plan purchase: threshold on the virtual credit allowance
-		// (deliberately more lenient, as a first-purchase guarantee).
-		if (
-			!creditsLimit.gt(0) ||
-			usageExceedsThreshold(creditsUsed, creditsLimit)
-		) {
-			return ineligible("usage_exceeded");
-		}
-		return { eligible: true };
-	}
-
-	// Renewals and re-subscribes: threshold on the dollar price instead of the
-	// virtual allowance. Virtual credits track provider cost, so at a 3x
-	// multiplier the threshold share of the allowance would leak three times as
-	// much of the payment in provider cost; gating on dollars caps the leak at
-	// the threshold share of revenue.
-	const price = isDev
-		? DEV_PLAN_PRICES[plan as DevPlanTier]
-		: CHAT_PLAN_PRICES[plan as ChatPlanTier];
-	if (!price || usageExceedsThreshold(creditsUsed, dec(price))) {
+	if (!creditsLimit.gt(0) || usageExceedsThreshold(creditsUsed, creditsLimit)) {
 		return ineligible("usage_exceeded");
 	}
 	return { eligible: true };


### PR DESCRIPTION
Repeat DevPass and Chat subscriptions could be denied a refund despite using less than 20% of their credit allowance because eligibility compared usage with the plan price.

Use the current cycle's credit allowance for first purchases, renewals, and re-subscriptions. Usage at or above 20% remains ineligible, with the existing refund window and latest-payment checks preserved.

Verified with `pnpm format`, `pnpm build`, and 92 tests across the self-refund and DevPass route suites in an isolated database. Regression coverage checks repeat subscriptions, the exact threshold, empty allowances, and agreement between billing eligibility and refund execution with Stripe mocked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Refund eligibility now uses virtual-credit allowance usage consistently across all plan payments.
  - Repeat purchases of DevPass and chat plans are now evaluated correctly, including purchases made at usage thresholds.
  - Refund and invoice eligibility information now remains accurate for repeat DevPass purchases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->