### PR TITLE
fix(ui): prefer global provider regions

### DIFF
--- a/apps/ui/src/app/models/[name]/[provider]/page.tsx
+++ b/apps/ui/src/app/models/[name]/[provider]/page.tsx
@@ -42,7 +42,10 @@ import {
 	expandAllProviderRegions,
 	type StabilityLevel,
 } from "@llmgateway/models";
-import { isMappingDeactivated } from "@llmgateway/shared/components";
+import {
+	getDefaultProviderMapping,
+	isMappingDeactivated,
+} from "@llmgateway/shared/components";
 
 import type { Metadata } from "next";
 
@@ -84,7 +87,7 @@ export default async function ModelProviderPage({ params }: PageProps) {
 		permanentRedirect(`/models/${encodeURIComponent(decodedName)}`);
 	}
 
-	const staticProviderMapping = providerMappings[0];
+	const staticProviderMapping = getDefaultProviderMapping(providerMappings);
 
 	const providerInfo =
 		providerDefinitions.find((p) => p.id === decodedProvider) ??

--- a/apps/ui/src/components/models/detail-provider-cards.tsx
+++ b/apps/ui/src/components/models/detail-provider-cards.tsx
@@ -15,6 +15,7 @@ import {
 import { cn } from "@/lib/utils";
 
 import {
+	getDefaultProviderMapping,
 	getProviderIcon,
 	isMappingDeactivated,
 } from "@llmgateway/shared/components";
@@ -77,8 +78,8 @@ function effectivePrice(
 	return priceNum * (1 - (Number.isFinite(discountNum) ? discountNum : 0));
 }
 
-// Sort values mirror what each card displays by default: the first (default
-// region) mapping, at peak pricing for mappings with a time-based schedule.
+// Sort values mirror the card's default mapping, at peak pricing for mappings
+// with a time-based schedule.
 // Sorting on a cheaper secondary region or off-peak price would contradict the
 // numbers the visitor sees.
 function groupSortValue(
@@ -86,7 +87,7 @@ function groupSortValue(
 	sort: SortKey,
 	throughputByProvider: Map<string, number>,
 ): number | null {
-	const mapping = group.mappings[0];
+	const mapping = getDefaultProviderMapping(group.mappings);
 	switch (sort) {
 		case "input-price":
 			return effectivePrice(

--- a/packages/shared/src/components/index.tsx
+++ b/packages/shared/src/components/index.tsx
@@ -9,6 +9,7 @@ export * from "./model-mapping-selector";
 export * from "./model-selector";
 export * from "./models-directory/all-models";
 export * from "./models-directory/api-types";
+export * from "./models-directory/default-provider-mapping";
 export * from "./models-directory/format";
 export * from "./models-directory/model-card";
 export * from "./models-directory/model-category-filters";

--- a/packages/shared/src/components/models-directory/default-provider-mapping.ts
+++ b/packages/shared/src/components/models-directory/default-provider-mapping.ts
@@ -1,0 +1,9 @@
+export function getDefaultProviderMapping<T extends { region?: string | null }>(
+	mappings: T[],
+): T {
+	return (
+		mappings.find((mapping) => mapping.region === "global") ??
+		mappings.find((mapping) => !mapping.region) ??
+		mappings[0]
+	);
+}

--- a/packages/shared/src/components/models-directory/model-card.tsx
+++ b/packages/shared/src/components/models-directory/model-card.tsx
@@ -57,6 +57,7 @@ import {
 import { discountFraction } from "@/lib/discount";
 import { cn } from "@/lib/utils";
 
+import { getDefaultProviderMapping } from "./default-provider-mapping";
 import {
 	formatContextSize,
 	formatDeprecationDate,
@@ -666,7 +667,9 @@ export function ProviderSection({
 	providerHref?: string;
 	headerExtra?: React.ReactNode;
 }) {
-	const [activeRegionIdx, setActiveRegionIdx] = useState(0);
+	const [selectedRegion, setSelectedRegion] = useState<
+		string | null | undefined
+	>();
 	const mappingDetailsId = useId();
 	const [showTokenPricing, setShowTokenPricing] = useState(false);
 	const [showMappingDetails, setShowMappingDetails] = useState(false);
@@ -675,7 +678,12 @@ export function ProviderSection({
 	>("peak");
 	const [selectedServiceTierId, setSelectedServiceTierId] =
 		useState("standard");
-	const activeMapping = mappings[activeRegionIdx] ?? mappings[0];
+	const activeMapping =
+		mappings.find(
+			(mapping) =>
+				selectedRegion !== undefined &&
+				(mapping.region ?? null) === selectedRegion,
+		) ?? getDefaultProviderMapping(mappings);
 	const isDeactivated = isMappingDeactivated(activeMapping);
 	const isScheduled =
 		!isDeactivated &&
@@ -871,13 +879,14 @@ export function ProviderSection({
 						<button
 							key={`${mapping.providerId}-${mapping.region ?? "default"}-${idx}`}
 							type="button"
+							aria-pressed={activeMapping === mapping}
 							onClick={(e) => {
 								e.stopPropagation();
-								setActiveRegionIdx(idx);
+								setSelectedRegion(mapping.region ?? null);
 							}}
 							className={cn(
 								"px-2 py-1 rounded text-[10px] font-medium transition-colors whitespace-nowrap",
-								activeRegionIdx === idx
+								activeMapping === mapping
 									? "bg-background text-foreground shadow-sm border border-border/50"
 									: "text-muted-foreground hover:text-foreground",
 							)}


### PR DESCRIPTION
Provider cards selected whichever regional mapping arrived first, so Bedrock could open on US pricing. Prefer Global, then the regionless Default mapping, independent of catalogue/API order. Use the same default for provider sorting and page summaries, and preserve manual region choices when mappings reorder.

Validated with `pnpm format`, the full `pnpm build --concurrency=2 --env-mode=loose` (19 tasks), 123 model-directory unit tests, all six Global/Default/US ordering permutations, and browser checks in both themes for defaults, region pricing, sorting, reloads, and provider pages.

| Theme | Before | After |
| --- | --- | --- |
| Light | ![US selected before](https://raw.githubusercontent.com/theopenco/llmgateway/61b3b3096dc1e578a1b564c161664e01ffde1cdb/before-light.png) | ![Global selected after](https://raw.githubusercontent.com/theopenco/llmgateway/61b3b3096dc1e578a1b564c161664e01ffde1cdb/after-light.png) |
| Dark | ![US selected before](https://raw.githubusercontent.com/theopenco/llmgateway/61b3b3096dc1e578a1b564c161664e01ffde1cdb/before-dark.png) | ![Global selected after](https://raw.githubusercontent.com/theopenco/llmgateway/61b3b3096dc1e578a1b564c161664e01ffde1cdb/after-dark.png) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider mapping selection across model pages and cards.
  * Global mappings are now prioritized, with sensible fallbacks when unavailable.
  * Region selection remains consistent when mappings are reordered or vary by region.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->