### PR TITLE
fix: round token limits before log insertion

### DIFF
--- a/apps/worker/src/log-queue.spec.ts
+++ b/apps/worker/src/log-queue.spec.ts
@@ -1,0 +1,91 @@
+import { randomUUID } from "node:crypto";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { LOG_QUEUE, publishToQueue, redisClient } from "@llmgateway/cache";
+import { db, inArray, log } from "@llmgateway/db";
+
+import { logInsertCircuit, processLogQueue } from "./worker.js";
+
+import type { LogInsertData } from "@llmgateway/db";
+
+describe("processLogQueue", () => {
+	let logIds: string[] = [];
+
+	beforeEach(async () => {
+		logIds = [];
+		logInsertCircuit.consecutiveFailures = 0;
+		logInsertCircuit.nextAttemptAt = 0;
+		await redisClient.del(LOG_QUEUE);
+	});
+
+	afterEach(async () => {
+		await redisClient.del(LOG_QUEUE);
+		if (logIds.length > 0) {
+			await db.delete(log).where(inArray(log.id, logIds));
+		}
+	});
+
+	it("rounds fractional token limits up when inserting a batch of logs", async () => {
+		const baseLog: LogInsertData = {
+			requestId: "request-id",
+			organizationId: "org-id",
+			projectId: "project-id",
+			apiKeyId: "api-key-id",
+			duration: 100,
+			requestedModel: "gpt-4o-mini",
+			usedModel: "gpt-4o-mini",
+			usedProvider: "openai",
+			responseSize: 0,
+			mode: "credits",
+			usedMode: "credits",
+		};
+		const fractionalId = randomUUID();
+		const validId = randomUUID();
+		const unsetId = randomUUID();
+		logIds.push(fractionalId, validId, unsetId);
+		await publishToQueue(LOG_QUEUE, {
+			...baseLog,
+			id: fractionalId,
+			maxTokens: 128.5,
+			reasoningMaxTokens: 64.25,
+			hasError: true,
+			finishReason: "client_error",
+		});
+		await publishToQueue(LOG_QUEUE, {
+			...baseLog,
+			id: validId,
+			maxTokens: 1024,
+			reasoningMaxTokens: 512,
+			promptTokens: "12.5",
+		});
+		await publishToQueue(LOG_QUEUE, {
+			...baseLog,
+			id: unsetId,
+			maxTokens: null,
+		});
+
+		expect(await processLogQueue()).toBe(3);
+		expect(await redisClient.llen(LOG_QUEUE)).toBe(0);
+		expect(logInsertCircuit.consecutiveFailures).toBe(0);
+		const rows = await db.query.log.findMany({
+			where: { id: { in: logIds } },
+		});
+		expect(rows).toHaveLength(3);
+		expect(rows.find((row) => row.id === fractionalId)).toMatchObject({
+			maxTokens: 129,
+			reasoningMaxTokens: 65,
+			hasError: true,
+			finishReason: "client_error",
+		});
+		expect(rows.find((row) => row.id === validId)).toMatchObject({
+			maxTokens: 1024,
+			reasoningMaxTokens: 512,
+			promptTokens: "12.5",
+		});
+		expect(rows.find((row) => row.id === unsetId)).toMatchObject({
+			maxTokens: null,
+			reasoningMaxTokens: null,
+		});
+	});
+});

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -2037,8 +2037,18 @@ export async function processLogQueue(): Promise<number> {
 	try {
 		// The gateway decides what to persist: it strips request/response payload
 		// fields before publishing for orgs that don't retain data, so the worker
-		// inserts the queued rows as-is with no per-batch org retention lookup.
-		const logData = message.map((i) => JSON.parse(i) as LogInsertData);
+		// inserts the queued rows with no per-batch org retention lookup.
+		const logData = message.map((i) => {
+			const data = JSON.parse(i) as LogInsertData;
+			// Failed requests can still carry fractional limits into integer columns.
+			if (typeof data.maxTokens === "number") {
+				data.maxTokens = Math.ceil(data.maxTokens);
+			}
+			if (typeof data.reasoningMaxTokens === "number") {
+				data.reasoningMaxTokens = Math.ceil(data.reasoningMaxTokens);
+			}
+			return data;
+		});
 
 		// Insert logs with retry logic
 		let lastError: Error | undefined;


### PR DESCRIPTION
Fractional token limits could make an entire log batch fail to insert. Round `maxTokens` and `reasoningMaxTokens` up before the worker inserts queued logs, including records already waiting in Redis. Existing integers, unset limits, and fractional usage counts are preserved.

Validation: formatting, full build, and 29 isolated worker tests, including a batch with fractional, integer, and unset limits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Token limit values containing fractions are now rounded up when queued logs are processed, ensuring they are stored consistently.
  - Log processing continues successfully when token limit fields are missing or provided in supported numeric formats.

- **Tests**
  - Added coverage for queued log processing, including error records, missing limits, fractional values, queue cleanup, and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->