### PR TITLE
fix(gateway): count out-of-funds keys as unhealthy

### DIFF
--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts
@@ -89,6 +89,15 @@ describe("getFinishReasonFromError", () => {
 		).toBe("gateway_error");
 	});
 
+	it("returns gateway_error for an exhausted trial quota on 400", () => {
+		expect(
+			getFinishReasonFromError(
+				400,
+				'{"error":{"code":"401008","message":"The free trial quota for the service has been exhausted and postpaid billing is not enabled, so the service cannot be accessed."}}',
+			),
+		).toBe("gateway_error");
+	});
+
 	it("returns gateway_error for 405 method not allowed", () => {
 		expect(getFinishReasonFromError(405)).toBe("gateway_error");
 		expect(getFinishReasonFromError(405, "Method Not Allowed")).toBe(

--- a/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
+++ b/apps/gateway/src/chat/tools/get-finish-reason-from-error.ts
@@ -1,4 +1,5 @@
 import { hasInvalidProviderCredentialError } from "@/lib/provider-auth-errors.js";
+import { hasExhaustedProviderAccountError } from "@/lib/provider-funding-errors.js";
 
 import { isContentFilterErrorText } from "@llmgateway/shared";
 
@@ -90,12 +91,7 @@ export function getFinishReasonFromError(
 	// case above this is a funding problem on our provider account, not a client
 	// fault, so classify as gateway_error to allow fallback to another key or
 	// provider.
-	if (
-		errorText &&
-		/credit balance is too low|insufficient balance|reaching the monthly spending limit/i.test(
-			errorText,
-		)
-	) {
+	if (hasExhaustedProviderAccountError(errorText)) {
 		return "gateway_error";
 	}
 

--- a/apps/gateway/src/lib/api-key-health.spec.ts
+++ b/apps/gateway/src/lib/api-key-health.spec.ts
@@ -53,6 +53,40 @@ describe("api-key-health", () => {
 			expect(isKeyHealthy("LLM_OPENAI_API_KEY", 0)).toBe(false);
 		});
 
+		it("should count 402 out-of-funds responses against the key", () => {
+			const body =
+				'{"error":{"code":"401008","message":"The free trial quota for the service has been exhausted and postpaid billing is not enabled."}}';
+			reportKeyError("LLM_TENCENT_API_KEY", 0, 402, body);
+			reportKeyError("LLM_TENCENT_API_KEY", 0, 402, body);
+			reportKeyError("LLM_TENCENT_API_KEY", 0, 402, body);
+			expect(isKeyHealthy("LLM_TENCENT_API_KEY", 0)).toBe(false);
+			expect(getKeyMetrics("LLM_TENCENT_API_KEY", 0).uptime).toBe(0);
+		});
+
+		it("should count out-of-funds payloads on other 4xx codes", () => {
+			const body =
+				"Your credit balance is too low to access the Anthropic API.";
+			reportKeyError("LLM_ANTHROPIC_API_KEY", 0, 400, body);
+			reportKeyError("LLM_ANTHROPIC_API_KEY", 0, 400, body);
+			reportKeyError("LLM_ANTHROPIC_API_KEY", 0, 400, body);
+			expect(isKeyHealthy("LLM_ANTHROPIC_API_KEY", 0)).toBe(false);
+		});
+
+		it("should not permanently blacklist an out-of-funds key", () => {
+			reportKeyError("LLM_TENCENT_API_KEY", 0, 402);
+			expect(
+				getKeyMetrics("LLM_TENCENT_API_KEY", 0).permanentlyBlacklisted,
+			).toBe(false);
+			expect(isKeyHealthy("LLM_TENCENT_API_KEY", 0)).toBe(true);
+		});
+
+		it("should count 402 against tracked provider keys", () => {
+			reportTrackedKeyError("provider-key-402", 402);
+			reportTrackedKeyError("provider-key-402", 402);
+			reportTrackedKeyError("provider-key-402", 402);
+			expect(isTrackedKeyHealthy("provider-key-402")).toBe(false);
+		});
+
 		it("should track different keys independently", () => {
 			reportKeyError("LLM_OPENAI_API_KEY", 0, 500);
 			reportKeyError("LLM_OPENAI_API_KEY", 0, 500);

--- a/apps/gateway/src/lib/api-key-health.ts
+++ b/apps/gateway/src/lib/api-key-health.ts
@@ -1,4 +1,5 @@
 import { hasInvalidProviderCredentialError } from "./provider-auth-errors.js";
+import { hasExhaustedProviderAccountError } from "./provider-funding-errors.js";
 
 /**
  * In-memory API key health tracking for uptime-aware routing
@@ -75,9 +76,17 @@ const PERMANENT_ERROR_CODES = [401, 403];
 /**
  * 4xx responses that should still count against provider/key health.
  * These usually indicate gateway/provider configuration issues rather than
- * end-user request problems.
+ * end-user request problems. 402 is included because it means the provider
+ * account behind the key is out of funds (exhausted trial quota, no postpaid
+ * billing) — without it an unfunded credential keeps 100% uptime and stays the
+ * cheapest pick, so every request eats a failed attempt before falling back.
  */
-const UPTIME_RELEVANT_4XX_CODES = new Set([...PERMANENT_ERROR_CODES, 404, 429]);
+const UPTIME_RELEVANT_4XX_CODES = new Set([
+	...PERMANENT_ERROR_CODES,
+	402,
+	404,
+	429,
+]);
 
 /**
  * Uptime threshold below which exponential penalty kicks in
@@ -433,6 +442,10 @@ export function reportKeyError(
 	}
 
 	const isPermanentErrorMessage = hasInvalidProviderCredentialError(errorText);
+	// Some providers report an out-of-funds account on a 4xx other than 402
+	// (e.g. Anthropic's 400 "Your credit balance is too low"), so match the
+	// payload as well as the status code.
+	const isExhaustedAccountMessage = hasExhaustedProviderAccountError(errorText);
 
 	// Most upstream 4xx responses are client-side request issues and should not
 	// degrade provider uptime or influence routing decisions.
@@ -441,7 +454,8 @@ export function reportKeyError(
 		statusCode >= 400 &&
 		statusCode < 500 &&
 		!UPTIME_RELEVANT_4XX_CODES.has(statusCode) &&
-		!isPermanentErrorMessage
+		!isPermanentErrorMessage &&
+		!isExhaustedAccountMessage
 	) {
 		return;
 	}
@@ -490,13 +504,15 @@ export function reportTrackedKeyError(
 	}
 
 	const isPermanentErrorMessage = hasInvalidProviderCredentialError(errorText);
+	const isExhaustedAccountMessage = hasExhaustedProviderAccountError(errorText);
 
 	if (
 		statusCode !== undefined &&
 		statusCode >= 400 &&
 		statusCode < 500 &&
 		!UPTIME_RELEVANT_4XX_CODES.has(statusCode) &&
-		!isPermanentErrorMessage
+		!isPermanentErrorMessage &&
+		!isExhaustedAccountMessage
 	) {
 		return;
 	}

--- a/apps/gateway/src/lib/provider-funding-errors.ts
+++ b/apps/gateway/src/lib/provider-funding-errors.ts
@@ -1,0 +1,22 @@
+/**
+ * Upstream error bodies that report OUR provider account as out of funds —
+ * trial quota exhausted, credit balance too low, spending limit reached —
+ * rather than a fault in the caller's request. Providers disagree on the
+ * status code: some answer 402, others (e.g. Anthropic) a plain 400.
+ */
+const EXHAUSTED_PROVIDER_ACCOUNT_PATTERNS = [
+	/credit balance is too low/i,
+	/insufficient balance/i,
+	/reaching the monthly spending limit/i,
+	/free trial quota for the service has been exhausted/i,
+];
+
+export function hasExhaustedProviderAccountError(errorText?: string): boolean {
+	if (!errorText) {
+		return false;
+	}
+
+	return EXHAUSTED_PROVIDER_ACCOUNT_PATTERNS.some((pattern) =>
+		pattern.test(errorText),
+	);
+}


### PR DESCRIPTION
## Context

The admin unstable-mappings view showed `tencent/deepseek-v4-flash` at a 100% error rate, every failure a 402 saying the provider account's free trial quota was exhausted and postpaid billing was not enabled.

The classification itself was already correct: a 402 maps to `gateway_error` (`get-finish-reason-from-error.ts`), which is in `isRetryableErrorType()`, so cross-provider fallback does fire. The actual gap was one layer down — **key health ignored the 402 entirely**.

`UPTIME_RELEVANT_4XX_CODES` was `{401, 403, 404, 429}`, so `reportKeyError` / `reportTrackedKeyError` returned early for a 402. An unfunded credential therefore kept 100% uptime, never hit the consecutive-error threshold, and stayed the cheapest pick — so every single request kept selecting it, ate a failed upstream attempt, and only then fell back.

## Changes

- Add 402 to `UPTIME_RELEVANT_4XX_CODES` so an out-of-funds credential accrues uptime damage and gets temporarily blacklisted after the existing consecutive-error threshold. Deliberately *not* a permanent blacklist: a top-up should recover without a gateway restart.
- Extract the out-of-funds payload patterns into `provider-funding-errors.ts` and match them in key health as well, since some providers report the same condition on a 400 rather than a 402 (e.g. Anthropic's "Your credit balance is too low"). Reused by `get-finish-reason-from-error.ts`, which previously inlined the same regex.
- Add Tencent's exhausted-trial-quota wording to that pattern list.

## Testing

- `pnpm vitest run apps/gateway/src/lib/api-key-health.spec.ts apps/gateway/src/chat/tools/get-finish-reason-from-error.spec.ts apps/gateway/src/chat/tools/retry-with-fallback.spec.ts` — all pass, including four new key-health cases and one new classification case.
- `pnpm build` — 19/19 successful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider account funding errors, including exhausted trial quotas and insufficient balances, are now consistently identified.
  * Out-of-funds responses are correctly reflected in API key health tracking, including relevant 402 and 4xx responses.
  * Affected keys can recover after isolated funding-related errors instead of being permanently marked unhealthy.

* **Tests**
  * Added coverage for trial quota exhaustion, provider balance errors, and API key health behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->