### PR TITLE
feat(admin): platform announcement banner

### DIFF
--- a/apps/airside/src/app/globals.css
+++ b/apps/airside/src/app/globals.css
@@ -1,6 +1,9 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+/* The shared announcement banner ships Tailwind classes from outside this app. */
+@source "../../../../packages/shared/src/components/system-banner.tsx";
+
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {

--- a/apps/airside/src/app/layout.tsx
+++ b/apps/airside/src/app/layout.tsx
@@ -2,6 +2,9 @@ import { Archivo, Geist_Mono, Inter } from "next/font/google";
 
 import { Providers } from "@/components/providers";
 import { getConfig } from "@/lib/config-server";
+import { fetchSystemBanner } from "@/lib/system-banner";
+
+import { SystemBannerBar } from "@llmgateway/shared/system-banner";
 
 import "./globals.css";
 
@@ -64,9 +67,11 @@ export const metadata: Metadata = {
 	},
 };
 
-export default function RootLayout({
+export default async function RootLayout({
 	children,
 }: Readonly<{ children: React.ReactNode }>) {
+	const systemBanner = await fetchSystemBanner();
+
 	return (
 		<html
 			lang="en"
@@ -74,6 +79,7 @@ export default function RootLayout({
 			suppressHydrationWarning
 		>
 			<body className="font-sans antialiased">
+				<SystemBannerBar banner={systemBanner} />
 				<Providers config={getConfig()}>{children}</Providers>
 			</body>
 		</html>

--- a/apps/airside/src/lib/system-banner.ts
+++ b/apps/airside/src/lib/system-banner.ts
@@ -1,0 +1,28 @@
+import createFetchClient from "openapi-fetch";
+
+import { getConfig } from "./config-server";
+
+import type { paths } from "./api/v1";
+import type { SystemBanner } from "@llmgateway/shared";
+
+/**
+ * Admin-toggled announcement banner. Revalidated often enough that switching
+ * it off takes effect within seconds, without a backend read per page view.
+ */
+export async function fetchSystemBanner(): Promise<SystemBanner | null> {
+	const client = createFetchClient<paths>({
+		baseUrl: getConfig().apiBackendUrl,
+	});
+
+	try {
+		const { data } = await client.GET("/public/banner", {
+			next: { revalidate: 30 },
+		});
+		return data?.banner ?? null;
+	} catch (error) {
+		// Every page renders this: a backend outage must not blank the site,
+		// which is exactly when an incident banner would be configured.
+		console.error("Failed to load the announcement banner:", error);
+		return null;
+	}
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -32,6 +32,7 @@ import { platformSessions } from "./routes/platform-sessions.js";
 import { platformWallet } from "./routes/platform-wallet.js";
 import { platformWebhooks } from "./routes/platform-webhooks.js";
 import { publicApps } from "./routes/public-apps.js";
+import { publicBanner } from "./routes/public-banner.js";
 import { publicChatShares } from "./routes/public-chat-shares.js";
 import { publicChatSupport } from "./routes/public-chat-support.js";
 import { publicConfig } from "./routes/public-config.js";
@@ -316,6 +317,7 @@ app.route("/", referral);
 
 app.route("/internal", internalModels);
 
+app.route("/public/banner", publicBanner);
 app.route("/public/discounts", publicDiscounts);
 app.route("/public/contact", publicContact);
 app.route("/public/newsletter", publicNewsletter);

--- a/apps/api/src/lib/system-banner.ts
+++ b/apps/api/src/lib/system-banner.ts
@@ -1,0 +1,56 @@
+import { db, tables } from "@llmgateway/db";
+import {
+	normalizeSystemBanner,
+	parseSystemBanner,
+	serializeSystemBanner,
+} from "@llmgateway/shared";
+
+import type { SystemBanner } from "@llmgateway/shared";
+
+/** Admin-configurable announcement banner, edited in the admin dashboard. */
+export const SYSTEM_BANNER_SETTING_ID = "system_banner";
+
+export interface SystemBannerSetting {
+	enabled: boolean;
+	banner: SystemBanner | null;
+}
+
+/** The stored draft, whether or not it is currently published. */
+export async function getSystemBannerSetting(): Promise<SystemBannerSetting> {
+	const setting = await db.query.systemSetting.findFirst({
+		where: { id: SYSTEM_BANNER_SETTING_ID },
+	});
+	return {
+		enabled: setting?.enabled ?? false,
+		banner: parseSystemBanner(setting?.value),
+	};
+}
+
+/** What the public sites render — null unless the banner is switched on. */
+export async function getActiveSystemBanner(): Promise<SystemBanner | null> {
+	const { enabled, banner } = await getSystemBannerSetting();
+	return enabled ? banner : null;
+}
+
+export async function setSystemBannerSetting(input: {
+	enabled: boolean;
+	message: string;
+	severity: string;
+	linkUrl: string | null;
+	linkLabel: string | null;
+}): Promise<SystemBannerSetting> {
+	const banner = normalizeSystemBanner(input);
+	// An empty message cannot be published, so the toggle follows the content.
+	const enabled = input.enabled && banner !== null;
+	const value = banner ? serializeSystemBanner(banner) : null;
+
+	await db
+		.insert(tables.systemSetting)
+		.values({ id: SYSTEM_BANNER_SETTING_ID, enabled, value })
+		.onConflictDoUpdate({
+			target: tables.systemSetting.id,
+			set: { enabled, value, updatedAt: new Date() },
+		});
+
+	return { enabled, banner };
+}

--- a/apps/api/src/routes/admin-system-banner.spec.ts
+++ b/apps/api/src/routes/admin-system-banner.spec.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { app } from "@/index.js";
+import { getActiveSystemBanner } from "@/lib/system-banner.js";
+import { createTestUser, deleteAll } from "@/testing.js";
+
+const endpoint = "/admin/settings/banner";
+
+async function putBanner(cookie: string, body: unknown) {
+	return await app.request(endpoint, {
+		method: "PUT",
+		headers: { Cookie: cookie, "Content-Type": "application/json" },
+		body: JSON.stringify(body),
+	});
+}
+
+describe("admin system banner", () => {
+	let cookie: string;
+
+	beforeEach(async () => {
+		process.env.ADMIN_EMAILS = "admin@example.com";
+		cookie = await createTestUser();
+	});
+
+	afterEach(async () => {
+		await deleteAll();
+	});
+
+	test("requires authentication", async () => {
+		const res = await app.request(endpoint);
+		expect(res.status).toBe(401);
+	});
+
+	test("returns an empty disabled banner by default", async () => {
+		const res = await app.request(endpoint, { headers: { Cookie: cookie } });
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			enabled: false,
+			message: "",
+			severity: "info",
+			linkUrl: null,
+			linkLabel: null,
+		});
+	});
+
+	test("stores and publishes a banner", async () => {
+		const res = await putBanner(cookie, {
+			enabled: true,
+			message: "  Upstream provider degraded  ",
+			severity: "warning",
+			linkUrl: "https://status.llmgateway.io/",
+			linkLabel: "Status page",
+		});
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			enabled: true,
+			message: "Upstream provider degraded",
+			severity: "warning",
+			linkUrl: "https://status.llmgateway.io/",
+			linkLabel: "Status page",
+		});
+		expect(await getActiveSystemBanner()).toEqual({
+			message: "Upstream provider degraded",
+			severity: "warning",
+			linkUrl: "https://status.llmgateway.io/",
+			linkLabel: "Status page",
+		});
+	});
+
+	test("keeps the draft when the banner is switched off", async () => {
+		await putBanner(cookie, {
+			enabled: true,
+			message: "Scheduled maintenance",
+			severity: "info",
+			linkUrl: null,
+			linkLabel: null,
+		});
+
+		const res = await putBanner(cookie, {
+			enabled: false,
+			message: "Scheduled maintenance",
+			severity: "info",
+			linkUrl: null,
+			linkLabel: null,
+		});
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toMatchObject({
+			enabled: false,
+			message: "Scheduled maintenance",
+		});
+		expect(await getActiveSystemBanner()).toBeNull();
+	});
+
+	test("rejects enabling an empty banner", async () => {
+		const res = await putBanner(cookie, {
+			enabled: true,
+			message: "   ",
+			severity: "info",
+			linkUrl: null,
+			linkLabel: null,
+		});
+
+		expect(res.status).toBe(400);
+		expect(await getActiveSystemBanner()).toBeNull();
+	});
+
+	test("rejects a non-https link", async () => {
+		const res = await putBanner(cookie, {
+			enabled: true,
+			message: "Degraded",
+			severity: "critical",
+			linkUrl: "http://status.llmgateway.io",
+			linkLabel: null,
+		});
+
+		expect(res.status).toBe(400);
+		expect(await getActiveSystemBanner()).toBeNull();
+	});
+
+	test("rejects an unknown severity", async () => {
+		const res = await putBanner(cookie, {
+			enabled: true,
+			message: "Degraded",
+			severity: "catastrophic",
+			linkUrl: null,
+			linkLabel: null,
+		});
+
+		expect(res.status).toBe(400);
+	});
+
+	test("serves the active banner publicly without auth", async () => {
+		await putBanner(cookie, {
+			enabled: true,
+			message: "Degraded routing",
+			severity: "critical",
+			linkUrl: "https://status.llmgateway.io/",
+			linkLabel: "Status",
+		});
+
+		const res = await app.request("/public/banner");
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({
+			banner: {
+				message: "Degraded routing",
+				severity: "critical",
+				linkUrl: "https://status.llmgateway.io/",
+				linkLabel: "Status",
+			},
+		});
+	});
+
+	test("serves null publicly when no banner is set", async () => {
+		const res = await app.request("/public/banner");
+
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ banner: null });
+	});
+});

--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -34,6 +34,10 @@ import {
 	tokenWindowSchema,
 } from "@/lib/stats-window.js";
 import {
+	getSystemBannerSetting,
+	setSystemBannerSetting,
+} from "@/lib/system-banner.js";
+import {
 	getForcedThreeDSecureMode,
 	getThreeDSecureEnvOverride,
 	setForcedThreeDSecureMode,
@@ -111,8 +115,10 @@ import {
 	MIN_BULK_BLOCK_SEARCH_LENGTH,
 	getOrgSpendTier,
 	getPlanClass,
+	isValidSystemBannerLink,
 	parseUsedModel,
 	resolveTrustTierOverride,
+	SYSTEM_BANNER_SEVERITIES,
 } from "@llmgateway/shared";
 import {
 	getResendClient,
@@ -121,6 +127,7 @@ import {
 } from "@llmgateway/shared/email";
 
 import type { ServerTypes } from "@/vars.js";
+import type { SystemBanner } from "@llmgateway/shared";
 
 function escapeHtml(text: string): string {
 	const htmlEscapeMap: Record<string, string> = {
@@ -5806,6 +5813,98 @@ admin.openapi(updateForceThreeDSecure, async (c) => {
 	await setForcedThreeDSecureMode(mode);
 
 	return c.json(await forceThreeDSecureState());
+});
+
+// --- Announcement Banner ---
+
+const systemBannerSchema = z
+	.object({
+		// Whether the banner is currently shown on the public sites.
+		enabled: z.boolean(),
+		message: z.string(),
+		severity: z.enum(SYSTEM_BANNER_SEVERITIES),
+		linkUrl: z.string().nullable(),
+		linkLabel: z.string().nullable(),
+	})
+	.openapi({});
+
+function systemBannerResponse(setting: {
+	enabled: boolean;
+	banner: SystemBanner | null;
+}) {
+	return {
+		enabled: setting.enabled,
+		message: setting.banner?.message ?? "",
+		severity: setting.banner?.severity ?? ("info" as const),
+		linkUrl: setting.banner?.linkUrl ?? null,
+		linkLabel: setting.banner?.linkLabel ?? null,
+	};
+}
+
+const getSystemBanner = createRoute({
+	method: "get",
+	path: "/settings/banner",
+	request: {},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: systemBannerSchema,
+				},
+			},
+			description: "The stored announcement banner.",
+		},
+	},
+});
+
+const updateSystemBanner = createRoute({
+	method: "put",
+	path: "/settings/banner",
+	request: {
+		body: {
+			content: {
+				"application/json": {
+					schema: systemBannerSchema,
+				},
+			},
+		},
+	},
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: systemBannerSchema,
+				},
+			},
+			description: "Updated announcement banner.",
+		},
+	},
+});
+
+admin.openapi(getSystemBanner, async (c) => {
+	return c.json(systemBannerResponse(await getSystemBannerSetting()));
+});
+
+admin.openapi(updateSystemBanner, async (c) => {
+	const body = c.req.valid("json");
+
+	if (body.enabled && !body.message.trim()) {
+		throw new HTTPException(400, {
+			message: "A banner needs a message before it can be enabled.",
+		});
+	}
+
+	const linkUrl = body.linkUrl?.trim() || null;
+	if (linkUrl && !isValidSystemBannerLink(linkUrl)) {
+		throw new HTTPException(400, {
+			message:
+				"The banner link must be an absolute https URL, e.g. https://status.llmgateway.io.",
+		});
+	}
+
+	return c.json(
+		systemBannerResponse(await setSystemBannerSetting({ ...body, linkUrl })),
+	);
 });
 
 // --- Flagged (high-risk) Accounts ---

