### PR TITLE
fix: require verified email changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -540,6 +540,9 @@ POSTHOG_HOST=https://app.posthog.com
 
 # =============================================================================
 # EMAIL (RESEND)
+# With NODE_ENV=development, save email-change links in private local files.
+# Opt in when testing confirmation locally; delete the files after use.
+# EMAIL_CHANGE_PREVIEW_DIR=/tmp/llmgateway-email-previews
 # =============================================================================
 # Resend configuration - needed for transactional emails and contact management
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,6 +16,7 @@
 		"start": "node --enable-source-maps dist/serve.js"
 	},
 	"dependencies": {
+		"@better-auth/core": "1.6.26",
 		"@better-auth/passkey": "1.6.26",
 		"@better-auth/sso": "1.6.26",
 		"@hono/node-server": "^2.0.10",

--- a/apps/api/src/auth/config.ts
+++ b/apps/api/src/auth/config.ts
@@ -447,7 +447,7 @@ export async function checkRateLimit(
 	}
 }
 
-async function createResendContact(
+export async function createResendContact(
 	email: string,
 	name?: string,
 	attributes?: Record<string, string | number | boolean>,

--- a/apps/api/src/auth/config.ts
+++ b/apps/api/src/auth/config.ts
@@ -2,11 +2,12 @@ import { passkey } from "@better-auth/passkey";
 import { sso } from "@better-auth/sso";
 import { instrumentBetterAuth } from "@kubiks/otel-better-auth";
 import { betterAuth } from "better-auth";
-import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { createAuthMiddleware } from "better-auth/api";
 import { bearer, deviceAuthorization } from "better-auth/plugins";
 import { Redis } from "ioredis";
 
+import { createAuthDatabase } from "@/auth/database.js";
+import { serializedPasswordReset } from "@/auth/password-reset.js";
 import { flagUserIfAbusiveIp } from "@/lib/account-risk.js";
 import { getApiBaseUrl } from "@/lib/api-url.js";
 import { getClientIpFromHeaders } from "@/lib/client-ip.js";
@@ -725,6 +726,7 @@ export const apiAuth: ReturnType<typeof instrumentBetterAuth> =
 				},
 			},
 			plugins: [
+				serializedPasswordReset(),
 				bearer(),
 				deviceAuthorization({
 					verificationUri: `${uiUrl}/connect/device`,
@@ -808,6 +810,7 @@ If you didn't request this, you can safely ignore this email. Your password won'
 							to: user.email,
 							subject: "Reset your LLM Gateway password",
 							text,
+							timeoutMs: 15000,
 							strict: true,
 							logSafe: true,
 						});
@@ -825,18 +828,7 @@ If you didn't request this, you can safely ignore this email. Your password won'
 			},
 			baseURL: apiUrl || "http://localhost:4002",
 			secret: process.env.AUTH_SECRET ?? "dev-secret-key-must-be-32-chars!",
