### PR TITLE
feat(skills): add model benchmark runner

### DIFF
--- a/.agents/skills/model-benchmarks/SKILL.md
+++ b/.agents/skills/model-benchmarks/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: model-benchmarks
+description: Run and report repository model or provider-mapping benchmarks. Use when asked to benchmark a model, compare all mappings or regions, collect latency or throughput metrics, run the smoke, standard, load, capability, quality, or performance suites, or inspect an existing benchmark JSON result.
+---
+
+# Model benchmarks
+
+Run paid benchmarks only when the user explicitly asks. Use the wrapper so raw
+results survive and failed evaluations still retain their timing data:
+
+```bash
+node .agents/skills/model-benchmarks/scripts/run-benchmark.mjs <model-id> [benchmark options]
+```
+
+The wrapper builds `@llmgateway/benchmarks`, creates an absolute output path,
+and writes results under `.context/benchmarks`. It defaults to every active
+mapping, the `smoke` profile, and a 120-second per-target budget. Override those
+defaults with ordinary CLI options, for example:
+
+```bash
+node .agents/skills/model-benchmarks/scripts/run-benchmark.mjs <model-id> \
+  --mapping <provider> --profile load --budget 300000
+```
+
+Do not pass `--output` or `--format`; the wrapper owns them. Set
+`BENCHMARK_OUTPUT_DIR` when results belong elsewhere. The benchmark CLI reads
+`LLM_GATEWAY_API_KEY`, falls back to `LLMGATEWAY_API_KEY`, and loads the root
+`.env` file.
+
+A budget is a maximum per target, not total run time. A request already in
+flight may finish after its target reaches the budget. Keep cache and fallback
+disabled unless the user explicitly asks otherwise, so results stay pinned to
+the selected mapping.
+
+The wrapper preserves:
+
+- `.json`: raw trials, responses, usage, cost, and stream events.
+- `.md` and `.html`: built-in benchmark reports.
+- `-timings.md`: timings grouped by target and case, including evaluator
+  failures.
+- `-timings.csv`: every trial's timing and usage fields.
+
+If rendering fails after JSON is saved, render it without rerunning paid
+requests:
+
+```bash
+node .agents/skills/model-benchmarks/scripts/render-results.mjs <absolute-json-path>
+```
+
+If a run makes requests but saves no JSON, report the loss and ask before
+rerunning. After completion, link the reports and summarize quality,
+reliability, TTFT, total latency, throughput, buffering, truncation, cost, and
+provider errors.

