### PR TITLE
feat(admin): devpass margin parts + usage range

### DIFF
--- a/apps/api/src/routes/admin-devpass-margin-components.spec.ts
+++ b/apps/api/src/routes/admin-devpass-margin-components.spec.ts
@@ -279,4 +279,14 @@ describe("admin devpass margin components", () => {
 		expect(weekBody.range).toEqual({ from, to });
 		expect(weekBody.models.map((m) => m.id)).toEqual(["carrier-model"]);
 	});
+
+	it("usage rejects a lone range bound instead of widening to all time", async () => {
+		const to = isoDay(now);
+		for (const qs of [`from=${to}`, `to=${to}`]) {
+			const res = await app.request(`/admin/devpass/usage?${qs}`, {
+				headers: { Cookie: cookie },
+			});
+			expect(res.status).toBe(400);
+		}
+	});
 });

--- a/apps/api/src/routes/admin-devpass-margin-components.spec.ts
+++ b/apps/api/src/routes/admin-devpass-margin-components.spec.ts
@@ -1,0 +1,282 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { app } from "@/index.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+import { db, tables } from "@llmgateway/db";
+
+const ORG_ID = "admin-devpass-margin-org";
+const PROJECT_ID = "admin-devpass-margin-project";
+const OTHER_ORG_ID = "admin-devpass-margin-default-org";
+const OTHER_PROJECT_ID = "admin-devpass-margin-default-project";
+const originalAdminEmails = process.env.ADMIN_EMAILS;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const HOUR_MS = 60 * 60 * 1000;
+
+interface KpisResponse {
+	planMargin: number;
+	totalMargin: number;
+	marginPct: number | null;
+	gatewayMarginCycle: number;
+	resetPassesSold: number;
+	resetPassRevenue: number;
+	resetPassesSoldCycle: number;
+	resetPassRevenueCycle: number;
+	paygFeeCycle: number;
+	paygFeeAllTime: number;
+	totalRealCostCycle: number;
+	totalOverflowCostCycle: number;
+}
+
+interface TimeseriesResponse {
+	data: Array<{ date: string; gatewayMargin: number; margin: number }>;
+	totals: {
+		revenue: number;
+		topupRevenue: number;
+		cost: number;
+		gatewayMargin: number;
+		margin: number;
+	};
+}
+
+interface UsageResponse {
+	models: Array<{ id: string; cost: number }>;
+	range: { from: string; to: string } | null;
+}
+
+function isoDay(date: Date) {
+	return date.toISOString().slice(0, 10);
+}
+
+function daysAgo(now: Date, days: number) {
+	const offset = days * DAY_MS;
+	return new Date(now.getTime() - offset);
+}
+
+describe("admin devpass margin components", () => {
+	let cookie: string;
+	const now = new Date();
+	const cycleStart = daysAgo(now, 5);
+	const inCycle = new Date(cycleStart.getTime() + HOUR_MS);
+	const beforeCycle = daysAgo(now, 10);
+
+	beforeEach(async () => {
+		process.env.ADMIN_EMAILS = "admin@example.com";
+		cookie = await createTestUser();
+
+		await db.insert(tables.organization).values([
+			{
+				id: ORG_ID,
+				name: "Margin Org",
+				billingEmail: "margin@example.com",
+				kind: "devpass",
+				devPlan: "pro",
+				devPlanCreditsUsed: "100",
+				devPlanCreditsLimit: "237",
+				devPlanBillingCycleStart: cycleStart,
+			},
+			{
+				id: OTHER_ORG_ID,
+				name: "Default Org",
+				billingEmail: "default@example.com",
+				kind: "default",
+			},
+		]);
+		await db.insert(tables.userOrganization).values({
+			userId: "test-user-id",
+			organizationId: ORG_ID,
+			role: "owner",
+		});
+		await db.insert(tables.project).values([
+			{
+				id: PROJECT_ID,
+				name: "Margin Project",
+				organizationId: ORG_ID,
+				mode: "credits",
+			},
+			{
+				id: OTHER_PROJECT_ID,
+				name: "Default Project",
+				organizationId: OTHER_ORG_ID,
+				mode: "credits",
+			},
+		]);
+		// $100 of credits-mode cost this cycle, all drawn from the plan pool.
+		await db.insert(tables.projectHourlyStats).values({
+			projectId: PROJECT_ID,
+			hourTimestamp: inCycle,
+			requestCount: 10,
+			creditsCost: 100,
+		});
+		await db.insert(tables.projectHourlyModelStats).values([
+			// Airside-carrier traffic inside the cycle: $40 at a 30% margin.
+			{
+				projectId: PROJECT_ID,
+				hourTimestamp: inCycle,
+				usedModel: "carrier-model",
+				usedProvider: "carrier",
+				requestCount: 4,
+				cost: 40,
+				creditsCost: 40,
+				providerMarginAmount: 12,
+			},
+			// Before the cycle started: all-time only.
+			{
+				projectId: PROJECT_ID,
+				hourTimestamp: beforeCycle,
+				usedModel: "older-model",
+				usedProvider: "carrier",
+				requestCount: 2,
+				cost: 20,
+				creditsCost: 20,
+				providerMarginAmount: 5,
+			},
+			// Traffic from a non-DevPass org never counts.
+			{
+				projectId: OTHER_PROJECT_ID,
+				hourTimestamp: inCycle,
+				usedModel: "carrier-model",
+				usedProvider: "carrier",
+				requestCount: 9,
+				cost: 900,
+				creditsCost: 900,
+				providerMarginAmount: 100,
+			},
+		]);
+		const inserted = await db
+			.insert(tables.transaction)
+			.values([
+				{
+					organizationId: ORG_ID,
+					type: "dev_plan_start",
+					amount: "79",
+					creditAmount: "237",
+					status: "completed",
+					stripeInvoiceId: "inv_margin_start",
+					createdAt: cycleStart,
+				},
+				// One Reset Pass inside the cycle, one before it.
+				{
+					organizationId: ORG_ID,
+					type: "dev_plan_reset_pass",
+					amount: "29",
+					status: "completed",
+					createdAt: daysAgo(now, 3),
+				},
+				{
+					organizationId: ORG_ID,
+					type: "dev_plan_reset_pass",
+					amount: "29",
+					status: "completed",
+					createdAt: beforeCycle,
+				},
+				// PAYG overflow top-up: $26.25 charged for $25 of credits.
+				{
+					organizationId: ORG_ID,
+					type: "credit_topup",
+					amount: "26.25",
+					creditAmount: "25",
+					status: "completed",
+					createdAt: daysAgo(now, 2),
+				},
+			])
+			.returning();
+		const topup = inserted.find((t) => t.type === "credit_topup")!;
+		// Partial refund of the top-up: $5.25 back for $5 of credits clawed
+		// back, so $0.25 of the fee is returned.
+		await db.insert(tables.transaction).values({
+			organizationId: ORG_ID,
+			type: "credit_refund",
+			amount: "5.25",
+			creditAmount: "-5",
+			status: "completed",
+			relatedTransactionId: topup.id,
+			createdAt: daysAgo(now, 1),
+		});
+	});
+
+	afterEach(async () => {
+		if (originalAdminEmails === undefined) {
+			delete process.env.ADMIN_EMAILS;
+		} else {
+			process.env.ADMIN_EMAILS = originalAdminEmails;
+		}
+		await db.delete(tables.transaction);
+		await db.delete(tables.projectHourlyStats);
+		await db.delete(tables.projectHourlyModelStats);
+		await deleteAll();
+	});
+
+	it("adds gateway margin, reset passes and the PAYG fee to the cycle margin", async () => {
+		const res = await app.request("/admin/devpass/kpis", {
+			headers: { Cookie: cookie },
+		});
+		expect(res.status).toBe(200);
+		const kpis = (await res.json()) as KpisResponse;
+
+		expect(kpis.totalRealCostCycle).toBe(100);
+		expect(kpis.totalOverflowCostCycle).toBe(0);
+		// Plan economics are unchanged: 79 − 100.
+		expect(kpis.planMargin).toBe(-21);
+		// Only the in-cycle carrier row, only the DevPass org.
+		expect(kpis.gatewayMarginCycle).toBe(12);
+		expect(kpis.resetPassesSold).toBe(2);
+		expect(kpis.resetPassRevenue).toBe(58);
+		expect(kpis.resetPassesSoldCycle).toBe(1);
+		expect(kpis.resetPassRevenueCycle).toBe(29);
+		// (26.25 − 25) charged above credits, minus (5.25 − 5) handed back.
+		expect(kpis.paygFeeCycle).toBeCloseTo(1, 6);
+		expect(kpis.paygFeeAllTime).toBeCloseTo(1, 6);
+		expect(kpis.totalMargin).toBeCloseTo(-21 + 12 + 29 + 1, 6);
+		// Over cycle revenue: MRR 79 + Reset Pass 29 + fee 1.
+		expect(kpis.marginPct).toBeCloseTo((21 / 109) * 100, 6);
+	});
+
+	it("carries gateway margin through the timeseries margin", async () => {
+		const from = isoDay(daysAgo(now, 30));
+		const to = isoDay(now);
+		const res = await app.request(
+			`/admin/devpass/timeseries?from=${from}&to=${to}`,
+			{ headers: { Cookie: cookie } },
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as TimeseriesResponse;
+
+		expect(body.totals.gatewayMargin).toBe(17);
+		// Plan start plus both Reset Passes.
+		expect(body.totals.revenue).toBe(137);
+		expect(body.totals.topupRevenue).toBe(21);
+		expect(body.totals.cost).toBe(100);
+		expect(body.totals.margin).toBe(137 + 21 + 17 - 100);
+		expect(body.data.some((point) => point.gatewayMargin === 12)).toBe(true);
+		expect(body.data.reduce((sum, point) => sum + point.margin, 0)).toBeCloseTo(
+			body.totals.margin,
+			6,
+		);
+	});
+
+	it("usage reads all time when no range is given", async () => {
+		const allTime = await app.request("/admin/devpass/usage", {
+			headers: { Cookie: cookie },
+		});
+		expect(allTime.status).toBe(200);
+		const allTimeBody = (await allTime.json()) as UsageResponse;
+		expect(allTimeBody.range).toBeNull();
+		expect(allTimeBody.models.map((m) => [m.id, m.cost]).sort()).toEqual([
+			["carrier-model", 40],
+			["older-model", 20],
+		]);
+
+		const from = isoDay(daysAgo(now, 7));
+		const to = isoDay(now);
+		const week = await app.request(
+			`/admin/devpass/usage?from=${from}&to=${to}`,
+			{ headers: { Cookie: cookie } },
+		);
+		expect(week.status).toBe(200);
+		const weekBody = (await week.json()) as UsageResponse;
+		expect(weekBody.range).toEqual({ from, to });
+		expect(weekBody.models.map((m) => m.id)).toEqual(["carrier-model"]);
+	});
+});

--- a/apps/api/src/routes/admin-devpass-payg.spec.ts
+++ b/apps/api/src/routes/admin-devpass-payg.spec.ts
@@ -33,6 +33,10 @@ interface KpisResponse {
 	topupRevenueThisMonth: number;
 	topupRevenueAllTime: number;
 	totalOverflowCostCycle: number;
+	planMargin: number;
+	gatewayMarginCycle: number;
+	resetPassRevenueCycle: number;
+	paygFeeCycle: number;
 	totalMargin: number;
 }
 
@@ -146,8 +150,13 @@ describe("admin devpass PAYG overflow reporting", () => {
 		expect(kpis.topupRevenueAllTime).toBe(26.25);
 		expect(kpis.topupRevenueThisMonth).toBe(26.25);
 		expect(kpis.totalOverflowCostCycle).toBe(3);
-		// Universe margin mirrors the per-org decomposition.
-		expect(kpis.totalMargin).toBe(79 - 237);
+		// Universe plan margin mirrors the per-org decomposition.
+		expect(kpis.planMargin).toBe(79 - 237);
+		// The $26.25 top-up granted $25 of credits: $1.25 of fee is margin.
+		expect(kpis.paygFeeCycle).toBe(1.25);
+		expect(kpis.gatewayMarginCycle).toBe(0);
+		expect(kpis.resetPassRevenueCycle).toBe(0);
+		expect(kpis.totalMargin).toBe(79 - 237 + 1.25);
 	});
 
 	it("dedicated /admin/devpass/payg reports top-up revenue windows", async () => {

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -14037,6 +14037,19 @@ const devpassKpisSchema = z.object({
 	refundedAmountThisMonth: z.number(),
 	resetPassesSold: z.number(),
 	resetPassRevenue: z.number(),
+	// Reset Pass sales inside the active subscribers' current billing cycles
+	// (net of refunds): the share counted into totalMargin.
+	resetPassesSoldCycle: z.number(),
+	resetPassRevenueCycle: z.number(),
+	// Gateway margin earned on Airside-carrier traffic from DevPass orgs in
+	// the current cycles (hourly project rollups). `totalRealCostCycle` is the
+	// catalogue price, which still contains this margin, so it is added back.
+	gatewayMarginCycle: z.number(),
+	// PAYG top-up dollars charged above the credits granted (the platform
+	// fee), net of refunds. The credits fund overflow usage 1:1, so the fee is
+	// the only top-up money that is margin.
+	paygFeeCycle: z.number(),
+	paygFeeAllTime: z.number(),
 	// PAYG overflow adoption + monetization across active subscribers.
 	paygOptedIn: z.number(),
 	// Sum of credits balances held by active subscribers (deferred revenue —
@@ -14050,7 +14063,11 @@ const devpassKpisSchema = z.object({
 	weightedAvgUtilization: z.number(),
 	totalRealCostCycle: z.number(),
 	totalMrrCycle: z.number(),
+	// Plan economics only: MRR minus the pool-funded provider cost.
+	planMargin: z.number(),
+	// planMargin + gatewayMarginCycle + resetPassRevenueCycle + paygFeeCycle.
 	totalMargin: z.number(),
+	// totalMargin over cycle revenue (MRR + Reset Passes + PAYG fee).
 	marginPct: z.number().nullable(),
 });
 
@@ -14380,6 +14397,9 @@ const devpassTimeseriesPointSchema = z.object({
 	// margin because `cost` includes the overflow usage they fund.
 	topupRevenue: z.number(),
 	cost: z.number(),
+	// Gateway margin on Airside-carrier traffic that day. Added into margin
+	// because `cost` is the catalogue price, which still contains it.
+	gatewayMargin: z.number(),
 	margin: z.number(),
 });
 
@@ -14390,6 +14410,7 @@ const devpassTimeseriesSchema = z.object({
 		rawRevenue: z.number(),
 		topupRevenue: z.number(),
 		cost: z.number(),
+		gatewayMargin: z.number(),
 		margin: z.number(),
 	}),
 	range: z.object({
@@ -14479,10 +14500,13 @@ const devpassUsageSchema = z.object({
 	models: z.array(devpassUsageRowSchema),
 	providers: z.array(devpassUsageRowSchema),
 	sources: z.array(devpassUsageRowSchema),
-	range: z.object({
-		from: z.string(),
-		to: z.string(),
-	}),
+	// null when no from/to was supplied (all time).
+	range: z
+		.object({
+			from: z.string(),
+			to: z.string(),
+		})
+		.nullable(),
 });
 
 const getDevpassUsage = createRoute({
@@ -14591,6 +14615,40 @@ function buildDevpassCycleCostExprs() {
 
 	return { realCostSub, realCostExpr, overflowCostExpr };
 }
+
+// Gateway margin earned on Airside-carrier traffic in the current cycle, per
+// org. `providerMarginAmount` is already credits-mode and non-cached only.
+function buildDevpassCycleGatewayMarginSub() {
+	return db
+		.select({
+			organizationId: tables.project.organizationId,
+			gatewayMargin:
+				sql<string>`COALESCE(SUM(CAST(${projectHourlyModelStats.providerMarginAmount} AS NUMERIC)), 0)`.as(
+					"gateway_margin",
+				),
+		})
+		.from(projectHourlyModelStats)
+		.innerJoin(
+			tables.project,
+			eq(projectHourlyModelStats.projectId, tables.project.id),
+		)
+		.innerJoin(
+			tables.organization,
+			and(
+				eq(tables.project.organizationId, tables.organization.id),
+				isNotNull(tables.organization.devPlanBillingCycleStart),
+				sql`${projectHourlyModelStats.hourTimestamp} >= ${tables.organization.devPlanBillingCycleStart}`,
+			),
+		)
+		.groupBy(tables.project.organizationId)
+		.as("gateway_margin_sub");
+}
+
+// Top-up dollars above the credits granted: the platform fee. A refund row
+// stores the gross refunded in `amount` and the credits clawed back as a
+// negative `creditAmount`, so the same shape (minus the absolute clawback)
+// yields the fee handed back.
+const topupFeeExpr = sql`CAST(${tables.transaction.amount} AS NUMERIC) - ABS(COALESCE(CAST(${tables.transaction.creditAmount} AS NUMERIC), 0))`;
 
 admin.openapi(getDevpassSubscribers, async (c) => {
 	const query = c.req.valid("query");
@@ -15123,10 +15181,23 @@ admin.openapi(getDevpassKpis, async (c) => {
 	);
 
 	const { realCostSub, overflowCostExpr } = buildDevpassCycleCostExprs();
+	const gatewayMarginSub = buildDevpassCycleGatewayMarginSub();
+
+	// Transactions booked inside each active subscriber's current billing
+	// cycle: the window the cycle cost and MRR are scoped to.
+	const inCurrentCycle = and(
+		devpassActiveUniverseWhere(),
+		isNotNull(tables.organization.devPlanBillingCycleStart),
+		sql`${tables.transaction.createdAt} >= ${tables.organization.devPlanBillingCycleStart}`,
+	)!;
 
 	const refundOriginalTx = aliasedTable(
 		tables.transaction,
 		"refund_original_tx",
+	);
+	const topupFeeRefundOriginalTx = aliasedTable(
+		tables.transaction,
+		"topup_fee_refund_original_tx",
 	);
 	const resetPassRefundOriginalTx = aliasedTable(
 		tables.transaction,
@@ -15232,6 +15303,7 @@ admin.openapi(getDevpassKpis, async (c) => {
 		[utilRow],
 		[universeRow],
 		[topupRevenueRow],
+		[topupFeeRefundRow],
 	] = await Promise.all([
 		// KPI strip — counts the full active subscriber base, matching Stripe's
 		// "active" filter which includes cancel-at-period-end subs until the period
@@ -15361,6 +15433,8 @@ admin.openapi(getDevpassKpis, async (c) => {
 			.select({
 				count: sql<number>`COUNT(*)`,
 				total: sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`,
+				countCycle: sql<number>`COUNT(*) FILTER (WHERE ${inCurrentCycle})`,
+				totalCycle: sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)) FILTER (WHERE ${inCurrentCycle}), 0)`,
 			})
 			.from(tables.transaction)
 			.innerJoin(
@@ -15377,6 +15451,7 @@ admin.openapi(getDevpassKpis, async (c) => {
 		db
 			.select({
 				total: sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`,
+				totalCycle: sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)) FILTER (WHERE ${inCurrentCycle}), 0)`,
 			})
 			.from(tables.transaction)
 			.innerJoin(
@@ -15412,6 +15487,7 @@ admin.openapi(getDevpassKpis, async (c) => {
 				totalCost: sql<string>`COALESCE(SUM(CAST(${realCostSub.realCost} AS NUMERIC)), 0)`,
 				totalMrr: sql<string>`COALESCE(SUM(${devpassTierPriceExpr}), 0)`,
 				totalOverflow: sql<string>`COALESCE(SUM(${overflowCostExpr}), 0)`,
+				totalGatewayMargin: sql<string>`COALESCE(SUM(CAST(${gatewayMarginSub.gatewayMargin} AS NUMERIC)), 0)`,
 				paygOptedIn: sql<number>`COUNT(*) FILTER (WHERE ${tables.organization.devPlanPaygEnabled})`,
 				paygBalanceHeld: sql<string>`COALESCE(SUM(CAST(${tables.organization.credits} AS NUMERIC)), 0)`,
 			})
@@ -15420,12 +15496,19 @@ admin.openapi(getDevpassKpis, async (c) => {
 				realCostSub,
 				eq(tables.organization.id, realCostSub.organizationId),
 			)
+			.leftJoin(
+				gatewayMarginSub,
+				eq(tables.organization.id, gatewayMarginSub.organizationId),
+			)
 			.where(devpassActiveUniverseWhere()),
-		// PAYG overflow top-up revenue on devpass orgs (gross Stripe amount).
+		// PAYG overflow top-up revenue on devpass orgs (gross Stripe amount),
+		// plus the fee share of it (gross minus credits granted).
 		db
 			.select({
 				allTime: sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)), 0)`,
 				thisMonth: sql<string>`COALESCE(SUM(CAST(${tables.transaction.amount} AS NUMERIC)) FILTER (WHERE ${tables.transaction.createdAt} >= ${monthStart}), 0)`,
+				feeAllTime: sql<string>`COALESCE(SUM(${topupFeeExpr}), 0)`,
+				feeCycle: sql<string>`COALESCE(SUM(${topupFeeExpr}) FILTER (WHERE ${inCurrentCycle}), 0)`,
 			})
 			.from(tables.transaction)
 			.innerJoin(
@@ -15438,6 +15521,35 @@ admin.openapi(getDevpassKpis, async (c) => {
 					eq(tables.transaction.status, "completed"),
 					eq(tables.organization.kind, "devpass"),
 					sql`CAST(${tables.transaction.amount} AS NUMERIC) > 0`,
+				),
+			),
+		// Fee handed back with top-up refunds.
+		db
+			.select({
+				feeAllTime: sql<string>`COALESCE(SUM(${topupFeeExpr}), 0)`,
+				feeCycle: sql<string>`COALESCE(SUM(${topupFeeExpr}) FILTER (WHERE ${inCurrentCycle}), 0)`,
+			})
+			.from(tables.transaction)
+			.innerJoin(
+				topupFeeRefundOriginalTx,
+				eq(
+					tables.transaction.relatedTransactionId,
+					topupFeeRefundOriginalTx.id,
+				),
+			)
+			.innerJoin(
+				tables.organization,
+				eq(tables.transaction.organizationId, tables.organization.id),
+			)
+			.where(
+				and(
+					eq(tables.transaction.type, "credit_refund"),
+					eq(tables.transaction.status, "completed"),
+					eq(tables.organization.kind, "devpass"),
+					refundsCountedTopupFilter(
+						tables.transaction,
+						topupFeeRefundOriginalTx,
+					),
 				),
 			),
 	]);
@@ -15471,6 +15583,15 @@ admin.openapi(getDevpassKpis, async (c) => {
 	const endsThisMonth = Number(endsRow?.count ?? 0);
 	const resetPassRevenue =
 		Number(resetPassRow?.total ?? 0) - Number(resetPassRefundRow?.total ?? 0);
+	const resetPassRevenueCycle =
+		Number(resetPassRow?.totalCycle ?? 0) -
+		Number(resetPassRefundRow?.totalCycle ?? 0);
+	const paygFeeCycle =
+		Number(topupRevenueRow?.feeCycle ?? 0) -
+		Number(topupFeeRefundRow?.feeCycle ?? 0);
+	const paygFeeAllTime =
+		Number(topupRevenueRow?.feeAllTime ?? 0) -
+		Number(topupFeeRefundRow?.feeAllTime ?? 0);
 
 	const totalUsed = Number(utilRow?.totalUsed ?? 0);
 	const totalLimit = Number(utilRow?.totalLimit ?? 0);
@@ -15480,10 +15601,17 @@ admin.openapi(getDevpassKpis, async (c) => {
 	const totalRealCostCycle = Number(universeRow?.totalCost ?? 0);
 	const totalMrrCycle = Number(universeRow?.totalMrr ?? 0);
 	const totalOverflowCostCycle = Number(universeRow?.totalOverflow ?? 0);
+	const gatewayMarginCycle = Number(universeRow?.totalGatewayMargin ?? 0);
 	// Plan economics: overflow cost is funded by the orgs' own top-ups, so it
 	// doesn't count against plan MRR.
-	const totalMargin =
+	const planMargin =
 		totalMrrCycle - (totalRealCostCycle - totalOverflowCostCycle);
+	// Everything else DevPass earns in the same cycles: the Airside margin
+	// hidden inside the catalogue-priced cost, Reset Pass sales, and the fee
+	// share of PAYG top-ups.
+	const totalMargin =
+		planMargin + gatewayMarginCycle + resetPassRevenueCycle + paygFeeCycle;
+	const cycleRevenue = totalMrrCycle + resetPassRevenueCycle + paygFeeCycle;
 
 	return c.json({
 		activeByTier,
@@ -15507,6 +15635,11 @@ admin.openapi(getDevpassKpis, async (c) => {
 		refundedAmountThisMonth: Number(refundsRow?.total ?? 0),
 		resetPassesSold: Number(resetPassRow?.count ?? 0),
 		resetPassRevenue,
+		resetPassesSoldCycle: Number(resetPassRow?.countCycle ?? 0),
+		resetPassRevenueCycle,
+		gatewayMarginCycle,
+		paygFeeCycle,
+		paygFeeAllTime,
 		paygOptedIn: Number(universeRow?.paygOptedIn ?? 0),
 		paygBalanceHeld: Number(universeRow?.paygBalanceHeld ?? 0),
 		topupRevenueThisMonth: Number(topupRevenueRow?.thisMonth ?? 0),
@@ -15515,8 +15648,9 @@ admin.openapi(getDevpassKpis, async (c) => {
 		weightedAvgUtilization,
 		totalRealCostCycle,
 		totalMrrCycle,
+		planMargin,
 		totalMargin,
-		marginPct: totalMrrCycle > 0 ? (totalMargin / totalMrrCycle) * 100 : null,
+		marginPct: cycleRevenue > 0 ? (totalMargin / cycleRevenue) * 100 : null,
 	});
 });
 
@@ -15748,6 +15882,36 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 		.groupBy(sql`DATE(${projectHourlyStats.hourTimestamp})`)
 		.orderBy(asc(sql`DATE(${projectHourlyStats.hourTimestamp})`));
 
+	// Gateway margin per day on Airside-carrier traffic from DevPass orgs.
+	const gatewayMarginPerDay = await db
+		.select({
+			date: sql<string>`DATE(${projectHourlyModelStats.hourTimestamp})`.as(
+				"date",
+			),
+			total:
+				sql<string>`COALESCE(SUM(CAST(${projectHourlyModelStats.providerMarginAmount} AS NUMERIC)), 0)`.as(
+					"total",
+				),
+		})
+		.from(projectHourlyModelStats)
+		.innerJoin(
+			tables.project,
+			eq(projectHourlyModelStats.projectId, tables.project.id),
+		)
+		.innerJoin(
+			tables.organization,
+			eq(tables.project.organizationId, tables.organization.id),
+		)
+		.where(
+			and(
+				gte(projectHourlyModelStats.hourTimestamp, startDate),
+				lte(projectHourlyModelStats.hourTimestamp, endDate),
+				eq(tables.organization.kind, "devpass"),
+			),
+		)
+		.groupBy(sql`DATE(${projectHourlyModelStats.hourTimestamp})`)
+		.orderBy(asc(sql`DATE(${projectHourlyModelStats.hourTimestamp})`));
+
 	const revenueMap = new Map<string, number>();
 	for (const row of revenuePerDay) {
 		revenueMap.set(row.date, Number(row.total));
@@ -15768,6 +15932,10 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 	for (const row of costPerDay) {
 		costMap.set(row.date, Number(row.total));
 	}
+	const gatewayMarginMap = new Map<string, number>();
+	for (const row of gatewayMarginPerDay) {
+		gatewayMarginMap.set(row.date, Number(row.total));
+	}
 
 	const data: Array<{
 		date: string;
@@ -15775,6 +15943,7 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 		rawRevenue: number;
 		topupRevenue: number;
 		cost: number;
+		gatewayMargin: number;
 		margin: number;
 	}> = [];
 
@@ -15795,11 +15964,14 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 	let totalRawRevenue = 0;
 	let totalTopupRevenue = 0;
 	let totalCost = 0;
+	let totalGatewayMargin = 0;
 
 	// `rawRevenue` is the gross amount collected from dev plan payments that
 	// day; `revenue` nets refunds out of it. `topupRevenue` is PAYG overflow
 	// top-ups net of their refunds — counted into margin because `cost`
-	// includes the overflow usage those top-ups fund. Margin stays net-based.
+	// includes the overflow usage those top-ups fund. `gatewayMargin` is added
+	// back because `cost` is the catalogue price, which still contains the
+	// Airside margin. Margin stays net-based.
 	while (cursor.getTime() <= lastDay) {
 		const iso = cursor.toISOString().slice(0, 10);
 		const rawRevenue = revenueMap.get(iso) ?? 0;
@@ -15807,12 +15979,22 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 		const topupRevenue =
 			(topupMap.get(iso) ?? 0) - (topupRefundMap.get(iso) ?? 0);
 		const cost = costMap.get(iso) ?? 0;
-		const margin = revenue + topupRevenue - cost;
-		data.push({ date: iso, revenue, rawRevenue, topupRevenue, cost, margin });
+		const gatewayMargin = gatewayMarginMap.get(iso) ?? 0;
+		const margin = revenue + topupRevenue + gatewayMargin - cost;
+		data.push({
+			date: iso,
+			revenue,
+			rawRevenue,
+			topupRevenue,
+			cost,
+			gatewayMargin,
+			margin,
+		});
 		totalRevenue += revenue;
 		totalRawRevenue += rawRevenue;
 		totalTopupRevenue += topupRevenue;
 		totalCost += cost;
+		totalGatewayMargin += gatewayMargin;
 		cursor.setUTCDate(cursor.getUTCDate() + 1);
 	}
 
@@ -15823,7 +16005,8 @@ admin.openapi(getDevpassTimeseries, async (c) => {
 			rawRevenue: totalRawRevenue,
 			topupRevenue: totalTopupRevenue,
 			cost: totalCost,
-			margin: totalRevenue + totalTopupRevenue - totalCost,
+			gatewayMargin: totalGatewayMargin,
+			margin: totalRevenue + totalTopupRevenue + totalGatewayMargin - totalCost,
 		},
 		range: {
 			from: startDate.toISOString().slice(0, 10),
@@ -15987,24 +16170,18 @@ admin.openapi(getDevpassPaygStats, async (c) => {
 admin.openapi(getDevpassUsage, async (c) => {
 	const query = c.req.valid("query");
 	const limit = query.limit ?? 10;
-	const now = new Date();
 
-	let startDate: Date;
-	let endDate: Date;
+	// No from/to means all time; the admin page always sends a window by
+	// default and only omits it when "All time" is picked explicitly.
+	let startDate: Date | null = null;
+	let endDate: Date | null = null;
 	if (query.from && query.to) {
 		startDate = new Date(query.from + "T00:00:00.000Z");
 		endDate = new Date(query.to + "T23:59:59.999Z");
-	} else {
-		startDate = new Date(now);
-		startDate.setUTCDate(startDate.getUTCDate() - 30);
-		startDate.setUTCHours(0, 0, 0, 0);
-		endDate = new Date(now);
-		endDate.setUTCHours(23, 59, 59, 999);
-	}
-
-	if (endDate.getTime() < startDate.getTime()) {
-		endDate = new Date(startDate);
-		endDate.setUTCHours(23, 59, 59, 999);
+		if (endDate.getTime() < startDate.getTime()) {
+			endDate = new Date(startDate);
+			endDate.setUTCHours(23, 59, 59, 999);
+		}
 	}
 
 	// Filter: only DevPass orgs (kind = 'devpass'). Stable across the
@@ -16015,8 +16192,10 @@ admin.openapi(getDevpassUsage, async (c) => {
 	// dashboard reads from rollups instead of the raw `log` table. Joins
 	// project -> organization to restrict to DevPass orgs.
 	const projectModelWhere = and(
-		gte(projectHourlyModelStats.hourTimestamp, startDate),
-		lte(projectHourlyModelStats.hourTimestamp, endDate),
+		startDate
+			? gte(projectHourlyModelStats.hourTimestamp, startDate)
+			: undefined,
+		endDate ? lte(projectHourlyModelStats.hourTimestamp, endDate) : undefined,
 		devpassOrgFilter,
 	);
 
@@ -16090,8 +16269,10 @@ admin.openapi(getDevpassUsage, async (c) => {
 	// is scoped to DevPass orgs (joins project -> organization), instead of the
 	// cross-org globalSourceStats table.
 	const projectSourceWhere = and(
-		gte(projectHourlySourceStats.hourTimestamp, startDate),
-		lte(projectHourlySourceStats.hourTimestamp, endDate),
+		startDate
+			? gte(projectHourlySourceStats.hourTimestamp, startDate)
+			: undefined,
+		endDate ? lte(projectHourlySourceStats.hourTimestamp, endDate) : undefined,
 		devpassOrgFilter,
 	);
 
@@ -16144,10 +16325,13 @@ admin.openapi(getDevpassUsage, async (c) => {
 		models: modelRows.map(mapRow),
 		providers: providerRows.map(mapRow),
 		sources: sourceRows.map(mapRow),
-		range: {
-			from: startDate.toISOString().slice(0, 10),
-			to: endDate.toISOString().slice(0, 10),
-		},
+		range:
+			startDate && endDate
+				? {
+						from: startDate.toISOString().slice(0, 10),
+						to: endDate.toISOString().slice(0, 10),
+					}
+				: null,
 	});
 });
 

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -16172,7 +16172,13 @@ admin.openapi(getDevpassUsage, async (c) => {
 	const limit = query.limit ?? 10;
 
 	// No from/to means all time; the admin page always sends a window by
-	// default and only omits it when "All time" is picked explicitly.
+	// default and only omits it when "All time" is picked explicitly. A lone
+	// bound is rejected rather than silently widening to all time.
+	if (Boolean(query.from) !== Boolean(query.to)) {
+		throw new HTTPException(400, {
+			message: "Both from and to are required to narrow the usage window",
+		});
+	}
 	let startDate: Date | null = null;
 	let endDate: Date | null = null;
 	if (query.from && query.to) {

--- a/ee/admin/src/app/devpass/page.tsx
+++ b/ee/admin/src/app/devpass/page.tsx
@@ -12,7 +12,10 @@ import {
 import { DevpassTimeseriesChart } from "@/components/devpass-timeseries-chart";
 import { DevpassUsage } from "@/components/devpass-usage";
 import { Button } from "@/components/ui/button";
-import { resolveDateRange } from "@/lib/date-range";
+import {
+	DEVPASS_USAGE_DEFAULT_RANGE,
+	resolveDateRange,
+} from "@/lib/date-range";
 import { requireSession } from "@/lib/require-session";
 import { cn } from "@/lib/utils";
 
@@ -157,6 +160,9 @@ export default async function DevpassPage({
 		range?: string;
 		from?: string;
 		to?: string;
+		usageRange?: string;
+		usageFrom?: string;
+		usageTo?: string;
 	}>;
 }) {
 	await requireSession();
@@ -168,6 +174,19 @@ export default async function DevpassPage({
 		from: params?.from,
 		to: params?.to,
 	});
+	// The usage cards have their own range (see DEVPASS_USAGE_DEFAULT_RANGE);
+	// only the raw params are round-tripped so the default never gets pinned
+	// into the URL as a custom span.
+	const usageRange =
+		typeof params?.usageRange === "string" ? params.usageRange : undefined;
+	const usageFromParam =
+		typeof params?.usageFrom === "string" ? params.usageFrom : undefined;
+	const usageToParam =
+		typeof params?.usageTo === "string" ? params.usageTo : undefined;
+	const { from: usageFrom, to: usageTo } = resolveDateRange(
+		{ range: usageRange, from: usageFromParam, to: usageToParam },
+		DEVPASS_USAGE_DEFAULT_RANGE,
+	);
 	const rawPage = parseInt(params?.page ?? "1", 10);
 	const page = Number.isFinite(rawPage) && rawPage >= 1 ? rawPage : 1;
 	const search = params?.search ?? "";
@@ -234,6 +253,12 @@ export default async function DevpassPage({
 			queryParams.set("to", to);
 		}
 	}
+	if (usageRange) {
+		queryParams.set("usageRange", usageRange);
+	} else if (usageFromParam && usageToParam) {
+		queryParams.set("usageFrom", usageFromParam);
+		queryParams.set("usageTo", usageToParam);
+	}
 	queryParams.set("sortBy", sortBy);
 	queryParams.set("sortOrder", sortOrder);
 	const queryString = queryParams.toString();
@@ -251,6 +276,9 @@ export default async function DevpassPage({
 		const rangeValue = formData.get("range") as string;
 		const fromValue = formData.get("from") as string;
 		const toValue = formData.get("to") as string;
+		const usageRangeValue = formData.get("usageRange") as string;
+		const usageFromValue = formData.get("usageFrom") as string;
+		const usageToValue = formData.get("usageTo") as string;
 		const sp = new URLSearchParams();
 		if (searchValue) {
 			sp.set("search", searchValue);
@@ -280,6 +308,12 @@ export default async function DevpassPage({
 				sp.set("to", toValue);
 			}
 		}
+		if (usageRangeValue) {
+			sp.set("usageRange", usageRangeValue);
+		} else if (usageFromValue && usageToValue) {
+			sp.set("usageFrom", usageFromValue);
+			sp.set("usageTo", usageToValue);
+		}
 		sp.set("sortBy", sortByValue);
 		sp.set("sortOrder", sortOrderValue);
 		sp.set("page", "1");
@@ -305,7 +339,7 @@ export default async function DevpassPage({
 
 			<DevpassTimeseriesChart from={from} to={to} />
 
-			<DevpassUsage from={from} to={to} />
+			<DevpassUsage from={usageFrom} to={usageTo} />
 
 			<form
 				action={handleSearch}
@@ -329,6 +363,17 @@ export default async function DevpassPage({
 				<input type="hidden" name="range" value={range ?? ""} />
 				<input type="hidden" name="from" value={range ? "" : (from ?? "")} />
 				<input type="hidden" name="to" value={range ? "" : (to ?? "")} />
+				<input type="hidden" name="usageRange" value={usageRange ?? ""} />
+				<input
+					type="hidden"
+					name="usageFrom"
+					value={usageRange ? "" : (usageFromParam ?? "")}
+				/>
+				<input
+					type="hidden"
+					name="usageTo"
+					value={usageRange ? "" : (usageToParam ?? "")}
+				/>
 				<div className="flex flex-col gap-2 sm:flex-row sm:items-center">
 					<div className="relative flex-1">
 						<Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />

--- a/ee/admin/src/components/date-range-picker.tsx
+++ b/ee/admin/src/components/date-range-picker.tsx
@@ -14,6 +14,7 @@ import {
 import {
 	ALL_TIME_RANGE,
 	RELATIVE_RANGE_PRESETS,
+	dateRangeParamNames,
 	findRelativeRangePreset,
 	resolveDateRange,
 } from "@/lib/date-range";
@@ -37,12 +38,14 @@ const MONTH_NAMES = [
 export function getDateRangeFromParams(
 	searchParams: URLSearchParams,
 	defaultRange?: string,
+	paramPrefix?: string,
 ) {
+	const names = dateRangeParamNames(paramPrefix);
 	const resolved = resolveDateRange(
 		{
-			range: searchParams.get("range") ?? undefined,
-			from: searchParams.get("from") ?? undefined,
-			to: searchParams.get("to") ?? undefined,
+			range: searchParams.get(names.range) ?? undefined,
+			from: searchParams.get(names.from) ?? undefined,
+			to: searchParams.get(names.to) ?? undefined,
 		},
 		defaultRange,
 	);
@@ -194,17 +197,28 @@ function MonthRangePicker({ from, to, onSelect }: MonthRangePickerProps) {
 	);
 }
 
-export function DateRangePicker({ defaultRange }: { defaultRange?: string }) {
+// `paramPrefix` scopes the picker to its own URL params (see
+// dateRangeParamNames) so a section can be re-ranged without touching the
+// page-level range.
+export function DateRangePicker({
+	defaultRange,
+	paramPrefix,
+}: {
+	defaultRange?: string;
+	paramPrefix?: string;
+}) {
 	const router = useRouter();
 	const pathname = usePathname();
 	const searchParams = useSearchParams();
 	const [open, setOpen] = useState(false);
 	const [search, setSearch] = useState("");
 	const [showCalendar, setShowCalendar] = useState(false);
+	const names = useMemo(() => dateRangeParamNames(paramPrefix), [paramPrefix]);
 
 	const { from, to, isAllTime } = getDateRangeFromParams(
 		searchParams,
 		defaultRange,
+		paramPrefix,
 	);
 	const today = useMemo(() => new Date(), []);
 
@@ -221,7 +235,7 @@ export function DateRangePicker({ defaultRange }: { defaultRange?: string }) {
 	);
 
 	const activePreset = useMemo(() => {
-		const rangeParam = searchParams.get("range") ?? undefined;
+		const rangeParam = searchParams.get(names.range) ?? undefined;
 		if (findRelativeRangePreset(rangeParam)) {
 			return rangeParam as string;
 		}
@@ -231,12 +245,13 @@ export function DateRangePicker({ defaultRange }: { defaultRange?: string }) {
 		// An empty URL means the page's own default is in force, so highlight
 		// that preset rather than the one the empty URL would otherwise imply.
 		const hasCustomSpan =
-			Boolean(searchParams.get("from")) && Boolean(searchParams.get("to"));
+			Boolean(searchParams.get(names.from)) &&
+			Boolean(searchParams.get(names.to));
 		if (!hasCustomSpan && findRelativeRangePreset(defaultRange)) {
 			return defaultRange as string;
 		}
 		return isAllTime ? ALL_TIME_RANGE : "custom";
-	}, [searchParams, isAllTime, defaultRange]);
+	}, [searchParams, isAllTime, defaultRange, names]);
 
 	const filteredPresets = useMemo(
 		() =>
@@ -250,26 +265,26 @@ export function DateRangePicker({ defaultRange }: { defaultRange?: string }) {
 
 	const updateDateRange = (newFrom: Date, newTo: Date) => {
 		const params = new URLSearchParams(searchParams.toString());
-		params.delete("range");
-		params.set("from", format(newFrom, "yyyy-MM-dd"));
-		params.set("to", format(newTo, "yyyy-MM-dd"));
-		router.push(`${pathname}?${params.toString()}`);
+		params.delete(names.range);
+		params.set(names.from, format(newFrom, "yyyy-MM-dd"));
+		params.set(names.to, format(newTo, "yyyy-MM-dd"));
+		router.push(`${pathname}?${params.toString()}`, { scroll: false });
 	};
 
 	const selectAllTime = () => {
 		const params = new URLSearchParams(searchParams.toString());
-		params.delete("from");
-		params.delete("to");
+		params.delete(names.from);
+		params.delete(names.to);
 		// On a page with its own default, an empty URL means that default, so
 		// "all time" has to be written out to override it. Pages without a
 		// default keep the shorter URL, which resolves to all time either way.
 		if (defaultRange) {
-			params.set("range", ALL_TIME_RANGE);
+			params.set(names.range, ALL_TIME_RANGE);
 		} else {
-			params.delete("range");
+			params.delete(names.range);
 		}
 		const qs = params.toString();
-		router.push(qs ? `${pathname}?${qs}` : pathname);
+		router.push(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
 	};
 
 	const handlePresetSelect = (value: string) => {
@@ -287,10 +302,10 @@ export function DateRangePicker({ defaultRange }: { defaultRange?: string }) {
 		// Relative presets only store the preset value; the concrete dates are
 		// resolved against "today" on every request.
 		const params = new URLSearchParams(searchParams.toString());
-		params.delete("from");
-		params.delete("to");
-		params.set("range", value);
-		router.push(`${pathname}?${params.toString()}`);
+		params.delete(names.from);
+		params.delete(names.to);
+		params.set(names.range, value);
+		router.push(`${pathname}?${params.toString()}`, { scroll: false });
 		setOpen(false);
 	};
 

--- a/ee/admin/src/components/devpass-kpis.tsx
+++ b/ee/admin/src/components/devpass-kpis.tsx
@@ -3,6 +3,8 @@
 import {
 	CircleDollarSign,
 	Info,
+	Percent,
+	PlaneTakeoff,
 	RotateCcw,
 	Ticket,
 	TrendingDown,
@@ -25,6 +27,10 @@ const currencyFormatter = new Intl.NumberFormat("en-US", {
 	currency: "USD",
 	maximumFractionDigits: 2,
 });
+
+function signedCurrency(value: number): string {
+	return `${value < 0 ? "−" : "+"}${currencyFormatter.format(Math.abs(value))}`;
+}
 
 function KpiCard({
 	icon,
@@ -268,9 +274,9 @@ export function DevpassKpis({ from, to }: { from?: string; to?: string }) {
 					</>
 				)}
 			</div>
-			<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+			<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
 				{kpisError ? null : !kpis ? (
-					<KpiSkeleton count={5} />
+					<KpiSkeleton count={7} />
 				) : (
 					<>
 						<KpiCard
@@ -302,11 +308,36 @@ export function DevpassKpis({ from, to }: { from?: string; to?: string }) {
 												? "border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-400"
 												: "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
 										)}
-										title="Profit margin: cycle margin / gross MRR"
+										title="Profit margin: cycle margin / cycle revenue (MRR + reset passes + PAYG fee)"
 									>
 										{kpis.marginPct.toFixed(1)}% profit
 									</span>
 								) : null}
+							</div>
+							<div className="mt-1 text-xs text-muted-foreground">
+								Plan{" "}
+								<span
+									className={cn(
+										"font-medium tabular-nums",
+										kpis.planMargin < 0
+											? "text-rose-600 dark:text-rose-400"
+											: "text-foreground",
+									)}
+								>
+									{currencyFormatter.format(kpis.planMargin)}
+								</span>{" "}
+								· gateway margin{" "}
+								<span className="font-medium tabular-nums text-foreground">
+									{signedCurrency(kpis.gatewayMarginCycle)}
+								</span>{" "}
+								· reset passes{" "}
+								<span className="font-medium tabular-nums text-foreground">
+									{signedCurrency(kpis.resetPassRevenueCycle)}
+								</span>{" "}
+								· PAYG fee{" "}
+								<span className="font-medium tabular-nums text-foreground">
+									{signedCurrency(kpis.paygFeeCycle)}
+								</span>
 							</div>
 							<div className="mt-1 text-xs text-muted-foreground">
 								{currencyFormatter.format(kpis.totalRealCostCycle)} provider
@@ -319,6 +350,51 @@ export function DevpassKpis({ from, to }: { from?: string; to?: string }) {
 										overflow, excluded from margin)
 									</>
 								) : null}
+							</div>
+						</KpiCard>
+						<KpiCard
+							icon={<PlaneTakeoff className="h-3.5 w-3.5" />}
+							label="Gateway margin"
+						>
+							<div className="mt-2 text-2xl font-semibold tabular-nums">
+								{currencyFormatter.format(kpis.gatewayMarginCycle)}
+							</div>
+							<div className="mt-1 text-xs text-muted-foreground">
+								Airside carrier margin on DevPass traffic in the current cycles.
+								Provider cost is the catalogue price, so this is added back into
+								cycle margin.
+							</div>
+						</KpiCard>
+						<KpiCard
+							icon={<Ticket className="h-3.5 w-3.5" />}
+							label="Reset passes sold"
+						>
+							<div className="mt-2 text-2xl font-semibold tabular-nums">
+								{kpis.resetPassesSold}
+							</div>
+							<div className="mt-1 text-xs text-muted-foreground">
+								{currencyFormatter.format(kpis.resetPassRevenue)} all-time
+								revenue
+							</div>
+							<div className="mt-1 text-xs text-muted-foreground">
+								{kpis.resetPassesSoldCycle} in the current cycles ·{" "}
+								<span className="font-medium tabular-nums text-foreground">
+									{currencyFormatter.format(kpis.resetPassRevenueCycle)}
+								</span>{" "}
+								counted in cycle margin
+							</div>
+						</KpiCard>
+						<KpiCard
+							icon={<Percent className="h-3.5 w-3.5" />}
+							label="PAYG fee"
+						>
+							<div className="mt-2 text-2xl font-semibold tabular-nums">
+								{currencyFormatter.format(kpis.paygFeeCycle)}
+							</div>
+							<div className="mt-1 text-xs text-muted-foreground">
+								Top-up dollars above the credits granted (5% platform fee) in
+								the current cycles, net of refunds ·{" "}
+								{currencyFormatter.format(kpis.paygFeeAllTime)} all-time
 							</div>
 						</KpiCard>
 						<KpiCard
@@ -338,18 +414,6 @@ export function DevpassKpis({ from, to }: { from?: string; to?: string }) {
 							<div className="mt-1 text-xs text-muted-foreground">
 								{kpis.refundsThisMonth} refund
 								{kpis.refundsThisMonth === 1 ? "" : "s"} processed
-							</div>
-						</KpiCard>
-						<KpiCard
-							icon={<Ticket className="h-3.5 w-3.5" />}
-							label="Reset passes sold"
-						>
-							<div className="mt-2 text-2xl font-semibold tabular-nums">
-								{kpis.resetPassesSold}
-							</div>
-							<div className="mt-1 text-xs text-muted-foreground">
-								{currencyFormatter.format(kpis.resetPassRevenue)} all-time
-								revenue
 							</div>
 						</KpiCard>
 						<KpiCard

--- a/ee/admin/src/components/devpass-timeseries-chart.tsx
+++ b/ee/admin/src/components/devpass-timeseries-chart.tsx
@@ -44,6 +44,10 @@ const chartConfig = {
 		label: "Provider cost",
 		color: "hsl(32 95% 44%)",
 	},
+	gatewayMargin: {
+		label: "Gateway margin",
+		color: "hsl(340 75% 55%)",
+	},
 	margin: {
 		label: "Margin",
 		color: "hsl(221 83% 53%)",
@@ -57,6 +61,7 @@ const SERIES_KEYS = [
 	"rawRevenue",
 	"topupRevenue",
 	"cost",
+	"gatewayMargin",
 	"margin",
 ] as const;
 
@@ -108,12 +113,14 @@ export function DevpassTimeseriesChart({
 		let rawRevenue = 0;
 		let topupRevenue = 0;
 		let cost = 0;
+		let gatewayMargin = 0;
 		let margin = 0;
 		return rows.map((row) => {
 			revenue += row.revenue;
 			rawRevenue += row.rawRevenue;
 			topupRevenue += row.topupRevenue;
 			cost += row.cost;
+			gatewayMargin += row.gatewayMargin;
 			margin += row.margin;
 			return {
 				date: row.date,
@@ -121,6 +128,7 @@ export function DevpassTimeseriesChart({
 				rawRevenue,
 				topupRevenue,
 				cost,
+				gatewayMargin,
 				margin,
 			};
 		});
@@ -142,8 +150,9 @@ export function DevpassTimeseriesChart({
 					<CardTitle>DevPass revenue & usage</CardTitle>
 					<CardDescription className="max-w-3xl">
 						Daily revenue net of refunds, raw gross subscription revenue, PAYG
-						overflow top-ups, real provider cost, and the resulting margin
-						(plans + top-ups − cost). Click a total to toggle its series. Range
+						overflow top-ups, real provider cost, the Airside gateway margin
+						inside that cost, and the resulting margin (plans + top-ups +
+						gateway margin − cost). Click a total to toggle its series. Range
 						totals won&apos;t match the cycle-scoped KPI cards above.
 					</CardDescription>
 				</div>
@@ -164,7 +173,7 @@ export function DevpassTimeseriesChart({
 					<ChartTypeToggle value={chartType} onValueChange={setChartType} />
 				</div>
 			</CardHeader>
-			<div className="grid grid-cols-2 border-y sm:grid-cols-5">
+			<div className="grid grid-cols-2 border-y sm:grid-cols-3 lg:grid-cols-6">
 				{SERIES_KEYS.map((key, index) => {
 					const value = totals?.[key] ?? 0;
 					const active = activeSeries.includes(key);
@@ -177,7 +186,9 @@ export function DevpassTimeseriesChart({
 							className={cn(
 								"flex flex-col gap-1 border-border/60 px-4 py-3 text-left transition-colors hover:bg-muted/30 data-[active=true]:bg-muted/50 sm:px-6",
 								index > 0 && "border-l max-sm:odd:border-l-0",
+								index % 3 === 0 && "sm:max-lg:border-l-0",
 								index > 1 && "max-sm:border-t",
+								index > 2 && "sm:max-lg:border-t",
 							)}
 							onClick={() => toggleSeries(key)}
 						>

--- a/ee/admin/src/components/devpass-usage.tsx
+++ b/ee/admin/src/components/devpass-usage.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { Bot, Cpu, Server } from "lucide-react";
+import { Suspense } from "react";
 
+import { DateRangePicker } from "@/components/date-range-picker";
 import {
 	Card,
 	CardContent,
@@ -9,6 +11,7 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/components/ui/card";
+import { DEVPASS_USAGE_DEFAULT_RANGE } from "@/lib/date-range";
 import { useApi } from "@/lib/fetch-client";
 import { cn } from "@/lib/utils";
 
@@ -128,33 +131,50 @@ export function DevpassUsage({ from, to }: { from?: string; to?: string }) {
 	const sources = data?.sources ?? [];
 
 	return (
-		<div className="grid gap-4 lg:grid-cols-3">
-			<UsageList
-				title="Top models"
-				description="DevPass spend from hourly project rollups."
-				icon={<Cpu className="h-4 w-4" />}
-				rows={models}
-				isLoading={isLoading}
-				emptyLabel="No model usage in the selected range."
-				monoIds
-			/>
-			<UsageList
-				title="Top providers"
-				description="DevPass spend from hourly project rollups."
-				icon={<Server className="h-4 w-4" />}
-				rows={providers}
-				isLoading={isLoading}
-				emptyLabel="No provider usage in the selected range."
-			/>
-			<UsageList
-				title="Top coding agents"
-				description="DevPass `source` header spend from hourly project rollups."
-				icon={<Bot className="h-4 w-4" />}
-				rows={sources}
-				isLoading={isLoading}
-				emptyLabel="No coding-agent traffic in the selected range."
-				monoIds
-			/>
-		</div>
+		<section className="space-y-3">
+			<div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+				<div className="space-y-1">
+					<h2 className="text-lg font-semibold tracking-tight">Usage</h2>
+					<p className="text-sm text-muted-foreground">
+						Top models, providers and coding agents by DevPass spend. Ranged on
+						its own, independent of the page-level picker.
+					</p>
+				</div>
+				<Suspense>
+					<DateRangePicker
+						paramPrefix="usage"
+						defaultRange={DEVPASS_USAGE_DEFAULT_RANGE}
+					/>
+				</Suspense>
+			</div>
+			<div className="grid gap-4 lg:grid-cols-3">
+				<UsageList
+					title="Top models"
+					description="DevPass spend from hourly project rollups."
+					icon={<Cpu className="h-4 w-4" />}
+					rows={models}
+					isLoading={isLoading}
+					emptyLabel="No model usage in the selected range."
+					monoIds
+				/>
+				<UsageList
+					title="Top providers"
+					description="DevPass spend from hourly project rollups."
+					icon={<Server className="h-4 w-4" />}
+					rows={providers}
+					isLoading={isLoading}
+					emptyLabel="No provider usage in the selected range."
+				/>
+				<UsageList
+					title="Top coding agents"
+					description="DevPass `source` header spend from hourly project rollups."
+					icon={<Bot className="h-4 w-4" />}
+					rows={sources}
+					isLoading={isLoading}
+					emptyLabel="No coding-agent traffic in the selected range."
+					monoIds
+				/>
+			</div>
+		</section>
 	);
 }

--- a/ee/admin/src/lib/date-range.ts
+++ b/ee/admin/src/lib/date-range.ts
@@ -156,6 +156,19 @@ export const ALL_TIME_RANGE = "all_time";
 // away in the picker.
 export const ORGANIZATIONS_DEFAULT_RANGE = "this_week";
 
+// The DevPass usage cards (top models / providers / coding agents) carry
+// their own picker so the rest of the page can stay on all time without
+// dragging the model-rollup scan along; they open on a recent window.
+export const DEVPASS_USAGE_DEFAULT_RANGE = "last_30_days";
+
+// A section-scoped picker keeps `<prefix>Range` / `<prefix>From` /
+// `<prefix>To`, so it moves independently of the page-level params.
+export function dateRangeParamNames(prefix?: string) {
+	return prefix
+		? { range: `${prefix}Range`, from: `${prefix}From`, to: `${prefix}To` }
+		: { range: "range", from: "from", to: "to" };
+}
+
 // Resolves the URL query state into concrete `from`/`to` date strings for API
 // calls. A valid `range` preset wins and is resolved against today; `from`/`to`
 // are honored only as a custom span; then the page's own `defaultRange`, if it

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -10,7 +10,11 @@ import {
 	models as allModels,
 	providers as allProviders,
 } from "@llmgateway/models";
-import { DEV_PLAN_PRICES, getDevPlanCreditsLimit } from "@llmgateway/shared";
+import {
+	DEV_PLAN_PRICES,
+	DEV_PLAN_RESET_PASS_PRICES,
+	getDevPlanCreditsLimit,
+} from "@llmgateway/shared";
 import { hashApiKeyForStorage } from "@llmgateway/shared/api-key-hash";
 
 import { and, closeDatabase, db, eq, isNull, tables } from "./index.js";
@@ -1172,6 +1176,9 @@ function generateProjectHourlySourceStats(projects: ProjectDef[]) {
 	return stats;
 }
 
+// Matches the seeded mistral provider_routing_settings marginPercent.
+const airsideMarginPercent = 0.3;
+
 function minutesAgo(minutes: number) {
 	/* eslint-disable no-mixed-operators */
 	return new Date(Date.now() - minutes * 60 * 1000);
@@ -2019,11 +2026,22 @@ async function seed() {
 	await bulkInsert(tables.projectHourlyStats, devpassHourlyStats);
 
 	// Split each hourly bucket across a few models so the Model Usage Overview chart has data.
-	const devpassModels: Array<{ provider: string; model: string }> = [
+	// The mistral share is routed through the seeded Airside carrier, so the
+	// admin DevPass page has gateway margin to show.
+	const devpassModels: Array<{
+		provider: string;
+		model: string;
+		marginPercent?: number;
+	}> = [
 		{ provider: "anthropic", model: "claude-3.5-sonnet" },
 		{ provider: "openai", model: "gpt-4o" },
 		{ provider: "anthropic", model: "claude-3-haiku" },
 		{ provider: "openai", model: "gpt-4o-mini" },
+		{
+			provider: "mistral",
+			model: "mistral-medium-4",
+			marginPercent: airsideMarginPercent,
+		},
 	];
 	const devpassHourlyModelStats: Array<Record<string, any>> = [];
 	for (const bucket of devpassHourlyStats) {
@@ -2076,6 +2094,9 @@ async function seed() {
 				videoOutputCost: 0,
 				cachedInputCost: 0,
 				cacheWriteInputCost: 0,
+				providerMarginAmount: Number(
+					(bucket.cost * w * (m.marginPercent ?? 0)).toFixed(4),
+				),
 				creditsRequestCount: reqs,
 				apiKeysRequestCount: 0,
 				creditsCost: Number((bucket.cost * w).toFixed(4)),
@@ -2537,6 +2558,52 @@ async function seed() {
 		stripePaymentIntentId: "pi_seed_devpass_renewal",
 		stripeInvoiceId: "in_seed_devpass_renewal",
 		description: "Seeded DevPass Pro renewal for admin dashboard",
+	});
+
+	// Two Reset Pass sales (one inside the current 12-day cycle, one before
+	// it) and a PAYG overflow top-up carrying the 5% fee, so every component
+	// of the admin DevPass margin breakdown is populated locally.
+	const devpassResetPassCycleCreatedAt = daysAgo(3);
+	await upsert(tables.transaction, {
+		id: "test-devpass-reset-pass-cycle-transaction-id",
+		organizationId: "test-personal-org-id",
+		createdAt: devpassResetPassCycleCreatedAt,
+		updatedAt: devpassResetPassCycleCreatedAt,
+		type: "dev_plan_reset_pass",
+		amount: String(DEV_PLAN_RESET_PASS_PRICES.pro),
+		creditAmount: null,
+		currency: "USD",
+		status: "completed",
+		stripePaymentIntentId: "pi_seed_devpass_reset_pass_cycle",
+		description: "DevPass Reset Pass (PRO)",
+	});
+	const devpassResetPassPastCreatedAt = daysAgo(20);
+	await upsert(tables.transaction, {
+		id: "test-devpass-reset-pass-past-transaction-id",
+		organizationId: "test-personal-org-id",
+		createdAt: devpassResetPassPastCreatedAt,
+		updatedAt: devpassResetPassPastCreatedAt,
+		type: "dev_plan_reset_pass",
+		amount: String(DEV_PLAN_RESET_PASS_PRICES.pro),
+		creditAmount: null,
+		currency: "USD",
+		status: "completed",
+		stripePaymentIntentId: "pi_seed_devpass_reset_pass_past",
+		description: "DevPass Reset Pass (PRO)",
+	});
+	const devpassTopupCreatedAt = daysAgo(4);
+	await upsert(tables.transaction, {
+		id: "test-devpass-payg-topup-transaction-id",
+		organizationId: "test-personal-org-id",
+		createdAt: devpassTopupCreatedAt,
+		updatedAt: devpassTopupCreatedAt,
+		type: "credit_topup",
+		amount: "26.25",
+		creditAmount: "25",
+		currency: "USD",
+		status: "completed",
+		stripePaymentIntentId: "pi_seed_devpass_payg_topup",
+		description: "Credit purchase for 25 USD (including fees)",
 	});
 
 	const devpassRefundCreatedAt = new Date();
@@ -3320,8 +3387,6 @@ async function seedAirside() {
 		{ model: "mistral-medium-4", inputPrice: 4e-7, outputPrice: 2e-6 },
 		{ model: "codestral-3", inputPrice: 9e-7, outputPrice: 3e-6 },
 	];
-	// Matches the seeded mistral provider_routing_settings marginPercent.
-	const airsideMarginPercent = 0.3;
 	let airsideStatId = 0;
 	for (let day = 0; day < 30; day++) {
 		for (const entry of airsideModels) {


### PR DESCRIPTION
## Problem

The admin DevPass page reported "Cycle margin" as tier MRR minus pool-funded provider cost. That leaves out three things DevPass actually earns in the same cycles:

- the Airside gateway margin on carrier traffic, which is hidden inside the catalogue-priced provider cost the margin subtracts;
- Reset Pass sales (shown all-time on their own card, but never counted into margin);
- the 5% platform fee on PAYG overflow top-ups. The whole PAYG side was excluded on the theory that top-ups fund overflow 1:1, which is true for the credits but not for the fee charged on top of them.

Separately, the whole page hangs off one date picker, so looking at the top models / providers / coding agents for a recent window meant re-ranging (and re-querying) the slow all-time KPI and timeseries queries too.

## Approach

**API (`GET /admin/devpass/kpis`)** — margin is now `planMargin + gatewayMarginCycle + resetPassRevenueCycle + paygFeeCycle`, all scoped to the active subscribers' current billing cycles, the same window the existing cost and MRR use. `planMargin` keeps the old definition so the breakdown stays visible. `marginPct` divides by cycle revenue (MRR + Reset Passes + fee) rather than MRR alone.

- Gateway margin sums `project_hourly_model_stats.providerMarginAmount` per org from its cycle start (same shape as the existing cycle-cost subquery).
- Reset Pass cycle count/revenue are `FILTER` columns folded into the existing all-time queries, netted against Reset Pass refunds in the window.
- PAYG fee is `amount − credits granted` on completed `credit_topup` rows, minus the same shape on their refunds (`amount − |creditAmount|`). It's the real take net of any bonus credits, not a hard-coded 5%, so it stays right if a top-up carried a bonus; the 1.5% international-card surcharge can't be separated from the transaction row and is included.

**Timeseries** gets a `gatewayMargin` series and adds it into the daily margin, so the range-scoped margin and the cycle-scoped one agree on what counts. Reset Passes and gross top-ups were already in that revenue.

**Usage section** gets its own `DateRangePicker` through a new `paramPrefix` prop (`usageRange` / `usageFrom` / `usageTo`), defaulting to the last 30 days and round-tripped through search/sort/pagination. Range changes no longer scroll the page to the top. `GET /admin/devpass/usage` now honours all time when no range is sent (previously it silently fell back to 30 days) — the page always sends a window unless "All time" is picked explicitly.

**Admin UI** — the KPI strip's second row becomes four columns: Cycle margin with a plan / gateway / passes / fee breakdown, plus new Gateway margin and PAYG fee cards and a cycle line on Reset passes sold. The chart grows a sixth tile.

**Seed** adds an Airside-routed model share to the DevPass hourly rollups, two Reset Pass sales and a fee-bearing top-up so every component is populated locally.

Not changed: the per-subscriber `margin` column and `marginNegative` filter keep the plan-only definition. They flag subscribers whose usage exceeds their tier price, and mixing carrier margin into that would blunt the signal.

## Verification

- New spec `admin-devpass-margin-components.spec.ts` covers the KPI decomposition (including a non-DevPass org that must not count, a pre-cycle Reset Pass that counts all-time only, and a partial top-up refund), the timeseries gateway-margin series, and usage all-time vs ranged. Existing `admin-devpass-payg.spec.ts` updated for the fee share.
- `pnpm test:unit` scoped to the five DevPass admin specs on an isolated stack: 25 passed.
- `pnpm build` green.
- Browser check on the isolated stack: with `?range=this_month`, picking a usage preset writes only `usageRange=…`, the page-level picker stays on "This month", scroll position is unchanged, and the usage request switches from the 30-day window to the picked window / no window for all time.

## Screenshots

_(seeded local data)_

**DevPass page, light — before / after** (new Gateway margin, Reset passes and PAYG fee cards, margin breakdown, gateway-margin chart tile, usage section with its own picker)

<img width="1440" alt="DevPass admin page before, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/82c2ea5fe63bb63305352b1c741a10c025b75893/before-light.png" />
<img width="1440" alt="DevPass admin page after, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/82c2ea5fe63bb63305352b1c741a10c025b75893/after-light.png" />

**DevPass page, dark — before / after**

<img width="1440" alt="DevPass admin page before, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/82c2ea5fe63bb63305352b1c741a10c025b75893/before-dark.png" />
<img width="1440" alt="DevPass admin page after, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/82c2ea5fe63bb63305352b1c741a10c025b75893/after-dark.png" />

**Usage section picker open — light / dark**

<img width="1440" alt="Usage section date picker open, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/82c2ea5fe63bb63305352b1c741a10c025b75893/after-usage-picker-light.png" />
<img width="1440" alt="Usage section date picker open, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/82c2ea5fe63bb63305352b1c741a10c025b75893/after-usage-picker-dark.png" />

https://claude.ai/code/session_011TooBWvSs6D2f4aXPEHfTM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - DevPass admin dashboards now show plan, gateway, Reset Pass, and PAYG fee margins.
  - Total margin and margin percentage include these revenue components.
  - Timeseries reporting now includes gateway margin.
  - DevPass usage has an independent date-range selector, including all-time reporting.
  - KPI cards provide current-cycle and all-time details for margin components.
- **Bug Fixes**
  - Usage date filters now apply consistently to the selected reporting period.
  - Incomplete usage date ranges are rejected with a clear error.
  - Date-range navigation no longer unexpectedly scrolls the page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->