-			database: drizzleAdapter(db, {
-				provider: "pg",
-				schema: {
-					user: tables.user,
-					session: tables.session,
-					account: tables.account,
-					verification: tables.verification,
-					deviceCode: tables.deviceCode,
-					passkey: tables.passkey,
-					ssoProvider: tables.ssoProvider,
-				},
-			}),
+			database: createAuthDatabase(db),
 			socialProviders: {
 				// Social sign-in must never silently create an account: the login
 				// pages ask the user to confirm first and retry with

--- a/apps/api/src/auth/database.ts
+++ b/apps/api/src/auth/database.ts
@@ -1,0 +1,22 @@
+import { drizzleAdapter } from "better-auth/adapters/drizzle";
+
+import { tables } from "@llmgateway/db";
+
+import type { db } from "@llmgateway/db";
+
+type Database = typeof db | Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+export function createAuthDatabase(database: Database) {
+	return drizzleAdapter(database, {
+		provider: "pg",
+		schema: {
+			user: tables.user,
+			session: tables.session,
+			account: tables.account,
+			verification: tables.verification,
+			deviceCode: tables.deviceCode,
+			passkey: tables.passkey,
+			ssoProvider: tables.ssoProvider,
+		},
+	});
+}

--- a/apps/api/src/auth/password-reset.ts
+++ b/apps/api/src/auth/password-reset.ts
@@ -1,0 +1,86 @@
+import { runWithTransaction } from "@better-auth/core/context";
+import {
+	createAuthEndpoint,
+	requestPasswordReset,
+	resetPassword,
+} from "better-auth/api";
+
+import { createAuthDatabase } from "@/auth/database.js";
+
+import { db, eq, tables } from "@llmgateway/db";
+
+import type { AuthContext, BetterAuthPlugin } from "better-auth";
+
+async function withUserTransaction<T>(
+	userId: string | undefined,
+	context: AuthContext,
+	callback: () => Promise<T>,
+): Promise<T> {
+	if (!userId) {
+		return await callback();
+	}
+	// Keep native reset issuance and consumption serialized with email confirmation.
+	return await runWithTransaction(
+		{
+			...context.adapter,
+			transaction: async (run) =>
+				await db.transaction(async (tx) => {
+					await tx
+						.select({ id: tables.user.id })
+						.from(tables.user)
+						.where(eq(tables.user.id, userId))
+						.for("update");
+					return await run(createAuthDatabase(tx)(context.options));
+				}),
+		},
+		callback,
+	);
+}
+
+export function serializedPasswordReset(): BetterAuthPlugin {
+	return {
+		id: "serialized-password-reset",
+		endpoints: {
+			resetPassword: createAuthEndpoint(
+				resetPassword.path,
+				resetPassword.options,
+				async (ctx) => {
+					const token = ctx.body.token || ctx.query?.token;
+					const verification = token
+						? await db.query.verification.findFirst({
+								where: { identifier: `reset-password:${token}` },
+							})
+						: undefined;
+					return await withUserTransaction(
+						verification?.value,
+						ctx.context,
+						() =>
+							resetPassword({
+								...ctx,
+								asResponse: false,
+								returnHeaders: false,
+								returnStatus: false,
+							}),
+					);
+				},
+			),
+			requestPasswordReset: createAuthEndpoint(
+				requestPasswordReset.path,
+				requestPasswordReset.options,
+				async (ctx) => {
+					const user = await db.query.user.findFirst({
+						where: { email: ctx.body.email.toLowerCase() },
+					});
+					return await withUserTransaction(user?.id, ctx.context, () =>
+						requestPasswordReset({
+							...ctx,
+							asResponse: false,
+							returnHeaders: false,
+							returnStatus: false,
+						}),
+					);
+				},
+			),
+		},
+	} satisfies BetterAuthPlugin;
+}

--- a/apps/api/src/auth/password-reset.ts
+++ b/apps/api/src/auth/password-reset.ts
@@ -1,15 +1,21 @@
-import { runWithTransaction } from "@better-auth/core/context";
 import {
+	getCurrentAdapter,
+	runWithTransaction,
+} from "@better-auth/core/context";
+import {
+	APIError,
 	createAuthEndpoint,
 	requestPasswordReset,
 	resetPassword,
+	signInEmail,
 } from "better-auth/api";
 
 import { createAuthDatabase } from "@/auth/database.js";
 
-import { db, eq, tables } from "@llmgateway/db";
+import { and, db, eq, tables } from "@llmgateway/db";
+import { logger } from "@llmgateway/logger";
 
-import type { AuthContext, BetterAuthPlugin } from "better-auth";
+import type { Account, AuthContext, BetterAuthPlugin, User } from "better-auth";
 
 async function withUserTransaction<T>(
 	userId: string | undefined,
@@ -19,7 +25,7 @@ async function withUserTransaction<T>(
 	if (!userId) {
 		return await callback();
 	}
-	// Keep native reset issuance and consumption serialized with email confirmation.
+	// Serialize reset and sign-in state with email confirmation.
 	return await runWithTransaction(
 		{
 			...context.adapter,
@@ -30,6 +36,16 @@ async function withUserTransaction<T>(
 						.from(tables.user)
 						.where(eq(tables.user.id, userId))
 						.for("update");
+					await tx
+						.select({ id: tables.account.id })
+						.from(tables.account)
+						.where(
+							and(
+								eq(tables.account.userId, userId),
+								eq(tables.account.providerId, "credential"),
+							),
+						)
+						.for("update");
 					return await run(createAuthDatabase(tx)(context.options));
 				}),
 		},
@@ -37,10 +53,99 @@ async function withUserTransaction<T>(
 	);
 }
 
+async function createVerifiedSession(
+	context: AuthContext,
+	email: string,
+	verifiedPassword: string | undefined,
+	args: Parameters<AuthContext["internalAdapter"]["createSession"]>,
+) {
+	return await withUserTransaction(args[0], context, async () => {
+		const adapter = await getCurrentAdapter(context.adapter);
+		const user = await adapter.findOne<User>({
+			model: "user",
+			where: [{ field: "id", value: args[0] }],
+		});
+		const account = await adapter.findOne<Account>({
+			model: "account",
+			where: [
+				{ field: "userId", value: args[0] },
+				{ field: "providerId", value: "credential" },
+			],
+		});
+		if (
+			!user ||
+			user.email !== email.toLowerCase() ||
+			!verifiedPassword ||
+			account?.password !== verifiedPassword
+		) {
+			throw new APIError("UNAUTHORIZED", {
+				code: "INVALID_EMAIL_OR_PASSWORD",
+				message: "Invalid email or password",
+			});
+		}
+		return await context.internalAdapter.createSession(...args);
+	});
+}
+
 export function serializedPasswordReset(): BetterAuthPlugin {
+	const nativeSignInEmail = signInEmail();
 	return {
 		id: "serialized-password-reset",
 		endpoints: {
+			signInEmail: createAuthEndpoint(
+				nativeSignInEmail.path,
+				nativeSignInEmail.options,
+				async (ctx) => {
+					let verifiedPassword: string | undefined;
+					const result = await nativeSignInEmail({
+						...ctx,
+						context: {
+							...ctx.context,
+							setNewSession: (
+								session: Parameters<AuthContext["setNewSession"]>[0],
+							) => ctx.context.setNewSession(session),
+							password: {
+								...ctx.context.password,
+								verify: async (
+									input: Parameters<AuthContext["password"]["verify"]>[0],
+								) => {
+									const valid = await ctx.context.password.verify(input);
+									if (valid) {
+										verifiedPassword = input.hash;
+									}
+									return valid;
+								},
+							},
+							internalAdapter: {
+								...ctx.context.internalAdapter,
+								createSession: async (
+									...args: Parameters<
+										AuthContext["internalAdapter"]["createSession"]
+									>
+								) =>
+									await createVerifiedSession(
+										ctx.context,
+										ctx.body.email,
+										verifiedPassword,
+										args,
+									),
+							},
+						},
+						asResponse: false,
+						returnHeaders: true,
+						returnStatus: false,
+					});
+					for (const [name, value] of result.headers) {
+						if (name !== "set-cookie") {
+							ctx.responseHeaders.set(name, value);
+						}
+					}
+					for (const cookie of result.headers.getSetCookie()) {
+						ctx.responseHeaders.append("set-cookie", cookie);
+					}
+					return result.response;
+				},
+			),
 			resetPassword: createAuthEndpoint(
 				resetPassword.path,
 				resetPassword.options,
@@ -106,7 +211,10 @@ export function serializedPasswordReset(): BetterAuthPlugin {
 							await ctx.context.internalAdapter.deleteVerificationByIdentifier(
 								`reset-password:${delivery[0].token}`,
 							);
-							throw error;
+							logger.error(
+								"Password reset delivery failed",
+								error instanceof Error ? error : new Error(String(error)),
+							);
 						}
 					}
 					return result;

--- a/apps/api/src/auth/password-reset.ts
+++ b/apps/api/src/auth/password-reset.ts
@@ -71,14 +71,45 @@ export function serializedPasswordReset(): BetterAuthPlugin {
 					const user = await db.query.user.findFirst({
 						where: { email: ctx.body.email.toLowerCase() },
 					});
-					return await withUserTransaction(user?.id, ctx.context, () =>
+					const emailAndPassword = ctx.context.options.emailAndPassword;
+					const sendResetPassword = emailAndPassword?.sendResetPassword;
+					let delivery:
+						Parameters<NonNullable<typeof sendResetPassword>> | undefined;
+					const context = {
+						...ctx.context,
+						options: { ...ctx.context.options },
+					};
+					if (emailAndPassword && sendResetPassword) {
+						context.options.emailAndPassword = {
+							...emailAndPassword,
+							sendResetPassword: async (
+								...args: Parameters<typeof sendResetPassword>
+							) => {
+								delivery = args;
+							},
+						};
+					}
+					const result = await withUserTransaction(user?.id, context, () =>
 						requestPasswordReset({
 							...ctx,
+							context,
 							asResponse: false,
 							returnHeaders: false,
 							returnStatus: false,
 						}),
 					);
+					// Mail delivery must not hold the user lock or a database connection.
+					if (delivery && sendResetPassword) {
+						try {
+							await sendResetPassword(...delivery);
+						} catch (error) {
+							await ctx.context.internalAdapter.deleteVerificationByIdentifier(
+								`reset-password:${delivery[0].token}`,
+							);
+							throw error;
+						}
+					}
+					return result;
 				},
 			),
 		},

--- a/apps/api/src/auth/password-reset.ts
+++ b/apps/api/src/auth/password-reset.ts
@@ -4,10 +4,12 @@ import {
 } from "@better-auth/core/context";
 import {
 	APIError,
+	changePassword,
 	createAuthEndpoint,
 	requestPasswordReset,
 	resetPassword,
 	signInEmail,
+	verifyEmail,
 } from "better-auth/api";
 
 import { createAuthDatabase } from "@/auth/database.js";
@@ -25,7 +27,7 @@ async function withUserTransaction<T>(
 	if (!userId) {
 		return await callback();
 	}
-	// Serialize reset and sign-in state with email confirmation.
+	// Serialize credential and session writes with email confirmation.
 	return await runWithTransaction(
 		{
 			...context.adapter,
@@ -55,8 +57,9 @@ async function withUserTransaction<T>(
 
 async function createVerifiedSession(
 	context: AuthContext,
-	email: string,
-	verifiedPassword: string | undefined,
+	proof:
+		| { email: string | undefined; passwordHash: string | undefined }
+		| { email: string | undefined },
 	args: Parameters<AuthContext["internalAdapter"]["createSession"]>,
 ) {
 	return await withUserTransaction(args[0], context, async () => {
@@ -65,26 +68,46 @@ async function createVerifiedSession(
 			model: "user",
 			where: [{ field: "id", value: args[0] }],
 		});
-		const account = await adapter.findOne<Account>({
-			model: "account",
-			where: [
-				{ field: "userId", value: args[0] },
-				{ field: "providerId", value: "credential" },
-			],
-		});
-		if (
-			!user ||
-			user.email !== email.toLowerCase() ||
-			!verifiedPassword ||
-			account?.password !== verifiedPassword
-		) {
+		let valid = user && user.email === proof.email?.toLowerCase();
+		if ("passwordHash" in proof) {
+			const account = await adapter.findOne<Account>({
+				model: "account",
+				where: [
+					{ field: "userId", value: args[0] },
+					{ field: "providerId", value: "credential" },
+				],
+			});
+			valid = !!(
+				valid &&
+				proof.passwordHash &&
+				account?.password === proof.passwordHash
+			);
+		}
+		if (!valid) {
 			throw new APIError("UNAUTHORIZED", {
-				code: "INVALID_EMAIL_OR_PASSWORD",
-				message: "Invalid email or password",
+				code:
+					"passwordHash" in proof
+						? "INVALID_EMAIL_OR_PASSWORD"
+						: "INVALID_USER",
+				message:
+					"passwordHash" in proof
+						? "Invalid email or password"
+						: "Invalid user",
 			});
 		}
 		return await context.internalAdapter.createSession(...args);
 	});
+}
+
+function forwardHeaders(target: Headers, source: Headers) {
+	for (const [name, value] of source) {
+		if (name !== "set-cookie") {
+			target.set(name, value);
+		}
+	}
+	for (const cookie of source.getSetCookie()) {
+		target.append("set-cookie", cookie);
+	}
 }
 
 export function serializedPasswordReset(): BetterAuthPlugin {
@@ -92,6 +115,96 @@ export function serializedPasswordReset(): BetterAuthPlugin {
 	return {
 		id: "serialized-password-reset",
 		endpoints: {
+			changePassword: createAuthEndpoint(
+				changePassword.path,
+				changePassword.options,
+				async (ctx) => {
+					let newSession:
+						Parameters<AuthContext["setNewSession"]>[0] | undefined;
+					const context = {
+						...ctx.context,
+						setNewSession: (
+							session: Parameters<AuthContext["setNewSession"]>[0],
+						) => {
+							newSession = session;
+						},
+					};
+					const result = await withUserTransaction(
+						ctx.context.session.user.id,
+						context,
+						async () => {
+							const session = await ctx.context.internalAdapter.findSession(
+								ctx.context.session.session.token,
+							);
+							if (
+								!session ||
+								session.user.email !== ctx.context.session.user.email
+							) {
+								throw new APIError("UNAUTHORIZED", {
+									code: "INVALID_SESSION",
+									message: "The authenticated session is no longer current",
+								});
+							}
+							return await changePassword({
+								...ctx,
+								context,
+								asResponse: false,
+								returnHeaders: true,
+								returnStatus: false,
+							});
+						},
+					);
+					if (newSession) {
+						ctx.context.setNewSession(newSession);
+					}
+					forwardHeaders(ctx.responseHeaders, result.headers);
+					return result.response;
+				},
+			),
+			verifyEmail: createAuthEndpoint(
+				verifyEmail.path,
+				verifyEmail.options,
+				async (ctx) => {
+					let verifiedEmail: string | undefined;
+					const result = await verifyEmail({
+						...ctx,
+						context: {
+							...ctx.context,
+							setNewSession: (
+								session: Parameters<AuthContext["setNewSession"]>[0],
+							) => ctx.context.setNewSession(session),
+							internalAdapter: {
+								...ctx.context.internalAdapter,
+								findUserByEmail: async (
+									...args: Parameters<
+										AuthContext["internalAdapter"]["findUserByEmail"]
+									>
+								) => {
+									const user =
+										await ctx.context.internalAdapter.findUserByEmail(...args);
+									verifiedEmail = user?.user.email;
+									return user;
+								},
+								createSession: async (
+									...args: Parameters<
+										AuthContext["internalAdapter"]["createSession"]
+									>
+								) =>
+									await createVerifiedSession(
+										ctx.context,
+										{ email: verifiedEmail },
+										args,
+									),
+							},
+						},
+						asResponse: false,
+						returnHeaders: true,
+						returnStatus: false,
+					});
+					forwardHeaders(ctx.responseHeaders, result.headers);
+					return result.response;
+				},
+			),
 			signInEmail: createAuthEndpoint(
 				nativeSignInEmail.path,
 				nativeSignInEmail.options,
@@ -125,8 +238,7 @@ export function serializedPasswordReset(): BetterAuthPlugin {
 								) =>
 									await createVerifiedSession(
 										ctx.context,
-										ctx.body.email,
-										verifiedPassword,
+										{ email: ctx.body.email, passwordHash: verifiedPassword },
 										args,
 									),
 							},
@@ -135,14 +247,7 @@ export function serializedPasswordReset(): BetterAuthPlugin {
 						returnHeaders: true,
 						returnStatus: false,
 					});
-					for (const [name, value] of result.headers) {
-						if (name !== "set-cookie") {
-							ctx.responseHeaders.set(name, value);
-						}
-					}
-					for (const cookie of result.headers.getSetCookie()) {
-						ctx.responseHeaders.append("set-cookie", cookie);
-					}
+					forwardHeaders(ctx.responseHeaders, result.headers);
 					return result.response;
 				},
 			),

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -21,6 +21,7 @@ import { authHandler } from "./auth/handler.js";
 import { tracingMiddleware } from "./middleware/tracing.js";
 import { beacon } from "./routes/beacon.js";
 import { cliSkills } from "./routes/cli-skills.js";
+import { emailChange } from "./routes/email-change.js";
 import { routes } from "./routes/index.js";
 import { internalModels } from "./routes/internal-models.js";
 import { mcp } from "./routes/mcp.js";
@@ -335,6 +336,7 @@ app.doc("/json", config);
 app.get("/docs", swaggerUI({ url: "./json" }));
 
 app.route("/", authHandler);
+app.route("/", emailChange);
 
 app.route("/v1/master", v1Master);
 app.route("/mcp", mcp);

--- a/apps/api/src/lib/email-change.ts
+++ b/apps/api/src/lib/email-change.ts
@@ -1,5 +1,6 @@
 import { createHash, randomBytes } from "node:crypto";
 
+import { hashPassword, verifyPassword } from "better-auth/crypto";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
@@ -7,10 +8,12 @@ import {
 	apiAuth,
 	createResendContact,
 	deleteResendContact,
+	redisClient,
 } from "@/auth/config.js";
+import { flagUserIfAbusiveIp } from "@/lib/account-risk.js";
 import { sendTransactionalEmail } from "@/utils/email.js";
 
-import { and, db, eq, gt, ne, sql, tables } from "@llmgateway/db";
+import { and, db, eq, gt, like, ne, sql, tables } from "@llmgateway/db";
 
 const EMAIL_CHANGE_TTL_MS = 60 * 60 * 1000;
 
@@ -18,12 +21,31 @@ const pendingEmailSchema = z.object({
 	userId: z.string(),
 	email: z.string(),
 	newEmail: z.string().email(),
-	passwordFingerprint: z.string(),
+	credentialProof: z.string().regex(/^[a-f0-9]{32}:[a-f0-9]{128}$/),
 });
 
-function fingerprint(value: string): string {
+function hashIdentifier(value: string): string {
 	return createHash("sha256").update(value).digest("hex");
 }
+
+export function getEmailChangeRateLimitKeys(userId: string, email: string) {
+	return [
+		`email-change:rate:user:${userId}`,
+		`email-change:rate:recipient:${hashIdentifier(email.trim().toLowerCase())}`,
+	];
+}
+
+const RESERVE_EMAIL_CHANGE = `
+for _, key in ipairs(KEYS) do
+	if tonumber(redis.call('get', key) or '0') >= tonumber(ARGV[1]) then return 0 end
+end
+for _, key in ipairs(KEYS) do
+	if redis.call('incr', key) == 1 then
+		redis.call('expire', key, ARGV[2])
+	end
+end
+return 1
+`;
 
 export async function requestEmailChange(
 	user: typeof tables.user.$inferSelect,
@@ -64,15 +86,28 @@ export async function requestEmailChange(
 		});
 	}
 
+	const reserved = await redisClient.eval(
+		RESERVE_EMAIL_CHANGE,
+		2,
+		...getEmailChangeRateLimitKeys(user.id, newEmail),
+		3,
+		60 * 60,
+	);
+	if (reserved !== 1) {
+		throw new HTTPException(429, {
+			message: "Too many email change requests. Try again in an hour.",
+		});
+	}
+
 	const token = randomBytes(32).toString("hex");
-	const identifier = `email-change:${fingerprint(token)}`;
+	const identifier = `email-change:${hashIdentifier(token)}`;
 	const pending = {
 		identifier,
 		value: JSON.stringify({
 			userId: user.id,
 			email: user.email,
 			newEmail,
-			passwordFingerprint: fingerprint(account.password),
+			credentialProof: await hashPassword(account.password),
 		}),
 		expiresAt: new Date(Date.now() + EMAIL_CHANGE_TTL_MS),
 	};
@@ -110,7 +145,10 @@ export async function requestEmailChange(
 	}
 }
 
-export async function confirmEmailChange(token: string): Promise<void> {
+export async function confirmEmailChange(
+	token: string,
+	headers: Headers,
+): Promise<void> {
 	const updated = await db
 		.transaction(async (tx) => {
 			const [pending] = await tx
@@ -119,7 +157,7 @@ export async function confirmEmailChange(token: string): Promise<void> {
 					and(
 						eq(
 							tables.verification.identifier,
-							`email-change:${fingerprint(token)}`,
+							`email-change:${hashIdentifier(token)}`,
 						),
 						gt(tables.verification.expiresAt, new Date()),
 					),
@@ -130,7 +168,14 @@ export async function confirmEmailChange(token: string): Promise<void> {
 					message: "This email change link is invalid or expired",
 				});
 			}
-			const change = pendingEmailSchema.parse(JSON.parse(pending.value));
+			let change: z.infer<typeof pendingEmailSchema>;
+			try {
+				change = pendingEmailSchema.parse(JSON.parse(pending.value));
+			} catch {
+				throw new HTTPException(400, {
+					message: "This email change link is no longer valid",
+				});
+			}
 			const [account] = await tx
 				.select()
 				.from(tables.account)
@@ -150,7 +195,10 @@ export async function confirmEmailChange(token: string): Promise<void> {
 				!user ||
 				user.email !== change.email ||
 				!account?.password ||
-				fingerprint(account.password) !== change.passwordFingerprint
+				!(await verifyPassword({
+					hash: change.credentialProof,
+					password: account.password,
+				}))
 			) {
 				throw new HTTPException(400, {
 					message: "This email change link is no longer valid",
@@ -178,6 +226,14 @@ export async function confirmEmailChange(token: string): Promise<void> {
 			await tx
 				.delete(tables.session)
 				.where(eq(tables.session.userId, change.userId));
+			await tx
+				.delete(tables.verification)
+				.where(
+					and(
+						eq(tables.verification.value, change.userId),
+						like(tables.verification.identifier, "reset-password:%"),
+					),
+				);
 			return { user, newEmail: change.newEmail };
 		})
 		.catch((error: unknown) => {
@@ -196,6 +252,11 @@ export async function confirmEmailChange(token: string): Promise<void> {
 			throw error;
 		});
 	if (process.env.HOSTED === "true") {
+		await flagUserIfAbusiveIp({
+			userId: updated.user.id,
+			source: "email_verification",
+			headers,
+		});
 		await deleteResendContact(updated.user.email);
 		await createResendContact(
 			updated.newEmail,

--- a/apps/api/src/lib/email-change.ts
+++ b/apps/api/src/lib/email-change.ts
@@ -1,4 +1,6 @@
 import { createHash, randomBytes } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 
 import { hashPassword, verifyPassword } from "better-auth/crypto";
 import { HTTPException } from "hono/http-exception";
@@ -34,6 +36,26 @@ export function getEmailChangeRateLimitKeys(userId: string, email: string) {
 		`email-change:rate:user:${userId}`,
 		`email-change:rate:recipient:${hashIdentifier(email.trim().toLowerCase())}`,
 	];
+}
+
+export function getEmailChangeConfirmationRateLimitKey(headers: Headers) {
+	return `email-change:confirm:ip:${hashIdentifier(getClientIpFromHeaders(headers) ?? "unknown")}`;
+}
+
+export async function checkEmailChangeConfirmationRateLimit(headers: Headers) {
+	if (
+		(await redisClient.eval(
+			RESERVE_EMAIL_CHANGE,
+			1,
+			getEmailChangeConfirmationRateLimitKey(headers),
+			60,
+			60,
+		)) !== 1
+	) {
+		throw new HTTPException(429, {
+			message: "Too many confirmation attempts. Try again in a minute.",
+		});
+	}
 }
 
 export function getEmailChangeProofRateLimitKeys(
@@ -171,6 +193,15 @@ export async function requestEmailChange(
 			strict: true,
 			logSafe: true,
 		});
+		const previewDirectory = process.env.EMAIL_CHANGE_PREVIEW_DIR;
+		if (process.env.NODE_ENV === "development" && previewDirectory) {
+			await mkdir(previewDirectory, { recursive: true, mode: 0o700 });
+			await writeFile(
+				join(previewDirectory, `${hashIdentifier(token)}.txt`),
+				`${url.toString()}\n`,
+				{ mode: 0o600, flag: "wx" },
+			);
+		}
 	} catch (error) {
 		await db
 			.delete(tables.verification)

--- a/apps/api/src/lib/email-change.ts
+++ b/apps/api/src/lib/email-change.ts
@@ -1,0 +1,208 @@
+import { createHash, randomBytes } from "node:crypto";
+
+import { HTTPException } from "hono/http-exception";
+import { z } from "zod";
+
+import {
+	apiAuth,
+	createResendContact,
+	deleteResendContact,
+} from "@/auth/config.js";
+import { sendTransactionalEmail } from "@/utils/email.js";
+
+import { and, db, eq, gt, ne, sql, tables } from "@llmgateway/db";
+
+const EMAIL_CHANGE_TTL_MS = 60 * 60 * 1000;
+
+const pendingEmailSchema = z.object({
+	userId: z.string(),
+	email: z.string(),
+	newEmail: z.string().email(),
+	passwordFingerprint: z.string(),
+});
+
+function fingerprint(value: string): string {
+	return createHash("sha256").update(value).digest("hex");
+}
+
+export async function requestEmailChange(
+	user: typeof tables.user.$inferSelect,
+	newEmail: string,
+	currentPassword: string | undefined,
+): Promise<void> {
+	if (!currentPassword) {
+		throw new HTTPException(400, {
+			message: "Your current password is required to change your email address",
+		});
+	}
+	const account = await db.query.account.findFirst({
+		where: { userId: user.id, providerId: "credential" },
+	});
+	const { password } = await apiAuth.$context;
+	if (
+		!account?.password ||
+		!(await password.verify({
+			hash: account.password,
+			password: currentPassword,
+		}))
+	) {
+		throw new HTTPException(401, { message: "Current password is incorrect" });
+	}
+	const [existing] = await db
+		.select({ id: tables.user.id })
+		.from(tables.user)
+		.where(
+			and(
+				sql`lower(${tables.user.email}) = ${newEmail}`,
+				ne(tables.user.id, user.id),
+			),
+		)
+		.limit(1);
+	if (existing) {
+		throw new HTTPException(400, {
+			message: "That email address is already in use",
+		});
+	}
+
+	const token = randomBytes(32).toString("hex");
+	const identifier = `email-change:${fingerprint(token)}`;
+	const pending = {
+		identifier,
+		value: JSON.stringify({
+			userId: user.id,
+			email: user.email,
+			newEmail,
+			passwordFingerprint: fingerprint(account.password),
+		}),
+		expiresAt: new Date(Date.now() + EMAIL_CHANGE_TTL_MS),
+	};
+	await db
+		.insert(tables.verification)
+		.values({ id: `email-change:${user.id}`, ...pending })
+		.onConflictDoUpdate({ target: tables.verification.id, set: pending });
+
+	const url = new URL(
+		"/confirm-email-change",
+		process.env.UI_URL ?? "http://localhost:3002",
+	);
+	// A fragment keeps the confirmation secret out of HTTP URLs and access logs.
+	url.hash = token;
+	try {
+		await sendTransactionalEmail({
+			to: user.email,
+			subject: "Email change requested for your LLM Gateway account",
+			text: "A change to your account email was requested. Your current address remains active until the new address is confirmed. If this wasn't you, reset your password to cancel the request and contact support.",
+			strict: true,
+			logSafe: true,
+		});
+		await sendTransactionalEmail({
+			to: newEmail,
+			subject: "Confirm your new LLM Gateway email",
+			text: `Confirm this email address for your LLM Gateway account:\n\n${url.toString()}\n\nThis link expires in one hour. After confirmation, sign in again with your new address. If you didn't request this, ignore this email.`,
+			strict: true,
+			logSafe: true,
+		});
+	} catch (error) {
+		await db
+			.delete(tables.verification)
+			.where(eq(tables.verification.identifier, identifier));
+		throw error;
+	}
+}
+
+export async function confirmEmailChange(token: string): Promise<void> {
+	const updated = await db
+		.transaction(async (tx) => {
+			const [pending] = await tx
+				.delete(tables.verification)
+				.where(
+					and(
+						eq(
+							tables.verification.identifier,
+							`email-change:${fingerprint(token)}`,
+						),
+						gt(tables.verification.expiresAt, new Date()),
+					),
+				)
+				.returning();
+			if (!pending) {
+				throw new HTTPException(400, {
+					message: "This email change link is invalid or expired",
+				});
+			}
+			const change = pendingEmailSchema.parse(JSON.parse(pending.value));
+			const [account] = await tx
+				.select()
+				.from(tables.account)
+				.where(
+					and(
+						eq(tables.account.userId, change.userId),
+						eq(tables.account.providerId, "credential"),
+					),
+				)
+				.for("update");
+			const [user] = await tx
+				.select()
+				.from(tables.user)
+				.where(eq(tables.user.id, change.userId))
+				.for("update");
+			if (
+				!user ||
+				user.email !== change.email ||
+				!account?.password ||
+				fingerprint(account.password) !== change.passwordFingerprint
+			) {
+				throw new HTTPException(400, {
+					message: "This email change link is no longer valid",
+				});
+			}
+			const [existing] = await tx
+				.select({ id: tables.user.id })
+				.from(tables.user)
+				.where(
+					and(
+						sql`lower(${tables.user.email}) = ${change.newEmail}`,
+						ne(tables.user.id, change.userId),
+					),
+				)
+				.limit(1);
+			if (existing) {
+				throw new HTTPException(400, {
+					message: "That email address is already in use",
+				});
+			}
+			await tx
+				.update(tables.user)
+				.set({ email: change.newEmail, emailVerified: true })
+				.where(eq(tables.user.id, change.userId));
+			await tx
+				.delete(tables.session)
+				.where(eq(tables.session.userId, change.userId));
+			return { user, newEmail: change.newEmail };
+		})
+		.catch((error: unknown) => {
+			for (let cause = error; cause instanceof Error; cause = cause.cause) {
+				if (
+					"code" in cause &&
+					cause.code === "23505" &&
+					"constraint" in cause &&
+					cause.constraint === "user_email_unique"
+				) {
+					throw new HTTPException(400, {
+						message: "That email address is already in use",
+					});
+				}
+			}
+			throw error;
+		});
+	if (process.env.HOSTED === "true") {
+		await deleteResendContact(updated.user.email);
+		await createResendContact(
+			updated.newEmail,
+			updated.user.name ?? undefined,
+			{
+				onboarding_completed: updated.user.onboardingCompleted,
+			},
+		);
+	}
+}

--- a/apps/api/src/lib/email-change.ts
+++ b/apps/api/src/lib/email-change.ts
@@ -11,6 +11,7 @@ import {
 	redisClient,
 } from "@/auth/config.js";
 import { flagUserIfAbusiveIp } from "@/lib/account-risk.js";
+import { getClientIpFromHeaders } from "@/lib/client-ip.js";
 import { sendTransactionalEmail } from "@/utils/email.js";
 
 import { and, db, eq, gt, like, ne, sql, tables } from "@llmgateway/db";
@@ -35,6 +36,17 @@ export function getEmailChangeRateLimitKeys(userId: string, email: string) {
 	];
 }
 
+export function getEmailChangeProofRateLimitKeys(
+	userId: string,
+	headers: Headers,
+) {
+	const ip = getClientIpFromHeaders(headers);
+	return [
+		`email-change:proof:user:${userId}`,
+		...(ip ? [`email-change:proof:ip:${hashIdentifier(ip)}`] : []),
+	];
+}
+
 const RESERVE_EMAIL_CHANGE = `
 for _, key in ipairs(KEYS) do
 	if tonumber(redis.call('get', key) or '0') >= tonumber(ARGV[1]) then return 0 end
@@ -51,10 +63,25 @@ export async function requestEmailChange(
 	user: typeof tables.user.$inferSelect,
 	newEmail: string,
 	currentPassword: string | undefined,
+	headers: Headers,
 ): Promise<void> {
 	if (!currentPassword) {
 		throw new HTTPException(400, {
 			message: "Your current password is required to change your email address",
+		});
+	}
+	const proofKeys = getEmailChangeProofRateLimitKeys(user.id, headers);
+	if (
+		(await redisClient.eval(
+			RESERVE_EMAIL_CHANGE,
+			proofKeys.length,
+			...proofKeys,
+			10,
+			60 * 60,
+		)) !== 1
+	) {
+		throw new HTTPException(429, {
+			message: "Too many password attempts. Try again in an hour.",
 		});
 	}
 	const account = await db.query.account.findFirst({
@@ -83,6 +110,13 @@ export async function requestEmailChange(
 	if (existing) {
 		throw new HTTPException(400, {
 			message: "That email address is already in use",
+		});
+	}
+
+	if (process.env.NODE_ENV === "production" && !process.env.RESEND_API_KEY) {
+		throw new HTTPException(503, {
+			message:
+				"Email changes require email delivery. Contact your administrator to configure it.",
 		});
 	}
 
@@ -176,6 +210,11 @@ export async function confirmEmailChange(
 					message: "This email change link is no longer valid",
 				});
 			}
+			const [user] = await tx
+				.select()
+				.from(tables.user)
+				.where(eq(tables.user.id, change.userId))
+				.for("update");
 			const [account] = await tx
 				.select()
 				.from(tables.account)
@@ -185,11 +224,6 @@ export async function confirmEmailChange(
 						eq(tables.account.providerId, "credential"),
 					),
 				)
-				.for("update");
-			const [user] = await tx
-				.select()
-				.from(tables.user)
-				.where(eq(tables.user.id, change.userId))
 				.for("update");
 			if (
 				!user ||

--- a/apps/api/src/routes/email-change.spec.ts
+++ b/apps/api/src/routes/email-change.spec.ts
@@ -2,6 +2,7 @@ import { mkdtemp, readdir, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { createEmailVerificationToken } from "better-auth/api";
 import * as crypto from "better-auth/crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -378,6 +379,217 @@ describe("email change confirmation", () => {
 			spy.mockRestore();
 		}
 		expect((await signingIn).status).toBe(200);
+		expect((await confirming).status).toBe(200);
+		expect(
+			await db.query.session.findMany({ where: { userId: "test-user-id" } }),
+		).toHaveLength(0);
+	});
+
+	it.each(["/auth/change-password", "/user/password"])(
+		"cancels email confirmation when a password change is in flight (%s)",
+		async (path) => {
+			await patch({ email: newEmail, currentPassword });
+			const context = await apiAuth.$context;
+			const verify = context.password.verify;
+			const entered = deferred();
+			const release = deferred();
+			const spy = vi
+				.spyOn(context.password, "verify")
+				.mockImplementationOnce(async (input) => {
+					const valid = await verify(input);
+					entered.resolve();
+					await release.promise;
+					return valid;
+				});
+			const changing = app.request(path, {
+				method: path === "/user/password" ? "PUT" : "POST",
+				headers: { Cookie: cookie, "Content-Type": "application/json" },
+				body: JSON.stringify({
+					currentPassword,
+					newPassword: "new-test-password1A",
+					revokeOtherSessions: true,
+				}),
+			});
+			await entered.promise;
+			const confirming = confirm(confirmationToken());
+			try {
+				await waitForDatabaseLock();
+			} finally {
+				release.resolve();
+				await Promise.all([changing, confirming]);
+				spy.mockRestore();
+			}
+			expect((await changing).status).toBe(200);
+			if (path === "/auth/change-password") {
+				expect((await changing).headers.get("set-cookie")).toContain(
+					"session_token=",
+				);
+			}
+			expect((await confirming).status).toBe(400);
+			expect((await storedUser())?.email).toBe("admin@example.com");
+		},
+	);
+
+	it.each(["/auth/change-password", "/user/password"])(
+		"rejects a cached password-change session after confirmation (%s)",
+		async (path) => {
+			await patch({ email: newEmail, currentPassword });
+			const verify = crypto.verifyPassword;
+			const entered = deferred();
+			const release = deferred();
+			const spy = vi
+				.spyOn(crypto, "verifyPassword")
+				.mockImplementationOnce(async (input) => {
+					entered.resolve();
+					await release.promise;
+					return await verify(input);
+				});
+			const confirming = confirm(confirmationToken());
+			await entered.promise;
+			const changing = app.request(path, {
+				method: path === "/user/password" ? "PUT" : "POST",
+				headers: { Cookie: cookie, "Content-Type": "application/json" },
+				body: JSON.stringify({
+					currentPassword,
+					newPassword: "new-test-password1A",
+				}),
+			});
+			try {
+				await waitForDatabaseLock();
+			} finally {
+				release.resolve();
+				await Promise.all([confirming, changing]);
+				spy.mockRestore();
+			}
+			expect((await confirming).status).toBe(200);
+			expect((await changing).status).toBe(
+				path === "/user/password" ? 500 : 401,
+			);
+			expect(
+				await db.query.session.findMany({ where: { userId: "test-user-id" } }),
+			).toHaveLength(0);
+			expect((await signIn(newEmail)).status).toBe(200);
+		},
+	);
+
+	it.each([false, true])(
+		"preserves native verification and auto-sign-in (redirect=%s)",
+		async (redirect) => {
+			const context = await apiAuth.$context;
+			const options = context.options.emailVerification!;
+			const original = { ...options };
+			options.autoSignInAfterVerification = true;
+			options.afterEmailVerification = vi.fn().mockResolvedValue(undefined);
+			await db
+				.update(tables.user)
+				.set({ emailVerified: false })
+				.where(eq(tables.user.id, "test-user-id"));
+			const token = await createEmailVerificationToken(
+				context.secret,
+				"admin@example.com",
+			);
+			const callback = `${process.env.UI_URL ?? "http://localhost:3002"}/dashboard`;
+			try {
+				const response = await app.request(
+					`/auth/verify-email?token=${token}${redirect ? `&callbackURL=${encodeURIComponent(callback)}` : ""}`,
+				);
+				expect(response.status).toBe(redirect ? 302 : 200);
+				if (redirect) {
+					expect(response.headers.get("location")).toBe(callback);
+				} else {
+					expect((await response.json()).status).toBe(true);
+				}
+				expect(response.headers.get("set-cookie")).toContain("session_token=");
+				expect(options.afterEmailVerification).toHaveBeenCalledOnce();
+				expect((await storedUser())?.emailVerified).toBe(true);
+				const session = await app.request("/user/me", {
+					headers: { Cookie: response.headers.get("set-cookie")! },
+				});
+				expect(session.status).toBe(200);
+			} finally {
+				options.autoSignInAfterVerification =
+					original.autoSignInAfterVerification;
+				options.afterEmailVerification = original.afterEmailVerification;
+			}
+		},
+	);
+
+	it("rejects old-address auto-sign-in when verification hooks finish after confirmation", async () => {
+		await patch({ email: newEmail, currentPassword });
+		const context = await apiAuth.$context;
+		const options = context.options.emailVerification!;
+		const original = { ...options };
+		const entered = deferred();
+		const release = deferred();
+		options.autoSignInAfterVerification = true;
+		options.afterEmailVerification = async () => {
+			entered.resolve();
+			await release.promise;
+		};
+		await db
+			.update(tables.user)
+			.set({ emailVerified: false })
+			.where(eq(tables.user.id, "test-user-id"));
+		const token = await createEmailVerificationToken(
+			context.secret,
+			"admin@example.com",
+		);
+		const verifying = app.request(`/auth/verify-email?token=${token}`);
+		try {
+			await entered.promise;
+			expect((await confirm(confirmationToken())).status).toBe(200);
+		} finally {
+			release.resolve();
+			await verifying;
+			options.autoSignInAfterVerification =
+				original.autoSignInAfterVerification;
+			options.afterEmailVerification = original.afterEmailVerification;
+		}
+		expect((await verifying).status).toBe(401);
+		expect(
+			await db.query.session.findMany({ where: { userId: "test-user-id" } }),
+		).toHaveLength(0);
+	});
+
+	it("revokes a verification session created before email confirmation", async () => {
+		await patch({ email: newEmail, currentPassword });
+		const context = await apiAuth.$context;
+		const options = context.options.emailVerification!;
+		const original = { ...options };
+		options.autoSignInAfterVerification = true;
+		options.afterEmailVerification = vi.fn().mockResolvedValue(undefined);
+		await db
+			.update(tables.user)
+			.set({ emailVerified: false })
+			.where(eq(tables.user.id, "test-user-id"));
+		const token = await createEmailVerificationToken(
+			context.secret,
+			"admin@example.com",
+		);
+		const create = context.internalAdapter.createSession;
+		const entered = deferred();
+		const release = deferred();
+		const spy = vi
+			.spyOn(context.internalAdapter, "createSession")
+			.mockImplementationOnce(async (...args) => {
+				entered.resolve();
+				await release.promise;
+				return await create(...args);
+			});
+		const verifying = app.request(`/auth/verify-email?token=${token}`);
+		await entered.promise;
+		const confirming = confirm(confirmationToken());
+		try {
+			await waitForDatabaseLock();
+		} finally {
+			release.resolve();
+			await Promise.all([verifying, confirming]);
+			spy.mockRestore();
+			options.autoSignInAfterVerification =
+				original.autoSignInAfterVerification;
+			options.afterEmailVerification = original.afterEmailVerification;
+		}
+		expect((await verifying).status).toBe(200);
 		expect((await confirming).status).toBe(200);
 		expect(
 			await db.query.session.findMany({ where: { userId: "test-user-id" } }),

--- a/apps/api/src/routes/email-change.spec.ts
+++ b/apps/api/src/routes/email-change.spec.ts
@@ -334,6 +334,52 @@ describe("email change confirmation", () => {
 		expect(await db.query.verification.findMany()).toHaveLength(0);
 	});
 
+	it("releases the user lock before delivering a committed reset token", async () => {
+		await patch({ email: newEmail, currentPassword });
+		const emailToken = confirmationToken();
+		const entered = deferred();
+		const release = deferred();
+		sendEmail.mockImplementationOnce(async () => {
+			entered.resolve();
+			await release.promise;
+		});
+		const issuing = app.request("/auth/request-password-reset", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ email: "admin@example.com" }),
+		});
+		let resetToken: string | undefined;
+		try {
+			await entered.promise;
+			const record = await db.query.verification.findFirst({
+				where: { value: "test-user-id" },
+			});
+			expect(record?.identifier).toMatch(/^reset-password:/);
+			resetToken = record!.identifier.slice("reset-password:".length);
+			expect((await confirm(emailToken)).status).toBe(200);
+			expect((await storedUser())?.email).toBe(newEmail);
+		} finally {
+			release.resolve();
+			await issuing;
+		}
+		expect((await issuing).status).toBe(200);
+		expect((await resetPassword(resetToken!)).status).toBe(400);
+		expect((await signIn(newEmail)).status).toBe(200);
+	});
+
+	it("removes committed reset tokens when delivery fails and permits retry", async () => {
+		sendEmail.mockRejectedValueOnce(new Error("Mail unavailable"));
+		const response = await app.request("/auth/request-password-reset", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ email: "admin@example.com" }),
+		});
+		expect(response.status).toBe(500);
+		expect(await db.query.verification.findMany()).toHaveLength(0);
+		expect((await signIn("admin@example.com")).status).toBe(200);
+		expect((await resetPassword(await requestReset())).status).toBe(200);
+	});
+
 	it("rolls back consumed reset tokens when the native reset hook fails", async () => {
 		const token = await requestReset();
 		const context = await apiAuth.$context;

--- a/apps/api/src/routes/email-change.spec.ts
+++ b/apps/api/src/routes/email-change.spec.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { apiAuth } from "@/auth/config.js";
+import { apiAuth, redisClient } from "@/auth/config.js";
 import { app } from "@/index.js";
+import { getEmailChangeRateLimitKeys } from "@/lib/email-change.js";
 import { createTestUser, deleteAll } from "@/testing.js";
+import * as abuseIp from "@/utils/abuse-ip.js";
 import * as email from "@/utils/email.js";
 
 import { db, eq, tables } from "@llmgateway/db";
@@ -10,9 +12,20 @@ import { db, eq, tables } from "@llmgateway/db";
 const currentPassword = "admin@example.com1A";
 const newEmail = "changed@example.com";
 const sendEmail = vi.spyOn(email, "sendTransactionalEmail");
+const checkIp = vi.spyOn(abuseIp, "checkIpAbuse");
+const rateLimitKeys = new Set<string>();
 let cookie: string;
 
-function patch(body: Record<string, unknown>, session = cookie) {
+function patch(
+	body: Record<string, unknown>,
+	session = cookie,
+	userId = "test-user-id",
+) {
+	if (typeof body.email === "string") {
+		for (const key of getEmailChangeRateLimitKeys(userId, body.email)) {
+			rateLimitKeys.add(key);
+		}
+	}
 	return app.request("/user/me", {
 		method: "PATCH",
 		headers: { Cookie: session, "Content-Type": "application/json" },
@@ -20,10 +33,10 @@ function patch(body: Record<string, unknown>, session = cookie) {
 	});
 }
 
-function confirm(token: string) {
+function confirm(token: string, headers: Record<string, string> = {}) {
 	return app.request("/user/email/confirm", {
 		method: "POST",
-		headers: { "Content-Type": "application/json" },
+		headers: { "Content-Type": "application/json", ...headers },
 		body: JSON.stringify({ token }),
 	});
 }
@@ -56,10 +69,15 @@ async function storedUser() {
 describe("email change confirmation", () => {
 	beforeEach(async () => {
 		sendEmail.mockReset().mockResolvedValue();
+		checkIp.mockReset().mockResolvedValue(null);
 		cookie = await createTestUser();
 	});
 
 	afterEach(async () => {
+		if (rateLimitKeys.size) {
+			await redisClient.del(...rateLimitKeys);
+			rateLimitKeys.clear();
+		}
 		await deleteAll();
 	});
 
@@ -122,6 +140,155 @@ describe("email change confirmation", () => {
 		expect((await signIn("admin@example.com")).status).toBe(401);
 	});
 
+	it("invalidates old-address reset links while preserving unrelated verifications", async () => {
+		await app.request("/auth/request-password-reset", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ email: "admin@example.com" }),
+		});
+		const reset = await db.query.verification.findFirst({
+			where: { value: "test-user-id" },
+		});
+		expect(reset?.identifier).toMatch(/^reset-password:/);
+		const token = reset!.identifier.slice("reset-password:".length);
+		await db.insert(tables.verification).values([
+			{
+				id: "other-reset",
+				identifier: "reset-password:other-reset",
+				value: "other-user-id",
+				expiresAt: new Date(Date.now() + 60000),
+			},
+			{
+				id: "other-verification",
+				identifier: "other-verification",
+				value: "test-user-id",
+				expiresAt: new Date(Date.now() + 60000),
+			},
+		]);
+		await patch({ email: newEmail, currentPassword });
+		expect((await confirm(confirmationToken())).status).toBe(200);
+		const response = await app.request("/auth/reset-password", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ token, newPassword: "new-test-password1A" }),
+		});
+		expect(response.status).toBe(400);
+		expect((await signIn(newEmail)).status).toBe(200);
+		expect(
+			(await db.query.verification.findMany()).map((row) => row.id).sort(),
+		).toEqual(["other-reset", "other-verification"]);
+	});
+
+	it("applies the hosted verification risk check to the confirmation IP", async () => {
+		await db
+			.update(tables.user)
+			.set({ emailVerified: false })
+			.where(eq(tables.user.id, "test-user-id"));
+		await patch({ email: newEmail, currentPassword });
+		const ip = "198.51.100.9";
+		checkIp
+			.mockClear()
+			.mockResolvedValue({ ipAddress: ip, abuseConfidenceScore: 100 });
+		expect(
+			(await confirm(confirmationToken(), { "x-forwarded-for": ip })).status,
+		).toBe(200);
+		const user = await storedUser();
+		expect(user?.emailVerified).toBe(true);
+		if (process.env.HOSTED === "true") {
+			expect(checkIp).toHaveBeenCalledWith(ip);
+			expect(user?.riskStatus).toBe("flagged");
+			expect(user?.riskFlagSource).toBe("email_verification");
+			expect(user?.riskFlagIp).toBe(ip);
+		} else {
+			expect(checkIp).not.toHaveBeenCalled();
+			expect(user?.riskStatus).toBe("none");
+		}
+	});
+
+	it("atomically limits a user's requests across recipients", async () => {
+		const responses = await Promise.all(
+			Array.from({ length: 6 }, (_, index) =>
+				patch({ email: `pending${index}@example.com`, currentPassword }),
+			),
+		);
+		expect(
+			responses.filter((response) => response.status === 200),
+		).toHaveLength(3);
+		expect(
+			responses.filter((response) => response.status === 429),
+		).toHaveLength(3);
+		expect(sendEmail).toHaveBeenCalledTimes(6);
+		const [key] = getEmailChangeRateLimitKeys("test-user-id", newEmail);
+		expect(await redisClient.ttl(key)).toBeGreaterThan(0);
+		expect(await redisClient.ttl(key)).toBeLessThanOrEqual(3600);
+	});
+
+	it("limits a normalized recipient across different users", async () => {
+		for (let count = 0; count < 3; count++) {
+			expect((await patch({ email: newEmail, currentPassword })).status).toBe(
+				200,
+			);
+		}
+		const account = await db.query.account.findFirst({
+			where: { id: "test-account-id" },
+		});
+		await db.insert(tables.user).values({
+			id: "other-user-id",
+			email: "other-user@example.com",
+			emailVerified: true,
+		});
+		await db.insert(tables.account).values({
+			id: "other-account-id",
+			accountId: "other-account-id",
+			userId: "other-user-id",
+			providerId: "credential",
+			password: account!.password,
+		});
+		const login = await signIn("other-user@example.com");
+		expect(login.status).toBe(200);
+		const otherCookie = login.headers.get("set-cookie")!;
+		expect(
+			(
+				await patch(
+					{ email: " CHANGED@EXAMPLE.COM ", currentPassword },
+					otherCookie,
+					"other-user-id",
+				)
+			).status,
+		).toBe(429);
+		expect(sendEmail).toHaveBeenCalledTimes(6);
+		const [key] = getEmailChangeRateLimitKeys("other-user-id", newEmail);
+		expect(await redisClient.get(key)).toBeNull();
+		expect(
+			(
+				await patch(
+					{ email: "available@example.com", currentPassword },
+					otherCookie,
+					"other-user-id",
+				)
+			).status,
+		).toBe(200);
+	});
+
+	it("does not send or create a pending change when Redis fails", async () => {
+		const reserve = vi
+			.spyOn(redisClient, "eval")
+			.mockRejectedValueOnce(new Error("Rate limit unavailable"));
+		try {
+			expect((await patch({ email: newEmail, currentPassword })).status).toBe(
+				500,
+			);
+			expect(sendEmail).not.toHaveBeenCalled();
+			expect(
+				await db.query.verification.findFirst({
+					where: { id: "email-change:test-user-id" },
+				}),
+			).toBeUndefined();
+		} finally {
+			reserve.mockRestore();
+		}
+	});
+
 	it("consumes the confirmation token atomically", async () => {
 		await patch({ email: newEmail, currentPassword });
 		const token = confirmationToken();
@@ -174,20 +341,46 @@ describe("email change confirmation", () => {
 		expect((await storedUser())?.email).toBe("admin@example.com");
 	});
 
-	it("invalidates pending changes when the password rotates", async () => {
-		await patch({ email: newEmail, currentPassword });
-		const response = await app.request("/auth/change-password", {
-			method: "POST",
-			headers: { Cookie: cookie, "Content-Type": "application/json" },
-			body: JSON.stringify({
-				currentPassword,
-				newPassword: "new-test-password1A",
-			}),
-		});
-		expect(response.status).toBe(200);
-		expect((await confirm(confirmationToken())).status).toBe(400);
-		expect((await storedUser())?.email).toBe("admin@example.com");
-	});
+	it.each(["legacy", "invalid proof", "invalid JSON"])(
+		"rejects malformed pending requests (%s)",
+		async (kind) => {
+			await patch({ email: newEmail, currentPassword });
+			const pending = await db.query.verification.findFirst({
+				where: { id: "email-change:test-user-id" },
+			});
+			const data: Record<string, unknown> = JSON.parse(pending!.value);
+			delete data.credentialProof;
+			if (kind === "legacy") {
+				data.passwordFingerprint = "0".repeat(64);
+			} else {
+				data.credentialProof = "invalid";
+			}
+			await db
+				.update(tables.verification)
+				.set({ value: kind === "invalid JSON" ? "{" : JSON.stringify(data) })
+				.where(eq(tables.verification.id, "email-change:test-user-id"));
+			expect((await confirm(confirmationToken())).status).toBe(400);
+			expect((await storedUser())?.email).toBe("admin@example.com");
+		},
+	);
+
+	it.each(["new-test-password1A", currentPassword])(
+		"invalidates pending changes when the credential hash rotates (%#)",
+		async (newPassword) => {
+			await patch({ email: newEmail, currentPassword });
+			const response = await app.request("/auth/change-password", {
+				method: "POST",
+				headers: { Cookie: cookie, "Content-Type": "application/json" },
+				body: JSON.stringify({
+					currentPassword,
+					newPassword,
+				}),
+			});
+			expect(response.status).toBe(200);
+			expect((await confirm(confirmationToken())).status).toBe(400);
+			expect((await storedUser())?.email).toBe("admin@example.com");
+		},
+	);
 
 	it("rejects a collision created after the change request", async () => {
 		await patch({ email: newEmail, currentPassword });

--- a/apps/api/src/routes/email-change.spec.ts
+++ b/apps/api/src/routes/email-change.spec.ts
@@ -1,13 +1,21 @@
+import * as crypto from "better-auth/crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { apiAuth, redisClient } from "@/auth/config.js";
 import { app } from "@/index.js";
-import { getEmailChangeRateLimitKeys } from "@/lib/email-change.js";
+import {
+	getEmailChangeRateLimitKeys,
+	getEmailChangeProofRateLimitKeys,
+} from "@/lib/email-change.js";
 import { createTestUser, deleteAll } from "@/testing.js";
 import * as abuseIp from "@/utils/abuse-ip.js";
 import * as email from "@/utils/email.js";
 
-import { db, eq, tables } from "@llmgateway/db";
+import { db, eq, sql, tables } from "@llmgateway/db";
+
+vi.mock("better-auth/crypto", async (importOriginal) => ({
+	...(await importOriginal<typeof crypto>()),
+}));
 
 const currentPassword = "admin@example.com1A";
 const newEmail = "changed@example.com";
@@ -20,15 +28,23 @@ function patch(
 	body: Record<string, unknown>,
 	session = cookie,
 	userId = "test-user-id",
+	headers: Record<string, string> = {},
 ) {
 	if (typeof body.email === "string") {
-		for (const key of getEmailChangeRateLimitKeys(userId, body.email)) {
+		for (const key of [
+			...getEmailChangeRateLimitKeys(userId, body.email),
+			...getEmailChangeProofRateLimitKeys(userId, new Headers(headers)),
+		]) {
 			rateLimitKeys.add(key);
 		}
 	}
 	return app.request("/user/me", {
 		method: "PATCH",
-		headers: { Cookie: session, "Content-Type": "application/json" },
+		headers: {
+			Cookie: session,
+			"Content-Type": "application/json",
+			...headers,
+		},
 		body: JSON.stringify(body),
 	});
 }
@@ -66,6 +82,48 @@ async function storedUser() {
 	return await db.query.user.findFirst({ where: { id: "test-user-id" } });
 }
 
+function deferred() {
+	let resolve!: () => void;
+	const promise = new Promise<void>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
+
+async function waitForDatabaseLock() {
+	await vi.waitFor(
+		async () => {
+			const waiting =
+				await db.execute(sql`select count(*)::int as count from pg_stat_activity
+			where datname = current_database() and wait_event_type = 'Lock' and pid <> pg_backend_pid()`);
+			expect(waiting.rows[0]?.count).toBeGreaterThan(0);
+		},
+		{ timeout: 5000 },
+	);
+}
+
+async function requestReset() {
+	const response = await app.request("/auth/request-password-reset", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ email: "admin@example.com" }),
+	});
+	expect(response.status).toBe(200);
+	expect((await response.json()).status).toBe(true);
+	const record = await db.query.verification.findFirst({
+		where: { value: "test-user-id" },
+	});
+	return record!.identifier.slice("reset-password:".length);
+}
+
+function resetPassword(token: string, newPassword = "new-test-password1A") {
+	return app.request("/auth/reset-password", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ token, newPassword }),
+	});
+}
+
 describe("email change confirmation", () => {
 	beforeEach(async () => {
 		sendEmail.mockReset().mockResolvedValue();
@@ -74,6 +132,7 @@ describe("email change confirmation", () => {
 	});
 
 	afterEach(async () => {
+		vi.unstubAllEnvs();
 		if (rateLimitKeys.size) {
 			await redisClient.del(...rateLimitKeys);
 			rateLimitKeys.clear();
@@ -177,6 +236,227 @@ describe("email change confirmation", () => {
 		expect(
 			(await db.query.verification.findMany()).map((row) => row.id).sort(),
 		).toEqual(["other-reset", "other-verification"]);
+	});
+
+	it("serializes an in-flight password reset before email confirmation", async () => {
+		const token = await requestReset();
+		await patch({ email: newEmail, currentPassword });
+		const emailToken = confirmationToken();
+		const context = await apiAuth.$context;
+		const hash = context.password.hash;
+		const entered = deferred();
+		const release = deferred();
+		const spy = vi
+			.spyOn(context.password, "hash")
+			.mockImplementationOnce(async (value) => {
+				entered.resolve();
+				await release.promise;
+				return await hash(value);
+			});
+		const resetting = resetPassword(token);
+		await entered.promise;
+		const confirming = confirm(emailToken);
+		try {
+			await waitForDatabaseLock();
+			expect(
+				await db.query.verification.findFirst({
+					where: { identifier: `reset-password:${token}` },
+				}),
+			).toBeDefined();
+		} finally {
+			release.resolve();
+			await Promise.all([resetting, confirming]);
+			spy.mockRestore();
+		}
+		expect((await resetting).status).toBe(200);
+		expect((await confirming).status).toBe(400);
+		expect((await storedUser())?.email).toBe("admin@example.com");
+	});
+
+	it("serializes email confirmation before an in-flight password reset", async () => {
+		const token = await requestReset();
+		await patch({ email: newEmail, currentPassword });
+		const verify = crypto.verifyPassword;
+		const entered = deferred();
+		const release = deferred();
+		const spy = vi
+			.spyOn(crypto, "verifyPassword")
+			.mockImplementationOnce(async (value) => {
+				entered.resolve();
+				await release.promise;
+				return await verify(value);
+			});
+		const confirming = confirm(confirmationToken());
+		await entered.promise;
+		const resetting = resetPassword(token);
+		try {
+			await waitForDatabaseLock();
+		} finally {
+			release.resolve();
+			await Promise.all([confirming, resetting]);
+			spy.mockRestore();
+		}
+		expect((await confirming).status).toBe(200);
+		expect((await resetting).status).toBe(400);
+		expect((await signIn(newEmail)).status).toBe(200);
+	});
+
+	it("serializes reset token issuance with email confirmation", async () => {
+		await patch({ email: newEmail, currentPassword });
+		const emailToken = confirmationToken();
+		const context = await apiAuth.$context;
+		const create = context.internalAdapter.createVerificationValue;
+		const entered = deferred();
+		const release = deferred();
+		const spy = vi
+			.spyOn(context.internalAdapter, "createVerificationValue")
+			.mockImplementationOnce(async (...args) => {
+				entered.resolve();
+				await release.promise;
+				return await create(...args);
+			});
+		const issuing = app.request("/auth/request-password-reset", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ email: "admin@example.com" }),
+		});
+		await entered.promise;
+		const confirming = confirm(emailToken);
+		try {
+			await waitForDatabaseLock();
+		} finally {
+			release.resolve();
+			await Promise.all([issuing, confirming]);
+			spy.mockRestore();
+		}
+		expect((await issuing).status).toBe(200);
+		expect((await confirming).status).toBe(200);
+		expect(await db.query.verification.findMany()).toHaveLength(0);
+	});
+
+	it("rolls back consumed reset tokens when the native reset hook fails", async () => {
+		const token = await requestReset();
+		const context = await apiAuth.$context;
+		const options = context.options.emailAndPassword!;
+		const original = options.onPasswordReset;
+		options.onPasswordReset = async () => {
+			throw new Error("Reset hook unavailable");
+		};
+		try {
+			expect((await resetPassword(token)).status).toBe(500);
+		} finally {
+			options.onPasswordReset = original;
+		}
+		expect((await signIn("admin@example.com")).status).toBe(200);
+		expect((await resetPassword(token)).status).toBe(200);
+	});
+
+	it("retains native reset session revocation", async () => {
+		const token = await requestReset();
+		const context = await apiAuth.$context;
+		const options = context.options.emailAndPassword!;
+		const original = options.revokeSessionsOnPasswordReset;
+		options.revokeSessionsOnPasswordReset = true;
+		try {
+			const response = await resetPassword(token);
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({ status: true });
+		} finally {
+			options.revokeSessionsOnPasswordReset = original;
+		}
+		expect(
+			await db.query.session.findMany({ where: { userId: "test-user-id" } }),
+		).toHaveLength(0);
+	});
+
+	it("retains native reset token and password errors", async () => {
+		const token = await requestReset();
+		for (const [value, password, code] of [
+			["", "new-test-password1A", "INVALID_TOKEN"],
+			["unknown", "new-test-password1A", "INVALID_TOKEN"],
+			[token, "short", "PASSWORD_TOO_SHORT"],
+			[token, "a".repeat(129), "PASSWORD_TOO_LONG"],
+		]) {
+			const response = await resetPassword(value, password);
+			expect(response.status).toBe(400);
+			expect((await response.json()).code).toBe(code);
+		}
+		expect((await resetPassword(token)).status).toBe(200);
+	});
+
+	it("limits failed password proofs before hashing without consuming mail quota", async () => {
+		const context = await apiAuth.$context;
+		const verify = vi.spyOn(context.password, "verify");
+		try {
+			for (let attempt = 0; attempt < 10; attempt++) {
+				expect(
+					(await patch({ email: newEmail, currentPassword: "incorrect" }))
+						.status,
+				).toBe(401);
+			}
+			expect(
+				(
+					await patch(
+						{ email: "another@example.com", currentPassword },
+						cookie,
+						"test-user-id",
+						{ "x-forwarded-for": "198.51.100.10" },
+					)
+				).status,
+			).toBe(429);
+			expect(verify).toHaveBeenCalledTimes(10);
+		} finally {
+			verify.mockRestore();
+		}
+		for (const key of getEmailChangeRateLimitKeys("test-user-id", newEmail)) {
+			expect(await redisClient.get(key)).toBeNull();
+		}
+		expect(sendEmail).not.toHaveBeenCalled();
+	});
+
+	it("limits password proofs by client IP as well as user", async () => {
+		const headers = { "x-forwarded-for": "198.51.100.11" };
+		const [actorKey, ipKey] = getEmailChangeProofRateLimitKeys(
+			"test-user-id",
+			new Headers(headers),
+		);
+		for (let attempt = 0; attempt < 10; attempt++) {
+			await redisClient.del(actorKey);
+			expect(
+				(
+					await patch(
+						{ email: newEmail, currentPassword: "incorrect" },
+						cookie,
+						"test-user-id",
+						headers,
+					)
+				).status,
+			).toBe(401);
+		}
+		await redisClient.del(actorKey);
+		expect(
+			(
+				await patch(
+					{ email: newEmail, currentPassword },
+					cookie,
+					"test-user-id",
+					headers,
+				)
+			).status,
+		).toBe(429);
+		expect(await redisClient.ttl(ipKey)).toBeGreaterThan(0);
+		expect(sendEmail).not.toHaveBeenCalled();
+	});
+
+	it("explains missing email delivery without changing identity", async () => {
+		vi.stubEnv("NODE_ENV", "production");
+		vi.stubEnv("RESEND_API_KEY", "");
+		const response = await patch({ email: newEmail, currentPassword });
+		expect(response.status).toBe(503);
+		expect((await response.json()).message).toContain("configure");
+		expect((await storedUser())?.email).toBe("admin@example.com");
+		expect(await db.query.verification.findMany()).toHaveLength(0);
+		expect(sendEmail).not.toHaveBeenCalled();
 	});
 
 	it("applies the hosted verification risk check to the confirmation IP", async () => {

--- a/apps/api/src/routes/email-change.spec.ts
+++ b/apps/api/src/routes/email-change.spec.ts
@@ -1,3 +1,7 @@
+import { mkdtemp, readdir, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import * as crypto from "better-auth/crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -6,6 +10,7 @@ import { app } from "@/index.js";
 import {
 	getEmailChangeRateLimitKeys,
 	getEmailChangeProofRateLimitKeys,
+	getEmailChangeConfirmationRateLimitKey,
 } from "@/lib/email-change.js";
 import { createTestUser, deleteAll } from "@/testing.js";
 import * as abuseIp from "@/utils/abuse-ip.js";
@@ -50,6 +55,9 @@ function patch(
 }
 
 function confirm(token: string, headers: Record<string, string> = {}) {
+	rateLimitKeys.add(
+		getEmailChangeConfirmationRateLimitKey(new Headers(headers)),
+	);
 	return app.request("/user/email/confirm", {
 		method: "POST",
 		headers: { "Content-Type": "application/json", ...headers },
@@ -95,7 +103,8 @@ async function waitForDatabaseLock() {
 		async () => {
 			const waiting =
 				await db.execute(sql`select count(*)::int as count from pg_stat_activity
-			where datname = current_database() and wait_event_type = 'Lock' and pid <> pg_backend_pid()`);
+			where datname = current_database() and wait_event_type = 'Lock' and pid <> pg_backend_pid()
+			and query ilike 'select%from "user"%for update%'`);
 			expect(waiting.rows[0]?.count).toBeGreaterThan(0);
 		},
 		{ timeout: 5000 },
@@ -148,6 +157,39 @@ describe("email change confirmation", () => {
 		).toBe(401);
 		expect((await storedUser())?.email).toBe("admin@example.com");
 		expect(sendEmail).not.toHaveBeenCalled();
+	});
+
+	it("limits confirmation requests before opening database transactions", async () => {
+		const headers = { "x-forwarded-for": "198.51.100.42" };
+		const key = getEmailChangeConfirmationRateLimitKey(new Headers(headers));
+		rateLimitKeys.add(key);
+		await redisClient.set(key, "59", "EX", 60);
+		expect((await confirm("0".repeat(64), headers)).status).toBe(400);
+		const transaction = vi.spyOn(db, "transaction");
+		try {
+			expect((await confirm("0".repeat(64), headers)).status).toBe(429);
+			expect(transaction).not.toHaveBeenCalled();
+		} finally {
+			transaction.mockRestore();
+		}
+		expect(
+			(await confirm("0".repeat(64), { "x-forwarded-for": "198.51.100.43" }))
+				.status,
+		).toBe(400);
+	});
+
+	it("fails closed on confirmation throttle errors before opening a transaction", async () => {
+		const evalScript = vi
+			.spyOn(redisClient, "eval")
+			.mockRejectedValueOnce(new Error("Redis unavailable"));
+		const transaction = vi.spyOn(db, "transaction");
+		try {
+			expect((await confirm("0".repeat(64))).status).toBe(500);
+			expect(transaction).not.toHaveBeenCalled();
+		} finally {
+			evalScript.mockRestore();
+			transaction.mockRestore();
+		}
 	});
 
 	it("keeps sign-in and password recovery at the old address until confirmation", async () => {
@@ -273,6 +315,105 @@ describe("email change confirmation", () => {
 		expect((await storedUser())?.email).toBe("admin@example.com");
 	});
 
+	it.each(["confirmation", "reset"])(
+		"rejects a stale sign-in after password verification when %s wins",
+		async (operation) => {
+			const resetToken = await requestReset();
+			await patch({ email: newEmail, currentPassword });
+			const emailToken = confirmationToken();
+			const context = await apiAuth.$context;
+			const verify = context.password.verify;
+			const entered = deferred();
+			const release = deferred();
+			const spy = vi
+				.spyOn(context.password, "verify")
+				.mockImplementationOnce(async (input) => {
+					const valid = await verify(input);
+					entered.resolve();
+					await release.promise;
+					return valid;
+				});
+			const signingIn = signIn("admin@example.com");
+			try {
+				await entered.promise;
+				const response =
+					operation === "confirmation"
+						? await confirm(emailToken)
+						: await resetPassword(resetToken);
+				expect(response.status).toBe(200);
+			} finally {
+				release.resolve();
+				await signingIn;
+				spy.mockRestore();
+			}
+			expect((await signingIn).status).toBe(401);
+			expect((await (await signingIn).json()).code).toBe(
+				"INVALID_EMAIL_OR_PASSWORD",
+			);
+		},
+	);
+
+	it("revokes a sign-in that creates its session before confirmation", async () => {
+		await patch({ email: newEmail, currentPassword });
+		const emailToken = confirmationToken();
+		const context = await apiAuth.$context;
+		const create = context.internalAdapter.createSession;
+		const entered = deferred();
+		const release = deferred();
+		const spy = vi
+			.spyOn(context.internalAdapter, "createSession")
+			.mockImplementationOnce(async (...args) => {
+				entered.resolve();
+				await release.promise;
+				return await create(...args);
+			});
+		const signingIn = signIn("admin@example.com");
+		await entered.promise;
+		const confirming = confirm(emailToken);
+		try {
+			await waitForDatabaseLock();
+		} finally {
+			release.resolve();
+			await Promise.all([signingIn, confirming]);
+			spy.mockRestore();
+		}
+		expect((await signingIn).status).toBe(200);
+		expect((await confirming).status).toBe(200);
+		expect(
+			await db.query.session.findMany({ where: { userId: "test-user-id" } }),
+		).toHaveLength(0);
+	});
+
+	it.each(["development", "production"])(
+		"captures private local confirmation previews only in development (%s)",
+		async (environment) => {
+			const directory = await mkdtemp(join(tmpdir(), "email-change-preview-"));
+			vi.stubEnv("NODE_ENV", environment);
+			vi.stubEnv("EMAIL_CHANGE_PREVIEW_DIR", directory);
+			if (environment === "production") {
+				vi.stubEnv("RESEND_API_KEY", "test");
+			}
+			try {
+				expect((await patch({ email: newEmail, currentPassword })).status).toBe(
+					200,
+				);
+				const files = await readdir(directory);
+				if (environment === "production") {
+					expect(files).toHaveLength(0);
+				} else {
+					expect(files).toHaveLength(1);
+					const path = join(directory, files[0]);
+					expect((await stat(path)).mode & 0o777).toBe(0o600);
+					const url = new URL((await readFile(path, "utf8")).trim());
+					expect((await confirm(url.hash.slice(1))).status).toBe(200);
+					expect((await storedUser())?.email).toBe(newEmail);
+				}
+			} finally {
+				await rm(directory, { recursive: true, force: true });
+			}
+		},
+	);
+
 	it("serializes email confirmation before an in-flight password reset", async () => {
 		const token = await requestReset();
 		await patch({ email: newEmail, currentPassword });
@@ -374,7 +515,13 @@ describe("email change confirmation", () => {
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ email: "admin@example.com" }),
 		});
-		expect(response.status).toBe(500);
+		expect(response.status).toBe(200);
+		const unknown = await app.request("/auth/request-password-reset", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ email: "unknown@example.com" }),
+		});
+		expect(await response.json()).toEqual(await unknown.json());
 		expect(await db.query.verification.findMany()).toHaveLength(0);
 		expect((await signIn("admin@example.com")).status).toBe(200);
 		expect((await resetPassword(await requestReset())).status).toBe(200);

--- a/apps/api/src/routes/email-change.spec.ts
+++ b/apps/api/src/routes/email-change.spec.ts
@@ -1,0 +1,252 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { apiAuth } from "@/auth/config.js";
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+import * as email from "@/utils/email.js";
+
+import { db, eq, tables } from "@llmgateway/db";
+
+const currentPassword = "admin@example.com1A";
+const newEmail = "changed@example.com";
+const sendEmail = vi.spyOn(email, "sendTransactionalEmail");
+let cookie: string;
+
+function patch(body: Record<string, unknown>, session = cookie) {
+	return app.request("/user/me", {
+		method: "PATCH",
+		headers: { Cookie: session, "Content-Type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+
+function confirm(token: string) {
+	return app.request("/user/email/confirm", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ token }),
+	});
+}
+
+function confirmationToken() {
+	const message = sendEmail.mock.calls
+		.slice()
+		.reverse()
+		.find(
+			([message]) => message.subject === "Confirm your new LLM Gateway email",
+		)?.[0];
+	expect(message?.text).toBeDefined();
+	const token = message!.text!.match(/#([a-f0-9]{64})/)?.[1];
+	expect(token).toBeDefined();
+	return token!;
+}
+
+function signIn(address: string) {
+	return app.request("/auth/sign-in/email", {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ email: address, password: currentPassword }),
+	});
+}
+
+async function storedUser() {
+	return await db.query.user.findFirst({ where: { id: "test-user-id" } });
+}
+
+describe("email change confirmation", () => {
+	beforeEach(async () => {
+		sendEmail.mockReset().mockResolvedValue();
+		cookie = await createTestUser();
+	});
+
+	afterEach(async () => {
+		await deleteAll();
+	});
+
+	it("requires a session and the current password", async () => {
+		expect((await patch({ email: newEmail }, "")).status).toBe(401);
+		expect((await patch({ email: newEmail })).status).toBe(400);
+		expect(
+			(await patch({ email: newEmail, currentPassword: "incorrect" })).status,
+		).toBe(401);
+		expect((await storedUser())?.email).toBe("admin@example.com");
+		expect(sendEmail).not.toHaveBeenCalled();
+	});
+
+	it("keeps sign-in and password recovery at the old address until confirmation", async () => {
+		expect((await patch({ email: newEmail, currentPassword })).status).toBe(
+			200,
+		);
+		expect((await storedUser())?.email).toBe("admin@example.com");
+		expect((await storedUser())?.emailVerified).toBe(true);
+		expect(sendEmail.mock.calls.map(([message]) => message.to)).toEqual([
+			"admin@example.com",
+			newEmail,
+		]);
+		expect((await signIn("admin@example.com")).status).toBe(200);
+		expect((await signIn(newEmail)).status).toBe(401);
+		for (const address of [newEmail, "admin@example.com"]) {
+			await app.request("/auth/request-password-reset", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ email: address }),
+			});
+		}
+		const resetMessages = sendEmail.mock.calls.filter(
+			([message]) => message.subject === "Reset your LLM Gateway password",
+		);
+		expect(resetMessages.map(([message]) => message.to)).toEqual([
+			"admin@example.com",
+		]);
+	});
+
+	it("confirms once, verifies the new address, and revokes every session", async () => {
+		await patch({ email: newEmail, currentPassword });
+		const token = confirmationToken();
+		const pending = await db.query.verification.findFirst({
+			where: { id: "email-change:test-user-id" },
+		});
+		expect(JSON.stringify(pending)).not.toContain(token);
+		await signIn("admin@example.com");
+		expect((await confirm(token)).status).toBe(200);
+		expect((await storedUser())?.email).toBe(newEmail);
+		expect((await storedUser())?.emailVerified).toBe(true);
+		expect(
+			await db.query.session.findMany({ where: { userId: "test-user-id" } }),
+		).toHaveLength(0);
+		expect(
+			(await app.request("/user/me", { headers: { Cookie: cookie } })).status,
+		).toBe(401);
+		expect((await confirm(token)).status).toBe(400);
+		expect((await signIn(newEmail)).status).toBe(200);
+		expect((await signIn("admin@example.com")).status).toBe(401);
+	});
+
+	it("consumes the confirmation token atomically", async () => {
+		await patch({ email: newEmail, currentPassword });
+		const token = confirmationToken();
+		const responses = await Promise.all([confirm(token), confirm(token)]);
+		expect(responses.map((response) => response.status).sort()).toEqual([
+			200, 400,
+		]);
+		expect((await storedUser())?.email).toBe(newEmail);
+	});
+
+	it("also keeps an unverified account unchanged until confirmation", async () => {
+		await db
+			.update(tables.user)
+			.set({ emailVerified: false })
+			.where(eq(tables.user.id, "test-user-id"));
+		await patch({ email: newEmail, currentPassword });
+		expect((await storedUser())?.email).toBe("admin@example.com");
+		expect((await storedUser())?.emailVerified).toBe(false);
+		expect((await confirm(confirmationToken())).status).toBe(200);
+		expect((await storedUser())?.emailVerified).toBe(true);
+	});
+
+	it("does not require proof for a case-only or profile update", async () => {
+		expect(
+			(await patch({ email: " ADMIN@EXAMPLE.COM ", name: "Updated Name" }))
+				.status,
+		).toBe(200);
+		expect((await storedUser())?.email).toBe("admin@example.com");
+		expect((await storedUser())?.name).toBe("Updated Name");
+		expect(sendEmail).not.toHaveBeenCalled();
+	});
+
+	it("invalidates an earlier request when another address is requested", async () => {
+		await patch({ email: newEmail, currentPassword });
+		const oldToken = confirmationToken();
+		await patch({ email: "other@example.com", currentPassword });
+		expect((await confirm(oldToken)).status).toBe(400);
+		expect((await confirm(confirmationToken())).status).toBe(200);
+		expect((await storedUser())?.email).toBe("other@example.com");
+	});
+
+	it("rejects expired and incorrect tokens", async () => {
+		await patch({ email: newEmail, currentPassword });
+		expect((await confirm("0".repeat(64))).status).toBe(400);
+		await db
+			.update(tables.verification)
+			.set({ expiresAt: new Date(0) })
+			.where(eq(tables.verification.id, "email-change:test-user-id"));
+		expect((await confirm(confirmationToken())).status).toBe(400);
+		expect((await storedUser())?.email).toBe("admin@example.com");
+	});
+
+	it("invalidates pending changes when the password rotates", async () => {
+		await patch({ email: newEmail, currentPassword });
+		const response = await app.request("/auth/change-password", {
+			method: "POST",
+			headers: { Cookie: cookie, "Content-Type": "application/json" },
+			body: JSON.stringify({
+				currentPassword,
+				newPassword: "new-test-password1A",
+			}),
+		});
+		expect(response.status).toBe(200);
+		expect((await confirm(confirmationToken())).status).toBe(400);
+		expect((await storedUser())?.email).toBe("admin@example.com");
+	});
+
+	it("rejects a collision created after the change request", async () => {
+		await patch({ email: newEmail, currentPassword });
+		await db.insert(tables.user).values({
+			id: "other-user",
+			email: "Changed@Example.com",
+			name: "Other User",
+		});
+		expect((await confirm(confirmationToken())).status).toBe(400);
+		expect((await storedUser())?.email).toBe("admin@example.com");
+	});
+
+	it("does not apply a stale request to a changed or replaced account", async () => {
+		await patch({ email: newEmail, currentPassword });
+		await db
+			.update(tables.user)
+			.set({ email: "other@example.com" })
+			.where(eq(tables.user.id, "test-user-id"));
+		await db.insert(tables.user).values({
+			id: "replacement-user",
+			email: "admin@example.com",
+			name: "Replacement User",
+		});
+		expect((await confirm(confirmationToken())).status).toBe(400);
+		expect((await storedUser())?.email).toBe("other@example.com");
+	});
+
+	it.each(["old", "new"])(
+		"removes the pending request when delivery to the %s address fails",
+		async (address) => {
+			if (address === "new") {
+				sendEmail.mockResolvedValueOnce();
+			}
+			sendEmail.mockRejectedValueOnce(new Error("Email delivery unavailable"));
+			expect((await patch({ email: newEmail, currentPassword })).status).toBe(
+				500,
+			);
+			expect(
+				await db.query.verification.findFirst({
+					where: { id: "email-change:test-user-id" },
+				}),
+			).toBeUndefined();
+			expect((await storedUser())?.email).toBe("admin@example.com");
+		},
+	);
+
+	it("keeps alternate auth email mutation endpoints closed", async () => {
+		expect(apiAuth.options.user?.changeEmail?.enabled).not.toBe(true);
+		for (const [path, body] of [
+			["/auth/change-email", { newEmail }],
+			["/auth/update-user", { email: newEmail, emailVerified: true }],
+		] as const) {
+			const response = await app.request(path, {
+				method: "POST",
+				headers: { Cookie: cookie, "Content-Type": "application/json" },
+				body: JSON.stringify(body),
+			});
+			expect(response.status).toBe(400);
+		}
+		expect((await storedUser())?.email).toBe("admin@example.com");
+	});
+});

--- a/apps/api/src/routes/email-change.ts
+++ b/apps/api/src/routes/email-change.ts
@@ -34,7 +34,7 @@ emailChange.openapi(
 		},
 	}),
 	async (c) => {
-		await confirmEmailChange(c.req.valid("json").token);
+		await confirmEmailChange(c.req.valid("json").token, c.req.raw.headers);
 		return c.json({
 			message: "Email updated. Sign in with your new email address.",
 		});

--- a/apps/api/src/routes/email-change.ts
+++ b/apps/api/src/routes/email-change.ts
@@ -1,0 +1,42 @@
+import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
+import { z } from "zod";
+
+import { confirmEmailChange } from "@/lib/email-change.js";
+
+export const emailChange = new OpenAPIHono();
+
+emailChange.openapi(
+	createRoute({
+		method: "post",
+		path: "/user/email/confirm",
+		request: {
+			body: {
+				content: {
+					"application/json": {
+						schema: z.object({ token: z.string().regex(/^[a-f0-9]{64}$/) }),
+					},
+				},
+			},
+		},
+		responses: {
+			400: {
+				description: "Invalid, expired, or conflicting email change.",
+				content: {
+					"application/json": { schema: z.object({ message: z.string() }) },
+				},
+			},
+			200: {
+				description: "Email confirmed. Sign in again with the new address.",
+				content: {
+					"application/json": { schema: z.object({ message: z.string() }) },
+				},
+			},
+		},
+	}),
+	async (c) => {
+		await confirmEmailChange(c.req.valid("json").token);
+		return c.json({
+			message: "Email updated. Sign in with your new email address.",
+		});
+	},
+);

--- a/apps/api/src/routes/email-change.ts
+++ b/apps/api/src/routes/email-change.ts
@@ -1,7 +1,10 @@
 import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
 import { z } from "zod";
 
-import { confirmEmailChange } from "@/lib/email-change.js";
+import {
+	checkEmailChangeConfirmationRateLimit,
+	confirmEmailChange,
+} from "@/lib/email-change.js";
 
 export const emailChange = new OpenAPIHono();
 
@@ -19,6 +22,12 @@ emailChange.openapi(
 			},
 		},
 		responses: {
+			429: {
+				description: "Too many confirmation attempts.",
+				content: {
+					"application/json": { schema: z.object({ message: z.string() }) },
+				},
+			},
 			400: {
 				description: "Invalid, expired, or conflicting email change.",
 				content: {
@@ -34,6 +43,7 @@ emailChange.openapi(
 		},
 	}),
 	async (c) => {
+		await checkEmailChangeConfirmationRateLimit(c.req.raw.headers);
 		await confirmEmailChange(c.req.valid("json").token, c.req.raw.headers);
 		return c.json({
 			message: "Email updated. Sign in with your new email address.",

--- a/apps/api/src/routes/user.spec.ts
+++ b/apps/api/src/routes/user.spec.ts
@@ -363,26 +363,29 @@ describe("user accounts and email editability", () => {
 		expect(json.user.accounts).toHaveLength(2);
 	});
 
-	it("PATCH /user/me should reset emailVerified when the email changes", async () => {
+	it("PATCH /user/me should preserve the current identity until email confirmation", async () => {
 		const res = await app.request("/user/me", {
 			method: "PATCH",
 			headers: {
 				Cookie: token,
 				"Content-Type": "application/json",
 			},
-			body: JSON.stringify({ email: "changed@example.com" }),
+			body: JSON.stringify({
+				email: "changed@example.com",
+				currentPassword: "admin@example.com1A",
+			}),
 		});
 
 		expect(res.status).toBe(200);
 		const json = await res.json();
-		expect(json.user.email).toBe("changed@example.com");
-		expect(json.user.emailVerified).toBe(false);
+		expect(json.user.email).toBe("admin@example.com");
+		expect(json.user.emailVerified).toBe(true);
 		expect(json.user.isAdmin).toBe(false);
 
 		const stored = await db.query.user.findFirst({
 			where: { id: { eq: "test-user-id" } },
 		});
-		expect(stored!.emailVerified).toBe(false);
+		expect(stored!.emailVerified).toBe(true);
 	});
 
 	it("PATCH /user/me should keep emailVerified when the email is unchanged", async () => {
@@ -400,20 +403,27 @@ describe("user accounts and email editability", () => {
 		expect(json.user.emailVerified).toBe(true);
 	});
 
-	it("PATCH /user/me should store a changed email lowercased", async () => {
+	it("PATCH /user/me should store a pending email lowercased", async () => {
 		const res = await app.request("/user/me", {
 			method: "PATCH",
 			headers: {
 				Cookie: token,
 				"Content-Type": "application/json",
 			},
-			body: JSON.stringify({ email: "Mixed.Case@Example.COM" }),
+			body: JSON.stringify({
+				email: "Mixed.Case@Example.COM",
+				currentPassword: "admin@example.com1A",
+			}),
 		});
 
 		expect(res.status).toBe(200);
 		const json = await res.json();
-		expect(json.user.email).toBe("mixed.case@example.com");
-		expect(json.user.emailVerified).toBe(false);
+		expect(json.user.email).toBe("admin@example.com");
+		const pending = await db.query.verification.findFirst({
+			where: { id: "email-change:test-user-id" },
+		});
+		expect(JSON.parse(pending!.value).newEmail).toBe("mixed.case@example.com");
+		expect(json.user.emailVerified).toBe(true);
 	});
 
 	it("PATCH /user/me should reject a case variant of another account's email", async () => {
@@ -430,7 +440,10 @@ describe("user accounts and email editability", () => {
 				Cookie: token,
 				"Content-Type": "application/json",
 			},
-			body: JSON.stringify({ email: "TAKEN@example.com" }),
+			body: JSON.stringify({
+				email: "TAKEN@example.com",
+				currentPassword: "admin@example.com1A",
+			}),
 		});
 
 		expect(res.status).toBe(400);
@@ -457,7 +470,10 @@ describe("user accounts and email editability", () => {
 				Cookie: token,
 				"Content-Type": "application/json",
 			},
-			body: JSON.stringify({ email: "taken@example.com" }),
+			body: JSON.stringify({
+				email: "taken@example.com",
+				currentPassword: "admin@example.com1A",
+			}),
 		});
 
 		expect(res.status).toBe(400);

--- a/apps/api/src/routes/user.spec.ts
+++ b/apps/api/src/routes/user.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 
 import { redisClient } from "@/auth/config.js";
 import { app } from "@/index.js";
@@ -376,28 +376,33 @@ describe("user accounts and email editability", () => {
 	});
 
 	it("PATCH /user/me should preserve the current identity until email confirmation", async () => {
-		const res = await app.request("/user/me", {
-			method: "PATCH",
-			headers: {
-				Cookie: token,
-				"Content-Type": "application/json",
-			},
-			body: JSON.stringify({
-				email: "changed@example.com",
-				currentPassword: "admin@example.com1A",
-			}),
-		});
+		vi.stubEnv("ADMIN_EMAILS", "changed@example.com");
+		try {
+			const res = await app.request("/user/me", {
+				method: "PATCH",
+				headers: {
+					Cookie: token,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					email: "changed@example.com",
+					currentPassword: "admin@example.com1A",
+				}),
+			});
 
-		expect(res.status).toBe(200);
-		const json = await res.json();
-		expect(json.user.email).toBe("admin@example.com");
-		expect(json.user.emailVerified).toBe(true);
-		expect(json.user.isAdmin).toBe(false);
+			expect(res.status).toBe(200);
+			const json = await res.json();
+			expect(json.user.email).toBe("admin@example.com");
+			expect(json.user.emailVerified).toBe(true);
+			expect(json.user.isAdmin).toBe(false);
 
-		const stored = await db.query.user.findFirst({
-			where: { id: { eq: "test-user-id" } },
-		});
-		expect(stored!.emailVerified).toBe(true);
+			const stored = await db.query.user.findFirst({
+				where: { id: { eq: "test-user-id" } },
+			});
+			expect(stored!.emailVerified).toBe(true);
+		} finally {
+			vi.unstubAllEnvs();
+		}
 	});
 
 	it("PATCH /user/me should keep emailVerified when the email is unchanged", async () => {

--- a/apps/api/src/routes/user.spec.ts
+++ b/apps/api/src/routes/user.spec.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest";
 
+import { redisClient } from "@/auth/config.js";
 import { app } from "@/index.js";
+import { getEmailChangeRateLimitKeys } from "@/lib/email-change.js";
 import { createTestUser, deleteAll } from "@/testing.js";
 
 import { db, eq, tables } from "@llmgateway/db";
@@ -175,12 +177,18 @@ describe("user account deletion", () => {
 
 describe("user accounts and email editability", () => {
 	let token: string;
+	const emailRateLimitKeys = [
+		...getEmailChangeRateLimitKeys("test-user-id", "changed@example.com"),
+		...getEmailChangeRateLimitKeys("test-user-id", "mixed.case@example.com"),
+	];
 
 	beforeEach(async () => {
+		await redisClient.del(...emailRateLimitKeys);
 		token = await createTestUser();
 	});
 
 	afterEach(async () => {
+		await redisClient.del(...emailRateLimitKeys);
 		await db.delete(tables.passkey);
 		await db.delete(tables.ssoProvider);
 		await deleteAll();

--- a/apps/api/src/routes/user.spec.ts
+++ b/apps/api/src/routes/user.spec.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, beforeEach, afterEach } from "vitest";
 
 import { redisClient } from "@/auth/config.js";
 import { app } from "@/index.js";
-import { getEmailChangeRateLimitKeys } from "@/lib/email-change.js";
+import {
+	getEmailChangeRateLimitKeys,
+	getEmailChangeProofRateLimitKeys,
+} from "@/lib/email-change.js";
 import { createTestUser, deleteAll } from "@/testing.js";
 
 import { db, eq, tables } from "@llmgateway/db";
@@ -178,6 +181,7 @@ describe("user account deletion", () => {
 describe("user accounts and email editability", () => {
 	let token: string;
 	const emailRateLimitKeys = [
+		...getEmailChangeProofRateLimitKeys("test-user-id", new Headers()),
 		...getEmailChangeRateLimitKeys("test-user-id", "changed@example.com"),
 		...getEmailChangeRateLimitKeys("test-user-id", "mixed.case@example.com"),
 	];

--- a/apps/api/src/routes/user.ts
+++ b/apps/api/src/routes/user.ts
@@ -12,10 +12,11 @@ import {
 	findSoleMemberOrganizations,
 	tearDownSoleMemberOrganizations,
 } from "@/lib/account-deletion.js";
+import { requestEmailChange } from "@/lib/email-change.js";
 import { notifyUserAccountDeleted } from "@/utils/discord.js";
 import { computeProfileData, profileSchema } from "@/utils/profile.js";
 
-import { and, db, eq, ne, sql, tables } from "@llmgateway/db";
+import { and, db, eq, tables } from "@llmgateway/db";
 import { getEnterpriseLicenseStatus } from "@llmgateway/shared/enterprise-license";
 
 import type { ServerTypes } from "@/vars.js";
@@ -204,6 +205,7 @@ user.openapi(get, async (c) => {
 });
 
 const updateUserSchema = z.object({
+	currentPassword: z.string().min(1).optional(),
 	name: z.string().optional(),
 	// Lowercased to match better-auth, which stores emails lowercase and looks
 	// them up lowercased on sign-in — a mixed-case stored email is unloginable.
@@ -349,7 +351,7 @@ user.openapi(updateUser, async (c) => {
 		});
 	}
 
-	const updateData = c.req.valid("json");
+	const { email, currentPassword, ...updateData } = c.req.valid("json");
 
 	const userRecord = await db.query.user.findFirst({
 		where: {
@@ -366,7 +368,7 @@ user.openapi(updateUser, async (c) => {
 	const authInfo = await getUserAuthInfo(authUser.id);
 
 	// Block email changes for users without password authentication
-	if (updateData.email && !authInfo.hasCredentialAccount) {
+	if (email && !authInfo.hasCredentialAccount) {
 		throw new HTTPException(400, {
 			message:
 				"Email cannot be changed for accounts without password authentication",
@@ -374,33 +376,7 @@ user.openapi(updateUser, async (c) => {
 	}
 
 	const emailChanged =
-		updateData.email !== undefined &&
-		updateData.email !== userRecord.email.toLowerCase();
-
-	// A new address is unproven until the owner clicks the verification link, so
-	// reject it if another account already holds it (clean 400 instead of a DB
-	// constraint 500) and drop `emailVerified` below. Skipping this let an
-	// attacker point their account at an invited/admin address and inherit its
-	// authority, since invite auto-accept and admin checks key on email.
-	// Compared via lower() to also catch legacy mixed-case rows the DB's
-	// case-sensitive unique constraint would treat as distinct.
-	if (emailChanged) {
-		const [existing] = await db
-			.select({ id: tables.user.id })
-			.from(tables.user)
-			.where(
-				and(
-					sql`lower(${tables.user.email}) = ${updateData.email}`,
-					ne(tables.user.id, authUser.id),
-				),
-			)
-			.limit(1);
-		if (existing) {
-			throw new HTTPException(400, {
-				message: "That email address is already in use",
-			});
-		}
-	}
+		email !== undefined && email !== userRecord.email.toLowerCase();
 
 	// Resolve the final state. `username` is only present in updateData when the
 	// client explicitly sends it (including null to clear it); otherwise the
@@ -433,15 +409,13 @@ user.openapi(updateUser, async (c) => {
 		}
 	}
 
+	if (emailChanged) {
+		await requestEmailChange(userRecord, email, currentPassword);
+	}
+
 	const [updatedUser] = await db
 		.update(tables.user)
-		.set({
-			...updateData,
-			// A changed address must be re-proven before it grants any authority.
-			// On self-hosted deployments the next sign-in re-verifies it (see
-			// auth/config.ts); on hosted the verification banner prompts the user.
-			...(emailChanged ? { emailVerified: false } : {}),
-		})
+		.set({ ...updateData, updatedAt: new Date() })
 		.where(eq(tables.user.id, authUser.id))
 		.returning();
 
@@ -454,7 +428,9 @@ user.openapi(updateUser, async (c) => {
 
 	return c.json({
 		user: toPublicUser(updatedUser, authInfo, isAdmin),
-		message: "User updated successfully",
+		message: emailChanged
+			? "Check your new email address to confirm the change. Your current address remains active until then."
+			: "User updated successfully",
 	});
 });
 

--- a/apps/api/src/routes/user.ts
+++ b/apps/api/src/routes/user.ts
@@ -335,6 +335,12 @@ const updateUser = createRoute({
 			},
 			description: "Too many email change requests.",
 		},
+		503: {
+			content: {
+				"application/json": { schema: z.object({ message: z.string() }) },
+			},
+			description: "Email delivery is not configured.",
+		},
 		404: {
 			content: {
 				"application/json": {
@@ -416,7 +422,12 @@ user.openapi(updateUser, async (c) => {
 	}
 
 	if (emailChanged) {
-		await requestEmailChange(userRecord, email, currentPassword);
+		await requestEmailChange(
+			userRecord,
+			email,
+			currentPassword,
+			c.req.raw.headers,
+		);
 	}
 
 	const [updatedUser] = await db

--- a/apps/api/src/routes/user.ts
+++ b/apps/api/src/routes/user.ts
@@ -329,6 +329,12 @@ const updateUser = createRoute({
 			},
 			description: "Unauthorized.",
 		},
+		429: {
+			content: {
+				"application/json": { schema: z.object({ message: z.string() }) },
+			},
+			description: "Too many email change requests.",
+		},
 		404: {
 			content: {
 				"application/json": {

--- a/apps/ui/src/app/confirm-email-change/layout.tsx
+++ b/apps/ui/src/app/confirm-email-change/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+	title: "Confirm Email Change",
+	robots: { index: false, follow: false },
+};
+
+export default function ConfirmEmailChangeLayout({
+	children,
+}: {
+	children: ReactNode;
+}) {
+	return children;
+}

--- a/apps/ui/src/app/confirm-email-change/page.tsx
+++ b/apps/ui/src/app/confirm-email-change/page.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/lib/components/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/lib/components/card";
+import { useApi } from "@/lib/fetch-client";
+
+export default function ConfirmEmailChangePage() {
+	const api = useApi();
+	const queryClient = useQueryClient();
+	const [token, setToken] = useState<string | null>(null);
+	const mutation = api.useMutation("post", "/user/email/confirm", {
+		onSuccess: () => queryClient.clear(),
+	});
+
+	useEffect(() => {
+		const fragment = window.location.hash.slice(1);
+		setToken((current) => current ?? fragment);
+		window.history.replaceState(null, "", window.location.pathname);
+	}, []);
+
+	const validToken = token !== null && /^[a-f0-9]{64}$/.test(token);
+
+	return (
+		<main className="flex min-h-screen items-center justify-center p-6">
+			<Card className="w-full max-w-md">
+				<CardHeader>
+					<CardTitle>
+						{mutation.isSuccess ? "Email updated" : "Confirm your new email"}
+					</CardTitle>
+					<CardDescription>
+						{mutation.isSuccess
+							? "Sign in with your new email address and existing password."
+							: "Confirm to use this address for sign-in and password recovery. You will be signed out on all devices."}
+					</CardDescription>
+				</CardHeader>
+				<CardContent className="space-y-4">
+					{mutation.isSuccess ? (
+						<Button asChild className="w-full">
+							<Link href="/login">Sign in</Link>
+						</Button>
+					) : (
+						<>
+							{token !== null && !validToken && (
+								<p role="alert" className="text-sm text-destructive">
+									This link is invalid. Request a new email change from your
+									account settings.
+								</p>
+							)}
+							{mutation.isError && (
+								<p role="alert" className="text-sm text-destructive">
+									This change could not be confirmed. The link may have expired
+									or the address may already be in use. Request a new link from
+									your account settings.
+								</p>
+							)}
+							<Button
+								className="w-full"
+								disabled={!validToken || mutation.isPending}
+								onClick={() => {
+									if (token) {
+										mutation.mutate({ body: { token } });
+									}
+								}}
+							>
+								{mutation.isPending ? "Confirming…" : "Confirm email change"}
+							</Button>
+						</>
+					)}
+				</CardContent>
+			</Card>
+		</main>
+	);
+}

--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/settings/account/account-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/settings/account/account-client.tsx
@@ -93,6 +93,8 @@ export function AccountClient() {
 
 	const [name, setName] = useState(user?.name ?? "");
 	const [email, setEmail] = useState(user?.email ?? "");
+	const [currentPassword, setCurrentPassword] = useState("");
+	const [pendingEmail, setPendingEmail] = useState("");
 
 	useEffect(() => {
 		if (user) {
@@ -105,6 +107,8 @@ export function AccountClient() {
 		(a) => a.providerId === "credential",
 	);
 	const emailEditable = !!hasCredentialAccount;
+	const emailChanged =
+		emailEditable && email.trim().toLowerCase() !== user?.email?.toLowerCase();
 
 	const socialProviders =
 		user?.accounts?.filter((a) => a.providerId !== "credential") ?? [];
@@ -123,16 +127,22 @@ export function AccountClient() {
 
 	const handleUpdateUser = async () => {
 		try {
-			await updateUserMutation.mutateAsync({
+			const result = await updateUserMutation.mutateAsync({
 				body: {
 					name: name ?? undefined,
-					email: emailEditable ? (email ?? undefined) : undefined,
+					email: emailChanged ? email : undefined,
+					currentPassword: emailChanged ? currentPassword : undefined,
 				},
 			});
 
+			if (emailChanged) {
+				setPendingEmail(email.trim().toLowerCase());
+				setEmail(result.user.email);
+			}
+			setCurrentPassword("");
 			toast({
 				title: "Success",
-				description: "Your account information has been updated.",
+				description: result.message,
 			});
 		} catch (error) {
 			toast({
@@ -195,6 +205,8 @@ export function AccountClient() {
 								<Label htmlFor="email">Email</Label>
 								<Input
 									id="email"
+									type="email"
+									autoComplete="email"
 									value={email}
 									onChange={(e) => setEmail(e.target.value)}
 									disabled={!emailEditable}
@@ -218,12 +230,39 @@ export function AccountClient() {
 									</div>
 								)}
 							</div>
+							{emailChanged && (
+								<div className="space-y-2">
+									<Label htmlFor="email-current-password">
+										Current password
+									</Label>
+									<Input
+										id="email-current-password"
+										type="password"
+										autoComplete="current-password"
+										value={currentPassword}
+										onChange={(event) => setCurrentPassword(event.target.value)}
+									/>
+									<p className="text-muted-foreground text-sm">
+										Confirm your new address by email before it replaces your
+										current sign-in and recovery address.
+									</p>
+								</div>
+							)}
+							{pendingEmail && (
+								<p role="status" className="text-muted-foreground text-sm">
+									Check {pendingEmail} for a confirmation link. Your current
+									email address remains active until you confirm.
+								</p>
+							)}
 						</CardContent>
 						<CardFooter className="flex justify-between">
 							<Button variant="outline">Cancel</Button>
 							<Button
 								onClick={handleUpdateUser}
-								disabled={updateUserMutation.isPending}
+								disabled={
+									updateUserMutation.isPending ||
+									(emailChanged && !currentPassword)
+								}
 							>
 								{updateUserMutation.isPending ? "Saving..." : "Save Changes"}
 							</Button>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@better-auth/core':
+        specifier: 1.6.26
+        version: 1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.75))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.0)
       '@better-auth/passkey':
         specifier: 1.6.26
         version: 1.6.26(@better-auth/core@1.6.26(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@3.25.75))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.5.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.6.26(@opentelemetry/api@1.9.0)(drizzle-orm@1.0.0-beta.1-fd5d1e8(@opentelemetry/api@1.9.0)(@types/pg@8.15.6)(kysely@0.28.17)(pg@8.16.3)(sql.js@1.13.0))(next@16.3.4(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.2.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.3.0(react@19.3.0))(react@19.3.0))(pg@8.16.3)(react-dom@19.3.0(react@19.3.0))(react@19.3.0)(vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.8.3))))(better-call@1.3.7(zod@3.25.75))(nanostores@1.5.0)


### PR DESCRIPTION
Email changes require the current password and confirmation from the new address. The old identity remains active until confirmation; password proofs, deliveries, and public confirmation attempts are throttled.

Confirmation revokes sessions and reset links, with transaction guards for concurrent password changes, resets, password sign-ins, and email verification. Reset email sends after commit and returns a generic response even on delivery failure. Hosted verification risk checks remain active. Production requires configured email delivery; development can opt into private local previews with `EMAIL_CHANGE_PREVIEW_DIR`.

Validation: `pnpm format --concurrency=2`; full `pnpm build --concurrency=2 --env-mode=loose`; 108 scoped user/email/auth/team tests and 49 hosted email tests. Tests cover transaction races, cookies/provisioning hooks, failed delivery, private previews, and throttling. Existing browser verification and screenshots remain applicable; mail and IP reputation are mocked in tests.

Known CI issue: the [unified Docker smoke check](https://github.com/theopenco/llmgateway/actions/runs/34688932478/job/103540706449) and split smoke check fail on Airside's main-branch `POSTHOG_HOST` validation when compose supplies an empty value. That configuration is unchanged by this PR.

| Screen | Light | Dark |
| --- | --- | --- |
| Account before | <img width="720" alt="Account before, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/e7ff14dcdf53e0a2d9d5c23be1743a4bbe166a68/account-before-light.png" /> | <img width="720" alt="Account before, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/e7ff14dcdf53e0a2d9d5c23be1743a4bbe166a68/account-before-dark.png" /> |
| Account after | <img width="720" alt="Account after, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/e7ff14dcdf53e0a2d9d5c23be1743a4bbe166a68/account-after-light.png" /> | <img width="720" alt="Account after, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/e7ff14dcdf53e0a2d9d5c23be1743a4bbe166a68/account-after-dark.png" /> |
| Email confirmation | <img width="720" alt="Email confirmation, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/e7ff14dcdf53e0a2d9d5c23be1743a4bbe166a68/confirm-email-light.png" /> | <img width="720" alt="Email confirmation, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/e7ff14dcdf53e0a2d9d5c23be1743a4bbe166a68/confirm-email-dark.png" /> |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added secure email-change verification requiring the current password and confirmation through a link.
  - Added account settings support for requesting changes and showing pending confirmation status.
  - Added a confirmation page with success and error states.
  - Added rate limiting and safeguards for requests and confirmations.
  - Added development previews for confirmation links.

- **Bug Fixes**
  - Email addresses are updated only after successful verification, with sessions invalidated afterward.
  - Improved password-reset and authentication processing to prevent conflicting simultaneous actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
