### PR TITLE
fix: classify blocked redirects as client errors

### DIFF
--- a/apps/gateway/src/chat/chat.ts
+++ b/apps/gateway/src/chat/chat.ts
@@ -78,6 +78,7 @@ import {
 import { rateLimitHeaders } from "@/lib/error-schemas.js";
 import { standardErrorResponses } from "@/lib/error-schemas.js";
 import { createFailedKeyTracker } from "@/lib/failed-key-tracker.js";
+import { fetchProvider } from "@/lib/fetch-provider.js";
 import {
 	getGcpAccessToken,
 	getVertexAnthropicProjectId,
@@ -8216,7 +8217,7 @@ chat.openapi(completions, async (c) => {
 							routingCfg,
 						);
 
-						res = await fetch(url, {
+						res = await fetchProvider(url, {
 							method: "POST",
 							// SSRF: never follow redirects on an authenticated provider
 							// request. A tenant-supplied baseUrl (validated at registration)
@@ -12649,7 +12650,7 @@ chat.openapi(completions, async (c) => {
 				forwardedServiceTier,
 			);
 
-			res = await fetch(url, {
+			res = await fetchProvider(url, {
 				method: "POST",
 				// SSRF: never follow redirects on an authenticated provider request
 				// (see streaming path above).

--- a/apps/gateway/src/embeddings/embeddings.ts
+++ b/apps/gateway/src/embeddings/embeddings.ts
@@ -50,6 +50,7 @@ import {
 } from "@/lib/error-schemas.js";
 import { extractApiToken } from "@/lib/extract-api-token.js";
 import { createFailedKeyTracker } from "@/lib/failed-key-tracker.js";
+import { fetchProvider } from "@/lib/fetch-provider.js";
 import { throwIamException, validateRequestModelAccess } from "@/lib/iam.js";
 import { calculateDataStorageCost, insertLog } from "@/lib/logs.js";
 import { formatUsedModelForDisplay } from "@/lib/model-response-id.js";
@@ -1010,7 +1011,7 @@ embeddings.openapi(createEmbeddings, async (c): Promise<any> => {
 			let fetchError: Error | null = null;
 			try {
 				const fetchSignal = createCombinedSignal(controller);
-				upstreamResponse = await fetch(attempt.upstreamUrl, {
+				upstreamResponse = await fetchProvider(attempt.upstreamUrl, {
 					method: "POST",
 					// SSRF: never follow redirects on an authenticated provider request. A
 					// tenant-supplied baseUrl could 3xx to an internal host at request

--- a/apps/gateway/src/lib/fetch-provider.ts
+++ b/apps/gateway/src/lib/fetch-provider.ts
@@ -1,0 +1,25 @@
+import { buildOpenAIErrorBody } from "@/lib/error-response.js";
+
+import { fetchNoRedirect, RedirectError } from "@llmgateway/actions";
+
+/** Route redirect policy rejections through the normal 4xx logging flow. */
+export async function fetchProvider(
+	input: string | URL | Request,
+	init?: RequestInit,
+): Promise<Response> {
+	try {
+		return await fetchNoRedirect(input, init);
+	} catch (error) {
+		if (!(error instanceof RedirectError)) {
+			throw error;
+		}
+		return Response.json(
+			buildOpenAIErrorBody({
+				message: error.message,
+				status: 400,
+				code: "unexpected_redirect",
+			}),
+			{ status: 400, statusText: "Bad Request" },
+		);
+	}
+}

--- a/apps/gateway/src/moderations/moderations.ts
+++ b/apps/gateway/src/moderations/moderations.ts
@@ -44,6 +44,7 @@ import {
 	standardErrorResponses,
 } from "@/lib/error-schemas.js";
 import { extractApiToken } from "@/lib/extract-api-token.js";
+import { fetchProvider } from "@/lib/fetch-provider.js";
 import { throwIamException, validateRequestModelAccess } from "@/lib/iam.js";
 import { calculateDataStorageCost, insertLog } from "@/lib/logs.js";
 import { formatUsedModelForDisplay } from "@/lib/model-response-id.js";
@@ -688,7 +689,7 @@ moderations.openapi(createModeration, async (c): Promise<any> => {
 
 			try {
 				const fetchSignal = createCombinedSignal(controller);
-				upstreamResponse = await fetch(resolveUpstreamUrl(), {
+				upstreamResponse = await fetchProvider(resolveUpstreamUrl(), {
 					method: "POST",
 					// SSRF: never follow redirects on an authenticated provider request. A
 					// tenant-supplied baseUrl could 3xx to an internal host at request time,

--- a/apps/gateway/src/ocr/ocr.ts
+++ b/apps/gateway/src/ocr/ocr.ts
@@ -49,6 +49,7 @@ import {
 } from "@/lib/error-schemas.js";
 import { extractApiToken } from "@/lib/extract-api-token.js";
 import { createFailedKeyTracker } from "@/lib/failed-key-tracker.js";
+import { fetchProvider } from "@/lib/fetch-provider.js";
 import { throwIamException, validateRequestModelAccess } from "@/lib/iam.js";
 import { calculateDataStorageCost, insertLog } from "@/lib/logs.js";
 import { formatUsedModelForDisplay } from "@/lib/model-response-id.js";
@@ -761,7 +762,7 @@ ocr.openapi(createOcr, async (c): Promise<any> => {
 			let fetchError: Error | null = null;
 			try {
 				const fetchSignal = createCombinedSignal(controller);
-				upstreamResponse = await fetch(attempt.upstreamUrl, {
+				upstreamResponse = await fetchProvider(attempt.upstreamUrl, {
 					method: "POST",
 					// SSRF: never follow redirects on an authenticated provider request. A
 					// tenant-supplied baseUrl could 3xx to an internal host at request

--- a/apps/gateway/src/redirect-errors.spec.ts
+++ b/apps/gateway/src/redirect-errors.spec.ts
@@ -1,0 +1,243 @@
+import { createServer } from "node:http";
+
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
+
+import { app } from "@/app.js";
+import { createGatewayApiTestHarness } from "@/test-utils/gateway-api-test-harness.js";
+import { waitForLogByRequestId } from "@/test-utils/test-helpers.js";
+
+import { encryptProviderKeyForStorage } from "@llmgateway/actions";
+import { db, eq, tables } from "@llmgateway/db";
+import { logger } from "@llmgateway/logger";
+import { hashApiKeyForStorage } from "@llmgateway/shared/api-key-hash";
+
+describe("blocked redirects", () => {
+	const harness = createGatewayApiTestHarness();
+	let redirectUrl: string;
+	let redirectRequests = 0;
+	let followedRedirects = 0;
+	const server = createServer((req, res) => {
+		if (req.url === "/target") {
+			followedRedirects++;
+			res.writeHead(200).end();
+			return;
+		}
+		redirectRequests++;
+		res.writeHead(307, { Location: "/target" }).end();
+	});
+
+	beforeAll(async () => {
+		await new Promise<void>((resolve) =>
+			server.listen(0, "127.0.0.1", resolve),
+		);
+		const address = server.address();
+		if (!address || typeof address === "string") {
+			throw new Error("Missing redirect server address");
+		}
+		redirectUrl = `http://127.0.0.1:${address.port}`;
+	});
+
+	afterAll(async () => {
+		server.closeAllConnections();
+		await new Promise<void>((resolve, reject) => {
+			server.close((error) => (error ? reject(error) : resolve()));
+		});
+	});
+
+	beforeEach(async () => {
+		redirectRequests = 0;
+		followedRedirects = 0;
+		vi.spyOn(logger, "error");
+		await db.insert(tables.apiKey).values({
+			id: "token-id",
+			...hashApiKeyForStorage("test-token"),
+			projectId: "project-id",
+			description: "Test API Key",
+			createdBy: "user-id",
+		});
+	});
+
+	afterEach(() => vi.restoreAllMocks());
+
+	async function seedProvider(provider: string, baseUrl: string) {
+		const id = `provider-key-${provider}`;
+		await db.insert(tables.providerKey).values({
+			id,
+			...encryptProviderKeyForStorage("test-token", id, "org-id"),
+			provider,
+			organizationId: "org-id",
+			baseUrl,
+		});
+	}
+
+	async function expectClientError(requestId: string) {
+		const log = await waitForLogByRequestId(requestId);
+		expect(log.finishReason).toBe("client_error");
+		expect(log.unifiedFinishReason).toBe("client_error");
+		expect(log.hasError).toBe(true);
+		expect(log.errorDetails?.statusCode).toBe(400);
+		expect(log.errorDetails?.responseText).toContain(
+			"redirects are not allowed",
+		);
+		expect(log.retried).toBeFalsy();
+		expect(
+			await db.query.log.findMany({
+				where: { requestId: { eq: requestId } },
+			}),
+		).toHaveLength(1);
+		expect(redirectRequests).toBe(1);
+		expect(followedRedirects).toBe(0);
+		expect(logger.error).not.toHaveBeenCalled();
+		return log;
+	}
+
+	test.each([false, true])(
+		"image input returns 400 before streaming starts (stream=%s)",
+		async (stream) => {
+			await seedProvider("google-ai-studio", harness.mockServerUrl);
+			const requestId = `image-redirect-${stream}`;
+			const response = await app.request("/v1/chat/completions", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer test-token",
+					"x-request-id": requestId,
+				},
+				body: JSON.stringify({
+					model: "google-ai-studio/gemini-2.5-flash",
+					stream,
+					messages: [
+						{
+							role: "user",
+							content: [{ type: "image_url", image_url: { url: redirectUrl } }],
+						},
+					],
+				}),
+			});
+			expect(response.status).toBe(400);
+			expect(await response.json()).toMatchObject({
+				error: {
+					type: "invalid_request_error",
+					message: expect.stringContaining("Use the final URL directly"),
+				},
+			});
+			await expectClientError(requestId);
+		},
+	);
+
+	test.each([
+		{
+			path: "/v1/chat/completions",
+			body: {
+				model: "openai/gpt-4o-mini",
+				messages: [{ role: "user", content: "hi" }],
+			},
+		},
+		{
+			path: "/v1/embeddings",
+			body: { model: "openai/text-embedding-3-small", input: "hi" },
+		},
+		{
+			path: "/v1/moderations",
+			body: { model: "openai/omni-moderation-latest", input: "hi" },
+		},
+		{
+			path: "/v1/audio/speech",
+			body: { model: "openai/tts-1", input: "hi", voice: "alloy" },
+		},
+		{
+			path: "/v1/videos",
+			body: {
+				model: "bytedance/seedance-2-0",
+				prompt: "A bird flying",
+				size: "1280x720",
+				seconds: 5,
+			},
+		},
+	])(
+		"$path records provider redirects as client errors",
+		async ({ path, body }) => {
+			await seedProvider(body.model.split("/")[0], redirectUrl);
+			const requestId = `provider-redirect-${path.split("/").at(-1)}`;
+			const response = await app.request(path, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer test-token",
+					"x-request-id": requestId,
+				},
+				body: JSON.stringify(body),
+			});
+			expect(response.status).toBe(400);
+			expect(await response.text()).toContain("redirects are not allowed");
+			await expectClientError(requestId);
+		},
+	);
+
+	test("audio download redirects return 400 and log a client error", async () => {
+		await seedProvider("alibaba", harness.mockServerUrl);
+		const nativeFetch = globalThis.fetch;
+		vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+			if (String(input).startsWith(harness.mockServerUrl)) {
+				return Promise.resolve(
+					Response.json({ output: { audio: { url: redirectUrl } } }),
+				);
+			}
+			return nativeFetch(input, init);
+		});
+		const requestId = "audio-download-redirect";
+		const response = await app.request("/v1/audio/speech", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer test-token",
+				"x-request-id": requestId,
+			},
+			body: JSON.stringify({
+				model: "alibaba/qwen-audio-3.0-tts-plus",
+				input: "hi",
+				voice: "longanlingxin",
+			}),
+		});
+		expect(response.status).toBe(400);
+		expect(await response.text()).toContain("redirects are not allowed");
+		await expectClientError(requestId);
+	});
+
+	test("provider redirects emit a client error on an open stream and respect retention", async () => {
+		await seedProvider("openai", redirectUrl);
+		await db
+			.update(tables.organization)
+			.set({ retentionLevel: "none" })
+			.where(eq(tables.organization.id, "org-id"));
+		const requestId = "stream-redirect";
+		const response = await app.request("/v1/chat/completions", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer test-token",
+				"x-request-id": requestId,
+			},
+			body: JSON.stringify({
+				model: "openai/gpt-4o-mini",
+				stream: true,
+				messages: [{ role: "user", content: "hi" }],
+			}),
+		});
+		const body = await response.text();
+		expect(body).toContain("invalid_request_error");
+		expect(body).toContain("redirects are not allowed");
+		const log = await expectClientError(requestId);
+		expect(log.messages).toBeNull();
+		expect(log.content).toBeNull();
+	});
+});

--- a/apps/gateway/src/rerank/rerank.ts
+++ b/apps/gateway/src/rerank/rerank.ts
@@ -50,6 +50,7 @@ import {
 } from "@/lib/error-schemas.js";
 import { extractApiToken } from "@/lib/extract-api-token.js";
 import { createFailedKeyTracker } from "@/lib/failed-key-tracker.js";
+import { fetchProvider } from "@/lib/fetch-provider.js";
 import { throwIamException, validateRequestModelAccess } from "@/lib/iam.js";
 import { calculateDataStorageCost, insertLog } from "@/lib/logs.js";
 import { formatUsedModelForDisplay } from "@/lib/model-response-id.js";
@@ -750,7 +751,7 @@ rerank.openapi(createRerank, async (c): Promise<any> => {
 			let fetchError: Error | null = null;
 			try {
 				const fetchSignal = createCombinedSignal(controller);
-				upstreamResponse = await fetch(attempt.upstreamUrl, {
+				upstreamResponse = await fetchProvider(attempt.upstreamUrl, {
 					method: "POST",
 					redirect: "error",
 					headers: {

--- a/apps/gateway/src/speech/speech.ts
+++ b/apps/gateway/src/speech/speech.ts
@@ -45,12 +45,14 @@ import {
 } from "@/lib/error-schemas.js";
 import { extractApiToken } from "@/lib/extract-api-token.js";
 import { createFailedKeyTracker } from "@/lib/failed-key-tracker.js";
+import { fetchProvider } from "@/lib/fetch-provider.js";
 import { throwIamException, validateRequestModelAccess } from "@/lib/iam.js";
 import { calculateDataStorageCost, insertLog } from "@/lib/logs.js";
 import { assertOrganizationUsable } from "@/lib/organization-access.js";
 import { assertSpendLimit } from "@/lib/spend-limit.js";
 import { createCombinedSignal, isTimeoutError } from "@/lib/timeout-config.js";
 
+import { fetchNoRedirect, RedirectError } from "@llmgateway/actions";
 import {
 	getGoogleVertexPublisherModelPath,
 	getProviderHeaders,
@@ -1003,7 +1005,7 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 			let fetchError: Error | null = null;
 			try {
 				const fetchSignal = createCombinedSignal(controller);
-				upstreamResponse = await fetch(attempt.upstreamUrl, {
+				upstreamResponse = await fetchProvider(attempt.upstreamUrl, {
 					method: "POST",
 					// SSRF: never follow redirects on an authenticated provider request. A
 					// tenant-supplied baseUrl could 3xx to an internal host at request
@@ -1613,9 +1615,10 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 				const audioUrl = dashScopeJson.output?.audio?.url;
 				let out: Buffer | null = null;
 				let downloadError: string | null = null;
+				let redirectBlocked = false;
 				if (typeof audioUrl === "string" && audioUrl) {
 					try {
-						const audioResponse = await fetch(audioUrl, {
+						const audioResponse = await fetchNoRedirect(audioUrl, {
 							// The download URL is provider-issued; still never follow
 							// redirects so the response can't be bounced elsewhere.
 							redirect: "error",
@@ -1627,6 +1630,7 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 							downloadError = `Audio download failed with status ${audioResponse.status}`;
 						}
 					} catch (error) {
+						redirectBlocked = error instanceof RedirectError;
 						downloadError =
 							error instanceof Error ? error.message : String(error);
 					}
@@ -1642,8 +1646,8 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 						buildRoutingAttempt(
 							providerId,
 							modelDefId,
-							upstreamResponse.status,
-							"upstream_error",
+							redirectBlocked ? 400 : upstreamResponse.status,
+							redirectBlocked ? "client_error" : "upstream_error",
 							false,
 							{
 								apiKeyHash: usedApiKeyHash,
@@ -1668,7 +1672,7 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 						responseSize: upstreamText.length,
 						content: null,
 						reasoningContent: null,
-						finishReason: "upstream_error",
+						finishReason: redirectBlocked ? "client_error" : "upstream_error",
 						promptTokens: null,
 						completionTokens: null,
 						totalTokens: null,
@@ -1678,8 +1682,8 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 						streamed: false,
 						canceled: false,
 						errorDetails: {
-							statusCode: upstreamResponse.status,
-							statusText: "no_audio",
+							statusCode: redirectBlocked ? 400 : upstreamResponse.status,
+							statusText: redirectBlocked ? "Bad Request" : "no_audio",
 							responseText: (downloadError ?? upstreamText).slice(0, 2000),
 						},
 						inputCost: 0,
@@ -1713,12 +1717,12 @@ speech.openapi(createSpeech, async (c): Promise<Response> => {
 										? `Failed to download synthesized audio: ${downloadError}`
 										: (dashScopeJson.message ??
 											"The model did not return any audio. The content may have been filtered."),
-								type: "upstream_error",
+								type: redirectBlocked ? "client_error" : "upstream_error",
 								param: null,
-								code: "no_audio",
+								code: redirectBlocked ? "unexpected_redirect" : "no_audio",
 							},
 						} satisfies SpeechErrorBody,
-						502,
+						redirectBlocked ? 400 : 502,
 					);
 				}
 

--- a/apps/gateway/src/transcriptions/transcriptions.ts
+++ b/apps/gateway/src/transcriptions/transcriptions.ts
@@ -49,6 +49,7 @@ import {
 } from "@/lib/error-schemas.js";
 import { extractApiToken } from "@/lib/extract-api-token.js";
 import { createFailedKeyTracker } from "@/lib/failed-key-tracker.js";
+import { fetchProvider } from "@/lib/fetch-provider.js";
 import { throwIamException, validateRequestModelAccess } from "@/lib/iam.js";
 import { calculateDataStorageCost, insertLog } from "@/lib/logs.js";
 import { formatUsedModelForDisplay } from "@/lib/model-response-id.js";
@@ -799,7 +800,7 @@ transcriptions.openapi(createTranscription, async (c): Promise<any> => {
 				const fetchSignal = createCombinedSignal(controller);
 				// No explicit Content-Type: fetch derives the multipart boundary
 				// from the FormData body.
-				upstreamResponse = await fetch(attempt.upstreamUrl, {
+				upstreamResponse = await fetchProvider(attempt.upstreamUrl, {
 					method: "POST",
 					// SSRF: never follow redirects on an authenticated provider request. A
 					// tenant-supplied baseUrl could 3xx to an internal host at request

--- a/apps/gateway/src/videos/videos.ts
+++ b/apps/gateway/src/videos/videos.ts
@@ -49,6 +49,7 @@ import {
 import { getLicensedOrganizationEnvVariant } from "@/lib/enterprise.js";
 import { rateLimitHeaders } from "@/lib/error-schemas.js";
 import { standardErrorResponses } from "@/lib/error-schemas.js";
+import { fetchProvider } from "@/lib/fetch-provider.js";
 import { validateRequestModelAccess } from "@/lib/iam.js";
 import { assertOrganizationUsable } from "@/lib/organization-access.js";
 import { getProviderMetricsForRouting } from "@/lib/provider-metrics-for-routing.js";
@@ -62,6 +63,7 @@ import {
 	getDiscountedProviderSelectionPrice,
 	getProviderHeaders,
 	managedCredentialOptions,
+	fetchNoRedirect,
 	processImageUrl,
 	providerKeyLabel,
 	readProviderKey,
@@ -2702,7 +2704,9 @@ async function streamVideoFromUrl(
 ): Promise<Response> {
 	// SSRF: refuse redirects so a tenant-controlled content URL cannot 3xx the
 	// gateway onward to an internal host whose body would then be streamed back.
-	const upstreamResponse = await fetch(contentUrl, { redirect: "error" });
+	const upstreamResponse = await fetchNoRedirect(contentUrl, {
+		redirect: "error",
+	});
 	if (!upstreamResponse.ok || !upstreamResponse.body) {
 		throw new HTTPException(502, {
 			message: "Failed to fetch video content from upstream provider",
@@ -2860,7 +2864,7 @@ async function streamDirectUpstreamVideoContent(
 			providerContext.baseUrl,
 			`/v1/files/retrieve?file_id=${fileId}`,
 		);
-		const retrieveResponse = await fetch(retrieveUrl, {
+		const retrieveResponse = await fetchNoRedirect(retrieveUrl, {
 			// SSRF: never follow redirects on a tenant-baseUrl provider request.
 			redirect: "error",
 			headers: getProviderHeaders(
@@ -2891,7 +2895,7 @@ async function streamDirectUpstreamVideoContent(
 		);
 	}
 
-	const upstreamResponse = await fetch(contentUrl, {
+	const upstreamResponse = await fetchNoRedirect(contentUrl, {
 		// SSRF: never follow redirects on a tenant-controlled content/baseUrl
 		// request; the followed body would be streamed back to the caller.
 		redirect: "error",
@@ -2972,7 +2976,7 @@ async function fetchUpstreamJson(
 	providerId: string,
 ): Promise<Record<string, unknown>> {
 	// SSRF: never follow redirects on a tenant-baseUrl provider request.
-	const response = await fetch(url, { ...init, redirect: "error" });
+	const response = await fetchProvider(url, init);
 	const text = await response.text();
 	let body: Record<string, unknown> = {};
 
@@ -4718,6 +4722,23 @@ videos.openapi(createVideo, async (c): Promise<any> => {
 			break;
 		} catch (error) {
 			const statusCode = error instanceof HTTPException ? error.status : 0;
+			if (statusCode === 400 && error instanceof HTTPException) {
+				await insertVideoClientErrorLog({
+					request,
+					requestId,
+					apiKey,
+					project,
+					organization,
+					normalizedModel,
+					requestedProvider,
+					providerContext: selectedProviderContext,
+					upstreamModelName: selectedUpstreamModelName,
+					routingMetadata: enrichedRoutingMetadata,
+					statusCode,
+					message: error.message,
+					startedAt,
+				});
+			}
 			const retryErrorType =
 				statusCode === 0
 					? "network_error"

--- a/packages/actions/src/fetch-no-redirect.spec.ts
+++ b/packages/actions/src/fetch-no-redirect.spec.ts
@@ -1,0 +1,122 @@
+import { createServer } from "node:http";
+
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	describe,
+	expect,
+	it,
+	vi,
+} from "vitest";
+
+import { fetchNoRedirect, RedirectError } from "./fetch-no-redirect.js";
+import { prepareRequestBody } from "./prepare-request-body.js";
+
+describe("fetchNoRedirect", () => {
+	let baseUrl: string;
+	let followedRedirects = 0;
+	const server = createServer((req, res) => {
+		if (req.url === "/target") {
+			followedRedirects++;
+			res.writeHead(200).end();
+			return;
+		}
+		res.writeHead(Number(req.url?.slice(1)), { Location: "/target" }).end();
+	});
+
+	beforeAll(async () => {
+		await new Promise<void>((resolve) =>
+			server.listen(0, "127.0.0.1", resolve),
+		);
+		const address = server.address();
+		if (!address || typeof address === "string") {
+			throw new Error("Missing redirect server address");
+		}
+		baseUrl = `http://127.0.0.1:${address.port}`;
+	});
+
+	afterEach(() => vi.restoreAllMocks());
+	afterAll(async () => {
+		server.closeAllConnections();
+		await new Promise<void>((resolve, reject) => {
+			server.close((error) => (error ? reject(error) : resolve()));
+		});
+	});
+
+	it.each([301, 302, 303, 307, 308])(
+		"rejects HTTP %s as a 400 without following the redirect",
+		async (status) => {
+			await expect(
+				fetchNoRedirect(`${baseUrl}/${status}`, { redirect: "follow" }),
+			).rejects.toMatchObject({
+				name: "RedirectError",
+				statusCode: 400,
+				message: expect.stringContaining("Use the final URL directly"),
+			});
+			expect(followedRedirects).toBe(0);
+		},
+	);
+
+	it("recognizes a wrapped redirect cause", async () => {
+		vi.spyOn(globalThis, "fetch").mockRejectedValue(
+			new Error("request failed", {
+				cause: new TypeError("fetch failed", {
+					cause: new Error("unexpected redirect"),
+				}),
+			}),
+		);
+		await expect(fetchNoRedirect(baseUrl)).rejects.toBeInstanceOf(
+			RedirectError,
+		);
+	});
+
+	it("preserves unrelated fetch failures", async () => {
+		const error = new TypeError("fetch failed", {
+			cause: new Error("connect ECONNREFUSED"),
+		});
+		vi.spyOn(globalThis, "fetch").mockRejectedValue(error);
+		await expect(fetchNoRedirect(baseUrl)).rejects.toBe(error);
+	});
+
+	it.each([
+		{
+			provider: "aws-bedrock",
+			model: "claude-sonnet-4-5",
+			externalId: "anthropic.claude-sonnet-4-5-20250929-v1:0",
+		},
+		{ provider: "openai", model: "gpt-image-1", externalId: "gpt-image-1" },
+	] as const)(
+		"preserves redirect rejections while preparing $provider images",
+		async ({ provider, model, externalId }) => {
+			const args: Parameters<typeof prepareRequestBody> = [
+				provider,
+				model,
+				null,
+				externalId,
+				[
+					{
+						role: "user",
+						content: [
+							{ type: "text", text: "Describe this image" },
+							{ type: "image_url", image_url: { url: `${baseUrl}/307` } },
+						],
+					},
+				],
+				false,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+			];
+			args[22] = provider === "openai";
+			await expect(prepareRequestBody(...args)).rejects.toMatchObject({
+				statusCode: 400,
+				message: expect.stringContaining("redirects are not allowed"),
+			});
+			expect(followedRedirects).toBe(0);
+		},
+	);
+});

--- a/packages/actions/src/fetch-no-redirect.ts
+++ b/packages/actions/src/fetch-no-redirect.ts
@@ -1,0 +1,32 @@
+import { RequestError } from "./request-error.js";
+
+export class RedirectError extends RequestError {
+	public constructor() {
+		super(
+			"URL redirects are not allowed for security reasons. Use the final URL directly.",
+		);
+		this.name = "RedirectError";
+	}
+}
+
+/** Fetch without redirects, preserving policy rejections as client errors. */
+export async function fetchNoRedirect(
+	input: string | URL | Request,
+	init?: RequestInit,
+): Promise<Response> {
+	try {
+		return await fetch(input, { ...init, redirect: "error" });
+	} catch (error) {
+		let cause: unknown = error;
+		for (let depth = 0; depth < 5 && cause instanceof Error; depth++) {
+			if (
+				cause.message === "unexpected redirect" ||
+				cause.message === "fetch failed: unexpected redirect"
+			) {
+				throw new RedirectError();
+			}
+			cause = cause.cause;
+		}
+		throw error;
+	}
+}

--- a/packages/actions/src/index.ts
+++ b/packages/actions/src/index.ts
@@ -22,3 +22,5 @@ export * from "./limit-hits.js";
 export * from "./org-spend.js";
 export * from "./model-verification.js";
 export * from "./provider-api-format.js";
+
+export { fetchNoRedirect, RedirectError } from "./fetch-no-redirect.js";

--- a/packages/actions/src/prepare-request-body.ts
+++ b/packages/actions/src/prepare-request-body.ts
@@ -36,9 +36,10 @@ import {
 	toAnthropicToolSearchTool,
 	usesAnthropicMessagesApi,
 } from "./anthropic-tool-search.js";
+import { fetchNoRedirect } from "./fetch-no-redirect.js";
 import { parseDataUrl } from "./parse-data-url.js";
 import { parseToolCallArguments } from "./parse-tool-call-arguments.js";
-import { ImageSizeLimitError, processImageUrl } from "./process-image-url.js";
+import { processImageUrl } from "./process-image-url.js";
 import { RequestError } from "./request-error.js";
 import { mappingSupportsToolChoice } from "./tool-choice-support.js";
 import {
@@ -239,7 +240,7 @@ async function fetchImageAsBlob(
 	// SSRF: the URL comes from the request body, so validate it does not resolve
 	// to an internal host and refuse redirects before fetching.
 	await assertSafeUserContentUrl(url);
-	const response = await fetch(url, { redirect: "error" });
+	const response = await fetchNoRedirect(url);
 	if (!response.ok) {
 		throw new Error(
 			`Failed to fetch image ${url}: ${response.status} ${response.statusText}`,
@@ -3718,10 +3719,10 @@ export async function prepareRequestBody(
 									},
 								});
 							} catch (error) {
-								// A size rejection is the user's to act on: degrading to a
+								// A client rejection is the user's to act on: degrading to a
 								// placeholder would return a 200 that silently ignores the
 								// image and still bills for the turn.
-								if (error instanceof ImageSizeLimitError) {
+								if (error instanceof RequestError) {
 									throw error;
 								}
 								logger.error("Failed to process image for Bedrock", {

--- a/packages/actions/src/process-image-url.ts
+++ b/packages/actions/src/process-image-url.ts
@@ -1,6 +1,7 @@
 import { logger } from "@llmgateway/logger";
 import { assertSafeUserContentUrl } from "@llmgateway/shared/url-safety-node";
 
+import { fetchNoRedirect } from "./fetch-no-redirect.js";
 import { parseDataUrl } from "./parse-data-url.js";
 import { RequestError } from "./request-error.js";
 
@@ -190,7 +191,7 @@ export async function processImageUrl(
 	await assertSafeUserContentUrl(url);
 
 	try {
-		const response = await fetch(url, { redirect: "error" });
+		const response = await fetchNoRedirect(url);
 
 		if (!response.ok) {
 			logger.warn(`Failed to fetch image from URL (${response.status})`, {
@@ -243,10 +244,7 @@ export async function processImageUrl(
 			mimeType: contentType,
 		};
 	} catch (error) {
-		// Typed client errors (bad status, wrong content type, size rejections)
-		// carry a message the caller is meant to see, and every one of them is
-		// already logged at warn where it is thrown — re-logging them here would
-		// raise an expected client outcome to error level twice over.
+		// Preserve client errors for the gateway's 4xx response and request log.
 		if (error instanceof RequestError) {
 			throw error;
 		}


### PR DESCRIPTION
Blocked URL redirects were surfacing as fetch failures and 5xx responses. Return HTTP 400 with a message to use the final URL, and record `client_error` for media preprocessing and provider requests without retrying or following redirects.

Provider rejections use the existing 4xx logging flow. Media preprocessing preserves typed client errors, including Bedrock image inputs. Already-open SSE streams emit an `invalid_request_error` event.

Validation: `pnpm format`, `pnpm build`, and focused regression suites covering real 301/302/303/307/308 responses, request logs, retention, streaming, images, audio, videos, embeddings, moderation, OCR, transcription, and reranking.
