### PR TITLE
fix(ci): fail closed on credential env names

### DIFF
--- a/scripts/mask-ci-credentials.mjs
+++ b/scripts/mask-ci-credentials.mjs
@@ -10,8 +10,30 @@
  * Standalone on purpose: it runs before anything is built.
  */
 
+/**
+ * Kept in step with `vitest/redact-credentials.ts` — `redact-credentials.spec.ts`
+ * asserts the two agree. Duplicated rather than imported so this stays runnable
+ * before anything is built.
+ *
+ * `LLM_*` is the provider-credential namespace and is treated as secret by
+ * default: `LLM_RUNPOD_KEY` carries a real key and matches none of the naming
+ * patterns below.
+ */
+const LLM_CONFIG_SUFFIX_PATTERN =
+	/_(BASE_URL|REGION|PROJECT|RESOURCE|API_VERSION|DEPLOYMENT_TYPE|USE_RESPONSES_API|WORKSPACE_ID|TOKEN_TYPE|MODE|METHOD|MODELS|KEYWORDS|THRESHOLD|BUCKET|PREFIX|COUNT|TTL_SECONDS)$/;
+
 const CREDENTIAL_NAME_PATTERN =
 	/(API_KEY|TOKEN|SECRET|PASSWORD|SERVICE_ACCOUNT_JSON)/;
+
+function isCredentialEnvName(name) {
+	// Variant and regional overrides (`__ENTERPRISE`, `__EU_FRANKFURT`) share
+	// the base variable's meaning.
+	const base = name.split("__")[0];
+	if (base.startsWith("LLM_")) {
+		return !LLM_CONFIG_SUFFIX_PATTERN.test(base);
+	}
+	return CREDENTIAL_NAME_PATTERN.test(name);
+}
 const MIN_SECRET_LENGTH = 12;
 
 /** Split on top-level commas only, so a service-account JSON stays one entry. */
