### PR TITLE
fix(admin): responsive UI + Airside margin

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -402,6 +402,17 @@ const adminMetricsSchema = z.object({
 	// Negotiated enterprise revenue recorded by an administrator. These rows do
 	// not grant credits and are kept separate from manual credit payments.
 	grossEnterpriseDealsRevenue: z.number(),
+	// Gateway margin accrued on Airside-carrier traffic (credits mode), summed
+	// from the daily global rollups. A profit share inside credits spend, so it
+	// is reported alongside — not added to — the grossRevenue splits.
+	airsideMarginProfit: z.number(),
+	airsideMarginByCarrier: z.array(
+		z.object({
+			providerId: z.string(),
+			companyName: z.string(),
+			amount: z.number(),
+		}),
+	),
 });
 
 const timeseriesRangeSchema = z.enum(["7d", "30d", "90d", "365d", "all"]);
@@ -1559,6 +1570,64 @@ admin.openapi(getMetrics, async (c) => {
 		grossEnterpriseDealsRow?.value ?? 0,
 	);
 
+	// Airside gateway margin, per carrier. dayTimestamp is `timestamp without
+	// time zone`, so compare against UTC strings rather than Date parameters.
+	const toUtcTimestamp = (date: Date) =>
+		date.toISOString().slice(0, 19).replace("T", " ");
+	const airsideMarginDateFilter = and(
+		startDate
+			? sql`${globalModelStats.dayTimestamp} >= ${toUtcTimestamp(startDate)}::timestamp`
+			: undefined,
+		endDate
+			? sql`${globalModelStats.dayTimestamp} <= ${toUtcTimestamp(endDate)}::timestamp`
+			: undefined,
+	);
+	const airsideMarginRows = await db
+		.select({
+			providerId: tables.providerRoutingSettings.providerId,
+			companyName: tables.providerCompany.name,
+			amount:
+				sql<number>`coalesce(sum(cast(${globalModelStats.providerMarginAmount} as double precision)), 0)`.as(
+					"amount",
+				),
+		})
+		.from(tables.providerRoutingSettings)
+		.innerJoin(
+			tables.providerCompany,
+			eq(
+				tables.providerRoutingSettings.providerCompanyId,
+				tables.providerCompany.id,
+			),
+		)
+		.leftJoin(
+			globalModelStats,
+			and(
+				eq(
+					globalModelStats.usedProvider,
+					tables.providerRoutingSettings.providerId,
+				),
+				eq(globalModelStats.usedMode, "credits"),
+				airsideMarginDateFilter,
+			),
+		)
+		.where(isNull(tables.providerRoutingSettings.modelId))
+		.groupBy(
+			tables.providerRoutingSettings.providerId,
+			tables.providerCompany.name,
+		);
+
+	const airsideMarginByCarrier = airsideMarginRows
+		.map((row) => ({
+			providerId: row.providerId,
+			companyName: row.companyName,
+			amount: Number(row.amount ?? 0),
+		}))
+		.sort((a, b) => b.amount - a.amount);
+	const airsideMarginProfit = airsideMarginByCarrier.reduce(
+		(sum, row) => sum + row.amount,
+		0,
+	);
+
 	const grossRevenue =
 		grossCreditsRevenue +
 		grossDevpassRevenue +
@@ -1602,6 +1671,8 @@ admin.openapi(getMetrics, async (c) => {
 		grossProSubscriptionsRevenue,
 		grossManualPaymentsRevenue,
 		grossEnterpriseDealsRevenue,
+		airsideMarginProfit,
+		airsideMarginByCarrier,
 	});
 });
 

