### PR TITLE
fix(admin): exclude client errors from error rate

### DIFF
--- a/ee/admin/src/components/mappings-table.tsx
+++ b/ee/admin/src/components/mappings-table.tsx
@@ -141,7 +141,7 @@ function MappingRow({
 	const ProviderIcon = getProviderIcon(mapping.providerId);
 	const stability = deriveStabilityMetrics(
 		mapping.logsCount,
-		mapping.errorsCount + mapping.clientErrorsCount,
+		mapping.errorsCount,
 		mapping.clientErrorsCount,
 	);
 	const errorRate = (stability.errorRate ?? 0).toFixed(1);

--- a/ee/admin/src/components/models-table.tsx
+++ b/ee/admin/src/components/models-table.tsx
@@ -151,7 +151,7 @@ function ModelRow({
 	const [expanded, setExpanded] = useState(false);
 	const stability = deriveStabilityMetrics(
 		model.logsCount,
-		model.errorsCount + model.clientErrorsCount,
+		model.errorsCount,
 		model.clientErrorsCount,
 	);
 	const errorRate = (stability.errorRate ?? 0).toFixed(1);

--- a/ee/admin/src/components/providers-table.tsx
+++ b/ee/admin/src/components/providers-table.tsx
@@ -136,7 +136,7 @@ function ProviderRow({
 	const [expanded, setExpanded] = useState(false);
 	const stability = deriveStabilityMetrics(
 		provider.logsCount,
-		provider.errorsCount + provider.clientErrorsCount,
+		provider.errorsCount,
 		provider.clientErrorsCount,
 	);
 	const errorRate = (stability.errorRate ?? 0).toFixed(1);


### PR DESCRIPTION
## Problem

On the admin Model Mappings, Models and Providers tables, client errors were still counted in the **Errors** column and the **Error Rate**. A mapping with 24 client errors and no gateway/upstream errors showed 24 errors and a 51% error rate.

The `errorsCount` returned by the admin list endpoints is the raw count of every log with `hasError`, which already includes client errors. The three table components added `clientErrorsCount` on top before calling `deriveStabilityMetrics`, so the subtraction inside the helper cancelled out and client errors were never removed. The denominator, however, did exclude them, which inflated the rate further.

## Approach

Pass the raw `errorsCount` straight into `deriveStabilityMetrics` in `mappings-table.tsx`, `models-table.tsx` and `providers-table.tsx`, matching how every other admin component (detail cards, history chart, provider-models table, project mappings table) and the API's own sort column already treat that field. Client errors keep their own column; they just no longer count as errors.

The two `apps/ui` callers that use `errorsCount + clientErrorsCount` are correct and unchanged: those endpoints return an already-net `errorsCount`.

## Verification

- `pnpm format`, `turbo run build --filter=admin` and `--filter=api` pass.
- Screenshots below are from locally seeded data, 4h window. Errors now equal the previous value minus the Client column, and the rate drops accordingly.

## Screenshots

### Model Mappings (light)

Before
<img width="2300" alt="Model mappings table before, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/9c197b0748582e871c1957bb33ce98bb4900d90c/model-provider-mappings-light-before.png" />

After
<img width="2300" alt="Model mappings table after, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/9c197b0748582e871c1957bb33ce98bb4900d90c/model-provider-mappings-light-after.png" />

### Model Mappings (dark)

Before
<img width="2300" alt="Model mappings table before, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/9c197b0748582e871c1957bb33ce98bb4900d90c/model-provider-mappings-dark-before.png" />

After
<img width="2300" alt="Model mappings table after, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/9c197b0748582e871c1957bb33ce98bb4900d90c/model-provider-mappings-dark-after.png" />

### Models (light)

Before
<img width="2300" alt="Models table before, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/9c197b0748582e871c1957bb33ce98bb4900d90c/models-light-before.png" />

After
<img width="2300" alt="Models table after, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/9c197b0748582e871c1957bb33ce98bb4900d90c/models-light-after.png" />

### Models (dark)

Before
<img width="2300" alt="Models table before, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/9c197b0748582e871c1957bb33ce98bb4900d90c/models-dark-before.png" />

After
<img width="2300" alt="Models table after, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/9c197b0748582e871c1957bb33ce98bb4900d90c/models-dark-after.png" />

### Providers (light)

Before
<img width="2300" alt="Providers table before, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/9c197b0748582e871c1957bb33ce98bb4900d90c/providers-light-before.png" />

After
<img width="2300" alt="Providers table after, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/9c197b0748582e871c1957bb33ce98bb4900d90c/providers-light-after.png" />

### Providers (dark)

Before
<img width="2300" alt="Providers table before, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/9c197b0748582e871c1957bb33ce98bb4900d90c/providers-dark-before.png" />

After
<img width="2300" alt="Providers table after, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/9c197b0748582e871c1957bb33ce98bb4900d90c/providers-dark-after.png" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqSwE2jTU6H1m4gdYw9BJT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected stability metrics for mappings, models, and providers to calculate error totals using server-side errors only.
  - Client errors are now reported separately rather than being combined with overall error counts.
  - Updated error rates and stability indicators provide a more accurate view of system-generated errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->