### PR TITLE
fix: store null for unrecognized log sources

### DIFF
--- a/apps/gateway/src/api.spec.ts
+++ b/apps/gateway/src/api.spec.ts
@@ -1529,7 +1529,7 @@ describe("api", () => {
 		expect(log.finishReason).toBe("client_error");
 		expect(log.apiOrigin).toBe("chat-completions");
 		expect(log.errorDetails?.cause).toBe("invalid_parameters");
-		expect(log.source).toBe("unknown");
+		expect(log.source).toBeNull();
 	});
 
 	test("/v1/responses logs invalid message roles", async () => {

--- a/apps/gateway/src/chat/tools/create-log-entry.spec.ts
+++ b/apps/gateway/src/chat/tools/create-log-entry.spec.ts
@@ -62,10 +62,8 @@ describe("createLogEntry", () => {
 		expect(entry({ source: "https://www.lounge.llmgateway.io" }).source).toBe(
 			"lounge.llmgateway.io",
 		);
-		expect(entry({ source: "invalid_source?request=123" }).source).toBe(
-			"unknown",
-		);
-		expect(entry({ source: "a".repeat(10_000) }).source).toBe("unknown");
+		expect(entry({ source: "invalid_source?request=123" }).source).toBeNull();
+		expect(entry({ source: "a".repeat(10_000) }).source).toBeNull();
 		expect(entry().source).toBeNull();
 	});
 
@@ -77,11 +75,11 @@ describe("createLogEntry", () => {
 					entry({ source: validateSource(`app-${index}.example.com`) }).source,
 			),
 		);
-		expect([...sources]).toEqual(["unknown"]);
+		expect([...sources]).toEqual([null]);
 		expect(
 			entry({ source: validateSource(undefined, "https://www.example.com") })
 				.source,
-		).toBe("unknown");
+		).toBeNull();
 		expect(entry({ source: "custom-claw-1" }).source).toBe("openclaw");
 		expect(entry({ source: "custom-claw-2" }).source).toBe("openclaw");
 	});

--- a/apps/gateway/src/lib/normalize-log-source.ts
+++ b/apps/gateway/src/lib/normalize-log-source.ts
@@ -33,5 +33,5 @@ export function normalizeLogSource(
 	}
 
 	// Keep wildcard agent recognition from creating unbounded aggregation keys.
-	return CLAW_FORK_PATTERN.test(normalized) ? "openclaw" : "unknown";
+	return CLAW_FORK_PATTERN.test(normalized) ? "openclaw" : null;
 }


### PR DESCRIPTION
Unrecognized request sources were stored as the literal `"unknown"`, while missing sources were already stored as `NULL`. Store both as `NULL`, preserving recognized sources and wildcard agent normalization.

Analytics already group `NULL` sources into their existing `"unknown"` bucket, so totals and grouping stay consistent. No schema migration is needed.

Validation: `pnpm format`, `pnpm build`, and the log-entry, gateway API, and source-aggregation tests via `pnpm test:unit` (221 passed, 2 skipped).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Unrecognized or invalid log sources are now recorded as `null` instead of `"unknown"`.
  - Updated request and client-error logging behavior to consistently handle unsupported source values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->