--- a/ee/admin/src/app/contact-submissions/[id]/page.tsx
+++ b/ee/admin/src/app/contact-submissions/[id]/page.tsx
@@ -98,7 +98,7 @@ export default async function ContactSubmissionDetailPage({
 			<BackToSubmissions />
 
 			<header className="flex flex-col gap-2">
-				<div className="flex items-center gap-3">
+				<div className="flex flex-wrap items-center gap-3">
 					<h1 className="text-3xl font-semibold tracking-tight">{data.name}</h1>
 					<Badge variant={getStatusBadgeVariant(data.spamFilterStatus)}>
 						{getStatusLabel(data.spamFilterStatus)}

--- a/ee/admin/src/app/contact-submissions/page.tsx
+++ b/ee/admin/src/app/contact-submissions/page.tsx
@@ -241,14 +241,14 @@ export default async function ContactSubmissionsPage({
 							</option>
 						))}
 					</select>
-					<div className="relative flex-1 sm:flex-initial">
+					<div className="relative min-w-0 flex-1 sm:max-w-64">
 						<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
 						<input
 							type="text"
 							name="search"
 							placeholder="Search by name, email, or message..."
 							defaultValue={search}
-							className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring sm:w-64"
+							className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
 						/>
 					</div>
 					<Button type="submit" size="sm">

--- a/ee/admin/src/app/model-provider-mappings/page.tsx
+++ b/ee/admin/src/app/model-provider-mappings/page.tsx
@@ -147,14 +147,14 @@ export default async function ModelProviderMappingsPage({
 					<input type="hidden" name="sortOrder" value={sortOrder} />
 					<input type="hidden" name="window" value={pageWindow} />
 					<input type="hidden" name="mode" value={usageMode} />
-					<div className="relative flex-1 sm:flex-initial">
+					<div className="relative min-w-0 flex-1 sm:max-w-64">
 						<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
 						<input
 							type="text"
 							name="search"
 							placeholder="Search by model or provider..."
 							defaultValue={search}
-							className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring sm:w-64"
+							className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
 						/>
 					</div>
 					<Button type="submit" size="sm">

--- a/ee/admin/src/app/models/page.tsx
+++ b/ee/admin/src/app/models/page.tsx
@@ -142,7 +142,7 @@ export default async function ModelsPage({
 						{data.total} models found — click a row to view details
 					</p>
 				</div>
-				<div className="flex items-center gap-3">
+				<div className="flex w-full items-center gap-3 sm:w-auto">
 					<form
 						action={handleSearch}
 						className="flex w-full items-center gap-2 sm:w-auto"

--- a/ee/admin/src/app/models/page.tsx
+++ b/ee/admin/src/app/models/page.tsx
@@ -151,14 +151,14 @@ export default async function ModelsPage({
 						<input type="hidden" name="sortOrder" value={sortOrder} />
 						<input type="hidden" name="window" value={pageWindow} />
 						<input type="hidden" name="mode" value={usageMode} />
-						<div className="relative flex-1 sm:flex-initial">
+						<div className="relative min-w-0 flex-1 sm:max-w-64">
 							<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
 							<input
 								type="text"
 								name="search"
 								placeholder="Search by name or ID..."
 								defaultValue={search}
-								className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring sm:w-64"
+								className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
 							/>
 						</div>
 						<Button type="submit" size="sm">

--- a/ee/admin/src/app/organizations/[orgId]/org-settings-tab.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/org-settings-tab.tsx
@@ -174,9 +174,9 @@ function SettingRow({
 	children: ReactNode;
 }) {
 	return (
-		<div className="flex items-center justify-between gap-4 border-b border-border/40 py-2 last:border-b-0">
+		<div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 border-b border-border/40 py-2 last:border-b-0">
 			<span className="text-sm text-muted-foreground">{label}</span>
-			<span className="text-sm font-medium">{children}</span>
+			<span className="min-w-0 text-sm font-medium">{children}</span>
 		</div>
 	);
 }

--- a/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/model-provider-mappings/page.tsx
+++ b/ee/admin/src/app/organizations/[orgId]/projects/[projectId]/model-provider-mappings/page.tsx
@@ -120,19 +120,22 @@ export default async function ProjectModelProviderMappingsPage({
 						<strong>{project.name}</strong>
 					</p>
 				</div>
-				<div className="flex items-center gap-3">
-					<form action={handleSearch} className="flex items-center gap-2">
+				<div className="flex w-full items-center gap-3 sm:w-auto">
+					<form
+						action={handleSearch}
+						className="flex w-full items-center gap-2 sm:w-auto"
+					>
 						<input type="hidden" name="sortBy" value={sortBy} />
 						<input type="hidden" name="sortOrder" value={sortOrder} />
 						<input type="hidden" name="window" value={pageWindow} />
-						<div className="relative">
+						<div className="relative min-w-0 flex-1 sm:max-w-64">
 							<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
 							<input
 								type="text"
 								name="search"
 								placeholder="Search by model or provider..."
 								defaultValue={search}
-								className="h-9 w-64 rounded-md border border-border bg-background pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+								className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
 							/>
 						</div>
 						<Button type="submit" size="sm">
@@ -163,7 +166,7 @@ export default async function ProjectModelProviderMappingsPage({
 						</p>
 					</div>
 				</div>
-				<div className="flex flex-col items-end gap-1">
+				<div className="flex flex-col items-start gap-1 sm:items-end">
 					<Suspense>
 						<TimeWindowSelector current={pageWindow} />
 					</Suspense>

--- a/ee/admin/src/app/organizations/page.tsx
+++ b/ee/admin/src/app/organizations/page.tsx
@@ -324,8 +324,8 @@ export default async function OrganizationsPage({
 						Spend, requests, and tokens cover {usageWindowLabel}.
 					</p>
 				</div>
-				<div className="flex w-full items-start gap-2 sm:w-auto sm:items-center">
-					<div className="flex min-w-0 flex-1 flex-col items-stretch gap-2 sm:flex-initial sm:flex-row sm:items-center">
+				<div className="flex w-full flex-wrap items-start gap-2 sm:w-auto sm:items-center">
+					<div className="flex min-w-0 flex-1 flex-col flex-wrap items-stretch gap-2 sm:flex-initial sm:flex-row sm:items-center">
 						<DateRangePicker defaultRange={ORGANIZATIONS_DEFAULT_RANGE} />
 						<form
 							action={handleSearch}
@@ -336,14 +336,14 @@ export default async function OrganizationsPage({
 							<input type="hidden" name="range" value={dateRange.range ?? ""} />
 							<input type="hidden" name="from" value={dateRange.from ?? ""} />
 							<input type="hidden" name="to" value={dateRange.to ?? ""} />
-							<div className="relative flex-1 sm:flex-initial">
+							<div className="relative min-w-0 flex-1 sm:max-w-64">
 								<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
 								<input
 									type="text"
 									name="search"
 									placeholder="Search by name, email, member email, ID, or safety identifier..."
 									defaultValue={search}
-									className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring sm:w-64"
+									className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
 								/>
 							</div>
 							<Button type="submit" size="sm">

--- a/ee/admin/src/app/page.tsx
+++ b/ee/admin/src/app/page.tsx
@@ -4,6 +4,7 @@ import {
 	CircleDollarSign,
 	Gift,
 	PiggyBank,
+	PlaneTakeoff,
 	TrendingUp,
 	Users,
 } from "lucide-react";
@@ -33,7 +34,7 @@ const numberFormatter = new Intl.NumberFormat("en-US", {
 	maximumFractionDigits: 0,
 });
 
-type Accent = "green" | "blue" | "violet" | "amber" | "teal";
+type Accent = "green" | "blue" | "violet" | "amber" | "teal" | "rose";
 
 const accentTick: Record<Accent, string> = {
 	green: "bg-emerald-500 dark:bg-emerald-400",
@@ -41,6 +42,7 @@ const accentTick: Record<Accent, string> = {
 	violet: "bg-violet-500 dark:bg-violet-400",
 	amber: "bg-amber-500 dark:bg-amber-400",
 	teal: "bg-teal-500 dark:bg-teal-400",
+	rose: "bg-rose-500 dark:bg-rose-400",
 };
 
 const accentIcon: Record<Accent, string> = {
@@ -49,6 +51,7 @@ const accentIcon: Record<Accent, string> = {
 	violet: "text-violet-600 dark:text-violet-400",
 	amber: "text-amber-600 dark:text-amber-400",
 	teal: "text-teal-600 dark:text-teal-400",
+	rose: "text-rose-600 dark:text-rose-400",
 };
 
 function revealAt(index: number): CSSProperties {
@@ -133,6 +136,7 @@ function MetricCell({
 	accent,
 	rows,
 	hero = false,
+	rowsGrid = false,
 	className,
 	style,
 }: {
@@ -144,6 +148,8 @@ function MetricCell({
 	accent: Accent;
 	rows: { label: string; value: string }[];
 	hero?: boolean;
+	/** Lay the ledger rows out in the hero's two-column grid. */
+	rowsGrid?: boolean;
 	className?: string;
 	style?: CSSProperties;
 }) {
@@ -199,7 +205,7 @@ function MetricCell({
 			<dl
 				className={cn(
 					"relative mt-auto border-t border-border/50 pt-4",
-					hero
+					hero || rowsGrid
 						? "grid grid-cols-1 gap-x-8 gap-y-2 sm:grid-cols-2"
 						: "flex flex-col gap-2",
 				)}
@@ -463,6 +469,21 @@ export default async function Page({
 									value: currencyFormatter.format(metrics.totalBonusCredits),
 								},
 							]}
+						/>
+						<MetricCell
+							label="Airside margin"
+							value={metrics.airsideMarginProfit}
+							format="currency"
+							sublabel="Gateway margin earned on Airside-carrier traffic"
+							icon={<PlaneTakeoff className="h-4 w-4" strokeWidth={1.75} />}
+							accent="rose"
+							rowsGrid
+							className="sm:col-span-2 xl:col-span-3"
+							style={revealAt(7)}
+							rows={metrics.airsideMarginByCarrier.map((carrier) => ({
+								label: carrier.companyName,
+								value: currencyFormatter.format(carrier.amount),
+							}))}
 						/>
 					</div>
 				</div>

--- a/ee/admin/src/app/provider-listing-requests/page.tsx
+++ b/ee/admin/src/app/provider-listing-requests/page.tsx
@@ -238,14 +238,14 @@ export default async function ProviderListingRequestsPage({
 							</option>
 						))}
 					</select>
-					<div className="relative flex-1 sm:flex-initial">
+					<div className="relative min-w-0 flex-1 sm:max-w-64">
 						<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
 						<input
 							type="text"
 							name="search"
 							placeholder="Search by provider, email, URL, or country..."
 							defaultValue={search}
-							className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring sm:w-64"
+							className="h-9 w-full rounded-md border border-border bg-background pl-9 pr-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
 						/>
 					</div>
 					<Button type="submit" size="sm">

--- a/ee/admin/src/components/chat-plans-timeseries-chart.tsx
+++ b/ee/admin/src/components/chat-plans-timeseries-chart.tsx
@@ -80,7 +80,7 @@ export function ChatPlansTimeseriesChart({
 
 	return (
 		<Card>
-			<CardHeader className="flex flex-col items-stretch space-y-0 border-b p-0 sm:flex-row">
+			<CardHeader className="flex flex-col items-stretch space-y-0 border-b p-0">
 				<div className="flex flex-1 flex-col justify-center gap-1 px-6 py-5 sm:py-6">
 					<div className="flex flex-wrap items-center justify-between gap-3">
 						<CardTitle>Lounge (chat) plans revenue & usage</CardTitle>
@@ -104,7 +104,7 @@ export function ChatPlansTimeseriesChart({
 								aria-pressed={activeSeries === key}
 								data-active={activeSeries === key}
 								className={cn(
-									"relative z-30 flex flex-1 flex-col justify-center gap-1 border-t px-6 py-4 text-left even:border-l data-[active=true]:bg-muted/50 sm:border-l sm:border-t-0 sm:px-8 sm:py-6",
+									"relative z-30 flex min-w-0 flex-1 flex-col justify-center gap-1 border-l border-t px-4 py-4 text-left first:border-l-0 data-[active=true]:bg-muted/50 sm:px-6",
 								)}
 								onClick={() => setActiveSeries(key)}
 							>

--- a/ee/admin/src/components/cost-by-model-chart.tsx
+++ b/ee/admin/src/components/cost-by-model-chart.tsx
@@ -233,7 +233,7 @@ export function CostByModelChart({
 						<CardTitle className="text-base">{title}</CardTitle>
 						{description && <CardDescription>{description}</CardDescription>}
 						{data && (
-							<div className="mt-1 flex items-center gap-4 text-xs text-muted-foreground">
+							<div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
 								<span>
 									{usageMode === "credits"
 										? "Credits Cost: "
@@ -260,7 +260,7 @@ export function CostByModelChart({
 				</div>
 				<div className="flex flex-wrap items-center justify-between gap-2 border-b pb-2">
 					<div
-						className="flex items-center gap-1"
+						className="flex flex-wrap items-center gap-1"
 						role="group"
 						aria-label="Metric"
 					>
@@ -285,7 +285,7 @@ export function CostByModelChart({
 						<UsageModeSelector />
 						{showGroupBy && (
 							<div
-								className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-1"
+								className="flex flex-wrap items-center gap-1 rounded-md border border-border/60 bg-background p-1"
 								role="group"
 								aria-label="Break down by"
 							>
@@ -309,7 +309,7 @@ export function CostByModelChart({
 						)}
 						{showModelView && groupBy === "model" && (
 							<div
-								className="flex items-center gap-1 rounded-md border border-border/60 bg-background p-1"
+								className="flex flex-wrap items-center gap-1 rounded-md border border-border/60 bg-background p-1"
 								role="group"
 								aria-label="Model view"
 							>

--- a/ee/admin/src/components/cost-by-model-timeseries-chart.tsx
+++ b/ee/admin/src/components/cost-by-model-timeseries-chart.tsx
@@ -221,7 +221,7 @@ export function CostByModelTimeseriesChart({
 				</div>
 				<div className="flex flex-wrap items-center justify-between gap-2 border-b pb-2">
 					<div
-						className="flex items-center gap-1"
+						className="flex flex-wrap items-center gap-1"
 						role="group"
 						aria-label="Metric"
 					>

--- a/ee/admin/src/components/history-chart.tsx
+++ b/ee/admin/src/components/history-chart.tsx
@@ -292,9 +292,9 @@ export function HistoryChart({
 	return (
 		<Card>
 			<CardHeader className="space-y-4 pb-2">
-				<div className="flex items-start justify-between gap-4">
+				<div className="flex flex-wrap items-start justify-between gap-4">
 					<div>
-						<div className="flex items-center gap-2">
+						<div className="flex flex-wrap items-center gap-2">
 							<CardTitle className="text-base">{title}</CardTitle>
 							<span
 								className="rounded border px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
@@ -390,7 +390,7 @@ export function HistoryChart({
 				</div>
 				<div className="flex flex-wrap items-center justify-between gap-2 border-b pb-2">
 					<div
-						className="flex items-center gap-1"
+						className="flex flex-wrap items-center gap-1"
 						role="group"
 						aria-label="Metric"
 					>

--- a/ee/admin/src/components/ignored-error-matchers.tsx
+++ b/ee/admin/src/components/ignored-error-matchers.tsx
@@ -41,7 +41,7 @@ export function IgnoredErrorsToggle({
 	);
 
 	return (
-		<div className="flex items-center gap-1">
+		<div className="flex flex-wrap items-center gap-1">
 			<Button
 				variant={ignoreExpected ? "default" : "outline"}
 				size="sm"

--- a/ee/admin/src/components/retried-filter-toggle.tsx
+++ b/ee/admin/src/components/retried-filter-toggle.tsx
@@ -28,7 +28,7 @@ export function RetriedFilterToggle({
 	);
 
 	return (
-		<div className="flex items-center gap-1">
+		<div className="flex flex-wrap items-center gap-1">
 			<Button
 				variant={includeRetried ? "outline" : "default"}
 				size="sm"

--- a/ee/admin/src/components/revenue-chart.tsx
+++ b/ee/admin/src/components/revenue-chart.tsx
@@ -123,7 +123,7 @@ export function RevenueChart({
 
 	return (
 		<Card>
-			<CardHeader className="flex flex-col items-stretch space-y-0 border-b p-0 sm:flex-row">
+			<CardHeader className="flex flex-col items-stretch space-y-0 border-b p-0">
 				<div className="flex flex-1 flex-col justify-center gap-1.5 px-6 py-5 sm:py-6">
 					<div className="flex flex-wrap items-center justify-between gap-3">
 						<CardTitle className="font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
@@ -140,7 +140,7 @@ export function RevenueChart({
 						<button
 							key={key}
 							data-active={activeView === key}
-							className="relative z-30 flex flex-1 flex-col justify-center gap-1.5 border-t px-6 py-4 text-left even:border-l data-[active=true]:bg-muted/50 sm:border-l sm:border-t-0 sm:px-8 sm:py-6"
+							className="relative z-30 flex min-w-0 flex-1 flex-col justify-center gap-1.5 border-t px-4 py-4 text-left border-l first:border-l-0 data-[active=true]:bg-muted/50 sm:px-6"
 							onClick={() => setActiveView(key)}
 						>
 							<span className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">

--- a/ee/admin/src/components/segmented-query-toggle.tsx
+++ b/ee/admin/src/components/segmented-query-toggle.tsx
@@ -39,7 +39,7 @@ export function SegmentedQueryToggle({
 	);
 
 	return (
-		<div className="flex items-center gap-1" aria-label={label}>
+		<div className="flex flex-wrap items-center gap-1" aria-label={label}>
 			{options.map((option) => (
 				<Button
 					key={option.value}

--- a/ee/admin/src/components/segmented-url-selector.tsx
+++ b/ee/admin/src/components/segmented-url-selector.tsx
@@ -68,7 +68,7 @@ export function SegmentedUrlSelector<T extends string>({
 	return (
 		<div
 			className={cn(
-				"flex items-center gap-1",
+				"flex flex-wrap items-center gap-1",
 				compact && "rounded-md border border-border/60 bg-background p-1",
 				className,
 			)}

--- a/ee/admin/src/components/signups-chart.tsx
+++ b/ee/admin/src/components/signups-chart.tsx
@@ -68,7 +68,7 @@ export function SignupsChart({
 
 	return (
 		<Card>
-			<CardHeader className="flex flex-col items-stretch space-y-0 border-b p-0 sm:flex-row">
+			<CardHeader className="flex flex-col items-stretch space-y-0 border-b p-0">
 				<div className="flex flex-1 flex-col justify-center gap-1.5 px-6 py-5 sm:py-6">
 					<div className="flex flex-wrap items-center justify-between gap-3">
 						<CardTitle className="font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
@@ -85,7 +85,7 @@ export function SignupsChart({
 						<button
 							key={key}
 							data-active={activeChart === key}
-							className="relative z-30 flex flex-1 flex-col justify-center gap-1.5 border-t px-6 py-4 text-left even:border-l data-[active=true]:bg-muted/50 sm:border-l sm:border-t-0 sm:px-8 sm:py-6"
+							className="relative z-30 flex min-w-0 flex-1 flex-col justify-center gap-1.5 border-l border-t px-4 py-4 text-left first:border-l-0 data-[active=true]:bg-muted/50 sm:px-6"
 							onClick={() => setActiveChart(key)}
 						>
 							<span className="font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground">

--- a/ee/admin/src/components/time-window-selector.tsx
+++ b/ee/admin/src/components/time-window-selector.tsx
@@ -32,8 +32,8 @@ export function TimeWindowSelector({
 	);
 
 	return (
-		<div className="flex items-center gap-2">
-			<div className="flex items-center gap-1">
+		<div className="flex flex-wrap items-center gap-2">
+			<div className="flex flex-wrap items-center gap-1">
 				{options.map((opt) => (
 					<Button
 						key={opt.value}

--- a/ee/admin/src/components/ui/table.tsx
+++ b/ee/admin/src/components/ui/table.tsx
@@ -4,11 +4,16 @@ import { cn } from "@/lib/utils";
 
 function Table({ className, ...props }: React.ComponentProps<"table">) {
 	return (
-		<table
-			data-slot="table"
-			className={cn("w-full caption-bottom text-sm", className)}
-			{...props}
-		/>
+		<div
+			data-slot="table-container"
+			className="relative w-full overflow-x-auto"
+		>
+			<table
+				data-slot="table"
+				className={cn("w-full caption-bottom text-sm", className)}
+				{...props}
+			/>
+		</div>
 	);
 }
 


### PR DESCRIPTION
## Problem

Many admin dashboard pages overflowed horizontally — the newer, wider tables (Airside carriers/filings, limit hits, payment failures, org members, …) blew out their cards because the shared `Table` component had no scroll container and every cell forces `whitespace-nowrap`. Several toolbars and chart headers also overflowed, some even at desktop widths (the revenue chart's stat buttons clipped at 1280+).

Separately, the gateway margin earned on Airside-carrier traffic was only visible per carrier on the Airside carriers page, not as a dashboard metric.

## Approach

**Responsive fixes**

- `ui/table.tsx`: wrap the table in the standard `overflow-x-auto` container (current shadcn layout), fixing every wide table in one place — tables scroll inside their card instead of stretching the page.
- Revenue / signups / Lounge-plans charts: the stat-button strip now always stacks below the title (side-by-side never fit in these half-width cards) with `min-w-0 flex-1` buttons.
- Segmented toggles, metric tab rows, and time-window selectors get `flex-wrap`; search forms swap the rigid `sm:w-64` input for a shrinkable `flex-1 sm:max-w-64` wrapper; assorted headers/toolbars (organizations, unstable mappings, contact-submission detail, org settings rows, project mappings) now wrap.

**Airside margin metric**

- `/admin/metrics` gains `airsideMarginProfit` plus an `airsideMarginByCarrier` breakdown, summed from the `global_model_stats` daily rollups (credits mode, carriers = provider routing settings rows, respecting the dashboard date range) — same source as the Airside carriers page.
- The dashboard renders it as a new full-width key-metric cell with one ledger row per carrier.

## Verification

- Playwright audit of all 33 admin routes (every nav page + detail pages + all tabs on tabbed pages) at 375/768/1280/1680 px: no document overflow and no element extends past the viewport outside a scroll container. Before the fix, 14 routes failed.
- `pnpm format`, `pnpm build`, and the admin metrics unit tests (`admin-metrics-bonus`, `admin-paid-customers`, `admin-devpass-payg`) pass.
- All screenshots below are from locally seeded data.

## Screenshots

### Dashboard (revenue-chart header fix + new Airside margin cell)

| Before (1440, light) | After (1440, light) |
| --- | --- |
| <img alt="dashboard before" src="https://raw.githubusercontent.com/theopenco/llmgateway/0708e0af50c9324c35ba124cd169dcc8473e1c20/dashboard-1440-light-before.png" /> | <img alt="dashboard after" src="https://raw.githubusercontent.com/theopenco/llmgateway/0708e0af50c9324c35ba124cd169dcc8473e1c20/dashboard-1440-light-after.png" /> |

| After (1440, dark) | After (375, light) | After (375, dark) |
| --- | --- | --- |
| <img alt="dashboard dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/0708e0af50c9324c35ba124cd169dcc8473e1c20/dashboard-1440-dark-after.png" /> | <img alt="dashboard mobile" src="https://raw.githubusercontent.com/theopenco/llmgateway/0708e0af50c9324c35ba124cd169dcc8473e1c20/dashboard-375-light-after.png" /> | <img alt="dashboard mobile dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/0708e0af50c9324c35ba124cd169dcc8473e1c20/dashboard-375-dark-after.png" /> |

### Airside carriers (table overflow, 375px)

| Before | After | After (1440, dark) |
| --- | --- | --- |
| <img alt="carriers before" src="https://raw.githubusercontent.com/theopenco/llmgateway/0708e0af50c9324c35ba124cd169dcc8473e1c20/airside-carriers-375-light-before.png" /> | <img alt="carriers after" src="https://raw.githubusercontent.com/theopenco/llmgateway/0708e0af50c9324c35ba124cd169dcc8473e1c20/airside-carriers-375-light-after.png" /> | <img alt="carriers dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/0708e0af50c9324c35ba124cd169dcc8473e1c20/airside-carriers-1440-dark-after.png" /> |

### Limit hits (table overflow, 375px)

| Before | After |
| --- | --- |
| <img alt="limit hits before" src="https://raw.githubusercontent.com/theopenco/llmgateway/0708e0af50c9324c35ba124cd169dcc8473e1c20/limit-hits-375-light-before.png" /> | <img alt="limit hits after" src="https://raw.githubusercontent.com/theopenco/llmgateway/0708e0af50c9324c35ba124cd169dcc8473e1c20/limit-hits-375-light-after.png" /> |

### Organizations toolbar (768px)

| Before | After |
| --- | --- |
| <img alt="organizations before" src="https://raw.githubusercontent.com/theopenco/llmgateway/0708e0af50c9324c35ba124cd169dcc8473e1c20/organizations-768-light-before.png" /> | <img alt="organizations after" src="https://raw.githubusercontent.com/theopenco/llmgateway/0708e0af50c9324c35ba124cd169dcc8473e1c20/organizations-768-light-after.png" /> |

### Models time-window selector (375px)

| Before | After |
| --- | --- |
| <img alt="models before" src="https://raw.githubusercontent.com/theopenco/llmgateway/0708e0af50c9324c35ba124cd169dcc8473e1c20/models-375-light-before.png" /> | <img alt="models after" src="https://raw.githubusercontent.com/theopenco/llmgateway/0708e0af50c9324c35ba124cd169dcc8473e1c20/models-375-light-after.png" /> |

### Recording

Full walkthrough of the admin UI after the fixes (all pages, desktop + mobile segment):
https://raw.githubusercontent.com/theopenco/llmgateway/0708e0af50c9324c35ba124cd169dcc8473e1c20/admin-ui-walkthrough.webm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgF9tspkhaXpSVSnRMMGyf

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgF9tspkhaXpSVSnRMMGyf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an Airside margin metric to the admin dashboard, including total earnings and a per-carrier breakdown.

- **UI Improvements**
  - Improved responsive layouts across admin pages, charts, filters, search fields, and settings.
  - Controls and content now wrap more gracefully on smaller screens.
  - Wide tables can be horizontally scrolled instead of overflowing the page.
  - Improved wrapping for long organization settings values and contact submission headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->