### PR TITLE
fix: retain upstream error details in logs

### DIFF
--- a/apps/gateway/src/fallback.spec.ts
+++ b/apps/gateway/src/fallback.spec.ts
@@ -649,6 +649,55 @@ describe("fallback and error status code handling", () => {
 	});
 
 	describe("error status code classification", () => {
+		test.each([false, true])(
+			"retains upstream error text with retention disabled (stream=%s)",
+			async (stream) => {
+				await setupCustomKeys();
+				await db
+					.update(tables.organization)
+					.set({ retentionLevel: "none" })
+					.where(eq(tables.organization.id, "org-id"));
+
+				const res = await app.request("/v1/chat/completions", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: "Bearer real-token",
+						"x-no-fallback": "true",
+						"x-debug": "true",
+					},
+					body: JSON.stringify({
+						model: "llmgateway/custom",
+						messages: [{ role: "user", content: "TRIGGER_STATUS_400" }],
+						stream,
+					}),
+				});
+
+				expect(res.status).toBe(stream ? 200 : 400);
+				expect(await res.text()).toContain("Invalid request: malformed input.");
+
+				const logs = await waitForLogs(1);
+				expect(logs).toHaveLength(1);
+				const log = logs[0];
+				expect(log.finishReason).toBe("client_error");
+				expect(log.errorDetails?.statusCode).toBe(400);
+				expect(JSON.parse(log.errorDetails?.responseText ?? "")).toEqual({
+					error: {
+						message: "Invalid request: malformed input.",
+						type: "invalid_request_error",
+						param: null,
+						code: "invalid_request",
+					},
+				});
+				expect(log.messages).toBeNull();
+				expect(log.content).toBeNull();
+				expect(log.rawRequest).toBeNull();
+				expect(log.rawResponse).toBeNull();
+				expect(log.upstreamRequest).toBeNull();
+				expect(log.upstreamResponse).toBeNull();
+			},
+		);
+
 		test("500 upstream error is classified as upstream_error with correct metadata in response and DB log", async () => {
 			await setupCustomKeys();
 

--- a/apps/gateway/src/lib/logs-retention.spec.ts
+++ b/apps/gateway/src/lib/logs-retention.spec.ts
@@ -56,7 +56,7 @@ function baseLogData(overrides: Partial<LogInsertData>): LogInsertData {
 		errorDetails: {
 			statusCode: 400,
 			statusText: "Bad Request",
-			responseText: "secret echoed prompt",
+			responseText: "Access to this model is not allowed for this account.",
 		},
 		...overrides,
 	} as LogInsertData;
@@ -83,7 +83,7 @@ describe("insertLog retention stripping", () => {
 		expect(published.errorDetails).toEqual({
 			statusCode: 400,
 			statusText: "Bad Request",
-			responseText: "",
+			responseText: "Access to this model is not allowed for this account.",
 		});
 		// Metadata is preserved.
 		expect(published.requestId).toBe("req-1");
@@ -96,6 +96,7 @@ describe("insertLog retention stripping", () => {
 
 		const published = publishToQueue.mock.calls[0][1] as LogInsertData;
 		expect(published.content).toBe("secret completion");
+		expect(published.errorDetails).toEqual(baseLogData({}).errorDetails);
 		expect(published.messages).toEqual([
 			{ role: "user", content: "secret prompt" },
 		]);
@@ -108,6 +109,7 @@ describe("insertLog retention stripping", () => {
 		expect(published.messages).toBeNull();
 		expect(published.content).toBeNull();
 		expect(published.reasoningContent).toBeNull();
+		expect(published.errorDetails).toEqual(baseLogData({}).errorDetails);
 	});
 
 	it("strips payload fields when retention is explicitly null (fail closed)", async () => {
@@ -116,6 +118,7 @@ describe("insertLog retention stripping", () => {
 		const published = publishToQueue.mock.calls[0][1] as LogInsertData;
 		expect(published.messages).toBeNull();
 		expect(published.content).toBeNull();
+		expect(published.errorDetails).toEqual(baseLogData({}).errorDetails);
 	});
 
 	it("strips all payload fields when retention is none", async () => {

--- a/apps/gateway/src/lib/logs-stealth-redaction.spec.ts
+++ b/apps/gateway/src/lib/logs-stealth-redaction.spec.ts
@@ -48,27 +48,30 @@ describe("insertLog stealth provider error redaction", () => {
 		publishToQueue.mockClear();
 	});
 
-	it("moves the raw error to internalErrorDetails for stealth providers", async () => {
-		await insertLog(
-			baseLogData({
-				usedProvider: "granite",
-				errorDetails: { ...rawErrorDetails },
-			}),
-			{ retentionLevel: "retain" },
-		);
+	it.each(["retain", "none"] as const)(
+		"keeps stealth errors internal with retention %s",
+		async (retentionLevel) => {
+			await insertLog(
+				baseLogData({
+					usedProvider: "granite",
+					errorDetails: { ...rawErrorDetails },
+				}),
+				{ retentionLevel },
+			);
 
-		expect(publishToQueue).toHaveBeenCalledTimes(1);
-		const published = publishToQueue.mock.calls[0][1] as LogInsertData;
-		expect(published.internalErrorDetails).toEqual(rawErrorDetails);
-		expect(published.errorDetails).toEqual({
-			statusCode: 429,
-			statusText: "Too Many Requests",
-			responseText: "Upstream provider error (429 Too Many Requests)",
-		});
-		expect(JSON.stringify(published.errorDetails)).not.toContain(
-			"SecretVendor",
-		);
-	});
+			expect(publishToQueue).toHaveBeenCalledTimes(1);
+			const published = publishToQueue.mock.calls[0][1] as LogInsertData;
+			expect(published.internalErrorDetails).toEqual(rawErrorDetails);
+			expect(published.errorDetails).toEqual({
+				statusCode: 429,
+				statusText: "Too Many Requests",
+				responseText: "Upstream provider error (429 Too Many Requests)",
+			});
+			expect(JSON.stringify(published.errorDetails)).not.toContain(
+				"SecretVendor",
+			);
+		},
+	);
 
 	it("leaves errorDetails untouched for regular providers", async () => {
 		await insertLog(

--- a/packages/db/src/log-retention.spec.ts
+++ b/packages/db/src/log-retention.spec.ts
@@ -40,12 +40,12 @@ function baseLogData(overrides: Partial<LogInsertData> = {}): LogInsertData {
 		errorDetails: {
 			statusCode: 400,
 			statusText: "Bad Request",
-			responseText: "secret echoed prompt",
+			responseText: "Access to this model is not allowed for this account.",
 		},
 		internalErrorDetails: {
 			statusCode: 400,
 			statusText: "Bad Request",
-			responseText: "secret provider error",
+			responseText: "Upstream account access denied",
 		},
 		...overrides,
 	} as LogInsertData;
@@ -68,19 +68,12 @@ describe("stripRetentionSensitiveLogFields", () => {
 		expect(stripped.upstreamResponse).toBeNull();
 	});
 
-	it("keeps error status metadata but drops the error body", () => {
-		const stripped = stripRetentionSensitiveLogFields(baseLogData());
+	it("preserves public and internal error details", () => {
+		const input = baseLogData();
+		const stripped = stripRetentionSensitiveLogFields(input);
 
-		expect(stripped.errorDetails).toEqual({
-			statusCode: 400,
-			statusText: "Bad Request",
-			responseText: "",
-		});
-		expect(stripped.internalErrorDetails).toEqual({
-			statusCode: 400,
-			statusText: "Bad Request",
-			responseText: "",
-		});
+		expect(stripped.errorDetails).toEqual(input.errorDetails);
+		expect(stripped.internalErrorDetails).toEqual(input.internalErrorDetails);
 		expect(
 			stripRetentionSensitiveLogFields(baseLogData({ errorDetails: null }))
 				.errorDetails,
@@ -98,8 +91,6 @@ describe("stripRetentionSensitiveLogFields", () => {
 				)
 			) {
 				expect(stripped[key]).toBeNull();
-			} else if (key === "errorDetails" || key === "internalErrorDetails") {
-				expect(stripped[key]).not.toBeNull();
 			} else {
 				expect(stripped[key]).toEqual(input[key]);
 			}

--- a/packages/db/src/log-retention.ts
+++ b/packages/db/src/log-retention.ts
@@ -23,27 +23,11 @@ export const RETENTION_SENSITIVE_LOG_FIELDS = [
 ] as const;
 
 /**
- * Provider error bodies can echo submitted content, so non-retaining orgs keep
- * only the status metadata of an error and lose the body.
- */
-function redactErrorDetailsBody<
-	T extends LogInsertData["errorDetails"] | undefined,
->(details: T): T {
-	if (!details) {
-		return details;
-	}
-	return {
-		statusCode: details.statusCode,
-		statusText: details.statusText,
-		responseText: "",
-	} as T;
-}
-
-/**
  * Return a copy of the log data with every retention-sensitive payload field
  * cleared. Used by the gateway so payloads for non-retaining orgs never travel
  * through Redis (or reach the database) in the first place — the gateway is the
  * sole decider of what gets persisted, so the worker inserts queued rows as-is.
+ * Error diagnostics remain available regardless of payload retention.
  */
 export function stripRetentionSensitiveLogFields<T extends LogInsertData>(
 	logData: T,
@@ -61,7 +45,5 @@ export function stripRetentionSensitiveLogFields<T extends LogInsertData>(
 		rawResponse: null,
 		upstreamRequest: null,
 		upstreamResponse: null,
-		errorDetails: redactErrorDetailsBody(logData.errorDetails),
-		internalErrorDetails: redactErrorDetailsBody(logData.internalErrorDetails),
 	};
 }


### PR DESCRIPTION
Upstream error messages reached clients but were saved with an empty `responseText` when payload retention was disabled. Preserve public and internal error diagnostics through retention filtering, including the provider's error body.

Prompt, completion, tool, and debug payloads continue to follow the retention setting. Stealth-provider error bodies remain restricted to internal diagnostics.

Validation: `pnpm format`, `pnpm build`, and 84 tests across log retention, stealth redaction, and gateway fallback suites, run sequentially against an isolated database. Both streaming and non-streaming regressions failed before the fix and pass afterward.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error diagnostics are now preserved when payload retention is disabled, making upstream error messages available for troubleshooting.
  * Request and response payloads continue to be omitted when retention is set to “none.”
  * Sensitive provider details remain redacted in user-facing errors, while retained internally for diagnostic purposes.
  * Client errors are consistently recorded with their original status and response details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->