--- a/apps/api/src/routes/public-banner.ts
+++ b/apps/api/src/routes/public-banner.ts
@@ -1,0 +1,50 @@
+import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
+import { z } from "zod";
+
+import { getActiveSystemBanner } from "@/lib/system-banner.js";
+
+import { SYSTEM_BANNER_SEVERITIES } from "@llmgateway/shared";
+
+import type { ServerTypes } from "@/vars.js";
+
+/**
+ * Public, unauthenticated announcement banner rendered by the main UI,
+ * DevPass, docs and Airside. Toggled from the admin dashboard.
+ */
+export const publicBanner = new OpenAPIHono<ServerTypes>();
+
+const getBanner = createRoute({
+	method: "get",
+	path: "/",
+	responses: {
+		200: {
+			content: {
+				"application/json": {
+					schema: z
+						.object({
+							banner: z
+								.object({
+									message: z.string(),
+									severity: z.enum(SYSTEM_BANNER_SEVERITIES),
+									linkUrl: z.string().nullable(),
+									linkLabel: z.string().nullable(),
+								})
+								.nullable(),
+						})
+						.openapi({}),
+				},
+			},
+			description:
+				"The active announcement banner, or null when there is none.",
+		},
+	},
+});
+
+publicBanner.openapi(getBanner, async (c) => {
+	// Short enough that switching the banner off reaches every site quickly,
+	// long enough that it does not add a database read per page view.
+	c.header("Cache-Control", "public, max-age=30");
+	return c.json({ banner: await getActiveSystemBanner() });
+});
+
+export default publicBanner;