@@ -66,9 +88,10 @@ function add(value) {
 }
 
 for (const [name, value] of Object.entries(process.env)) {
-	if (!value || !CREDENTIAL_NAME_PATTERN.test(name)) {
+	if (!value || !isCredentialEnvName(name)) {
 		continue;
 	}
+	add(value);
 	for (const entry of splitTopLevel(value)) {
 		const part = entry.trim();
 		add(part);

--- a/vitest/redact-credentials.spec.ts
+++ b/vitest/redact-credentials.spec.ts
@@ -1,6 +1,12 @@
+import { execFileSync } from "node:child_process";
+
 import { afterEach, describe, expect, test } from "vitest";
 
-import { redactCredentials } from "./redact-credentials.js";
+import {
+	collectCredentialValues,
+	isCredentialEnvName,
+	redactCredentials,
+} from "./redact-credentials.js";
 
 const added: string[] = [];
 
@@ -11,8 +17,40 @@ function setEnv(name: string, value: string): void {
 
 afterEach(() => {
 	for (const name of added.splice(0)) {
-		delete process.env[name];
+		Reflect.deleteProperty(process.env, name);
 	}
+});
+
+describe("isCredentialEnvName", () => {
+	test("treats the LLM_ namespace as secret by default", () => {
+		// Neither name contains API_KEY, TOKEN or SECRET.
+		expect(isCredentialEnvName("LLM_RUNPOD_KEY")).toBe(true);
+		expect(isCredentialEnvName("LLM_SOMETHING_NEW")).toBe(true);
+	});
+
+	test("exempts the catalogue's non-secret knobs", () => {
+		for (const name of [
+			"LLM_OPENAI_BASE_URL",
+			"LLM_AWS_BEDROCK_REGION",
+			"LLM_GOOGLE_CLOUD_PROJECT",
+			"LLM_AZURE_RESOURCE",
+			"LLM_AZURE_API_VERSION",
+			"LLM_ALIBABA_WORKSPACE_ID",
+			"LLM_GOOGLE_VERTEX_TOKEN_TYPE",
+		]) {
+			expect(isCredentialEnvName(name)).toBe(false);
+		}
+	});
+
+	test("resolves variant and regional overrides to their base variable", () => {
+		expect(isCredentialEnvName("LLM_ALIBABA_API_KEY__EU_FRANKFURT")).toBe(true);
+		expect(isCredentialEnvName("LLM_OPENAI_BASE_URL__ENTERPRISE")).toBe(false);
+	});
+
+	test("falls back to name patterns outside the LLM_ namespace", () => {
+		expect(isCredentialEnvName("GITHUB_TOKEN")).toBe(true);
+		expect(isCredentialEnvName("TEST_MODELS")).toBe(false);
+	});
 });
 
 describe("redactCredentials", () => {
@@ -63,5 +101,44 @@ describe("redactCredentials", () => {
 		expect(redactCredentials("test-token us-east-1-not-a-secret")).toBe(
 			"test-token us-east-1-not-a-secret",
 		);
+	});
+});
+
+describe("mask-ci-credentials.mjs", () => {
+	/** The script is a standalone copy so it can run before anything is built;
+	 * this is what stops the two from drifting apart. */
+	test("masks exactly the values this module redacts", () => {
+		const fixture: Record<string, string> = {
+			PATH: process.env.PATH ?? "",
+			LLM_PARITY_API_KEY: "sk-parity-first-value,sk-parity-second-value",
+			LLM_PARITY_KEY: "rp-parity-credential-value",
+			LLM_PARITY_BASE_URL: "https://parity.example.com/v1",
+			LLM_PARITY_SERVICE_ACCOUNT_JSON: JSON.stringify({
+				client_email: "sa@example.com",
+				private_key: "-----BEGIN PRIVATE KEY-----\nPARITYLINEONE\n",
+			}),
+		};
+
+		const realEnv = process.env;
+		process.env = { ...fixture };
+		const expected = collectCredentialValues().filter(
+			(value) => !/[\r\n]/.test(value),
+		);
+		process.env = realEnv;
+
+		const stdout = execFileSync(
+			process.execPath,
+			["scripts/mask-ci-credentials.mjs"],
+			{ env: fixture, encoding: "utf8" },
+		);
+		const masks = stdout
+			.split("\n")
+			.filter((line) => line.startsWith("::add-mask::"))
+			.map((line) => line.slice("::add-mask::".length));
+
+		expect(masks.length).toBeGreaterThan(0);
+		expect(new Set(masks)).toEqual(new Set(expected));
+		// A multi-line mask would make the runner echo everything after line one.
+		expect(masks.every((mask) => !mask.includes("\n"))).toBe(true);
 	});
 });

--- a/vitest/redact-credentials.ts
+++ b/vitest/redact-credentials.ts
@@ -11,8 +11,28 @@ import { inspect } from "node:util";
  * string. Redacting at the console boundary covers both.
  */
 
+/**
+ * `LLM_*` is the provider-credential namespace, so it is treated as secret by
+ * default: `LLM_RUNPOD_KEY` carries a real key and matches none of the naming
+ * patterns below. Only the catalogue's non-secret knobs are exempt, and a
+ * missing exemption costs a redacted config value in test output — the
+ * opposite mistake costs a credential.
+ */
+const LLM_CONFIG_SUFFIX_PATTERN =
+	/_(BASE_URL|REGION|PROJECT|RESOURCE|API_VERSION|DEPLOYMENT_TYPE|USE_RESPONSES_API|WORKSPACE_ID|TOKEN_TYPE|MODE|METHOD|MODELS|KEYWORDS|THRESHOLD|BUCKET|PREFIX|COUNT|TTL_SECONDS)$/;
+
 const CREDENTIAL_NAME_PATTERN =
 	/(API_KEY|TOKEN|SECRET|PASSWORD|SERVICE_ACCOUNT_JSON)/;
+
+export function isCredentialEnvName(name: string): boolean {
+	// Variant and regional overrides (`__ENTERPRISE`, `__EU_FRANKFURT`) share
+	// the base variable's meaning.
+	const base = name.split("__")[0];
+	if (base.startsWith("LLM_")) {
+		return !LLM_CONFIG_SUFFIX_PATTERN.test(base);
+	}
+	return CREDENTIAL_NAME_PATTERN.test(name);
+}
 
 /** Short values are config (`true`, `dev`), not credentials, and redacting
  * them would hide the seeded `test-token` fixtures the suites assert on. */
@@ -71,7 +91,7 @@ function splitTopLevel(value: string): string[] {
 	return entries;
 }
 
-function collectSecrets(): string[] {
+export function collectCredentialValues(): string[] {
 	const secrets = new Set<string>();
 
 	const add = (value: string | undefined) => {
@@ -82,7 +102,7 @@ function collectSecrets(): string[] {
 	};
 
 	for (const [name, value] of Object.entries(process.env)) {
-		if (!value || !CREDENTIAL_NAME_PATTERN.test(name)) {
+		if (!value || !isCredentialEnvName(name)) {
 			continue;
 		}
 		add(value);
@@ -124,7 +144,7 @@ let cache: { fingerprint: string; secrets: string[] } | null = null;
 function envFingerprint(): string {
 	let fingerprint = "";
 	for (const [name, value] of Object.entries(process.env)) {
-		if (value && CREDENTIAL_NAME_PATTERN.test(name)) {
+		if (value && isCredentialEnvName(name)) {
 			fingerprint += `${name}:${value.length},`;
 		}
 	}
@@ -134,7 +154,7 @@ function envFingerprint(): string {
 function currentSecrets(): string[] {
 	const fingerprint = envFingerprint();
 	if (!cache || cache.fingerprint !== fingerprint) {
-		cache = { fingerprint, secrets: collectSecrets() };
+		cache = { fingerprint, secrets: collectCredentialValues() };
 	}
 	return cache.secrets;
 }
@@ -167,6 +187,7 @@ export function installConsoleCredentialRedaction(): void {
 	installed = true;
 
 	for (const method of CONSOLE_METHODS) {
+		/* eslint-disable no-console -- wrapping the console is the point here. */
 		const original = console[method].bind(console);
 		console[method] = (...args: unknown[]) => {
 			if (currentSecrets().length === 0) {
@@ -175,5 +196,6 @@ export function installConsoleCredentialRedaction(): void {
 			}
 			original(...args.map(redactArgument));
 		};
+		/* eslint-enable no-console */
 	}
 }


### PR DESCRIPTION
Follow-up to #4045, which landed before this fix was pushed to the branch.

## Problem

#4045 decided which environment variables hold credentials with a name heuristic, `/(API_KEY|TOKEN|SECRET|PASSWORD|SERVICE_ACCOUNT_JSON)/`. That fails **open**: `LLM_RUNPOD_KEY` is a real provider credential and matches none of those, so it would have been redacted from neither the blob artifacts nor the run log. The next credential added under an unusual name would be silently unprotected the same way.

## Approach

Invert the rule for the provider namespace. Everything under `LLM_*` is treated as secret unless its name ends in one of the catalogue's non-secret knobs — `_BASE_URL`, `_REGION`, `_PROJECT`, `_RESOURCE`, `_API_VERSION`, `_DEPLOYMENT_TYPE`, `_WORKSPACE_ID`, `_TOKEN_TYPE` and friends. Variant and regional suffixes (`__ENTERPRISE`, `__EU_FRANKFURT`) resolve to the base variable first. Outside `LLM_*` the previous name patterns still apply, so `GITHUB_TOKEN` stays covered.

A missing exemption only costs a redacted config value in test output; the opposite mistake costs a credential.

`scripts/mask-ci-credentials.mjs` has to duplicate this logic — it runs before anything is built — so a parity test now runs it as a subprocess and asserts it emits exactly the values the redaction module would redact, all single-line.

## Verification

- Checked the predicate against every `env.required` / `env.optional` entry in `packages/models`: no credential-bearing variable is missed, and no config variable is caught. (`LLM_GOOGLE_VERTEX_TOKEN_TYPE` holds `oauth`/`api-key`, a mode selector, and is correctly exempt.)
- End-to-end through a blob report: an `LLM_RUNPOD_KEY` value no longer appears, while the sibling `LLM_RUNPOD_BASE_URL` stays readable.
- New specs cover the namespace default, the exemptions, variant/regional suffixes, the non-`LLM_` fallback, and script parity.
- `pnpm format`, `pnpm build`, eslint on the changed files, and the console-spy specs (`logger`, `code-block`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential masking for `LLM_*` environment variables.
  * Variables are now masked by default unless they use recognized non-secret configuration suffixes, such as base URL, region, or project settings.
  * Regional and enterprise-specific variants are handled consistently when identifying credentials.
  * Credential collection and CI masking now produce matching results, reducing the risk of sensitive values being exposed in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->