### PR TITLE
fix(airside): allow empty analytics host

### DIFF
--- a/.github/workflows/image-tests.yml
+++ b/.github/workflows/image-tests.yml
@@ -13,6 +13,7 @@ on:
       - "**/tsconfig.json"
       - "pnpm-lock.yaml"
       - "infra/**"
+      - "apps/airside/src/lib/config-server.ts"
       - ".github/workflows/image-tests.yml"
 
 concurrency:

--- a/apps/airside/src/lib/config-server.spec.ts
+++ b/apps/airside/src/lib/config-server.spec.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getConfig } from "./config-server";
+
+describe("PostHog host configuration", () => {
+	beforeEach(() => {
+		vi.stubEnv("NODE_ENV", "production");
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it.each([undefined, ""])("treats %j as an unset host", (host) => {
+		vi.stubEnv("POSTHOG_HOST", host);
+		expect(getConfig().posthogHost).toBeUndefined();
+	});
+
+	it("preserves a configured HTTPS host", () => {
+		const host = "https://us.i.posthog.com";
+		vi.stubEnv("POSTHOG_HOST", host);
+		expect(getConfig().posthogHost).toBe(host);
+	});
+
+	it.each([
+		"not-a-url",
+		"http://us.i.posthog.com",
+		"http://localhost:8080",
+		"ftp://example.com",
+	])("rejects %s in production", (host) => {
+		vi.stubEnv("POSTHOG_HOST", host);
+		expect(() => getConfig()).toThrow();
+	});
+
+	it.each(["localhost", "127.0.0.1", "[::1]"])(
+		"allows HTTP on %s during development",
+		(hostname) => {
+			const host = `http://${hostname}:8080`;
+			vi.stubEnv("NODE_ENV", "development");
+			vi.stubEnv("POSTHOG_HOST", host);
+			expect(getConfig().posthogHost).toBe(host);
+		},
+	);
+
+	it("rejects remote HTTP hosts during development", () => {
+		vi.stubEnv("NODE_ENV", "development");
+		vi.stubEnv("POSTHOG_HOST", "http://example.com");
+		expect(() => getConfig()).toThrow("POSTHOG_HOST must use HTTPS");
+	});
+});

--- a/apps/airside/src/lib/config-server.ts
+++ b/apps/airside/src/lib/config-server.ts
@@ -14,7 +14,7 @@ export interface AppConfig {
 
 export function getConfig(): AppConfig {
 	const apiUrl = process.env.API_URL ?? "http://localhost:4002";
-	const posthogHost = process.env.POSTHOG_HOST;
+	const posthogHost = process.env.POSTHOG_HOST || undefined;
 	if (posthogHost !== undefined) {
 		const url = new URL(posthogHost);
 		const localDevelopment =


### PR DESCRIPTION
Docker Compose defaults the optional `POSTHOG_HOST` to an empty string. Airside's URL validation then throws during rendering, returning HTTP 500 and failing both Docker image smoke tests on main.

Treat an empty host as unset while preserving validation for configured hosts. Add regression coverage and run image tests on Airside configuration changes.

Validation:

- Reproduced the empty-host failure before the fix; all 11 configuration tests pass afterward using an isolated test environment.
- `pnpm format` and `pnpm build`.
- The production Airside server returns HTTP 200 with `POSTHOG_HOST=""`.