--- a/apps/code/src/app/layout.tsx
+++ b/apps/code/src/app/layout.tsx
@@ -3,7 +3,10 @@ import { Bricolage_Grotesque, Inter, Geist_Mono } from "next/font/google";
 import { GoogleTag } from "@/components/google-tag";
 import { Providers } from "@/components/providers";
 import { getConfig } from "@/lib/config-server";
+import { fetchSystemBanner } from "@/lib/system-banner";
 import { getTimeZonePreference } from "@/lib/timezone-server";
+
+import { SystemBannerBar } from "@llmgateway/shared/system-banner";
 
 import "./globals.css";
 
@@ -91,7 +94,10 @@ export default async function RootLayout({
 	children: ReactNode;
 }) {
 	const config = getConfig();
-	const timeZone = await getTimeZonePreference();
+	const [timeZone, systemBanner] = await Promise.all([
+		getTimeZonePreference(),
+		fetchSystemBanner(),
+	]);
 
 	return (
 		<html
@@ -109,6 +115,7 @@ export default async function RootLayout({
 				/>
 			</head>
 			<body className="antialiased">
+				<SystemBannerBar banner={systemBanner} />
 				<GoogleTag
 					googleTagId={config.googleTagId}
 					googleAdsSignupConversion={config.googleAdsSignupConversion}

--- a/apps/code/src/lib/system-banner.ts
+++ b/apps/code/src/lib/system-banner.ts
@@ -1,0 +1,28 @@
+import createFetchClient from "openapi-fetch";
+
+import { getConfig } from "./config-server";
+
+import type { paths } from "./api/v1";
+import type { SystemBanner } from "@llmgateway/shared";
+
+/**
+ * Admin-toggled announcement banner. Revalidated often enough that switching
+ * it off takes effect within seconds, without a backend read per page view.
+ */
+export async function fetchSystemBanner(): Promise<SystemBanner | null> {
+	const client = createFetchClient<paths>({
+		baseUrl: getConfig().apiBackendUrl,
+	});
+
+	try {
+		const { data } = await client.GET("/public/banner", {
+			next: { revalidate: 30 },
+		});
+		return data?.banner ?? null;
+	} catch (error) {
+		// Every page renders this: a backend outage must not blank the site,
+		// which is exactly when an incident banner would be configured.
+		console.error("Failed to load the announcement banner:", error);
+		return null;
+	}
+}

--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -3,6 +3,9 @@
 @import "fumadocs-ui/css/preset.css";
 @import "fumadocs-openapi/css/preset.css";
 
+/* The shared announcement banner ships Tailwind classes from outside this app. */
+@source "../../../packages/shared/src/components/system-banner.tsx";
+
 :root {
 	--fd-layout-width: 1600px;
 }

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -7,6 +7,9 @@ import { Geist_Mono, Inter } from "next/font/google";
 import { docsBaseUrl } from "@/lib/base-url";
 import { ConfigProvider } from "@/lib/context";
 import { PostHogProvider } from "@/lib/providers";
+import { fetchSystemBanner } from "@/lib/system-banner";
+
+import { SystemBannerBar } from "@llmgateway/shared/system-banner";
 
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
@@ -47,10 +50,11 @@ export const metadata: Metadata = {
 	},
 };
 
-export default function Layout({ children }: { children: ReactNode }) {
+export default async function Layout({ children }: { children: ReactNode }) {
 	// Access environment variables directly on the server
 	const posthogKey = process.env.POSTHOG_KEY ?? "";
 	const posthogHost = process.env.POSTHOG_HOST ?? "";
+	const systemBanner = await fetchSystemBanner();
 
 	return (
 		<html
@@ -59,6 +63,7 @@ export default function Layout({ children }: { children: ReactNode }) {
 			suppressHydrationWarning
 		>
 			<body className="flex flex-col min-h-screen">
+				<SystemBannerBar banner={systemBanner} />
 				<ConfigProvider posthogKey={posthogKey} posthogHost={posthogHost}>
 					<PostHogProvider>
 						<RootProvider>{children}</RootProvider>

--- a/apps/docs/lib/system-banner.ts
+++ b/apps/docs/lib/system-banner.ts
@@ -1,0 +1,28 @@
+import type { SystemBanner } from "@llmgateway/shared";
+
+const apiBackendUrl =
+	process.env.API_BACKEND_URL ?? process.env.API_URL ?? "http://localhost:4002";
+
+/**
+ * Admin-toggled announcement banner. Plain fetch because the docs app has no
+ * generated API client; revalidated often enough that switching the banner off
+ * takes effect within seconds, without a backend read per page view.
+ */
+export async function fetchSystemBanner(): Promise<SystemBanner | null> {
+	try {
+		const response = await fetch(`${apiBackendUrl}/public/banner`, {
+			next: { revalidate: 30 },
+		});
+		if (!response.ok) {
+			return null;
+		}
+		const body = (await response.json()) as { banner: SystemBanner | null };
+		return body.banner;
+	} catch (error) {
+		// Every page renders this: a backend outage must not blank the docs,
+		// which is exactly when an incident banner would be configured.
+		// eslint-disable-next-line no-console -- the docs app has no logger
+		console.error("Failed to load the announcement banner:", error);
+		return null;
+	}
+}

--- a/apps/ui/src/app/layout.tsx
+++ b/apps/ui/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { Inter, Geist_Mono, Plus_Jakarta_Sans } from "next/font/google";
 
 import { Providers } from "@/components/providers";
 import { getConfig } from "@/lib/config-server";
+import { fetchSystemBanner } from "@/lib/system-banner";
 import { getTimeZonePreference } from "@/lib/timezone-server";
 
 import "./globals.css";
@@ -154,7 +155,10 @@ export default async function RootLayout({
 	children: ReactNode;
 }) {
 	const config = getConfig();
-	const timeZone = await getTimeZonePreference();
+	const [timeZone, systemBanner] = await Promise.all([
+		getTimeZonePreference(),
+		fetchSystemBanner(),
+	]);
 
 	return (
 		<html
@@ -187,7 +191,11 @@ export default async function RootLayout({
 				/>
 			</head>
 			<body className="min-h-screen antialiased">
-				<Providers config={config} timeZone={timeZone}>
+				<Providers
+					config={config}
+					timeZone={timeZone}
+					systemBanner={systemBanner}
+				>
 					{children}
 				</Providers>
 			</body>

--- a/apps/ui/src/components/dashboard/dashboard-layout-client.tsx
+++ b/apps/ui/src/components/dashboard/dashboard-layout-client.tsx
@@ -12,6 +12,9 @@ import { TopBar } from "@/components/dashboard/top-bar";
 import { EmailVerificationBanner } from "@/components/email-verification-banner";
 import { DashboardProvider } from "@/lib/dashboard-context";
 import { useDashboardState } from "@/lib/dashboard-state";
+import { useSystemBanner } from "@/lib/system-banner-context";
+
+import { SystemBannerBar } from "@llmgateway/shared/system-banner";
 
 import type { AnnouncementEntry } from "@/components/dashboard/changelog-notifications";
 
@@ -33,6 +36,7 @@ export function DashboardLayoutClient({
 	announcementEntries = [],
 }: DashboardLayoutClientProps) {
 	const posthog = usePostHog();
+	const systemBanner = useSystemBanner();
 
 	const {
 		organizations,
@@ -85,6 +89,7 @@ export function DashboardLayoutClient({
 							onProjectCreated={handleProjectCreated}
 							announcementEntries={announcementEntries}
 						/>
+						<SystemBannerBar banner={systemBanner} />
 						<EmailVerificationBanner />
 						<EnterpriseLicenseBanner />
 						<PlanExpiryBanner />

--- a/apps/ui/src/components/landing/navbar.tsx
+++ b/apps/ui/src/components/landing/navbar.tsx
@@ -49,9 +49,11 @@ import {
 } from "@/lib/components/navigation-menu";
 import { useAppConfig } from "@/lib/config";
 import Logo from "@/lib/icons/Logo";
+import { useSystemBanner } from "@/lib/system-banner-context";
 import { cn } from "@/lib/utils";
 
 import { MARKETING_STATS } from "@llmgateway/shared";
+import { SystemBannerBar } from "@llmgateway/shared/system-banner";
 
 import { ProviderPromoBanner } from "./provider-promo-banner";
 import { ThemeToggle } from "./theme-toggle";
@@ -418,6 +420,7 @@ export const Navbar = ({
 		},
 	];
 
+	const systemBanner = useSystemBanner();
 	const [menuState, setMenuState] = useState(false);
 	const [isScrolled, setIsScrolled] = useState(false);
 	const [openMobileSection, setOpenMobileSection] = useState<string | null>(
@@ -434,6 +437,9 @@ export const Navbar = ({
 
 	return (
 		<header>
+			{/* In flow, above the fixed nav, so it pushes the page down instead
+			    of covering it. */}
+			<SystemBannerBar banner={systemBanner} />
 			<nav
 				data-state={menuState && "active"}
 				className={cn("z-20 w-full px-2 group", sticky && "fixed")}

--- a/apps/ui/src/components/providers.tsx
+++ b/apps/ui/src/components/providers.tsx
@@ -15,11 +15,12 @@ import { classifyChannel } from "@/lib/attribution";
 import { Toaster } from "@/lib/components/toaster";
 import { toast } from "@/lib/components/use-toast";
 import { AppConfigProvider } from "@/lib/config";
+import { SystemBannerProvider } from "@/lib/system-banner-context";
 
 import { TimeZoneProvider } from "@llmgateway/shared";
 
 import type { AppConfig } from "@/lib/config-server";
-import type { TimeZonePreference } from "@llmgateway/shared";
+import type { SystemBanner, TimeZonePreference } from "@llmgateway/shared";
 import type { ReactNode } from "react";
 
 // The support widget starts collapsed but statically pulls in the AI SDK and
@@ -36,6 +37,8 @@ interface ProvidersProps {
 	/** Read from the timezone cookie by the root layout, so the first render
 	 *  already uses the user's chosen zone. */
 	timeZone: TimeZonePreference;
+	/** Admin-toggled announcement banner, fetched by the root layout. */
+	systemBanner: SystemBanner | null;
 }
 
 function extractErrorMessage(error: unknown): string {
@@ -57,7 +60,12 @@ function extractErrorMessage(error: unknown): string {
 	return "An unknown error occurred.";
 }
 
-export function Providers({ children, config, timeZone }: ProvidersProps) {
+export function Providers({
+	children,
+	config,
+	timeZone,
+	systemBanner,
+}: ProvidersProps) {
 	// useState, not useMemo: React may discard a useMemo cache, which would
 	// silently swap in a fresh QueryClient and drop the whole query cache.
 	const [queryClient] = useState(
@@ -125,35 +133,37 @@ export function Providers({ children, config, timeZone }: ProvidersProps) {
 	return (
 		<TimeZoneProvider initial={timeZone}>
 			<AppConfigProvider config={config}>
-				<ThemeProvider
-					attribute="class"
-					defaultTheme="system"
-					enableSystem
-					storageKey="theme"
-				>
-					<QueryClientProvider client={queryClient}>
-						<PostHogProvider client={posthog}>
-							{children}
-							{/* Gated on init: posthog-js drops captures fired before
+				<SystemBannerProvider banner={systemBanner}>
+					<ThemeProvider
+						attribute="class"
+						defaultTheme="system"
+						enableSystem
+						storageKey="theme"
+					>
+						<QueryClientProvider client={queryClient}>
+							<PostHogProvider client={posthog}>
+								{children}
+								{/* Gated on init: posthog-js drops captures fired before
 						    init(), and the OAuth signup event has exactly one
 						    chance to fire. */}
-							{posthogReady && (
-								<Suspense>
-									<SignupMethodTracker />
-								</Suspense>
+								{posthogReady && (
+									<Suspense>
+										<SignupMethodTracker />
+									</Suspense>
+								)}
+							</PostHogProvider>
+							{process.env.NODE_ENV === "development" && (
+								<ReactQueryDevtools buttonPosition="bottom-left" />
 							)}
-						</PostHogProvider>
-						{process.env.NODE_ENV === "development" && (
-							<ReactQueryDevtools buttonPosition="bottom-left" />
-						)}
-						<ChatSupport />
-					</QueryClientProvider>
-					<Toaster />
-					<SonnerToaster richColors position="bottom-right" />
-					<Suspense>
-						<ReferralHandler />
-					</Suspense>
-				</ThemeProvider>
+							<ChatSupport />
+						</QueryClientProvider>
+						<Toaster />
+						<SonnerToaster richColors position="bottom-right" />
+						<Suspense>
+							<ReferralHandler />
+						</Suspense>
+					</ThemeProvider>
+				</SystemBannerProvider>
 			</AppConfigProvider>
 		</TimeZoneProvider>
 	);

--- a/apps/ui/src/lib/system-banner-context.tsx
+++ b/apps/ui/src/lib/system-banner-context.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { createContext, use, type ReactNode } from "react";
+
+import type { SystemBanner } from "@llmgateway/shared";
+
+const SystemBannerContext = createContext<SystemBanner | null>(null);
+
+export function SystemBannerProvider({
+	banner,
+	children,
+}: {
+	banner: SystemBanner | null;
+	children: ReactNode;
+}) {
+	return <SystemBannerContext value={banner}>{children}</SystemBannerContext>;
+}
+
+export function useSystemBanner(): SystemBanner | null {
+	return use(SystemBannerContext);
+}

--- a/apps/ui/src/lib/system-banner.ts
+++ b/apps/ui/src/lib/system-banner.ts
@@ -1,0 +1,28 @@
+import createFetchClient from "openapi-fetch";
+
+import { getConfig } from "./config-server";
+
+import type { paths } from "./api/v1";
+import type { SystemBanner } from "@llmgateway/shared";
+
+/**
+ * Admin-toggled announcement banner. Revalidated often enough that switching
+ * it off takes effect within seconds, without a backend read per page view.
+ */
+export async function fetchSystemBanner(): Promise<SystemBanner | null> {
+	const client = createFetchClient<paths>({
+		baseUrl: getConfig().apiBackendUrl,
+	});
+
+	try {
+		const { data } = await client.GET("/public/banner", {
+			next: { revalidate: 30 },
+		});
+		return data?.banner ?? null;
+	} catch (error) {
+		// Every page renders this: a backend outage must not blank the site,
+		// which is exactly when an incident banner would be configured.
+		console.error("Failed to load the announcement banner:", error);
+		return null;
+	}
+}

--- a/ee/admin/src/app/settings/page.tsx
+++ b/ee/admin/src/app/settings/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { BlockedSignupCountriesForm } from "@/components/blocked-signup-countries-form";
 import { CreditPurchaseBlockToggle } from "@/components/credit-purchase-block-toggle";
 import { ForceThreeDSecureForm } from "@/components/force-three-d-secure-form";
+import { SystemBannerForm } from "@/components/system-banner-form";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -16,12 +17,17 @@ import {
 	getBlockedSignupCountries,
 	getCreditPurchaseBlock,
 	getForceThreeDSecure,
+	getSystemBanner,
 	updateBlockedSignupCountries,
 	updateCreditPurchaseBlock,
 	updateForceThreeDSecure,
+	updateSystemBanner,
 } from "@/lib/admin-settings";
 
-import type { ForceThreeDSecureMode } from "@/lib/admin-settings";
+import type {
+	ForceThreeDSecureMode,
+	SystemBannerSettingInput,
+} from "@/lib/admin-settings";
 
 function SignInPrompt() {
 	return (
@@ -44,17 +50,23 @@ function SignInPrompt() {
 }
 
 export default async function SettingsPage() {
-	const [creditPurchaseBlock, blockedSignupCountries, forceThreeDSecure] =
-		await Promise.all([
-			getCreditPurchaseBlock(),
-			getBlockedSignupCountries(),
-			getForceThreeDSecure(),
-		]);
+	const [
+		creditPurchaseBlock,
+		blockedSignupCountries,
+		forceThreeDSecure,
+		systemBanner,
+	] = await Promise.all([
+		getCreditPurchaseBlock(),
+		getBlockedSignupCountries(),
+		getForceThreeDSecure(),
+		getSystemBanner(),
+	]);
 
 	if (
 		creditPurchaseBlock === null ||
 		blockedSignupCountries === null ||
-		forceThreeDSecure === null
+		forceThreeDSecure === null ||
+		systemBanner === null
 	) {
 		return <SignInPrompt />;
 	}
@@ -70,6 +82,13 @@ export default async function SettingsPage() {
 		"use server";
 
 		return await updateBlockedSignupCountries(countries);
+	}
+
+	async function handleSaveBanner(input: SystemBannerSettingInput) {
+		"use server";
+
+		const result = await updateSystemBanner(input);
+		return { ok: result.banner !== null, message: result.message };
 	}
 
 	async function handleSaveThreeDSecure(mode: ForceThreeDSecureMode) {
@@ -88,10 +107,24 @@ export default async function SettingsPage() {
 				<div>
 					<h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
 					<p className="text-sm text-muted-foreground">
-						Platform-wide emergency switches
+						Platform-wide announcements and emergency switches
 					</p>
 				</div>
 			</header>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Announcement banner</CardTitle>
+					<CardDescription>
+						Shown at the top of the main dashboard and landing pages, DevPass,
+						the docs and Airside. Use it for incidents and short-lived notices —
+						switch it off as soon as it stops being true.
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<SystemBannerForm banner={systemBanner} onSave={handleSaveBanner} />
+				</CardContent>
+			</Card>
 
 			<Card>
 				<CardHeader>

--- a/ee/admin/src/components/system-banner-form.tsx
+++ b/ee/admin/src/components/system-banner-form.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+
+import {
+	SYSTEM_BANNER_DEFAULT_LINK_LABEL,
+	SYSTEM_BANNER_LINK_LABEL_MAX_LENGTH,
+	SYSTEM_BANNER_MESSAGE_MAX_LENGTH,
+} from "@llmgateway/shared";
+import { SystemBannerBar } from "@llmgateway/shared/system-banner";
+
+import type { SystemBannerSettingInput } from "@/lib/admin-settings";
+import type { SystemBannerSeverity } from "@llmgateway/shared";
+
+const severityLabels: Record<SystemBannerSeverity, string> = {
+	info: "Info — announcements and maintenance notices",
+	warning: "Warning — degraded service",
+	critical: "Critical — outage or data-affecting incident",
+};
+
+interface SystemBannerFormProps {
+	banner: SystemBannerSettingInput;
+	onSave: (
+		input: SystemBannerSettingInput,
+	) => Promise<{ ok: boolean; message: string | null }>;
+}
+
+export function SystemBannerForm({ banner, onSave }: SystemBannerFormProps) {
+	const router = useRouter();
+	const [pending, startTransition] = useTransition();
+	const [enabled, setEnabled] = useState(banner.enabled);
+	const [message, setMessage] = useState(banner.message);
+	const [severity, setSeverity] = useState<SystemBannerSeverity>(
+		banner.severity,
+	);
+	const [linkUrl, setLinkUrl] = useState(banner.linkUrl ?? "");
+	const [linkLabel, setLinkLabel] = useState(banner.linkLabel ?? "");
+	const [error, setError] = useState<string | null>(null);
+	const [saved, setSaved] = useState(false);
+
+	const trimmedMessage = message.trim();
+	const trimmedLink = linkUrl.trim();
+
+	const save = (nextEnabled: boolean) => {
+		setError(null);
+		setSaved(false);
+		startTransition(async () => {
+			const result = await onSave({
+				enabled: nextEnabled,
+				message,
+				severity,
+				linkUrl: trimmedLink || null,
+				linkLabel: linkLabel.trim() || null,
+			});
+			if (!result.ok) {
+				setError(result.message);
+				return;
+			}
+			setEnabled(nextEnabled);
+			setSaved(true);
+			router.refresh();
+		});
+	};
+
+	return (
+		<form
+			className="flex flex-col gap-4"
+			onSubmit={(event) => {
+				event.preventDefault();
+				save(enabled);
+			}}
+		>
+			<div className="flex items-center gap-3">
+				<Switch
+					id="system-banner-enabled"
+					checked={enabled}
+					disabled={pending || (!enabled && !trimmedMessage)}
+					onCheckedChange={(checked) => {
+						setEnabled(checked);
+						save(checked);
+					}}
+				/>
+				<Label htmlFor="system-banner-enabled">
+					{enabled ? "Live on all sites" : "Hidden"}
+				</Label>
+			</div>
+
+			<div className="flex flex-col gap-2">
+				<Label htmlFor="system-banner-message">Message</Label>
+				<Textarea
+					id="system-banner-message"
+					rows={2}
+					maxLength={SYSTEM_BANNER_MESSAGE_MAX_LENGTH}
+					placeholder="e.g. Some providers are returning errors. We're on it."
+					value={message}
+					disabled={pending}
+					onChange={(event) => {
+						setMessage(event.target.value);
+						setSaved(false);
+					}}
+				/>
+				<p className="text-xs text-muted-foreground">
+					{trimmedMessage.length}/{SYSTEM_BANNER_MESSAGE_MAX_LENGTH}
+				</p>
+			</div>
+
+			<div className="flex flex-col gap-2">
+				<Label htmlFor="system-banner-severity">Severity</Label>
+				<Select
+					value={severity}
+					disabled={pending}
+					onValueChange={(value) => {
+						setSeverity(value as SystemBannerSeverity);
+						setSaved(false);
+					}}
+				>
+					<SelectTrigger id="system-banner-severity" className="w-full">
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						{Object.entries(severityLabels).map(([value, label]) => (
+							<SelectItem key={value} value={value}>
+								{label}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</div>
+
+			<div className="flex flex-col gap-2 sm:flex-row">
+				<div className="flex flex-1 flex-col gap-2">
+					<Label htmlFor="system-banner-link-url">Link (optional)</Label>
+					<Input
+						id="system-banner-link-url"
+						type="url"
+						inputMode="url"
+						placeholder="https://status.llmgateway.io"
+						value={linkUrl}
+						disabled={pending}
+						onChange={(event) => {
+							setLinkUrl(event.target.value);
+							setSaved(false);
+						}}
+					/>
+				</div>
+				<div className="flex flex-col gap-2 sm:w-56">
+					<Label htmlFor="system-banner-link-label">Button label</Label>
+					<Input
+						id="system-banner-link-label"
+						maxLength={SYSTEM_BANNER_LINK_LABEL_MAX_LENGTH}
+						placeholder={SYSTEM_BANNER_DEFAULT_LINK_LABEL}
+						value={linkLabel}
+						disabled={pending || !trimmedLink}
+						onChange={(event) => {
+							setLinkLabel(event.target.value);
+							setSaved(false);
+						}}
+					/>
+				</div>
+			</div>
+
+			<div className="flex flex-col gap-2">
+				<Label>Preview</Label>
+				{trimmedMessage ? (
+					<div className="overflow-hidden rounded-lg border">
+						<SystemBannerBar
+							banner={{
+								message: trimmedMessage,
+								severity,
+								linkUrl: trimmedLink || null,
+								linkLabel: (trimmedLink && linkLabel.trim()) || null,
+							}}
+							className="border-b-0"
+						/>
+					</div>
+				) : (
+					<p className="text-sm text-muted-foreground">
+						Write a message to preview the banner.
+					</p>
+				)}
+			</div>
+
+			<div className="flex items-center gap-3">
+				<Button type="submit" disabled={pending}>
+					{pending ? "Saving…" : "Save"}
+				</Button>
+				{error && <p className="text-sm text-destructive">{error}</p>}
+				{saved && !error && (
+					<p className="text-sm text-muted-foreground">Saved.</p>
+				)}
+			</div>
+		</form>
+	);
+}

--- a/ee/admin/src/lib/admin-settings.ts
+++ b/ee/admin/src/lib/admin-settings.ts
@@ -2,6 +2,8 @@
 
 import { createServerApiClient } from "./server-api";
 
+import type { SystemBannerSeverity } from "@llmgateway/shared";
+
 export async function getCreditPurchaseBlock() {
 	const $api = await createServerApiClient();
 	const { data } = await $api.GET("/admin/settings/credit-purchase-block");
@@ -61,4 +63,34 @@ export async function updateForceThreeDSecure(mode: ForceThreeDSecureMode) {
 		};
 	}
 	return { state: data, message: null };
+}
+
+export interface SystemBannerSettingInput {
+	enabled: boolean;
+	message: string;
+	severity: SystemBannerSeverity;
+	linkUrl: string | null;
+	linkLabel: string | null;
+}
+
+export async function getSystemBanner() {
+	const $api = await createServerApiClient();
+	const { data } = await $api.GET("/admin/settings/banner");
+	return data ?? null;
+}
+
+export async function updateSystemBanner(input: SystemBannerSettingInput) {
+	const $api = await createServerApiClient();
+	const { data, error } = await $api.PUT("/admin/settings/banner", {
+		body: input,
+	});
+	if (!data) {
+		return {
+			banner: null,
+			message:
+				(error as { message?: string } | undefined)?.message ??
+				"Failed to update the banner.",
+		};
+	}
+	return { banner: data, message: null };
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -40,6 +40,11 @@
 			"import": "./dist/components/index.js",
 			"default": "./dist/components/index.js"
 		},
+		"./system-banner": {
+			"types": "./dist/components/system-banner.d.ts",
+			"import": "./dist/components/system-banner.js",
+			"default": "./dist/components/system-banner.js"
+		},
 		"./carrier-mark": {
 			"types": "./dist/components/carrier-mark.d.ts",
 			"import": "./dist/components/carrier-mark.js",

--- a/packages/shared/src/components/system-banner.tsx
+++ b/packages/shared/src/components/system-banner.tsx
@@ -1,0 +1,74 @@
+import { Info, OctagonAlert, TriangleAlert } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { SYSTEM_BANNER_DEFAULT_LINK_LABEL } from "@/system-banner";
+
+import type { SystemBanner, SystemBannerSeverity } from "@/system-banner";
+
+export type { SystemBanner, SystemBannerSeverity };
+
+// Palette utilities only, no design-system tokens: this renders inside the
+// docs (fumadocs) theme too, which does not define --background/--foreground.
+const severityStyles: Record<
+	SystemBannerSeverity,
+	{ bar: string; button: string; icon: typeof Info }
+> = {
+	info: {
+		bar: "border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-900 dark:bg-blue-950 dark:text-blue-100",
+		button:
+			"border-blue-300 bg-blue-100 hover:bg-blue-200 dark:border-blue-800 dark:bg-blue-900 dark:hover:bg-blue-800",
+		icon: Info,
+	},
+	warning: {
+		bar: "border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100",
+		button:
+			"border-amber-300 bg-amber-100 hover:bg-amber-200 dark:border-amber-800 dark:bg-amber-900 dark:hover:bg-amber-800",
+		icon: TriangleAlert,
+	},
+	critical: {
+		bar: "border-red-200 bg-red-50 text-red-900 dark:border-red-900 dark:bg-red-950 dark:text-red-100",
+		button:
+			"border-red-300 bg-red-100 hover:bg-red-200 dark:border-red-800 dark:bg-red-900 dark:hover:bg-red-800",
+		icon: OctagonAlert,
+	},
+};
+
+interface SystemBannerBarProps {
+	banner: SystemBanner | null;
+	className?: string;
+}
+
+export function SystemBannerBar({ banner, className }: SystemBannerBarProps) {
+	if (!banner) {
+		return null;
+	}
+
+	const { bar, button, icon: Icon } = severityStyles[banner.severity];
+
+	return (
+		<div
+			role="status"
+			className={cn("w-full border-b px-4 py-2 text-sm", bar, className)}
+		>
+			<div className="mx-auto flex max-w-[1400px] flex-wrap items-center justify-center gap-x-3 gap-y-1.5">
+				<Icon aria-hidden="true" className="h-4 w-4 shrink-0" />
+				<span className="text-center font-medium leading-tight">
+					{banner.message}
+				</span>
+				{banner.linkUrl && (
+					<a
+						href={banner.linkUrl}
+						target="_blank"
+						rel="noopener noreferrer"
+						className={cn(
+							"shrink-0 rounded-md border px-2.5 py-1 text-xs font-semibold transition-colors",
+							button,
+						)}
+					>
+						{banner.linkLabel ?? SYSTEM_BANNER_DEFAULT_LINK_LABEL}
+					</a>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -413,3 +413,17 @@ export {
 	UNKNOWN_MONTH_KEY,
 	withinOneEdit,
 } from "./model-search.js";
+
+export {
+	isSystemBannerSeverity,
+	isValidSystemBannerLink,
+	normalizeSystemBanner,
+	parseSystemBanner,
+	serializeSystemBanner,
+	SYSTEM_BANNER_DEFAULT_LINK_LABEL,
+	SYSTEM_BANNER_LINK_LABEL_MAX_LENGTH,
+	SYSTEM_BANNER_MESSAGE_MAX_LENGTH,
+	SYSTEM_BANNER_SEVERITIES,
+	type SystemBanner,
+	type SystemBannerSeverity,
+} from "./system-banner.js";

--- a/packages/shared/src/system-banner.spec.ts
+++ b/packages/shared/src/system-banner.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "vitest";
+
+import {
+	isValidSystemBannerLink,
+	normalizeSystemBanner,
+	parseSystemBanner,
+	serializeSystemBanner,
+	SYSTEM_BANNER_LINK_LABEL_MAX_LENGTH,
+	SYSTEM_BANNER_MESSAGE_MAX_LENGTH,
+} from "./system-banner.js";
+
+describe("normalizeSystemBanner", () => {
+	test("returns null without a message", () => {
+		expect(normalizeSystemBanner({ message: "   " })).toBeNull();
+		expect(normalizeSystemBanner({})).toBeNull();
+	});
+
+	test("defaults an unknown severity to info", () => {
+		expect(normalizeSystemBanner({ message: "hi", severity: "nope" })).toEqual({
+			message: "hi",
+			severity: "info",
+			linkUrl: null,
+			linkLabel: null,
+		});
+	});
+
+	test("drops the label when there is no link", () => {
+		expect(
+			normalizeSystemBanner({
+				message: "hi",
+				severity: "warning",
+				linkLabel: "Status",
+			}),
+		).toEqual({
+			message: "hi",
+			severity: "warning",
+			linkUrl: null,
+			linkLabel: null,
+		});
+	});
+
+	test("truncates message and label", () => {
+		const banner = normalizeSystemBanner({
+			message: "a".repeat(SYSTEM_BANNER_MESSAGE_MAX_LENGTH + 20),
+			linkUrl: "https://status.llmgateway.io",
+			linkLabel: "b".repeat(SYSTEM_BANNER_LINK_LABEL_MAX_LENGTH + 20),
+		});
+		expect(banner?.message).toHaveLength(SYSTEM_BANNER_MESSAGE_MAX_LENGTH);
+		expect(banner?.linkLabel).toHaveLength(SYSTEM_BANNER_LINK_LABEL_MAX_LENGTH);
+	});
+});
+
+describe("isValidSystemBannerLink", () => {
+	test("accepts https urls only", () => {
+		expect(isValidSystemBannerLink("https://status.llmgateway.io")).toBe(true);
+		expect(isValidSystemBannerLink("http://status.llmgateway.io")).toBe(false);
+		expect(isValidSystemBannerLink("/status")).toBe(false);
+		expect(isValidSystemBannerLink("javascript:alert(1)")).toBe(false);
+		expect(isValidSystemBannerLink("not a url")).toBe(false);
+	});
+});
+
+describe("parseSystemBanner", () => {
+	test("round-trips a serialized banner", () => {
+		const banner = {
+			message: "Upstream provider degraded",
+			severity: "warning" as const,
+			linkUrl: "https://status.llmgateway.io/",
+			linkLabel: "Status",
+		};
+		expect(parseSystemBanner(serializeSystemBanner(banner))).toEqual(banner);
+	});
+
+	test("returns null for empty or malformed values", () => {
+		expect(parseSystemBanner(null)).toBeNull();
+		expect(parseSystemBanner("")).toBeNull();
+		expect(parseSystemBanner("{not json")).toBeNull();
+		expect(parseSystemBanner("[]")).toBeNull();
+		expect(parseSystemBanner('{"severity":"info"}')).toBeNull();
+	});
+});

--- a/packages/shared/src/system-banner.ts
+++ b/packages/shared/src/system-banner.ts
@@ -1,0 +1,97 @@
+/**
+ * Platform-wide announcement banner, toggled from the admin dashboard and
+ * rendered by every public surface (main UI, DevPass, docs, Airside).
+ */
+export const SYSTEM_BANNER_SEVERITIES = [
+	"info",
+	"warning",
+	"critical",
+] as const;
+
+export type SystemBannerSeverity = (typeof SYSTEM_BANNER_SEVERITIES)[number];
+
+export interface SystemBanner {
+	message: string;
+	severity: SystemBannerSeverity;
+	/** Absolute https URL rendered as a button, or null for a text-only banner. */
+	linkUrl: string | null;
+	linkLabel: string | null;
+}
+
+export const SYSTEM_BANNER_MESSAGE_MAX_LENGTH = 280;
+export const SYSTEM_BANNER_LINK_LABEL_MAX_LENGTH = 32;
+export const SYSTEM_BANNER_DEFAULT_LINK_LABEL = "Learn more";
+
+export function isSystemBannerSeverity(
+	value: unknown,
+): value is SystemBannerSeverity {
+	return SYSTEM_BANNER_SEVERITIES.includes(value as SystemBannerSeverity);
+}
+
+/**
+ * Banners render on four public sites, so a relative path would resolve
+ * differently on each one — only absolute https URLs are accepted.
+ */
+export function isValidSystemBannerLink(url: string): boolean {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return false;
+	}
+	return parsed.protocol === "https:";
+}
+
+function trimToLength(value: string, max: number): string {
+	return value.trim().slice(0, max);
+}
+
+/** Normalizes admin input, returning null when there is nothing to show. */
+export function normalizeSystemBanner(input: {
+	message?: string | null;
+	severity?: string | null;
+	linkUrl?: string | null;
+	linkLabel?: string | null;
+}): SystemBanner | null {
+	const message = trimToLength(
+		input.message ?? "",
+		SYSTEM_BANNER_MESSAGE_MAX_LENGTH,
+	);
+	if (!message) {
+		return null;
+	}
+	const linkUrl = input.linkUrl?.trim() || null;
+	return {
+		message,
+		severity: isSystemBannerSeverity(input.severity) ? input.severity : "info",
+		linkUrl,
+		linkLabel: linkUrl
+			? trimToLength(
+					input.linkLabel ?? "",
+					SYSTEM_BANNER_LINK_LABEL_MAX_LENGTH,
+				) || null
+			: null,
+	};
+}
+
+export function serializeSystemBanner(banner: SystemBanner): string {
+	return JSON.stringify(banner);
+}
+
+export function parseSystemBanner(
+	value: string | null | undefined,
+): SystemBanner | null {
+	if (!value) {
+		return null;
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(value);
+	} catch {
+		return null;
+	}
+	if (typeof parsed !== "object" || parsed === null) {
+		return null;
+	}
+	return normalizeSystemBanner(parsed as Record<string, string | null>);
+}


### PR DESCRIPTION
## Problem

There is no way to tell users that something is broken. The only banner we have is the hardcoded provider promo in `packages/shared/src/marketing.ts`, which is a compile-time constant — putting up an incident notice, or taking one down, means a deploy of four apps.

## What this adds

An **announcement banner** toggled from the admin dashboard (Settings → Announcement banner) and rendered by every public surface:

- **Main UI** — landing/marketing pages (inside `Navbar`, above the provider promo) and the dashboard (in the existing banner stack under the top bar)
- **DevPass** (`apps/code`), **docs** and **Airside** — top of `<body>` in the root layout

Fields: message, severity (`info` / `warning` / `critical`) and an optional link that renders as a button with a custom label. The admin form previews the real banner component as you type.

## How it works

- Stored as a single `system_setting` row (`system_banner`), the same mechanism as the other platform switches on that page — **no migration**. `enabled` is the on/off toggle; `value` holds the JSON payload, so switching off keeps the draft for next time.
- `GET /public/banner` serves it unauthenticated; each app fetches it server-side in its root layout with `next: { revalidate: 30 }`, so toggling reaches every site within ~30s without a deploy and without a backend read per page view. If the API is unreachable the helper logs and returns `null` — an incident banner must never be the thing that blanks the site.
- Admin `PUT /admin/settings/banner` rejects enabling an empty message and rejects a link that is not an absolute `https` URL (the banner renders on four different domains, so a relative path would resolve differently on each).
- The banner component lives in `@llmgateway/shared/system-banner` and uses only Tailwind palette utilities — no `--background`/`--foreground` tokens — because the docs app runs the fumadocs theme, which does not define them. `@source` lines were added to the docs and Airside stylesheets so those classes get generated.

## Deliberately not included

- **No dismiss button.** The banner is meant to be short-lived and switched off from the admin dashboard; letting users hide an outage notice defeats the point.
- Auth screens in the main UI (`/login`, `/signup`, …) use their own layouts and do not show the banner.
- The Lounge/playground app is not covered — it was not in scope.

## Verification

- `pnpm build` — 19/19 tasks pass.
- `pnpm test:unit` — 6712 passed. Two pre-existing failures unrelated to this change (`admin-devpass-payg`, `admin-enterprise-deals`) are local-clock artifacts on a UTC+7 machine; both pass under `TZ=UTC`.
- New: `packages/shared/src/system-banner.spec.ts` and `apps/api/src/routes/admin-system-banner.spec.ts` (admin CRUD, validation, public endpoint).
- Exercised end to end locally: set the banner in the admin dashboard, confirmed it appears in all four apps, toggled it off and confirmed `GET /public/banner` returns `null`.

## Screenshots

### Admin dashboard — Settings → Announcement banner

<img width="1176" alt="Admin settings, announcement banner card, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/7d10bbacb0badb7b271344bfea0e5b3be29fdb6f/admin-settings-light.png" />
<img width="1176" alt="Admin settings, announcement banner card, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/7d10bbacb0badb7b271344bfea0e5b3be29fdb6f/admin-settings-dark.png" />

### Main UI — landing page

<img width="1440" alt="Landing page with the warning banner, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/7d10bbacb0badb7b271344bfea0e5b3be29fdb6f/ui-landing-light.png" />
<img width="1440" alt="Landing page with the warning banner, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/7d10bbacb0badb7b271344bfea0e5b3be29fdb6f/ui-landing-dark.png" />

### Main UI — dashboard

<img width="1440" alt="Dashboard with the warning banner, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/7d10bbacb0badb7b271344bfea0e5b3be29fdb6f/ui-dashboard-light.png" />
<img width="1440" alt="Dashboard with the warning banner, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/7d10bbacb0badb7b271344bfea0e5b3be29fdb6f/ui-dashboard-dark.png" />

### DevPass

<img width="1440" alt="DevPass landing page with the warning banner, light" src="https://raw.githubusercontent.com/theopenco/llmgateway/7d10bbacb0badb7b271344bfea0e5b3be29fdb6f/code-landing-light.png" />
<img width="1440" alt="DevPass landing page with the warning banner, dark" src="https://raw.githubusercontent.com/theopenco/llmgateway/7d10bbacb0badb7b271344bfea0e5b3be29fdb6f/code-landing-dark.png" />

### Docs and Airside

<img width="1440" alt="Docs with the warning banner" src="https://raw.githubusercontent.com/theopenco/llmgateway/7d10bbacb0badb7b271344bfea0e5b3be29fdb6f/docs-light.png" />
<img width="1440" alt="Airside with the warning banner" src="https://raw.githubusercontent.com/theopenco/llmgateway/7d10bbacb0badb7b271344bfea0e5b3be29fdb6f/airside.png" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable platform-wide announcement banners with informational, warning, and critical severity levels.
  * Administrators can enable banners, customize messages, add secure links, preview changes, and save updates.
  * Active announcements now appear across the main application, documentation, dashboard, and landing pages.
  * Banners gracefully handle unavailable or invalid content without interrupting page loading.

* **Tests**
  * Added coverage for banner validation, formatting, persistence, administration, and public delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->