### PR TITLE
fix(models): mark Runware as ZDR compliant

### DIFF
--- a/packages/models/src/providers.ts
+++ b/packages/models/src/providers.ts
@@ -1976,8 +1976,8 @@ export const providers: ProviderDefinition[] = [
 		headquarters: "GB",
 		dataPolicy: {
 			apiTraining: false,
-			promptLogging: true,
-			retentionPeriod: "30 days",
+			promptLogging: false,
+			retentionPeriod: "0 days",
 		},
 	},
 	{


### PR DESCRIPTION
Runware was excluded from routing that requires zero data retention. Set its data policy to disable prompt logging and retain data for zero days so it passes the existing ZDR filter.

Validation: `pnpm format`, `pnpm build`, 100 provider/compliance tests, and a direct check that the built Runware metadata passes the ZDR filter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Privacy**
  * Runware no longer logs prompts and does not retain prompt data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->