### PR TITLE
fix: treat Anthropic access errors as upstream

### DIFF
--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
@@ -36,6 +36,35 @@ describe("getFinishReasonFromError", () => {
 		).toBe("gateway_error");
 	});
 
+	it.each([400, 401, 403, 422])(
+		"returns upstream_error for Anthropic account access restrictions on %i",
+		(statusCode) => {
+			const message =
+				"Access to Anthropic models is not allowed for this account";
+			expect(getFinishReasonFromError(statusCode, message)).toBe(
+				"upstream_error",
+			);
+			expect(
+				getFinishReasonFromError(
+					statusCode,
+					JSON.stringify({
+						error: {
+							type: "invalid_request_error",
+							message: message.toLowerCase(),
+						},
+					}),
+				),
+			).toBe("upstream_error");
+		},
+	);
+
+	it.each([
+		"This content type is not allowed for this model",
+		"The requested parameter is not supported for Anthropic models",
+	])("keeps request validation errors as client_error: %s", (message) => {
+		expect(getFinishReasonFromError(400, message)).toBe("client_error");
+	});
+
 	it("returns gateway_error for Anthropic low credit balance on 400", () => {
 		expect(
 			getFinishReasonFromError(

--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
@@ -34,6 +34,16 @@ export function getFinishReasonFromError(
 		return "upstream_error";
 	}
 
+	// This restriction belongs to the upstream account, even on a 4xx response.
+	if (
+		errorText &&
+		/access to anthropic models is not allowed for this account/i.test(
+			errorText,
+		)
+	) {
+		return "upstream_error";
+	}
+
 	// 402 Payment Required indicates the gateway's provider account is out of
 	// funds (e.g. DeepSeek "Insufficient Balance"). This is a gateway-side
 	// account problem, not a client error, so classify as gateway_error to allow

--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -2414,6 +2414,87 @@ describe("fallback and error status code handling", () => {
 	});
 
 	describe("retry with fallback to alternate provider", () => {
+		test.each([false, true])(
+			"retries Anthropic account access restrictions (stream: %s)",
+			async (stream) => {
+				await setupMultiProviderKeys();
+
+				const res = await app.request("/v1/chat/completions", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: "Bearer real-token",
+					},
+					body: JSON.stringify({
+						model: "glm-4.7",
+						stream,
+						messages: [
+							{ role: "user", content: "TRIGGER_FAIL_ONCE_ANTHROPIC_ACCESS" },
+						],
+					}),
+				});
+
+				expect(res.status).toBe(200);
+				if (stream) {
+					expect(await readAll(res.body)).toMatchObject({
+						hasError: false,
+						hasContent: true,
+					});
+				} else {
+					expect(await res.json()).toHaveProperty([
+						"choices",
+						0,
+						"message",
+						"content",
+					]);
+				}
+
+				const logs = await waitForLogs(2);
+				const failedLog = logs.find((log) => log.hasError);
+				const successLog = logs.find((log) => !log.hasError);
+				expect(successLog).toBeDefined();
+				expect(failedLog).toMatchObject({
+					finishReason: "upstream_error",
+					unifiedFinishReason: "upstream_error",
+					errorDetails: { statusCode: 400 },
+					retried: true,
+					retriedByLogId: successLog?.id,
+				});
+				expect(successLog?.usedProvider).not.toBe(failedLog?.usedProvider);
+			},
+		);
+
+		test("returns an upstream error for Anthropic account restrictions when fallback is disabled", async () => {
+			await setupMultiProviderKeys();
+
+			const res = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer real-token",
+					"X-No-Fallback": "true",
+				},
+				body: JSON.stringify({
+					model: "glm-4.7",
+					messages: [
+						{ role: "user", content: "TRIGGER_FAIL_ONCE_ANTHROPIC_ACCESS" },
+					],
+				}),
+			});
+
+			expect(res.status).toBe(500);
+			expect(await res.json()).toMatchObject({
+				error: { type: "upstream_error" },
+			});
+			const logs = await waitForLogs(1);
+			expect(logs).toHaveLength(1);
+			expect(logs[0]).toMatchObject({
+				finishReason: "upstream_error",
+				errorDetails: { statusCode: 400 },
+				retried: false,
+			});
+		});
+
 		test("non-streaming: retries on 500 and succeeds on fallback provider with failed_attempts in metadata", async () => {
 			await setupMultiProviderKeys();
 

--- a/apps/gateway/src/test-utils/mock-openai-server.ts
+++ b/apps/gateway/src/test-utils/mock-openai-server.ts
@@ -841,6 +841,20 @@ mockOpenAIServer.post("/v1/chat/completions", async (c) => {
 			});
 		}
 		// Subsequent requests succeed - fall through to normal response
+	} else if (userMessage.includes("TRIGGER_FAIL_ONCE_ANTHROPIC_ACCESS")) {
+		failOnceCounter++;
+		if (failOnceCounter === 1) {
+			return c.json(
+				{
+					error: {
+						message:
+							"Access to Anthropic models is not allowed for this account",
+						type: "invalid_request_error",
+					},
+				},
+				400,
+			);
+		}
 	} else if (userMessage.includes("TRIGGER_FAIL_ONCE_INVALID_KEY")) {
 		failOnceCounter++;
 		if (failOnceCounter === 1) {


### PR DESCRIPTION
Providers returning "Access to Anthropic models is not allowed for this account" with HTTP 400 were classified as client errors, preventing fallback. Classify this exact account restriction as `upstream_error`, including on 401/403 responses, so provider fallback works and disabled fallback returns HTTP 500.

Validation:
- `pnpm format`
- `pnpm build`
- 101 tests passed across the error-classification and fallback suites, run sequentially against an isolated database. Coverage includes streaming, non-streaming, disabled fallback, and unrelated client validation errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Anthropic account access restriction errors are now classified as upstream errors, including when returned with 4xx status codes.
  - Requests encountering these restrictions can retry through an alternate provider when fallback is enabled.
  - Disabling fallback continues to return the original upstream error without retrying.

- **Tests**
  - Added coverage for streaming and non-streaming fallback behavior and related error classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->