### PR TITLE
fix: expire routing metadata safely

### DIFF
--- a/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
+++ b/apps/ui/src/app/dashboard/[orgId]/[projectId]/activity/[logId]/log-detail-client.tsx
@@ -49,7 +49,9 @@ import {
 import {
 	API_ORIGIN_LABELS,
 	CredentialSourceBadge,
+	RoutingMetadataExpired,
 } from "@llmgateway/shared/components";
+import { isRoutingMetadataExpired } from "@llmgateway/shared/log-retention";
 
 import type { LogDetailData } from "@/types/activity";
 import type { Log } from "@llmgateway/db";
@@ -678,6 +680,13 @@ export function LogDetailClient({
 							</div>
 						</Section>
 
+						{isRoutingMetadataExpired(log) && (
+							<Section title="Routing">
+								<div className="rounded-lg border bg-card p-4">
+									<RoutingMetadataExpired />
+								</div>
+							</Section>
+						)}
 						{log.routingMetadata && (
 							<Section title="Routing">
 								<div className="rounded-lg border bg-card p-4">

--- a/apps/worker/src/cleanup-routing-metadata.spec.ts
+++ b/apps/worker/src/cleanup-routing-metadata.spec.ts
@@ -1,0 +1,174 @@
+import { readFileSync } from "node:fs";
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { db, pool, tables } from "@llmgateway/db";
+
+import type { InferInsertModel } from "@llmgateway/db";
+
+const installSql = readFileSync(
+	new URL("../../../scripts/cleanup-log-routing-metadata.sql", import.meta.url),
+	"utf8",
+);
+
+function logRow(
+	id: string,
+	overrides: Partial<InferInsertModel<typeof tables.log>> = {},
+): InferInsertModel<typeof tables.log> {
+	return {
+		id,
+		requestId: id,
+		organizationId: "cleanup-org",
+		projectId: "cleanup-project",
+		apiKeyId: "cleanup-key",
+		duration: 100,
+		requestedModel: "gpt-4o-mini",
+		usedModel: "gpt-4o-mini",
+		usedProvider: "openai",
+		responseSize: 10,
+		mode: "credits",
+		usedMode: "credits",
+		createdAt: new Date("2020-01-01T00:00:00Z"),
+		dataRetentionCleanedUp: true,
+		routingMetadata: { selectedProvider: "openai" },
+		content: "unchanged",
+		...overrides,
+	};
+}
+
+async function progress() {
+	const result = await pool.query<{
+		last_id: string;
+		scanned_rows: string;
+		cleared_rows: string;
+		completed: boolean;
+	}>("SELECT * FROM maintenance.log_routing_metadata_cleanup");
+	return result.rows[0];
+}
+
+describe("routing metadata backfill", () => {
+	beforeAll(async () => {
+		await pool.query(installSql);
+	});
+
+	beforeEach(async () => {
+		await db.delete(tables.log);
+		await pool.query("TRUNCATE maintenance.log_routing_metadata_cleanup");
+	});
+
+	afterAll(async () => {
+		await db.delete(tables.log);
+		await pool.query(`
+			DROP PROCEDURE maintenance.cleanup_log_routing_metadata(integer, double precision, integer);
+			DROP TABLE maintenance.log_routing_metadata_cleanup;
+		`);
+	});
+
+	it("bounds scans, resumes empty batches, and preserves the cutoff", async () => {
+		await db
+			.insert(tables.log)
+			.values([
+				logRow("a", { routingMetadata: null }),
+				logRow("b", { createdAt: new Date() }),
+				logRow("c"),
+				logRow("d", { dataRetentionCleanedUp: false }),
+				logRow("e"),
+			]);
+
+		await pool.query("CALL maintenance.cleanup_log_routing_metadata(2, 0, 1)");
+		expect(await progress()).toMatchObject({
+			last_id: "b",
+			scanned_rows: "2",
+			cleared_rows: "0",
+			completed: false,
+		});
+
+		await pool.query(`
+			UPDATE public.log SET created_at = (
+				SELECT cutoff FROM maintenance.log_routing_metadata_cleanup
+			) WHERE id = 'e'
+		`);
+		await pool.query(installSql);
+		await pool.query("CALL maintenance.cleanup_log_routing_metadata(2, 0, 1)");
+		expect(await progress()).toMatchObject({
+			last_id: "d",
+			scanned_rows: "4",
+			cleared_rows: "2",
+			completed: false,
+		});
+
+		await pool.query("CALL maintenance.cleanup_log_routing_metadata(2, 0, 10)");
+		expect(await progress()).toMatchObject({
+			last_id: "e",
+			scanned_rows: "5",
+			cleared_rows: "2",
+			completed: true,
+		});
+
+		const logs = await db.query.log.findMany({ orderBy: { id: "asc" } });
+		expect(logs.map((log) => log.routingMetadata)).toEqual([
+			null,
+			{ selectedProvider: "openai" },
+			null,
+			null,
+			{ selectedProvider: "openai" },
+		]);
+		expect(logs.map((log) => log.dataRetentionCleanedUp)).toEqual([
+			true,
+			true,
+			true,
+			false,
+			true,
+		]);
+		expect(logs.every((log) => log.content === "unchanged")).toBe(true);
+
+		await pool.query("CALL maintenance.cleanup_log_routing_metadata(2, 0, 1)");
+		expect((await progress()).scanned_rows).toBe("5");
+	});
+
+	it("commits earlier batches and retries locked rows without skipping", async () => {
+		await db.insert(tables.log).values([logRow("a"), logRow("b")]);
+		const blocker = await pool.connect();
+		try {
+			await blocker.query("BEGIN");
+			await blocker.query(
+				"SELECT id FROM public.log WHERE id = 'b' FOR UPDATE",
+			);
+			await expect(
+				pool.query("CALL maintenance.cleanup_log_routing_metadata(1, 0, 2)"),
+			).rejects.toThrow(/lock timeout/);
+			expect(await progress()).toMatchObject({
+				last_id: "a",
+				scanned_rows: "1",
+				cleared_rows: "1",
+			});
+		} finally {
+			await blocker.query("ROLLBACK");
+			blocker.release();
+		}
+
+		await pool.query("CALL maintenance.cleanup_log_routing_metadata(1, 0, 10)");
+		expect(await progress()).toMatchObject({
+			last_id: "b",
+			scanned_rows: "2",
+			cleared_rows: "2",
+			completed: true,
+		});
+		const logs = await db.query.log.findMany();
+		expect(logs.every((log) => log.routingMetadata === null)).toBe(true);
+	});
+
+	it.each([
+		[0, 0, 1],
+		[10001, 0, 1],
+		[1, -1, 1],
+		[1, 0, 0],
+	])("rejects invalid limits (%i, %i, %i)", async (...limits) => {
+		await expect(
+			pool.query(
+				"CALL maintenance.cleanup_log_routing_metadata($1, $2, $3)",
+				limits,
+			),
+		).rejects.toThrow(/Use batch_size/);
+	});
+});

--- a/apps/worker/src/services/routing-telemetry-aggregator.spec.ts
+++ b/apps/worker/src/services/routing-telemetry-aggregator.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
 	apiKey,
@@ -75,6 +75,7 @@ async function exclusions() {
 
 describe("routing telemetry aggregator", () => {
 	beforeEach(async () => {
+		vi.setSystemTime(new Date("2026-08-08T00:00:00Z"));
 		await db.delete(routingElectionHourly);
 		await db.delete(routingExclusionHourly);
 		await db.delete(log);
@@ -106,6 +107,53 @@ describe("routing telemetry aggregator", () => {
 			projectId: "rt-proj",
 			createdBy: testUser.id,
 		});
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it.each(["2026-09-06T10:30:00Z", "2026-09-07T10:00:00Z"])(
+		"preserves saved rollups when an hour expires (%s)",
+		async (expiredNow) => {
+			await db.insert(log).values([
+				withMetadata(
+					{
+						selectionReason: "weighted-score",
+						serviceTierSource: "coding-plan-default",
+						availableProviders: ["openai", "azure"],
+						filteredProviders: [
+							{ providerId: "azure", reasons: ["vision"], codes: ["vision"] },
+						],
+					},
+					{ requestedServiceTier: "flex" },
+				),
+			]);
+			await calculateRoutingTelemetryForHour(HOUR);
+			const savedElections = await db.select().from(routingElectionHourly);
+			const savedExclusions = await db.select().from(routingExclusionHourly);
+
+			await db.update(log).set({ routingMetadata: null });
+			vi.setSystemTime(new Date(expiredNow));
+			expect(await calculateRoutingTelemetryForHour(HOUR)).toEqual({
+				electionRows: 0,
+				exclusionRows: 0,
+			});
+			expect(await db.select().from(routingElectionHourly)).toEqual(
+				savedElections,
+			);
+			expect(await db.select().from(routingExclusionHourly)).toEqual(
+				savedExclusions,
+			);
+		},
+	);
+
+	it("does not create unknown elections from expired logs", async () => {
+		await db.insert(log).values([logRow({ routingMetadata: null })]);
+		vi.setSystemTime(new Date("2026-09-07T10:00:00Z"));
+		await calculateRoutingTelemetryForHour(HOUR);
+		expect(await elections()).toEqual([]);
+		expect(await exclusions()).toEqual([]);
 	});
 
 	it("splits requests by selection reason and sums the candidate set size", async () => {

--- a/apps/worker/src/services/routing-telemetry-aggregator.ts
+++ b/apps/worker/src/services/routing-telemetry-aggregator.ts
@@ -300,11 +300,9 @@ async function aggregateExclusions(tx: Tx, targetHour: Date) {
  * Roll up one hour of routing decisions from log.routingMetadata.
  *
  * Reading `log` is deliberate and safe here despite the table's volume: the
- * fields used (routingMetadata, the service-tier columns) survive retention
- * stripping, each pass scans a single hour's rows rather than running per
- * dashboard request, and the resulting hourly rows are what the admin dashboard
- * queries. Backfilling an hour whose logs have already been pruned simply
- * produces no rows and leaves any existing ones untouched.
+ * each pass scans a single hour's rows, and the admin dashboard queries the
+ * resulting hourly rows. Routing details must be aggregated before the 30-day
+ * cleanup clears routingMetadata; they cannot be reconstructed afterward.
  *
  * Both aggregations share one transaction so the hour lands all-or-nothing.
  * Presence in routing_election_hourly is what tells the backfill an hour is

--- a/apps/worker/src/services/routing-telemetry-aggregator.ts
+++ b/apps/worker/src/services/routing-telemetry-aggregator.ts
@@ -9,6 +9,7 @@ import {
 	sql,
 } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
+import { getLogRetentionCutoff } from "@llmgateway/shared/log-retention";
 import {
 	ROUTING_EXCLUSION_REASONS,
 	ROUTING_SELECTION_REASONS,
@@ -299,7 +300,7 @@ async function aggregateExclusions(tx: Tx, targetHour: Date) {
 /**
  * Roll up one hour of routing decisions from log.routingMetadata.
  *
- * Reading `log` is deliberate and safe here despite the table's volume: the
+ * Reading `log` is deliberate and safe here despite the table's volume:
  * each pass scans a single hour's rows, and the admin dashboard queries the
  * resulting hourly rows. Routing details must be aggregated before the 30-day
  * cleanup clears routingMetadata; they cannot be reconstructed afterward.
@@ -310,6 +311,11 @@ async function aggregateExclusions(tx: Tx, targetHour: Date) {
  * the hour would look complete and its exclusion rows would never be filled in.
  */
 export async function calculateRoutingTelemetryForHour(targetHour: Date) {
+	// An expired hour may be partially cleaned. Preserve its saved rollups.
+	if (hourWindow(targetHour).start < getLogRetentionCutoff()) {
+		return { electionRows: 0, exclusionRows: 0 };
+	}
+
 	const { electionRows, exclusionRows } = await db.transaction(async (tx) => ({
 		electionRows: await aggregateElections(tx, targetHour),
 		exclusionRows: await aggregateExclusions(tx, targetHour),

--- a/apps/worker/src/services/stats-calculator.spec.ts
+++ b/apps/worker/src/services/stats-calculator.spec.ts
@@ -9,6 +9,8 @@ import {
 	modelHistory,
 	modelProviderMappingHistoryHourly,
 	modelHistoryHourly,
+	routingElectionHourly,
+	routingExclusionHourly,
 	log,
 	organization,
 	project,
@@ -19,6 +21,7 @@ import {
 	getTableColumns,
 	sql,
 } from "@llmgateway/db";
+import * as logRetention from "@llmgateway/shared/log-retention";
 
 import {
 	calculateMinutelyHistory,
@@ -38,6 +41,8 @@ describe("stats-calculator", () => {
 
 		// Clean up test data before each test
 		await db.delete(log);
+		await db.delete(routingElectionHourly);
+		await db.delete(routingExclusionHourly);
 		await db.delete(modelProviderMappingHistoryHourly);
 		await db.delete(modelHistoryHourly);
 		await db.delete(modelProviderMappingHistory);
@@ -148,6 +153,7 @@ describe("stats-calculator", () => {
 	});
 
 	afterEach(() => {
+		vi.restoreAllMocks();
 		vi.useRealTimers();
 	});
 
@@ -2004,6 +2010,61 @@ describe("stats-calculator", () => {
 	});
 
 	describe("backfillHourlyHistoryIfNeeded", () => {
+		it("uses saved minute counters without rebuilding expired routing", async () => {
+			vi.spyOn(logRetention, "getLogRetentionCutoff").mockReturnValue(
+				new Date("2024-01-01T11:00:00Z"),
+			);
+			const minuteTimestamp = new Date("2024-01-01T10:30:00Z");
+			await db.insert(modelHistory).values({
+				modelId: "gpt-4",
+				minuteTimestamp,
+				logsCount: 1,
+				serviceTierImplicitCount: 1,
+			});
+			await db.insert(modelProviderMappingHistory).values({
+				modelId: "gpt-4",
+				providerId: "openai",
+				modelProviderMappingId: "mapping-1",
+				minuteTimestamp,
+				logsCount: 1,
+				serviceTierImplicitCount: 1,
+			});
+			await db.insert(log).values({
+				id: "expired-routing-log",
+				requestId: "expired-routing-request",
+				organizationId: "org-1",
+				projectId: "proj-1",
+				apiKeyId: "key-1",
+				createdAt: minuteTimestamp,
+				duration: 100,
+				requestedModel: "gpt-4",
+				usedModel: "openai/gpt-4",
+				usedProvider: "openai",
+				responseSize: 0,
+				mode: "credits",
+				usedMode: "credits",
+				requestedServiceTier: "flex",
+				routingMetadata: null,
+				dataRetentionCleanedUp: true,
+			});
+
+			await backfillHourlyHistoryIfNeeded();
+
+			for (const table of [
+				modelHistoryHourly,
+				modelProviderMappingHistoryHourly,
+			]) {
+				const rows = await db.select().from(table);
+				expect(rows).toHaveLength(1);
+				expect(rows[0]).toMatchObject({
+					logsCount: 1,
+					serviceTierImplicitCount: 1,
+					serviceTierExplicitCount: 0,
+				});
+			}
+			expect(await db.select().from(routingElectionHourly)).toEqual([]);
+		});
+
 		it("should backfill from the earliest minute entry when hourly is empty", async () => {
 			// mockDate 12:30Z → previous complete hour is 11:00; current hour 12:00
 			// is in progress and must NOT be produced by backfill.

--- a/apps/worker/src/services/stats-calculator.ts
+++ b/apps/worker/src/services/stats-calculator.ts
@@ -20,6 +20,7 @@ import {
 	type SQL,
 } from "@llmgateway/db";
 import { logger } from "@llmgateway/logger";
+import { getLogRetentionCutoff } from "@llmgateway/shared/log-retention";
 
 import { excludeRecoveredSameProviderRegionRetry } from "./log-filters.js";
 import { calculateRoutingTelemetryForHour } from "./routing-telemetry-aggregator.js";
@@ -293,6 +294,9 @@ function getCurrentHourStart(): Date {
  */
 async function calculateModelHistoryForMinute(targetMinute: Date) {
 	const roundedTargetMinute = roundToMinuteStart(targetMinute);
+	if (roundedTargetMinute < getLogRetentionCutoff()) {
+		return { totalModels: 0, activeModels: 0, inactiveModels: 0 };
+	}
 
 	const minuteEnd = new Date(roundedTargetMinute.getTime() + ONE_MINUTE_MS);
 	const database = db;
@@ -592,6 +596,9 @@ async function calculateModelHistoryForMinute(targetMinute: Date) {
  */
 async function calculateHistoryForMinute(targetMinute: Date) {
 	const roundedTargetMinute = roundToMinuteStart(targetMinute);
+	if (roundedTargetMinute < getLogRetentionCutoff()) {
+		return { totalMappings: 0, activeMappings: 0, inactiveMappings: 0 };
+	}
 
 	const minuteEnd = new Date(roundedTargetMinute.getTime() + ONE_MINUTE_MS);
 	const database = db;
@@ -991,12 +998,21 @@ export async function backfillHistoryIfNeeded() {
 		}
 
 		const previousMinute = getPreviousMinuteStart();
+		const earliestRetainedMinute = new Date(
+			Math.ceil(getLogRetentionCutoff().getTime() / ONE_MINUTE_MS) *
+				ONE_MINUTE_MS,
+		);
 
 		if (!lastMinute) {
 			// No history exists, start from configured backfill duration ago
 			const backfillMs = BACKFILL_DURATION_SECONDS * 1000;
 			const backfillStart = new Date(Date.now() - backfillMs);
-			const backfillStartRounded = roundToMinuteStart(backfillStart);
+			const backfillStartRounded = new Date(
+				Math.max(
+					roundToMinuteStart(backfillStart).getTime(),
+					earliestRetainedMinute.getTime(),
+				),
+			);
 
 			logger.info(
 				`No existing history found. Starting backfill from ${backfillStartRounded.toISOString()} to ${previousMinute.toISOString()}`,
@@ -1051,7 +1067,12 @@ export async function backfillHistoryIfNeeded() {
 				`Found gap of ${minutesBehind} minutes. Backfilling from ${lastMinute.toISOString()}`,
 			);
 
-			let minute = new Date(lastMinute.getTime() + ONE_MINUTE_MS); // Start from the minute after the last recorded
+			let minute = new Date(
+				Math.max(
+					lastMinute.getTime() + ONE_MINUTE_MS,
+					earliestRetainedMinute.getTime(),
+				),
+			);
 			let iterationCount = 0;
 			const maxIterations = 1440; // Safety limit for 24 hours of backfill
 
@@ -1407,7 +1428,7 @@ export async function calculateHourlyHistory() {
  * Backfill missing hourly summary rows by walking every completed hour from the
  * earliest minute-history entry up to the previous complete hour and recomputing
  * only the hours absent from ANY summary table — the two history rollups, plus
- * routing telemetry for hours whose logs still exist. Detecting missing hours
+ * routing telemetry for hours within log retention. Detecting missing hours
  * (rather than resuming from the latest entry) is what makes this robust: the
  * minutely loop writes the current and previous hour on startup, so the latest
  * hourly entry is never a reliable "everything before this is done" watermark —
@@ -1467,13 +1488,14 @@ export async function backfillHourlyHistoryIfNeeded() {
 			return;
 		}
 
-		// Oldest hour that still has logs to aggregate. Routing telemetry is derived
-		// from `log` rather than from minute history, so hours whose logs retention
-		// has already pruned can never produce routing rows — requiring them below
-		// would recompute the same empty hours on every worker start.
+		// Only complete hours within retention can reconstruct routing details.
+		const earliestRetainedHour = new Date(
+			Math.ceil(getLogRetentionCutoff().getTime() / ONE_HOUR_MS) * ONE_HOUR_MS,
+		);
 		const earliestLog = await database
 			.select({ createdAt: log.createdAt })
 			.from(log)
+			.where(gte(log.createdAt, earliestRetainedHour))
 			.orderBy(asc(log.createdAt))
 			.limit(1);
 		const earliestLogHourMs = earliestLog[0]

--- a/apps/worker/src/worker.spec.ts
+++ b/apps/worker/src/worker.spec.ts
@@ -556,7 +556,7 @@ describe("worker", () => {
 	});
 
 	describe("cleanupExpiredLogData", () => {
-		test("should null moderation payloads during retention cleanup", async () => {
+		test("should clear expired payloads and routing metadata", async () => {
 			process.env.ENABLE_DATA_RETENTION_CLEANUP = "true";
 
 			const testUser = await db
@@ -606,44 +606,55 @@ describe("worker", () => {
 			// eslint-disable-next-line no-mixed-operators
 			const oldCreatedAt = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000);
 
+			const [expiredLog] = await db
+				.insert(tables.log)
+				.values({
+					id: retentionTestIds.logId,
+					requestId: retentionTestIds.requestId,
+					createdAt: oldCreatedAt,
+					updatedAt: oldCreatedAt,
+					organizationId: testOrg.id,
+					projectId: testProject.id,
+					apiKeyId: testApiKey.id,
+					duration: 100,
+					requestedModel: "openai/gpt-4o-mini",
+					requestedProvider: "openai",
+					usedModel: "gpt-4o-mini",
+					usedProvider: "openai",
+					responseSize: 100,
+					content: "response content",
+					messages: [{ role: "user", content: "hello" }],
+					rawRequest: { input: "hello" },
+					upstreamResponse: { output: "response content" },
+					userAgent: "test-user-agent",
+					routingMetadata: { selectedProvider: "openai" },
+					gatewayContentFilterResponse: [
+						{
+							id: "modr-retention-test",
+							model: "omni-moderation-latest",
+							results: [
+								{
+									flagged: true,
+									categories: {
+										violence: true,
+									},
+									category_scores: {
+										violence: 0.95,
+									},
+								},
+							],
+						},
+					],
+					mode: "credits",
+					usedMode: "credits",
+				})
+				.returning();
+
 			await db.insert(tables.log).values({
-				id: retentionTestIds.logId,
-				requestId: retentionTestIds.requestId,
-				createdAt: oldCreatedAt,
-				updatedAt: oldCreatedAt,
-				organizationId: testOrg.id,
-				projectId: testProject.id,
-				apiKeyId: testApiKey.id,
-				duration: 100,
-				requestedModel: "openai/gpt-4o-mini",
-				requestedProvider: "openai",
-				usedModel: "gpt-4o-mini",
-				usedProvider: "openai",
-				responseSize: 100,
-				content: "response content",
-				messages: [{ role: "user", content: "hello" }],
-				rawRequest: { input: "hello" },
-				upstreamResponse: { output: "response content" },
-				userAgent: "test-user-agent",
-				gatewayContentFilterResponse: [
-					{
-						id: "modr-retention-test",
-						model: "omni-moderation-latest",
-						results: [
-							{
-								flagged: true,
-								categories: {
-									violence: true,
-								},
-								category_scores: {
-									violence: 0.95,
-								},
-							},
-						],
-					},
-				],
-				mode: "credits",
-				usedMode: "credits",
+				...expiredLog,
+				id: "retention-recent-log",
+				requestId: "retention-recent-request",
+				createdAt: new Date(),
 			});
 
 			await cleanupExpiredLogData();
@@ -663,7 +674,14 @@ describe("worker", () => {
 			expect(cleanedLog?.upstreamResponse).toBeNull();
 			expect(cleanedLog?.userAgent).toBeNull();
 			expect(cleanedLog?.gatewayContentFilterResponse).toBeNull();
+			expect(cleanedLog?.routingMetadata).toBeNull();
 			expect(cleanedLog?.dataRetentionCleanedUp).toBe(true);
+
+			const recentLog = await db.query.log.findFirst({
+				where: { id: { eq: "retention-recent-log" } },
+			});
+			expect(recentLog?.routingMetadata).toEqual(expiredLog.routingMetadata);
+			expect(recentLog?.dataRetentionCleanedUp).toBe(false);
 		});
 	});
 

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -51,6 +51,10 @@ import {
 	isPremiumWeekExpired,
 	isPrivateOrReservedIp,
 } from "@llmgateway/shared";
+import {
+	getLogRetentionCutoff,
+	LOG_RETENTION_DAYS,
+} from "@llmgateway/shared/log-retention";
 
 import { posthog } from "./posthog.js";
 import {
@@ -814,17 +818,8 @@ export async function cleanupExpiredLogData(): Promise<void> {
 	try {
 		logger.info("Starting data retention cleanup...");
 
-		// Unified retention period - 30 days for all users
-		const RETENTION_DAYS = 30;
 		const CLEANUP_BATCH_SIZE = 10000;
-
-		const now = new Date();
-
-		// Calculate cutoff date (30 days ago)
-		const cutoffDate = new Date(
-			// eslint-disable-next-line no-mixed-operators
-			now.getTime() - RETENTION_DAYS * 24 * 60 * 60 * 1000,
-		);
+		const cutoffDate = getLogRetentionCutoff();
 
 		let totalCleaned = 0;
 
@@ -906,7 +901,7 @@ export async function cleanupExpiredLogData(): Promise<void> {
 
 		if (totalCleaned > 0) {
 			logger.info(
-				`Total cleaned up verbose data from ${totalCleaned} logs (older than ${RETENTION_DAYS} days)`,
+				`Total cleaned up verbose data from ${totalCleaned} logs (older than ${LOG_RETENTION_DAYS} days)`,
 			);
 		}
 

--- a/apps/worker/src/worker.ts
+++ b/apps/worker/src/worker.ts
@@ -878,6 +878,7 @@ export async function cleanupExpiredLogData(): Promise<void> {
 						userAgent: null,
 						gatewayContentFilterResponse: null,
 						responsesApiData: null,
+						routingMetadata: null,
 						dataRetentionCleanedUp: true,
 					})
 					// Use `= ANY($1)` with a single array parameter instead of

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -89,6 +89,11 @@
 			"import": "./dist/dynamic-route.js",
 			"default": "./dist/dynamic-route.js"
 		},
+		"./log-retention": {
+			"types": "./dist/log-retention.d.ts",
+			"import": "./dist/log-retention.js",
+			"default": "./dist/log-retention.js"
+		},
 		"./routing-telemetry": {
 			"types": "./dist/routing-telemetry.d.ts",
 			"import": "./dist/routing-telemetry.js",

--- a/packages/shared/src/components/index.tsx
+++ b/packages/shared/src/components/index.tsx
@@ -31,3 +31,4 @@ export * from "./ui/index";
 export * from "./models-directory/capability-filters";
 export * from "./models-directory/pricing-schedule";
 export * from "./models-directory/use-case-filters";
+export { RoutingMetadataExpired } from "./routing-metadata-expired.js";

--- a/packages/shared/src/components/log-card.tsx
+++ b/packages/shared/src/components/log-card.tsx
@@ -30,6 +30,7 @@ import prettyBytes from "pretty-bytes";
 import { useState } from "react";
 
 import { CredentialSourceBadge } from "@/components/credential-source-badge";
+import { RoutingMetadataExpired } from "@/components/routing-metadata-expired";
 import { Time } from "@/components/time";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -45,6 +46,7 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { isRoutingMetadataExpired } from "@/log-retention.js";
 import { regionFromUsedModel } from "@/used-model.js";
 
 import {
@@ -388,6 +390,7 @@ export function LogCard({
 	fetchInputImages,
 }: LogCardProps) {
 	const routingMetadata = log.routingMetadata as RoutingMetadata | undefined;
+	const routingMetadataExpired = isRoutingMetadataExpired(log);
 	// Regional mappings encode the served region as a `:region` suffix on
 	// `usedModel`; providers without regional deployments have none.
 	const usedRegion = regionFromUsedModel(log.usedModel, log.usedProvider);
@@ -668,6 +671,11 @@ export function LogCard({
 									</>
 								)}
 							</div>
+							{routingMetadataExpired && (
+								<div className="mt-3 border-t pt-3">
+									<RoutingMetadataExpired />
+								</div>
+							)}
 							{routingMetadata && (
 								<div className="mt-3">
 									<h5 className="text-xs font-medium text-muted-foreground mb-2">

--- a/packages/shared/src/components/routing-metadata-expired.tsx
+++ b/packages/shared/src/components/routing-metadata-expired.tsx
@@ -1,0 +1,19 @@
+import { Clock } from "lucide-react";
+
+export function RoutingMetadataExpired() {
+	return (
+		<div className="flex items-start gap-2 text-sm">
+			<Clock
+				className="mt-0.5 size-4 shrink-0 text-muted-foreground"
+				aria-hidden
+			/>
+			<div>
+				<p className="font-medium">Routing metadata expired</p>
+				<p className="mt-1 text-muted-foreground">
+					Routing details are removed after 30 days. Usage and costs are still
+					available.
+				</p>
+			</div>
+		</div>
+	);
+}

--- a/packages/shared/src/log-retention.spec.ts
+++ b/packages/shared/src/log-retention.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	getLogRetentionCutoff,
+	isRoutingMetadataExpired,
+} from "./log-retention.js";
+
+const now = new Date("2026-09-12T12:00:00Z");
+const expiredAt = "2026-08-12T12:00:00Z";
+
+describe("routing metadata expiration", () => {
+	it("uses the same exact 30-day boundary as cleanup", () => {
+		expect(getLogRetentionCutoff(now).toISOString()).toBe(
+			"2026-08-13T12:00:00.000Z",
+		);
+		expect(
+			isRoutingMetadataExpired(
+				{ createdAt: getLogRetentionCutoff(now), routingMetadata: null },
+				now,
+			),
+		).toBe(false);
+	});
+
+	it("shows expiration for removed metadata on an old log", () => {
+		expect(
+			isRoutingMetadataExpired(
+				{ createdAt: expiredAt, routingMetadata: null },
+				now,
+			),
+		).toBe(true);
+	});
+
+	it("does not label recent missing metadata as expired", () => {
+		expect(
+			isRoutingMetadataExpired({ createdAt: now, routingMetadata: null }, now),
+		).toBe(false);
+	});
+
+	it.each([undefined, { selectedProvider: "openai" }])(
+		"does not label omitted or retained metadata as expired (%j)",
+		(routingMetadata) => {
+			expect(
+				isRoutingMetadataExpired(
+					{ createdAt: expiredAt, routingMetadata },
+					now,
+				),
+			).toBe(false);
+		},
+	);
+});

--- a/packages/shared/src/log-retention.ts
+++ b/packages/shared/src/log-retention.ts
@@ -1,0 +1,16 @@
+export const LOG_RETENTION_DAYS = 30;
+
+export function getLogRetentionCutoff(now = new Date()): Date {
+	const retentionMs = LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+	return new Date(now.getTime() - retentionMs);
+}
+
+export function isRoutingMetadataExpired(
+	log: { createdAt: string | Date; routingMetadata?: unknown },
+	now = new Date(),
+): boolean {
+	return (
+		log.routingMetadata === null &&
+		new Date(log.createdAt) < getLogRetentionCutoff(now)
+	);
+}

--- a/scripts/cleanup-log-routing-metadata.md
+++ b/scripts/cleanup-log-routing-metadata.md
@@ -1,0 +1,59 @@
+# Backfill routing metadata cleanup
+
+Deploy the worker's 30-day cleanup change first. This separate, operator-run
+backfill also clears expired rows already marked `data_retention_cleaned_up`.
+It changes only `routing_metadata`; it does not reset retention flags or delete
+logs. Installing the SQL does not run the backfill.
+
+Ensure any required historical routing rollups are complete first: cleared
+routing details cannot be reconstructed. Existing aggregation rows are retained.
+
+Install using a database connection selected explicitly for this operation:
+
+```sh
+psql "$CLEANUP_DATABASE_URL" -X -v ON_ERROR_STOP=1 -f scripts/cleanup-log-routing-metadata.sql
+```
+
+Run with autocommit enabled, outside `BEGIN` and without `psql --single-transaction`:
+
+```sql
+CALL maintenance.cleanup_log_routing_metadata(
+	batch_size => 1000,
+	pause_seconds => 1,
+	max_batches => 1000
+);
+
+SELECT cutoff, scanned_rows, cleared_rows, completed, updated_at
+FROM maintenance.log_routing_metadata_cleanup;
+```
+
+Each call examines up to one million rows, committing every 1,000 and pausing
+one second between batches. Repeat the call until `completed` is true. Use one
+runner; cancel or disconnect to stop, then repeat the call to resume. A lock
+wait longer than one second aborts the call; earlier batches stay committed and
+the failed batch is retried on the next call. Reinstalling the SQL preserves
+progress.
+
+The procedure walks the existing `log` primary-key index with `id > last_id`,
+without `OFFSET`, a new index, or repeated scans from the beginning. It limits
+rows **before** checking age and non-null metadata, so batches with no matches
+still advance. Its fixed cutoff is 30 days before the first call, in UTC; the
+worker handles rows that expire afterward. Run after historical imports finish;
+backdated rows inserted behind the cursor require a new pass.
+
+A billion examined rows need at least about 11.6 days at these defaults, plus
+query time. Increase the pause or reduce the batch size if database latency,
+WAL volume, replica lag, or vacuum backlog rises. Updates create dead tuples;
+allow autovacuum to reclaim them. This does not immediately shrink the table's
+files, and `VACUUM FULL` would take an exclusive table lock.
+
+After completion, remove only these maintenance objects if desired:
+
+```sql
+DROP PROCEDURE maintenance.cleanup_log_routing_metadata(integer, double precision, integer);
+DROP TABLE maintenance.log_routing_metadata_cleanup;
+```
+
+PostgreSQL [procedures support per-batch commits](https://www.postgresql.org/docs/17/plpgsql-transactions.html);
+ordinary functions cannot provide this transaction boundary. See also
+[routine vacuuming](https://www.postgresql.org/docs/17/routine-vacuuming.html).

--- a/scripts/cleanup-log-routing-metadata.md
+++ b/scripts/cleanup-log-routing-metadata.md
@@ -5,8 +5,10 @@ backfill also clears expired rows already marked `data_retention_cleaned_up`.
 It changes only `routing_metadata`; it does not reset retention flags or delete
 logs. Installing the SQL does not run the backfill.
 
-Ensure any required historical routing rollups are complete first: cleared
-routing details cannot be reconstructed. Existing aggregation rows are retained.
+Existing routing elections, exclusions, and service-tier counters remain in their
+aggregation tables. Log-based rollups skip periods outside the 30-day retention
+window to avoid rebuilding incomplete routing data. Cleared details cannot be
+reconstructed; hourly summaries built from minute history remain available.
 
 Install using a database connection selected explicitly for this operation:
 

--- a/scripts/cleanup-log-routing-metadata.sql
+++ b/scripts/cleanup-log-routing-metadata.sql
@@ -1,0 +1,94 @@
+-- Operator-run backfill; installing this file does not update logs.
+-- See cleanup-log-routing-metadata.md before calling the procedure.
+CREATE SCHEMA IF NOT EXISTS maintenance;
+
+CREATE TABLE IF NOT EXISTS maintenance.log_routing_metadata_cleanup (
+	singleton boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+	cutoff timestamp NOT NULL,
+	last_id text NOT NULL DEFAULT '',
+	stop_id text NOT NULL,
+	scanned_rows bigint NOT NULL DEFAULT 0,
+	cleared_rows bigint NOT NULL DEFAULT 0,
+	completed boolean NOT NULL DEFAULT false,
+	updated_at timestamptz NOT NULL DEFAULT clock_timestamp()
+);
+
+CREATE OR REPLACE PROCEDURE maintenance.cleanup_log_routing_metadata(
+	batch_size integer DEFAULT 1000,
+	pause_seconds double precision DEFAULT 1,
+	max_batches integer DEFAULT 1000
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+	progress maintenance.log_routing_metadata_cleanup%ROWTYPE;
+	batch_ids text[];
+	cleared integer;
+BEGIN
+	IF batch_size IS NULL OR batch_size NOT BETWEEN 1 AND 10000
+		OR pause_seconds IS NULL OR pause_seconds NOT BETWEEN 0 AND 60
+		OR max_batches IS NULL OR max_batches < 1 THEN
+		RAISE EXCEPTION 'Use batch_size 1..10000, pause_seconds 0..60, and max_batches >= 1';
+	END IF;
+
+	-- Freeze the cutoff and upper bound on the first call, including on resume.
+	INSERT INTO maintenance.log_routing_metadata_cleanup (cutoff, stop_id)
+	VALUES (
+		(clock_timestamp() AT TIME ZONE 'UTC') - interval '30 days',
+		coalesce((SELECT id FROM public.log ORDER BY id DESC LIMIT 1), '')
+	)
+	ON CONFLICT (singleton) DO NOTHING;
+
+	FOR batch_number IN 1..max_batches LOOP
+		PERFORM set_config('lock_timeout', '1s', true);
+		SELECT * INTO STRICT progress
+		FROM maintenance.log_routing_metadata_cleanup
+		WHERE singleton
+		FOR UPDATE NOWAIT;
+
+		IF progress.completed THEN
+			COMMIT;
+			RETURN;
+		END IF;
+
+		-- Limit examined rows before filtering metadata/age, so sparse matches
+		-- cannot cause an unbounded scan. Generated log IDs are nonempty.
+		SELECT array_agg(id ORDER BY id) INTO batch_ids
+		FROM (
+			SELECT id FROM public.log
+			WHERE id > progress.last_id AND id <= progress.stop_id
+			ORDER BY id
+			LIMIT batch_size
+		) AS batch;
+
+		IF batch_ids IS NULL THEN
+			UPDATE maintenance.log_routing_metadata_cleanup
+			SET completed = true, updated_at = clock_timestamp()
+			WHERE singleton;
+			COMMIT;
+			RETURN;
+		END IF;
+
+		-- Do not skip locked rows: advancing the cursor would lose them.
+		UPDATE public.log
+		SET routing_metadata = NULL
+		WHERE id = ANY(batch_ids)
+			AND created_at < progress.cutoff
+			AND routing_metadata IS NOT NULL;
+		GET DIAGNOSTICS cleared = ROW_COUNT;
+
+		UPDATE maintenance.log_routing_metadata_cleanup
+		SET last_id = batch_ids[cardinality(batch_ids)],
+			scanned_rows = scanned_rows + cardinality(batch_ids),
+			cleared_rows = cleared_rows + cleared,
+			updated_at = clock_timestamp()
+		WHERE singleton;
+
+		-- The checkpoint and updates commit together; sleep holds no row locks.
+		COMMIT;
+		IF batch_number < max_batches THEN
+			PERFORM pg_sleep(pause_seconds);
+		END IF;
+	END LOOP;
+END;
+$$;


### PR DESCRIPTION
The 30-day log cleanup retained routing metadata indefinitely. It now clears `routing_metadata` alongside expired payloads and shows “Routing metadata expired” in log details and expanded activity/admin cards when metadata is null and the log is older than 30 days. Recent logs without metadata are not labeled expired; usage and costs remain visible.

Routing election/exclusion rollups and explicit/implicit service-tier counters depend on this metadata. Log-based calculations now skip expired periods, including partially expired hours/minutes, to preserve saved aggregates instead of rebuilding them from incomplete data. Hourly summaries can still be rebuilt from saved minute history. Deleted routing details cannot be reconstructed; usage and billing totals do not depend on them.

Adds an operator-run SQL backfill for existing expired logs, including rows already marked as cleaned. It scans bounded batches through the existing primary-key index, commits updates and a durable checkpoint together, and pauses between batches. The cutoff is fixed on the first call; interrupted batches can be retried without skipping locked rows. The [runbook](https://github.com/theopenco/llmgateway/blob/routing-metadata-retention/scripts/cleanup-log-routing-metadata.md) covers installation, throttling, progress, and completion. No backfill runs during deployment.

Validation: `pnpm format`, `pnpm build`, and 80 scoped tests passed against an isolated database. A separate 100,000-row PostgreSQL fixture completed successfully; `EXPLAIN ANALYZE` confirmed primary-key index access for selection and updates. Browser checks covered the three affected views in light/dark themes and the expiry notice at 390px; existing page overflow is unchanged by the notice.

<details>
<summary>Before/after screenshots (local fixtures)</summary>

| View | Before | After |
| --- | --- | --- |
| Log detail, light | <img width="450" alt="Log detail, light, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/ba398321b7e98623482880ce9ab0091de58daeaf/before-detail-light.png" /> | <img width="450" alt="Log detail, light, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/ba398321b7e98623482880ce9ab0091de58daeaf/after-detail-light.png" /> |
| Log detail, dark | <img width="450" alt="Log detail, dark, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/ba398321b7e98623482880ce9ab0091de58daeaf/before-detail-dark.png" /> | <img width="450" alt="Log detail, dark, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/ba398321b7e98623482880ce9ab0091de58daeaf/after-detail-dark.png" /> |
| Activity log, light | <img width="450" alt="Activity log, light, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/ba398321b7e98623482880ce9ab0091de58daeaf/before-activity-light.png" /> | <img width="450" alt="Activity log, light, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/ba398321b7e98623482880ce9ab0091de58daeaf/after-activity-light.png" /> |
| Activity log, dark | <img width="450" alt="Activity log, dark, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/ba398321b7e98623482880ce9ab0091de58daeaf/before-activity-dark.png" /> | <img width="450" alt="Activity log, dark, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/ba398321b7e98623482880ce9ab0091de58daeaf/after-activity-dark.png" /> |
| Admin log, light | <img width="450" alt="Admin log, light, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/ba398321b7e98623482880ce9ab0091de58daeaf/before-admin-light.png" /> | <img width="450" alt="Admin log, light, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/ba398321b7e98623482880ce9ab0091de58daeaf/after-admin-light.png" /> |
| Admin log, dark | <img width="450" alt="Admin log, dark, before" src="https://raw.githubusercontent.com/theopenco/llmgateway/ba398321b7e98623482880ce9ab0091de58daeaf/before-admin-dark.png" /> | <img width="450" alt="Admin log, dark, after" src="https://raw.githubusercontent.com/theopenco/llmgateway/ba398321b7e98623482880ce9ab0091de58daeaf/after-admin-dark.png" /> |

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Data Retention**
  - Expired log cleanup now removes routing metadata while preserving log content.
  - Recent logs retain their routing metadata and remain unaffected.

- **Analytics**
  - Expired periods no longer create new routing telemetry or rebuild routing history.
  - Existing saved usage and cost summaries remain available.

- **User Experience**
  - Log views now clearly indicate when routing details have expired, while usage and cost information remains available.

- **Maintenance**
  - Added a resumable, batched backfill for previously processed expired logs.

- **Documentation**
  - Added operator guidance for running and monitoring the cleanup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->