### PR TITLE
feat(models): add Fugu Max and Ultra v2

### DIFF
--- a/packages/models/src/models/sakana.ts
+++ b/packages/models/src/models/sakana.ts
@@ -11,7 +11,6 @@ export const sakanaModels = [
 		providers: [
 			{
 				providerId: "sakana" as const,
-				// Unpinned alias; Sakana currently resolves it to fugu-ultra-v1.1.
 				externalId: "fugu-ultra",
 				// Multi-agent orchestration is far too slow for e2e (reasoning
 				// prompts exceed the test timeout); excluded from the suite
@@ -40,9 +39,6 @@ export const sakanaModels = [
 				contextSize: 1000000,
 				streaming: true,
 				reasoning: true,
-				// Fugu has no off switch and rejects none/minimal/low/medium. "max" is
-				// a distinct top tier on fugu-ultra-v1.1; the older fugu-ultra-v1.0
-				// deployment still accepts it as an alias of "xhigh".
 				reasoningEfforts: ["high", "xhigh", "max"],
 				// Fugu reasoning summaries are only exposed via the OpenAI Responses
 				// API, so route through it. Summaries are adaptive (omitted for
@@ -52,6 +48,80 @@ export const sakanaModels = [
 				vision: true,
 				tools: true,
 				jsonOutput: true,
+			},
+		],
+	},
+	{
+		id: "fugu-max",
+		name: "Fugu Max",
+		description:
+			"Sakana AI's multi-agent orchestration model optimized for cost and performance, coordinating a diverse pool of open and specialized models.",
+		family: "sakana",
+		releasedAt: new Date("2026-09-11"),
+		providers: [
+			{
+				providerId: "sakana" as const,
+				externalId: "fugu-max-v1.0",
+				inputPrice: "2e-6",
+				outputPrice: "6e-6",
+				cachedInputPrice: "0.25e-6",
+				requestPrice: "0",
+				contextSize: 1000000,
+				streaming: true,
+				reasoning: true,
+				reasoningEfforts: ["high", "xhigh", "max"],
+				supportsResponsesApi: true,
+				reasoningOutput: "omit" as const,
+				vision: true,
+				tools: true,
+				supportedToolChoices: ["auto"],
+				jsonOutput: true,
+				jsonOutputSchema: true,
+			},
+		],
+	},
+	{
+		id: "fugu-ultra-v2.0",
+		name: "Fugu Ultra v2.0",
+		description:
+			"Sakana AI's flagship multi-agent orchestration model, coordinating frontier and specialized models for complex reasoning, research, and software development.",
+		family: "sakana",
+		releasedAt: new Date("2026-09-11"),
+		providers: [
+			{
+				providerId: "sakana" as const,
+				externalId: "fugu-ultra-v2.0",
+				inputPrice: "5e-6",
+				outputPrice: "30e-6",
+				cachedInputPrice: "0.5e-6",
+				pricingTiers: [
+					{
+						name: "Up to 272K",
+						upToTokens: 272000,
+						inputPrice: "5e-6",
+						outputPrice: "30e-6",
+						cachedInputPrice: "0.5e-6",
+					},
+					{
+						name: "Over 272K",
+						upToTokens: Infinity,
+						inputPrice: "10e-6",
+						outputPrice: "45e-6",
+						cachedInputPrice: "1e-6",
+					},
+				],
+				requestPrice: "0",
+				contextSize: 1000000,
+				streaming: true,
+				reasoning: true,
+				reasoningEfforts: ["high", "xhigh", "max"],
+				supportsResponsesApi: true,
+				reasoningOutput: "omit" as const,
+				vision: true,
+				tools: true,
+				supportedToolChoices: ["auto"],
+				jsonOutput: true,
+				jsonOutputSchema: true,
 			},
 		],
 	},


### PR DESCRIPTION
Adds Fugu Max and the pinned Fugu Ultra v2.0 deployment to the catalogue, with live-verified reasoning, vision, tool calling, streaming, and structured output. Removes outdated comments about the existing Ultra alias, which now resolves to v2.0.

| Model | Upstream ID | Input / output / cached input per 1M tokens | Context |
| --- | --- | --- | --- |
| Fugu Max | `fugu-max-v1.0` | $2 / $6 / $0.25 at all context lengths | 1M |
| Fugu Ultra v2.0 | `fugu-ultra-v2.0` | $5 / $30 / $0.50; $10 / $45 / $1 above 272K | 1M |

Rates come from [Sakana's pricing page](https://console.sakana.ai/pricing); IDs and context metadata match its [models](https://console.sakana.ai/models) and [getting started](https://console.sakana.ai/get-started) pages. Oversized inputs were rejected, but errors did not expose an exact numeric limit. No maximum output is declared: Sakana accepted an oversized output cap without returning a bound.

Both models accept `high`, `xhigh`, and `max`, and reject `none`, `minimal`, `low`, and `medium`. Reasoning summaries may be absent. Only automatic tool selection is declared: live probes showed that `none`, `required`, and named choices were accepted but ignored. Both JSON object and JSON schema output are supported.

Validation:

- `pnpm format` and `pnpm build` passed.
- 170 catalogue and billing unit tests passed.
- `CI=true TEST_MODELS="sakana/fugu-max,sakana/fugu-ultra-v2.0" FULL_MODE=true pnpm test:e2e` passed: **30 Max cases and 26 Ultra v2 cases**, zero failures; 135 tests passed overall.

Live billing samples matched the retained upstream usage, stored token counts, and `log.cost`, including Ultra's higher context tier. Billable output includes reasoning exactly once; orchestration input/output and cached tokens are added to their respective totals. Hand calculation: `(input - cached) × inputPrice + output × outputPrice + cached × cachedInputPrice`.

| Model | Request | Input tokens | Output tokens | Cached input |
| --- | --- | ---: | ---: | ---: |
| fugu-max | small | 234 | 17 | 0 |
| fugu-max | large | 300,093 | 128 | 0 |
| fugu-ultra-v2.0 | small | 1,853 | 70 | 0 |
| fugu-ultra-v2.0 | large | 301,952 | 37 | 0 |

Additional streaming and cached-request samples also reconciled, including Max's separately reported reasoning tokens and Ultra's cached orchestration tokens.