--- a/.agents/skills/model-benchmarks/scripts/render-results.mjs
+++ b/.agents/skills/model-benchmarks/scripts/render-results.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { extname, resolve } from "node:path";
+
+import { renderBenchmarkResult } from "../../../../packages/benchmarks/dist/src/reporters.js";
+import { summarizeNumbers } from "../../../../packages/benchmarks/dist/src/statistics.js";
+
+function formatNumber(value) {
+	return value === null || value === undefined ? "—" : value.toFixed(1);
+}
+
+function formatRate(numerator, denominator) {
+	return denominator === 0
+		? "—"
+		: `${numerator}/${denominator} (${((numerator / denominator) * 100).toFixed(1)}%)`;
+}
+
+function csvCell(value) {
+	if (value === null || value === undefined) {
+		return "";
+	}
+	const text = String(value);
+	return /[",\n]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+}
+
+const jsonArgument = process.argv[2];
+if (!jsonArgument || process.argv.length !== 3) {
+	throw new Error("Usage: render-results.mjs <benchmark.json>");
+}
+
+const jsonPath = resolve(jsonArgument);
+const result = JSON.parse(await readFile(jsonPath, "utf8"));
+if (
+	!Array.isArray(result.targets) ||
+	!Array.isArray(result.cases) ||
+	!Array.isArray(result.trials)
+) {
+	throw new Error(`${jsonPath} is not a benchmark result`);
+}
+
+const stem = jsonPath.slice(0, -extname(jsonPath).length);
+const markdownPath = `${stem}.md`;
+const htmlPath = `${stem}.html`;
+const timingsMarkdownPath = `${stem}-timings.md`;
+const timingsCsvPath = `${stem}-timings.csv`;
+
+const measuredTrials = result.trials.filter((trial) => !trial.warmup);
+const timingRows = [];
+for (const target of result.targets) {
+	for (const benchmarkCase of result.cases) {
+		const trials = measuredTrials.filter(
+			(trial) =>
+				trial.targetId === target.id && trial.caseId === benchmarkCase.id,
+		);
+		if (trials.length === 0) {
+			continue;
+		}
+		const successful = trials.filter(
+			(trial) => !trial.response.error && trial.response.timing,
+		);
+		const evaluated = trials.filter(
+			(trial) => typeof trial.evaluation?.passed === "boolean",
+		);
+		const metric = (key) =>
+			summarizeNumbers(successful.map((trial) => trial.response.timing[key]));
+		const buffered = successful.filter(
+			(trial) => trial.response.timing.buffered,
+		).length;
+		timingRows.push(
+			[
+				target.id,
+				benchmarkCase.id,
+				formatRate(successful.length, trials.length),
+				formatRate(
+					evaluated.filter((trial) => trial.evaluation.passed).length,
+					evaluated.length,
+				),
+				formatNumber(metric("headersMs")?.p50),
+				formatNumber(metric("firstContentMs")?.p50),
+				formatNumber(metric("firstContentMs")?.p90),
+				formatNumber(metric("totalMs")?.p50),
+				formatNumber(metric("totalMs")?.p90),
+				formatNumber(metric("visibleTokensPerSecond")?.p50),
+				formatNumber(metric("maxContentStallMs")?.p50),
+				formatRate(buffered, successful.length),
+			].join(" | "),
+		);
+	}
+}
+
+const timingsMarkdown = `# Benchmark timings
+
+Started: ${result.startedAt}
+
+Finished: ${result.finishedAt}
+
+These aggregates include every successful measured response with timing data,
+even when its evaluator failed. The built-in report only aggregates valid
+trials.
+
+| Target | Case | Request success | Evaluation pass | Headers p50 ms | TTFT p50 ms | TTFT p90 ms | Total p50 ms | Total p90 ms | Visible tok/s p50 | Stall p50 ms | Buffered |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+${timingRows.map((row) => `| ${row} |`).join("\n")}
+`;
+
+const csvHeaders = [
+	"targetId",
+	"caseId",
+	"run",
+	"warmup",
+	"evaluationPassed",
+	"responseError",
+	"finishReason",
+	"promptTokens",
+	"completionTokens",
+	"reasoningTokens",
+	"estimatedCostUsd",
+	"headersMs",
+	"firstEventMs",
+	"firstReasoningMs",
+	"firstContentMs",
+	"generationMs",
+	"totalMs",
+	"visibleTokensPerSecond",
+	"maxContentStallMs",
+	"averageContentChunkCharacters",
+	"finalContentBurstRatio",
+	"buffered",
+	"contentChunkCount",
+];
+const timingsCsv = [
+	csvHeaders.join(","),
+	...result.trials.map((trial) => {
+		const timing = trial.response.timing;
+		return [
+			trial.targetId,
+			trial.caseId,
+			trial.run,
+			trial.warmup,
+			trial.evaluation?.passed,
+			trial.response.error?.message,
+			trial.response.finishReason,
+			trial.response.usage.promptTokens,
+			trial.response.usage.completionTokens,
+			trial.response.usage.reasoningTokens,
+			trial.estimatedCostUsd,
+			timing?.headersMs,
+			timing?.firstEventMs,
+			timing?.firstReasoningMs,
+			timing?.firstContentMs,
+			timing?.generationMs,
+			timing?.totalMs,
+			timing?.visibleTokensPerSecond,
+			timing?.maxContentStallMs,
+			timing?.averageContentChunkCharacters,
+			timing?.finalContentBurstRatio,
+			timing?.buffered,
+			timing?.contentChunkCount,
+		]
+			.map(csvCell)
+			.join(",");
+	}),
+].join("\n");
+
+await Promise.all([
+	writeFile(markdownPath, renderBenchmarkResult(result, "markdown")),
+	writeFile(htmlPath, renderBenchmarkResult(result, "html")),
+	writeFile(timingsMarkdownPath, timingsMarkdown),
+	writeFile(timingsCsvPath, `${timingsCsv}\n`),
+]);
+
+process.stdout.write(
+	`${[jsonPath, markdownPath, htmlPath, timingsMarkdownPath, timingsCsvPath].join("\n")}\n`,
+);

--- a/.agents/skills/model-benchmarks/scripts/run-benchmark.mjs
+++ b/.agents/skills/model-benchmarks/scripts/run-benchmark.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = fileURLToPath(new URL("../../../../", import.meta.url));
+const rendererPath = fileURLToPath(
+	new URL("./render-results.mjs", import.meta.url),
+);
+
+const HELP = `Usage:
+  node .agents/skills/model-benchmarks/scripts/run-benchmark.mjs <model-id> [benchmark options]
+
+Defaults:
+  --mapping '*'
+  --profile smoke
+  --budget 120000
+
+Results are written beneath .context/benchmarks. Set BENCHMARK_OUTPUT_DIR to
+override that directory. Do not pass --output or --format.
+`;
+
+function hasOption(arguments_, names) {
+	return arguments_.some((argument) =>
+		names.some((name) => argument === name || argument.startsWith(`${name}=`)),
+	);
+}
+
+function run(command, arguments_) {
+	const result = spawnSync(command, arguments_, {
+		cwd: repositoryRoot,
+		env: process.env,
+		stdio: "inherit",
+	});
+	if (result.error) {
+		throw result.error;
+	}
+	return result.status ?? 1;
+}
+
+const arguments_ = process.argv.slice(2);
+if (arguments_.length === 0 || hasOption(arguments_, ["--help", "-h"])) {
+	process.stdout.write(HELP);
+	process.exit(arguments_.length === 0 ? 1 : 0);
+}
+
+const modelId = arguments_.shift();
+if (!modelId || modelId.startsWith("-")) {
+	throw new Error("The first argument must be a model id");
+}
+if (hasOption(arguments_, ["--model", "--output", "-o", "--format"])) {
+	throw new Error(
+		"Pass one positional model id and omit --output and --format",
+	);
+}
+
+const benchmarkArguments = ["--model", modelId, ...arguments_];
+if (!hasOption(arguments_, ["--mapping"])) {
+	benchmarkArguments.push("--mapping", "*");
+}
+if (!hasOption(arguments_, ["--profile", "--suite", "--external"])) {
+	benchmarkArguments.push("--profile", "smoke");
+}
+if (!hasOption(arguments_, ["--budget", "--no-budget"])) {
+	benchmarkArguments.push("--budget", "120000");
+}
+
+const outputDirectory = resolve(
+	repositoryRoot,
+	process.env.BENCHMARK_OUTPUT_DIR ?? ".context/benchmarks",
+);
+mkdirSync(outputDirectory, { recursive: true });
+const safeModelId = modelId.replaceAll(/[^a-zA-Z0-9._-]+/g, "-");
+const timestamp = new Date().toISOString().replaceAll(/[:.]/g, "-");
+const jsonPath = join(outputDirectory, `${safeModelId}-${timestamp}.json`);
+
+const buildStatus = run("pnpm", [
+	"turbo",
+	"run",
+	"build",
+	"--filter=@llmgateway/benchmarks",
+]);
+if (buildStatus !== 0) {
+	process.exit(buildStatus);
+}
+
+const benchmarkStatus = run("pnpm", [
+	"--filter",
+	"@llmgateway/benchmarks",
+	"benchmark",
+	"--",
+	...benchmarkArguments,
+	"--format",
+	"json",
+	"--output",
+	jsonPath,
+]);
+
+if (existsSync(jsonPath)) {
+	const renderStatus = run(process.execPath, [rendererPath, jsonPath]);
+	if (renderStatus !== 0) {
+		process.exit(renderStatus);
+	}
+}
+if (benchmarkStatus !== 0) {
+	process.exit(benchmarkStatus);
+}
+if (!existsSync(jsonPath)) {
+	throw new Error(`Benchmark completed without saving ${jsonPath}`);
+}

--- a/.claude/skills/model-benchmarks
+++ b/.claude/skills/model-benchmarks
@@ -1,0 +1,1 @@
+../../.agents/skills/model-benchmarks


### PR DESCRIPTION
## Problem

Benchmark output can be lost when relative paths resolve from the package working directory, and built-in summaries omit performance data for evaluator-failed trials.

## Changes

- add a repository-local model benchmark skill and Claude symlink
- default to all active mappings with a two-minute per-target budget
- save timestamped results under `.context/benchmarks` using absolute paths
- render JSON, Markdown, HTML, timing Markdown, and per-trial timing CSV artifacts
- allow saved JSON to be rendered again without paid model requests

## Verification

- repository skill audit
- standard skill validator
- runner and renderer syntax/help checks
- renderer tested against a saved benchmark result
- `pnpm format`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a model benchmarking workflow with configurable output locations, default smoke testing, per-target time limits, and support for environment-based API credentials.
  - Benchmark runs now preserve raw results along with Markdown, HTML, timing, and CSV reports.
  - Added the ability to render reports from previously saved benchmark results without rerunning requests.
  - Reports summarize quality, reliability, latency, throughput, cost, buffering, truncation, and provider errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->