### PR TITLE
fix(models): keep DeepSeek V4 Pro active

### DIFF
--- a/packages/models/src/models/deepseek.ts
+++ b/packages/models/src/models/deepseek.ts
@@ -283,7 +283,6 @@ export const deepseekModels = [
 			{
 				providerId: "deepseek",
 				externalId: "deepseek-v4-pro",
-				deactivatedAt: new Date("2026-09-14"),
 				// Peak hours (01:00-04:00 and 06:00-10:00 UTC) bill at the peak
 				// rates below. All other hours and Beijing-time weekends bill at
 				// the off-peak rates.


### PR DESCRIPTION
DeepSeek walked back the planned retirement of V4 Pro on the direct `deepseek` provider, so remove the `deactivatedAt: 2026-09-14` stamp and keep the mapping routable.

No other provider mapping for this model was deactivated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored availability for the DeepSeek V4 Pro provider by removing its deactivation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->