### PR TITLE
fix: keep team invitations pending

### DIFF
--- a/apps/api/src/routes/project-admin.spec.ts
+++ b/apps/api/src/routes/project-admin.spec.ts
@@ -246,11 +246,23 @@ describe("project admin access", () => {
 			projectIds: [projectId],
 		});
 		expect(add.status).toBe(200);
-		const { member } = await add.json();
-		expect(member.projects).toEqual([{ id: projectId, name: projectId }]);
+		const { invite } = await add.json();
+		expect(invite.projects).toEqual([{ id: projectId, name: projectId }]);
+		expect(await getUserProjectIds("project-peer")).toEqual([]);
+		await acceptPendingInvitesForUser({
+			id: "project-peer",
+			email: "project-peer@example.com",
+		});
+		const member = await db.query.userOrganization.findFirst({
+			where: {
+				userId: { eq: "project-peer" },
+				organizationId: { eq: orgId },
+			},
+		});
+		expect(member).toBeDefined();
 		expect(await getUserProjectIds("project-peer")).toEqual([projectId]);
 		const change = await request(
-			`/team/${orgId}/members/${member.id}`,
+			`/team/${orgId}/members/${member!.id}`,
 			"PATCH",
 			{
 				role: "project_admin",
@@ -260,7 +272,7 @@ describe("project admin access", () => {
 		expect(change.status).toBe(200);
 		expect(await getUserProjectIds("project-peer")).toEqual([otherProjectId]);
 		expect(
-			(await request(`/team/${orgId}/members/${member.id}`, "DELETE")).status,
+			(await request(`/team/${orgId}/members/${member!.id}`, "DELETE")).status,
 		).toBe(200);
 		expect(await getUserProjectIds("project-peer")).toEqual([]);
 	});

--- a/apps/api/src/routes/team-invites.spec.ts
+++ b/apps/api/src/routes/team-invites.spec.ts
@@ -34,10 +34,13 @@ async function createAccountFor(userId: string, email: string) {
 
 // Signing in creates a new session, which runs the auth after-hook that
 // auto-accepts pending invites.
-async function signInAs(email: string) {
+async function signInAs(email: string, cookie?: string) {
 	return await app.request("/auth/sign-in/email", {
 		method: "POST",
-		headers: { "Content-Type": "application/json" },
+		headers: {
+			"Content-Type": "application/json",
+			...(cookie ? { Cookie: cookie } : {}),
+		},
 		body: JSON.stringify({ email, password: PASSWORD }),
 	});
 }
@@ -136,7 +139,7 @@ describe("team invites", () => {
 					organizationId: ORG_ID,
 					subject:
 						"You've been invited to Invite Test Organization on LLM Gateway",
-					text: expect.stringContaining("Sign in using this email address"),
+					text: expect.stringContaining("/login?reauthenticate=true"),
 				},
 			);
 
@@ -315,6 +318,34 @@ describe("team invites", () => {
 			expect(auditLogs).toHaveLength(1);
 		},
 	);
+
+	test("an existing session accepts an invitation only after signing in again", async () => {
+		await createAccountFor("invited-user-id", INVITED_EMAIL);
+		const initialSignIn = await signInAs(INVITED_EMAIL);
+		expect(initialSignIn.status).toBe(200);
+		const cookie = initialSignIn.headers.get("set-cookie")!;
+		await addMember({ email: INVITED_EMAIL, role: "admin" });
+
+		const session = await app.request("/auth/get-session", {
+			headers: { Cookie: cookie },
+		});
+		expect(session.status).toBe(200);
+		expect((await session.json()).user.email).toBe(INVITED_EMAIL);
+		const pending = await db.query.organizationInvite.findFirst({
+			where: { organizationId: { eq: ORG_ID } },
+		});
+		expect(pending?.status).toBe("pending");
+
+		const signIn = await signInAs(INVITED_EMAIL, cookie);
+		expect(signIn.status).toBe(200);
+		const accepted = await db.query.organizationInvite.findFirst({
+			where: { organizationId: { eq: ORG_ID } },
+		});
+		expect(accepted).toMatchObject({
+			status: "accepted",
+			acceptedByUserId: "invited-user-id",
+		});
+	});
 
 	test("developer invite grants the invited projects at acceptance", async () => {
 		await db.insert(tables.project).values({

--- a/apps/api/src/routes/team-invites.spec.ts
+++ b/apps/api/src/routes/team-invites.spec.ts
@@ -1,7 +1,8 @@
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { app } from "@/index.js";
 import { createTestUser, deleteAll } from "@/testing.js";
+import * as emailUtils from "@/utils/email.js";
 
 import { db, eq, tables } from "@llmgateway/db";
 import { hashApiKeyForStorage } from "@llmgateway/shared/api-key-hash";
@@ -46,6 +47,7 @@ describe("team invites", () => {
 
 	beforeEach(async () => {
 		token = await createTestUser();
+		vi.spyOn(emailUtils, "sendTransactionalEmail").mockResolvedValue(undefined);
 
 		await db.insert(tables.organization).values({
 			id: ORG_ID,
@@ -65,6 +67,7 @@ describe("team invites", () => {
 	});
 
 	afterEach(async () => {
+		vi.restoreAllMocks();
 		await deleteAll();
 	});
 
@@ -79,36 +82,78 @@ describe("team invites", () => {
 		});
 	}
 
-	test("adding an unknown email creates a pending invite", async () => {
-		const response = await addMember({ email: INVITED_EMAIL, role: "admin" });
+	test.each([false, true])(
+		"creates the same pending invitation when registered=%s",
+		async (registered) => {
+			let recipientToken: string | null = null;
+			if (registered) {
+				await createAccountFor("invited-user-id", INVITED_EMAIL);
+				const signIn = await signInAs(INVITED_EMAIL);
+				expect(signIn.status).toBe(200);
+				recipientToken = signIn.headers.get("set-cookie");
+			}
+			vi.mocked(emailUtils.sendTransactionalEmail).mockClear();
 
-		expect(response.status).toBe(200);
-		const body = await response.json();
-		expect(body.member).toBeNull();
-		expect(body.invite).toMatchObject({
-			email: INVITED_EMAIL,
-			role: "admin",
-			projects: null,
-		});
+			const response = await addMember({ email: INVITED_EMAIL, role: "admin" });
+			expect(response.status).toBe(200);
+			const body = await response.json();
+			expect(body).toEqual({
+				message: "Invitation sent",
+				member: null,
+				invite: {
+					id: expect.any(String),
+					email: INVITED_EMAIL,
+					role: "admin",
+					projects: null,
+					createdAt: expect.any(String),
+					expiresAt: expect.any(String),
+				},
+			});
 
-		const invite = await db.query.organizationInvite.findFirst({
-			where: { organizationId: { eq: ORG_ID } },
-		});
-		expect(invite).toMatchObject({
-			email: INVITED_EMAIL,
-			role: "admin",
-			status: "pending",
-			invitedBy: "test-user-id",
-		});
+			const listed = await app.request(`/team/${ORG_ID}/members`, {
+				headers: { Cookie: token },
+			});
+			expect(listed.status).toBe(200);
+			const listing = await listed.json();
+			expect(listing.members).toHaveLength(1);
+			expect(listing.members[0].userId).toBe("test-user-id");
+			expect(listing.invites).toEqual([body.invite]);
 
-		const auditLogs = await db.query.auditLog.findMany({
-			where: {
-				organizationId: { eq: ORG_ID },
-				action: { eq: "team_member.invite" },
-			},
-		});
-		expect(auditLogs).toHaveLength(1);
-	});
+			const invite = await db.query.organizationInvite.findFirst({
+				where: { organizationId: { eq: ORG_ID } },
+			});
+			expect(invite).toMatchObject({
+				email: INVITED_EMAIL,
+				role: "admin",
+				status: "pending",
+				invitedBy: "test-user-id",
+				acceptedAt: null,
+				acceptedByUserId: null,
+			});
+			expect(emailUtils.sendTransactionalEmail).toHaveBeenCalledExactlyOnceWith(
+				{
+					to: INVITED_EMAIL,
+					organizationId: ORG_ID,
+					subject:
+						"You've been invited to Invite Test Organization on LLM Gateway",
+					text: expect.stringContaining("Sign in using this email address"),
+				},
+			);
+
+			if (recipientToken) {
+				const access = await app.request(`/team/${ORG_ID}/members`, {
+					headers: { Cookie: recipientToken },
+				});
+				expect(access.status).toBe(403);
+			}
+
+			const auditLogs = await db.query.auditLog.findMany({
+				where: { organizationId: { eq: ORG_ID } },
+			});
+			expect(auditLogs).toHaveLength(1);
+			expect(auditLogs[0]?.action).toBe("team_member.invite");
+		},
+	);
 
 	test("invite emails are normalized to lowercase", async () => {
 		const response = await addMember({
@@ -123,11 +168,54 @@ describe("team invites", () => {
 		expect(invite?.email).toBe(INVITED_EMAIL);
 	});
 
-	test("duplicate pending invite is rejected", async () => {
+	test("registration does not change duplicate invitation behavior", async () => {
 		await addMember({ email: INVITED_EMAIL, role: "admin" });
+		await createAccountFor("invited-user-id", INVITED_EMAIL);
 		const response = await addMember({ email: INVITED_EMAIL, role: "admin" });
 
 		expect(response.status).toBe(400);
+		expect((await response.json()).message).toBe(
+			"An invitation for this email is already pending",
+		);
+	});
+
+	test.each(["developer", "project_admin", "outsider"] as const)(
+		"%s cannot invite members",
+		async (role) => {
+			if (role === "outsider") {
+				await db
+					.delete(tables.userOrganization)
+					.where(eq(tables.userOrganization.organizationId, ORG_ID));
+			} else {
+				await db
+					.update(tables.userOrganization)
+					.set({ role })
+					.where(eq(tables.userOrganization.organizationId, ORG_ID));
+			}
+			expect(
+				(await addMember({ email: INVITED_EMAIL, role: "admin" })).status,
+			).toBe(403);
+			expect(await db.query.organizationInvite.findMany()).toHaveLength(0);
+			expect(emailUtils.sendTransactionalEmail).not.toHaveBeenCalled();
+		},
+	);
+
+	test("admins cannot invite owners", async () => {
+		await db
+			.update(tables.userOrganization)
+			.set({ role: "admin" })
+			.where(eq(tables.userOrganization.organizationId, ORG_ID));
+		expect(
+			(await addMember({ email: INVITED_EMAIL, role: "owner" })).status,
+		).toBe(403);
+		expect(await db.query.organizationInvite.findMany()).toHaveLength(0);
+	});
+
+	test("already joined members cannot be invited again", async () => {
+		expect(
+			(await addMember({ email: "ADMIN@EXAMPLE.COM", role: "admin" })).status,
+		).toBe(400);
+		expect(await db.query.organizationInvite.findMany()).toHaveLength(0);
 	});
 
 	test("pending invites are listed and count toward the seat limit", async () => {
@@ -189,37 +277,44 @@ describe("team invites", () => {
 		expect(body.members[0]?.spend.activeApiKeys).toBe(1);
 	});
 
-	test("pending invite is auto-accepted on first sign-in", async () => {
-		await addMember({ email: INVITED_EMAIL, role: "admin" });
+	test.each([false, true])(
+		"pending invite is accepted on sign-in when registered=%s",
+		async (registered) => {
+			if (registered) {
+				await createAccountFor("invited-user-id", INVITED_EMAIL);
+			}
+			await addMember({ email: INVITED_EMAIL, role: "admin" });
+			if (!registered) {
+				await createAccountFor("invited-user-id", INVITED_EMAIL);
+			}
+			const signIn = await signInAs(INVITED_EMAIL);
+			expect(signIn.status).toBe(200);
 
-		await createAccountFor("invited-user-id", INVITED_EMAIL);
-		const signIn = await signInAs(INVITED_EMAIL);
-		expect(signIn.status).toBe(200);
+			const memberships = await db.query.userOrganization.findMany({
+				where: { userId: { eq: "invited-user-id" } },
+			});
+			// Joined the invited org only — no personal default org was created.
+			expect(memberships).toHaveLength(1);
+			expect(memberships[0]).toMatchObject({
+				organizationId: ORG_ID,
+				role: "admin",
+			});
 
-		const memberships = await db.query.userOrganization.findMany({
-			where: { userId: { eq: "invited-user-id" } },
-		});
-		// Joined the invited org only — no personal default org was created.
-		expect(memberships).toHaveLength(1);
-		expect(memberships[0]).toMatchObject({
-			organizationId: ORG_ID,
-			role: "admin",
-		});
+			const invite = await db.query.organizationInvite.findFirst({
+				where: { organizationId: { eq: ORG_ID } },
+			});
+			expect(invite?.status).toBe("accepted");
+			expect(invite?.acceptedByUserId).toBe("invited-user-id");
 
-		const invite = await db.query.organizationInvite.findFirst({
-			where: { organizationId: { eq: ORG_ID } },
-		});
-		expect(invite?.status).toBe("accepted");
-		expect(invite?.acceptedByUserId).toBe("invited-user-id");
-
-		const auditLogs = await db.query.auditLog.findMany({
-			where: {
-				organizationId: { eq: ORG_ID },
-				action: { eq: "team_member.invite_accept" },
-			},
-		});
-		expect(auditLogs).toHaveLength(1);
-	});
+			const auditLogs = await db.query.auditLog.findMany({
+				where: {
+					organizationId: { eq: ORG_ID },
+					action: { eq: "team_member.invite_accept" },
+				},
+			});
+			expect(auditLogs).toHaveLength(1);
+		},
+	);
 
 	test("developer invite grants the invited projects at acceptance", async () => {
 		await db.insert(tables.project).values({

--- a/apps/api/src/routes/team.ts
+++ b/apps/api/src/routes/team.ts
@@ -3,10 +3,6 @@ import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 
 import {
-	EnterpriseSeatLimitError,
-	withEnterpriseSeatForOrganization,
-} from "@/lib/enterprise-seats.js";
-import {
 	assertEnterpriseForIpCidrRule,
 	createIamRuleSchema,
 	iamRuleStatusEnum,
@@ -750,15 +746,14 @@ const addMember = createRoute({
 				"application/json": {
 					schema: z.object({
 						message: z.string(),
-						// Set when the email already had an account and was added directly.
+						// Kept for compatibility; invitations do not activate membership.
 						member: teamMemberSchema.nullable(),
-						// Set when the email has no account yet: a pending invitation that
-						// is auto-accepted when they sign up (email, SSO, or SCIM).
+						// Pending until the recipient signs in with a verified email.
 						invite: teamInviteSchema.nullable(),
 					}),
 				},
 			},
-			description: "Member added or invitation sent",
+			description: "Invitation sent",
 		},
 	},
 });
@@ -831,6 +826,7 @@ team.openapi(addMember, async (c) => {
 				eq: organizationId,
 			},
 		},
+		with: { user: { columns: { email: true } } },
 	});
 
 	// Pending invites reserve a seat so accepted invites can't blow the cap.
@@ -862,47 +858,50 @@ team.openapi(addMember, async (c) => {
 
 	const normalizedEmail = email.trim().toLowerCase();
 
-	const targetUser = await db.query.user.findFirst({
-		where: {
-			email: {
-				eq: normalizedEmail,
-			},
-		},
-	});
+	if (
+		currentMembers.some(
+			(member) => member.user?.email.trim().toLowerCase() === normalizedEmail,
+		)
+	) {
+		throw new HTTPException(400, {
+			message: "User is already a member of this organization",
+		});
+	}
 
-	// No account with this email yet: create a pending invitation that is
-	// auto-accepted when they sign up (email/social/SSO) or are provisioned via
-	// SCIM, and email them a signup link.
-	if (!targetUser) {
-		if (pendingInvites.some((invite) => invite.email === normalizedEmail)) {
-			throw new HTTPException(400, {
-				message: "An invitation for this email is already pending",
-			});
-		}
+	// Use the same invitation flow regardless of whether an account exists.
+	if (pendingInvites.some((invite) => invite.email === normalizedEmail)) {
+		throw new HTTPException(400, {
+			message: "An invitation for this email is already pending",
+		});
+	}
 
-		const [invite] = await db
-			.insert(tables.organizationInvite)
-			.values({
-				organizationId,
-				email: normalizedEmail,
-				role,
-				projectIds: isProjectScopedRole(role)
-					? grantedProjects.map((p) => p.id)
-					: null,
-				invitedBy: authUser.id,
-				expiresAt: new Date(Date.now() + INVITE_EXPIRY_MS),
-			})
-			.returning();
+	const [invite] = await db
+		.insert(tables.organizationInvite)
+		.values({
+			organizationId,
+			email: normalizedEmail,
+			role,
+			projectIds: isProjectScopedRole(role)
+				? grantedProjects.map((p) => p.id)
+				: null,
+			invitedBy: authUser.id,
+			expiresAt: new Date(Date.now() + INVITE_EXPIRY_MS),
+		})
+		.returning();
 
-		const orgName = userOrganization.organization?.name ?? "an organization";
-		const inviterName = authUser.name?.trim() || authUser.email;
-		const uiUrl = process.env.UI_URL ?? "http://localhost:3002";
+	const orgName = userOrganization.organization?.name ?? "an organization";
+	const inviterName = authUser.name?.trim() || authUser.email;
+	const uiUrl = process.env.UI_URL ?? "http://localhost:3002";
 
-		const text = `Hey!
+	const text = `Hey!
 
 ${inviterName} invited you to join the "${orgName}" organization on LLM Gateway as ${role === "admin" ? "an" : "a"} ${role === "project_admin" ? "project admin" : role}.
 
-Create an account using this email address (${normalizedEmail}) and you'll be added to the organization automatically:
+Sign in using this email address (${normalizedEmail}) to join the organization automatically:
+
+${uiUrl}/login
+
+If you do not have an account yet, create one and verify this email address:
 
 ${uiUrl}/signup
 
@@ -912,127 +911,37 @@ This invitation expires in ${INVITE_EXPIRY_DAYS} days. If you weren't expecting 
 
 — The LLM Gateway Team`.trim();
 
-		await sendTransactionalEmail({
-			to: normalizedEmail,
-			subject: `You've been invited to ${orgName} on LLM Gateway`,
-			text,
-			organizationId,
-		});
-
-		await logAuditEvent({
-			organizationId,
-			userId: authUser.id,
-			action: "team_member.invite",
-			resourceType: "team_invite",
-			resourceId: invite.id,
-			metadata: {
-				targetUserEmail: normalizedEmail,
-				role,
-				projectIds: grantedProjects.map((p) => p.id),
-			},
-		});
-
-		return c.json({
-			message: "Invitation sent",
-			member: null,
-			invite: {
-				id: invite.id,
-				email: invite.email,
-				role: invite.role,
-				createdAt: invite.createdAt,
-				expiresAt: invite.expiresAt,
-				projects: isProjectScopedRole(role) ? grantedProjects : null,
-			},
-		});
-	}
-
-	const existingMember = await db.query.userOrganization.findFirst({
-		where: {
-			userId: {
-				eq: targetUser.id,
-			},
-			organizationId: {
-				eq: organizationId,
-			},
-		},
+	await sendTransactionalEmail({
+		to: normalizedEmail,
+		subject: `You've been invited to ${orgName} on LLM Gateway`,
+		text,
+		organizationId,
 	});
-
-	if (existingMember) {
-		throw new HTTPException(400, {
-			message: "User is already a member of this organization",
-		});
-	}
-
-	let newMember: typeof tables.userOrganization.$inferSelect;
-	try {
-		[newMember] = await withEnterpriseSeatForOrganization(
-			organizationId,
-			targetUser.id,
-			async (tx) =>
-				await tx
-					.insert(tables.userOrganization)
-					.values({
-						userId: targetUser.id,
-						organizationId,
-						role,
-					})
-					.returning(),
-		);
-	} catch (error) {
-		if (error instanceof EnterpriseSeatLimitError) {
-			throw new HTTPException(403, { message: error.message });
-		}
-		throw error;
-	}
-
-	if (isProjectScopedRole(role)) {
-		await cdb.transaction(async (tx) => {
-			await syncMemberProjects(
-				newMember.id,
-				grantedProjects.map((p) => p.id),
-				tx,
-			);
-		});
-		if (role === "developer") {
-			await recomputeUserTeam(targetUser.id, organizationId);
-		}
-	}
 
 	await logAuditEvent({
 		organizationId,
 		userId: authUser.id,
-		action: "team_member.add",
-		resourceType: "team_member",
-		resourceId: newMember.id,
+		action: "team_member.invite",
+		resourceType: "team_invite",
+		resourceId: invite.id,
 		metadata: {
-			targetUserId: targetUser.id,
-			targetUserEmail: email,
+			targetUserEmail: normalizedEmail,
 			role,
 			projectIds: grantedProjects.map((p) => p.id),
 		},
 	});
 
 	return c.json({
-		message: "Member added successfully",
-		member: {
-			id: newMember.id,
-			userId: newMember.userId,
-			role: newMember.role,
-			createdAt: newMember.createdAt,
-			user: {
-				id: targetUser.id,
-				email: targetUser.email,
-				name: targetUser.name,
-			},
-			budget: budgetFromRow(newMember),
-			effectiveBudget: budgetFromRow(newMember),
-			spend: EMPTY_SPEND,
-			team: null,
-			teamBudget: null,
-			personalProjects: isProjectScopedRole(role) ? grantedProjects : null,
+		message: "Invitation sent",
+		member: null,
+		invite: {
+			id: invite.id,
+			email: invite.email,
+			role: invite.role,
+			createdAt: invite.createdAt,
+			expiresAt: invite.expiresAt,
 			projects: isProjectScopedRole(role) ? grantedProjects : null,
 		},
-		invite: null,
 	});
 });
 

--- a/apps/api/src/routes/team.ts
+++ b/apps/api/src/routes/team.ts
@@ -476,8 +476,7 @@ const getMembers = createRoute({
 				"application/json": {
 					schema: z.object({
 						members: z.array(teamMemberSchema).openapi({}),
-						// Pending invitations to people without an account yet; they join
-						// automatically when they sign up (or are SCIM-provisioned).
+						// Pending invitations are accepted on verified sign-in or provisioning.
 						invites: z.array(teamInviteSchema),
 						// The org-wide default developer budget (owner/admin only).
 						defaultDeveloperBudget: memberBudgetSchema.nullable(),
@@ -899,7 +898,7 @@ ${inviterName} invited you to join the "${orgName}" organization on LLM Gateway 
 
 Sign in using this email address (${normalizedEmail}) to join the organization automatically:
 
-${uiUrl}/login
+${uiUrl}/login?reauthenticate=true
 
 If you do not have an account yet, create one and verify this email address:
 

--- a/apps/ui/e2e/team-invites.pw.ts
+++ b/apps/ui/e2e/team-invites.pw.ts
@@ -1,0 +1,108 @@
+import { expect, test } from "@playwright/test";
+
+const apiUrl = process.env.PW_API_URL ?? "http://localhost:4002";
+const orgId = "test-org-id";
+const recipientEmail = "enterprise@example.com";
+const invitationLoginPath = "/login?reauthenticate=true";
+
+test("a signed-in recipient can follow an invitation and sign in again", async ({
+	page,
+	request,
+}) => {
+	const owner = await request.post(`${apiUrl}/auth/sign-in/email`, {
+		data: { email: "admin@example.com", password: "admin@example.com" },
+	});
+	expect(owner.status()).toBe(200);
+	const recipient = await page.request.post(`${apiUrl}/auth/sign-in/email`, {
+		data: { email: recipientEmail, password: recipientEmail },
+	});
+	expect(recipient.status()).toBe(200);
+	await page.goto("/login");
+	await expect(page).toHaveURL(/\/(?:dashboard|onboarding)(?:\/|$)/);
+
+	const created = await request.post(`${apiUrl}/team/${orgId}/members`, {
+		data: { email: recipientEmail, role: "admin" },
+	});
+	expect(created.status()).toBe(200);
+	const { invite, member } = await created.json();
+	try {
+		expect(member).toBeNull();
+		await page.goto(invitationLoginPath, { waitUntil: "networkidle" });
+		await expect(page).toHaveURL(/\/login\?reauthenticate=true$/);
+		await expect(page.getByLabel("Email", { exact: true })).toBeVisible();
+		expect(
+			(await page.request.get(`${apiUrl}/team/${orgId}/members`)).status(),
+		).toBe(403);
+		const pending = await request.get(`${apiUrl}/team/${orgId}/members`);
+		expect((await pending.json()).invites).toContainEqual(invite);
+
+		await page.getByLabel("Email", { exact: true }).fill(recipientEmail);
+		await page.locator('input[type="password"]').fill(recipientEmail);
+		await page.getByRole("button", { name: "Sign in", exact: true }).click();
+		await expect(page).toHaveURL(/\/(?:dashboard|onboarding)(?:\/|$)/);
+		const accepted = await page.request.get(`${apiUrl}/team/${orgId}/members`);
+		expect(accepted.status()).toBe(200);
+		const listing = await accepted.json();
+		expect(listing.invites).toHaveLength(0);
+		expect(listing.members).toContainEqual(
+			expect.objectContaining({
+				role: "admin",
+				user: expect.objectContaining({ email: recipientEmail }),
+			}),
+		);
+	} finally {
+		const response = await request.get(`${apiUrl}/team/${orgId}/members`);
+		const listing = await response.json();
+		const acceptedMember = listing.members.find(
+			(item: { user: { email: string } }) => item.user.email === recipientEmail,
+		);
+		const path = acceptedMember
+			? `/members/${acceptedMember.id}`
+			: `/invites/${invite.id}`;
+		expect(
+			(await request.delete(`${apiUrl}/team/${orgId}${path}`)).status(),
+		).toBe(200);
+	}
+});
+
+test("reauthentication survives SSO navigation and errors", async ({
+	page,
+}) => {
+	const signedIn = await page.request.post(`${apiUrl}/auth/sign-in/email`, {
+		data: { email: recipientEmail, password: recipientEmail },
+	});
+	expect(signedIn.status()).toBe(200);
+	await page.goto(invitationLoginPath);
+	await page
+		.getByRole("button", { name: "Sign in with SSO", exact: true })
+		.click();
+	await expect(page).toHaveURL(/\/sso\?/);
+	expect(new URL(page.url()).searchParams.get("reauthenticate")).toBe("true");
+	await page.getByLabel("Email", { exact: true }).fill(recipientEmail);
+	let errorCallback = "";
+	await page.route(`${apiUrl}/auth/sign-in/sso`, async (route) => {
+		errorCallback = route.request().postDataJSON().errorCallbackURL;
+		expect(new URL(errorCallback).searchParams.get("reauthenticate")).toBe(
+			"true",
+		);
+		await route.fulfill({
+			status: 400,
+			contentType: "application/json",
+			body: JSON.stringify({ message: "Test identity provider unavailable" }),
+		});
+	});
+	await page
+		.getByRole("button", { name: "Continue with SSO", exact: true })
+		.click();
+	await expect(
+		page.getByText("Test identity provider unavailable").first(),
+	).toBeVisible();
+	await page.goto(`${errorCallback}&error=access_denied`);
+	await expect(page.getByLabel("Email", { exact: true })).toHaveValue(
+		recipientEmail,
+	);
+	await page.getByRole("link", { name: "Back to login", exact: true }).click();
+	await expect(page).toHaveURL(/\/login\?/);
+	expect(new URL(page.url()).searchParams.get("reauthenticate")).toBe("true");
+	await expect(page.getByLabel("Email", { exact: true })).toBeVisible();
+});

--- a/apps/ui/src/app/dashboard/[orgId]/org/team/team-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/org/team/team-client.tsx
@@ -863,7 +863,7 @@ export function TeamClient({ initialData }: { initialData?: TeamMembersData }) {
 			return;
 		}
 
-		const result = await addMemberMutation.mutateAsync({
+		await addMemberMutation.mutateAsync({
 			params: {
 				path: {
 					organizationId,
@@ -879,9 +879,8 @@ export function TeamClient({ initialData }: { initialData?: TeamMembersData }) {
 		});
 		toast({
 			title: "Success",
-			description: result.invite
-				? "Invitation sent — they'll join automatically once they sign up with this email."
-				: "Team member added successfully",
+			description:
+				"Invitation sent — they'll join after signing in or signing up with this email.",
 		});
 		setEmail("");
 		setRole("developer");
@@ -982,10 +981,9 @@ export function TeamClient({ initialData }: { initialData?: TeamMembersData }) {
 									<DialogHeader>
 										<DialogTitle>Add Team Member</DialogTitle>
 										<DialogDescription>
-											Add a new member to your organization by entering their
-											email address. If they don't have an account yet, we'll
-											email them an invitation and they'll join automatically
-											when they sign up (including via SSO).
+											Invite a new member by email. They'll join automatically
+											after signing in or creating an account with that email
+											address, including via SSO.
 										</DialogDescription>
 									</DialogHeader>
 									<div className="space-y-4 py-4">
@@ -1400,9 +1398,9 @@ export function TeamClient({ initialData }: { initialData?: TeamMembersData }) {
 							<CardHeader>
 								<CardTitle>Pending Invitations</CardTitle>
 								<CardDescription>
-									People invited by email who haven't created an account yet.
-									They'll join automatically when they sign up — via email, SSO,
-									or SCIM provisioning.
+									People invited by email who haven't joined yet. They'll join
+									after signing in or signing up with their invited email,
+									including via SSO or SCIM provisioning.
 								</CardDescription>
 							</CardHeader>
 							<CardContent>

--- a/apps/ui/src/app/login/page.tsx
+++ b/apps/ui/src/app/login/page.tsx
@@ -58,11 +58,13 @@ export default function Login() {
 
 	const searchParams = useSearchParams();
 	const redirectTarget = getAuthRedirect(searchParams.get("redirect"));
+	const reauthenticate = searchParams.get("reauthenticate") === "true";
+	const loginPath = reauthenticate ? "/login?reauthenticate=true" : "/login";
 
 	const { isAuthenticated } = useSessionStatus();
 
 	useUser({
-		redirectTo: redirectTarget,
+		redirectTo: reauthenticate ? undefined : redirectTarget,
 		redirectWhen: "authenticated",
 		checkOnboarding: !isCliAuthRedirect(redirectTarget),
 		enabled: isAuthenticated,
@@ -192,6 +194,9 @@ export default function Login() {
 			// email — clearer than the full email+password form when SSO only needs
 			// the email. Carry over whatever they've already typed.
 			const query = new URLSearchParams({ redirect: redirectTarget });
+			if (reauthenticate) {
+				query.set("reauthenticate", "true");
+			}
 			if (email) {
 				query.set("email", email);
 			}
@@ -208,7 +213,7 @@ export default function Login() {
 			// Carry the validated `?redirect=` target through the error path too, so a
 			// failed SSO attempt returns to /login with the intended destination and a
 			// retry still lands the user there.
-			const errorUrl = new URL("/login", origin);
+			const errorUrl = new URL(loginPath, origin);
 			if (redirectTarget !== "/dashboard") {
 				errorUrl.searchParams.set("redirect", redirectTarget);
 			}
@@ -354,7 +359,7 @@ export default function Login() {
 					isLoading={isLoading}
 					setIsLoading={setIsLoading}
 					callbackPath={redirectTarget}
-					errorCallbackPath="/login"
+					errorCallbackPath={loginPath}
 					newUserCallbackPath={redirectTarget}
 				/>
 

--- a/apps/ui/src/app/login/page.tsx
+++ b/apps/ui/src/app/login/page.tsx
@@ -173,6 +173,7 @@ export default function Login() {
 				});
 				return;
 			}
+			queryClient.clear();
 			posthog.capture("user_logged_in", { method: "passkey" });
 			toast({ title: "Login successful" });
 			router.push(redirectTarget as Route);

--- a/apps/ui/src/app/sso/page.tsx
+++ b/apps/ui/src/app/sso/page.tsx
@@ -44,20 +44,26 @@ export default function Sso() {
 
 	const searchParams = useSearchParams();
 	const redirectTarget = getAuthRedirect(searchParams.get("redirect"));
+	const reauthenticate = searchParams.get("reauthenticate") === "true";
+	const loginQuery = new URLSearchParams({ redirect: redirectTarget });
+	if (reauthenticate) {
+		loginQuery.set("reauthenticate", "true");
+	}
+	const loginPath = `/login?${loginQuery.toString()}` as Route;
 
 	const defaultEmail = searchParams.get("email") ?? "";
 
 	useUser({
-		redirectTo: redirectTarget,
+		redirectTo: reauthenticate ? undefined : redirectTarget,
 		redirectWhen: "authenticated",
 		checkOnboarding: !isCliAuthRedirect(redirectTarget),
 	});
 
 	useEffect(() => {
 		if (!ssoEnabled) {
-			router.replace(`/login?redirect=${encodeURIComponent(redirectTarget)}`);
+			router.replace(loginPath);
 		}
-	}, [ssoEnabled, router, redirectTarget]);
+	}, [ssoEnabled, router, loginPath]);
 
 	useEffect(() => {
 		posthog.capture("page_viewed_sso");
@@ -90,6 +96,9 @@ export default function Sso() {
 			const errorUrl = new URL("/sso", location.origin);
 			errorUrl.searchParams.set("redirect", redirectTarget);
 			errorUrl.searchParams.set("email", values.email);
+			if (reauthenticate) {
+				errorUrl.searchParams.set("reauthenticate", "true");
+			}
 			const res = await signIn.sso({
 				email: values.email,
 				callbackURL: location.protocol + "//" + location.host + redirectTarget,
@@ -172,11 +181,7 @@ export default function Sso() {
 				</Form>
 
 				<Button asChild variant="ghost" className="w-full">
-					<Link
-						href={
-							`/login?redirect=${encodeURIComponent(redirectTarget)}` as Route
-						}
-					>
+					<Link href={loginPath}>
 						<ArrowLeft className="mr-2 h-4 w-4" />
 						Back to login
 					</Link>


### PR DESCRIPTION
Team invitations treated existing accounts differently from new ones. Send every nonmember the same pending invitation and notification, then apply the existing membership, project, and seat checks on verified sign-in or provisioning.

Invitation links explicitly allow signing in again, so recipients with an existing session can join without signing out first. Preserve that flow through SSO navigation and social-login retries, refresh cached account data after manual passkey sign-in, and update the team screen's invitation text.

Validation: full `pnpm format` and `pnpm build`; team invitation, IAM, project-admin, enterprise-seat, and authentication-redirect tests; browser invitation/revocation checks in both themes, signed-in recipient acceptance using the actual emailed URL, and SSO retry coverage.

Screenshots use locally seeded data.

| Screen | Before | After |
| --- | --- | --- |
| Invitation result, light | <img width="720" alt="Invitation result, before, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/56da01116733b7eca5b00fa954a733871be8e3ba/team-invites-before-light.png" /> | <img width="720" alt="Invitation result, after, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/56da01116733b7eca5b00fa954a733871be8e3ba/team-invites-after-light.png" /> |
| Invitation result, dark | <img width="720" alt="Invitation result, before, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/56da01116733b7eca5b00fa954a733871be8e3ba/team-invites-before-dark.png" /> | <img width="720" alt="Invitation result, after, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/56da01116733b7eca5b00fa954a733871be8e3ba/team-invites-after-dark.png" /> |
| Add member dialog, light | <img width="720" alt="Add member dialog, before, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/56da01116733b7eca5b00fa954a733871be8e3ba/team-invites-before-light-dialog.png" /> | <img width="720" alt="Add member dialog, after, light theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/56da01116733b7eca5b00fa954a733871be8e3ba/team-invites-after-light-dialog.png" /> |
| Add member dialog, dark | <img width="720" alt="Add member dialog, before, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/56da01116733b7eca5b00fa954a733871be8e3ba/team-invites-before-dark-dialog.png" /> | <img width="720" alt="Add member dialog, after, dark theme" src="https://raw.githubusercontent.com/theopenco/llmgateway/56da01116733b7eca5b00fa954a733871be8e3ba/team-invites-after-dark-dialog.png" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Team invitations now remain pending until the recipient signs in or signs up with the invited email, including through SSO or SCIM provisioning.
  - Added reauthentication support for invitation acceptance, including preserved login state across SSO redirects and error flows.
  - Invitation messaging and status descriptions now clearly explain when recipients gain team access.

- **Bug Fixes**
  - Prevented unauthorized roles from inviting members or owners.
  - Prevented invitations from being sent to people who have already joined the team.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->